### PR TITLE
html!: fix explicit return types in callbacks

### DIFF
--- a/crates/macro/src/html_tree/html_prop.rs
+++ b/crates/macro/src/html_tree/html_prop.rs
@@ -32,9 +32,9 @@ impl Parse for HtmlProp {
 }
 
 pub struct HtmlPropSuffix {
+    pub stream: TokenStream,
     pub div: Option<Token![/]>,
     pub gt: Token![>],
-    pub stream: TokenStream,
 }
 
 impl Parse for HtmlPropSuffix {
@@ -67,6 +67,14 @@ impl Parse for HtmlPropSuffix {
                             break;
                         }
                     }
+                    '-' => {
+                        if input.peek(Token![>]) {
+                            // Handle explicit return types in callbacks (#560)
+                            // We increase angle_count here in order to ignore
+                            // the following >.
+                            angle_count += 1;
+                        }
+                    }
                     _ => {}
                 };
             }
@@ -77,6 +85,6 @@ impl Parse for HtmlPropSuffix {
         let stream: proc_macro2::TokenStream = trees.into_iter().collect();
         let stream = TokenStream::from(stream);
 
-        Ok(HtmlPropSuffix { div, gt, stream })
+        Ok(HtmlPropSuffix { stream, div, gt })
     }
 }

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -380,6 +380,10 @@ fn it_checks_mixed_closing_tags() {
     let b: VNode<CompInt> = html! { <div> <div onblur=|_| 3></div> </div> };
     assert_eq!(a, b); // NB: assert_eq! doesn't (cannot) compare the closures
 
+    let b: VNode<CompInt> = html! { <div> <a onblur=|_| 0></a> </div> };
+    let a: VNode<CompInt> = html! { <div> <a onblur=|_| -> u32 { 0 } />  </div> };
+    assert_eq!(a, b); // NB: assert_eq! doesn't (cannot) compare the closures
+
     // This is a known limitation of the html! macro:
     //
     //   html! { <div> <img onblur=|_| 2 > 1 /> </div> }


### PR DESCRIPTION
### Problem (see #560)
The html! macro didn't properly handle explicit return types in
callbacks, considering the '>' in '->' as the end of the HTML tag.

```rust
html! {
    <div onblur=|_| -> u32 0 />
    //               ^ here
}
```

Fixes: #560