### PR TITLE
Implement Transferable for anything that is Serialize + Deserialize

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -20,23 +20,12 @@ enum ToWorker<T> {
     Destroy,
 }
 
-impl<T> Transferable for ToWorker<T>
-where
-    T: Serialize + for <'de> Deserialize<'de>,
-{
-}
 
 #[derive(Serialize, Deserialize)]
 enum FromWorker<T> {
     /// Worker sends this message when `wasm` bundle has loaded.
     WorkerLoaded,
     ProcessOutput(HandlerId, T),
-}
-
-impl<T> Transferable for FromWorker<T>
-where
-    T: Serialize + for <'de> Deserialize<'de>,
-{
 }
 
 
@@ -46,6 +35,8 @@ where
     Self: Serialize + for <'de> Deserialize<'de>,
 {
 }
+
+impl <T> Transferable for T where T: Serialize + for <'de> Deserialize<'de> {}
 
 trait Packed {
     fn pack(&self) -> Vec<u8>;


### PR DESCRIPTION
Anything that is Serialize + Deserialize<'de>  will implement Transferable. Implementing Transferable will mark the struct or enum as a valid agent input or output type.

I think either this or https://github.com/DenisKolodin/yew/pull/319 should be merged, as either broadens the set of types that can be sent between Agents and the rest of an application. Either of these PRs should allow types defined in other crates to be be `Agent::Input` or `Agent::Output` as long as they implement the Serde traits without having to "newtype" them. This allows `()` to be `Input` or `Output`, which is nicer than having to define a `Void` empty-struct that implements Transferable to represent the same thing.

The particular drawback of this change is that if you have a type that should _not_ be an agent input or output, but is `Serialize + Deserialize<'de>`, it would be allowed as an `Input` or `Output`. As far as I'm aware, things that shouldn't be sent (like tasks) don't implement the Serde traits, so this wouldn't allow any behavior that is currently prohibited for safety reasons. Going on, the inability to implement `Serialize + Deserialize<'de>` for non-agent-message-same types would remain as a design constraint.