### PR TITLE
html!: handle misleading '>' in tag attributes

### DIFF
--- a/crates/macro/src/html_tree/html_prop.rs
+++ b/crates/macro/src/html_tree/html_prop.rs
@@ -49,12 +49,18 @@ impl Parse for HtmlPropSuffix {
             if let TokenTree::Punct(punct) = &next {
                 match punct.as_char() {
                     '>' => {
-                        angle_count -= 1;
-                        if angle_count == 0 {
-                            gt = Some(syn::token::Gt {
-                                spans: [punct.span()],
-                            });
-                            break;
+                        let possible_tag_end = input.peek(Token![<])
+                            || input.peek(syn::token::Brace)
+                            || input.is_empty();
+
+                        if angle_count > 1 || possible_tag_end {
+                            angle_count -= 1;
+                            if angle_count == 0 {
+                                gt = Some(syn::token::Gt {
+                                    spans: [punct.span()],
+                                });
+                                break;
+                            }
                         }
                     }
                     '<' => angle_count += 1,

--- a/tests/macro/html-tag-fail.rs
+++ b/tests/macro/html-tag-fail.rs
@@ -31,10 +31,6 @@ fn compile_fail() {
     html! { <input onclick=|| () /> };
     html! { <input onclick=|a, b| () /> };
     html! { <input onclick=|a: String| () /> };
-
-    // This is a known limitation. Put braces or parenthesis around expressions
-    // that contain '>'.
-    html! { <div> <div onblur=|_| 2 > 1 /> </div> };
 }
 
 fn main() {}

--- a/tests/macro/html-tag-fail.stderr
+++ b/tests/macro/html-tag-fail.stderr
@@ -5,10 +5,10 @@ error: this open tag has no corresponding close tag
   |             ^^^^^
 
 error: this open tag has no corresponding close tag
- --> $DIR/html-tag-fail.rs:5:13
+ --> $DIR/html-tag-fail.rs:5:18
   |
 5 |     html! { <div><div> };
-  |             ^^^^^
+  |                  ^^^^^
 
 error: this close tag has no corresponding open tag
  --> $DIR/html-tag-fail.rs:6:13
@@ -28,17 +28,17 @@ error: only one root html element allowed
 8 |     html! { <div></div><div></div> };
   |                        ^^^^^^^^^^^
 
-error: this open tag has no corresponding close tag
- --> $DIR/html-tag-fail.rs:9:13
+error: this close tag has no corresponding open tag
+ --> $DIR/html-tag-fail.rs:9:18
   |
 9 |     html! { <div></span> };
-  |             ^^^^^
+  |                  ^^^^^^^
 
-error: this open tag has no corresponding close tag
-  --> $DIR/html-tag-fail.rs:10:13
+error: this close tag has no corresponding open tag
+  --> $DIR/html-tag-fail.rs:10:20
    |
 10 |     html! { <tag-a></tag-b> };
-   |             ^^^^^^^
+   |                    ^^^^^^^^
 
 error: this close tag has no corresponding open tag
   --> $DIR/html-tag-fail.rs:11:18
@@ -52,11 +52,13 @@ error: only one root html element allowed
 12 |     html! { <img /></img> };
    |                    ^^^^^^
 
-error: expected valid html element
-  --> $DIR/html-tag-fail.rs:13:18
+error: unexpected end of input, expected token tree
+  --> $DIR/html-tag-fail.rs:13:5
    |
 13 |     html! { <div>Invalid</div> };
-   |                  ^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: only one `attr` attribute allowed
   --> $DIR/html-tag-fail.rs:15:27
@@ -123,13 +125,6 @@ error: invalid closure argument
    |
 33 |     html! { <input onclick=|a: String| () /> };
    |                            ^^^^^^^^^^^
-
-HELP: You must wrap expressions containing '>' in braces or parenthesis. See #523.
-error: expected valid html element
-  --> $DIR/html-tag-fail.rs:37:39
-   |
-37 |     html! { <div> <div onblur=|_| 2 > 1 /> </div> };
-   |                                       ^
 
 error[E0308]: mismatched types
   --> $DIR/html-tag-fail.rs:23:28

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -377,24 +377,25 @@ fn it_checks_mixed_closing_tags() {
     assert_eq!(a, b);
 
     let a: VNode<CompInt> = html! { <div> <div onblur=|_| 2 / 1/>  </div> };
-    let b: VNode<CompInt> = html! { <div> <div onblur=|_| 3></div> </div> };
-    assert_eq!(a, b); // NB: assert_eq! doesn't (cannot) compare the closures
+    let b: VNode<CompInt> = html! { <div> <div onblur=|_| 2></div> </div> };
+    assert_eq!(a, b);
+}
 
-    let b: VNode<CompInt> = html! { <div> <a onblur=|_| 0></a> </div> };
+#[test]
+fn it_checks_misleading_gt() {
+    let a: VNode<CompBool> = html! { <div> <div onblur=|_|   2 > 1   /> </div> };
+    let b: VNode<CompBool> = html! { <div> <div onblur=|_| { 2 > 1 } /> </div> };
+    let c: VNode<CompBool> = html! { <div> <div onblur=|_| ( 2 > 1 ) /> </div> };
+    let d: VNode<CompBool> = html! { <div> <div onblur=|_| true ></div> </div> };
+    assert_eq!(a, b);
+    assert_eq!(a, c);
+    assert_eq!(a, d);
+
+    let a: VNode<CompBool> = html! { <div><div onblur=|_|  2 > 1 />      </div> };
+    let b: VNode<CompBool> = html! { <div><div onblur=|_| { true }></div></div> };
+    assert_eq!(a, b);
+
     let a: VNode<CompInt> = html! { <div> <a onblur=|_| -> u32 { 0 } />  </div> };
-    assert_eq!(a, b); // NB: assert_eq! doesn't (cannot) compare the closures
-
-    // This is a known limitation of the html! macro:
-    //
-    //   html! { <div> <img onblur=|_| 2 > 1 /> </div> }
-    //
-    // You have to put braces or parenthesis around the expression:
-    //
-    //   html! { <div> <img onblur=|_| { 2 > 1 } /> </div> }
-    //
-    let a: VNode<CompBool> = html! { <div> <div onblur=|_| { 2 > 1 } />  </div> };
-    let b: VNode<CompBool> = html! { <div> <div onblur=|_| ( 2 > 1 ) />  </div> };
-    let c: VNode<CompBool> = html! { <div> <div onblur=|_| false></div> </div> };
-    assert_eq!(a, c); // NB: assert_eq! doesn't (cannot) compare the closures
-    assert_eq!(b, c);
+    let b: VNode<CompInt> = html! { <div> <a onblur=|_| 0></a> </div> };
+    assert_eq!(a, b);
 }


### PR DESCRIPTION
### Problem
The `html!` macro didn't handle cases like this one:

```rust
html! {
    <div onclick=|_| 2 > 1 />
    //                 ^ this
}
```

Moreover, the introduction of handling of mixed self-closing and not
self-closing tags introduced a buggy error message, which is now fixed.

### Solution
The parser only allows `<`, `{` or nothing after a tag's closing `>`.

`verify_end` is removed, and the presence of a closing tag is checked
when parsing the children.

### Regression
Unfortunately, this change has a regression: the error message is less
good now, like here in `html-tag-fail.stderr`:

```diff
diff --git a/tests/macro/html-tag-fail.stderr b/tests/macro/html-tag-fail.stderr
index b14fc14..d59e8f4 100644
--- a/tests/macro/html-tag-fail.stderr
+++ b/tests/macro/html-tag-fail.stderr
@@ -52,11 +52,13 @@ error: only one root html element allowed
 12 |     html! { <img /></img> };
    |                    ^^^^^^

-error: expected valid html element
-  --> $DIR/html-tag-fail.rs:13:18
+error: unexpected end of input, expected token tree
+  --> $DIR/html-tag-fail.rs:13:5
    |
 13 |     html! { <div>Invalid</div> };
-   |                  ^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

 error: only one `attr` attribute allowed
   --> $DIR/html-tag-fail.rs:15:27
```