### PR TITLE
Applied clippy feedback

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -42,7 +42,7 @@ where
 
 trait Packed {
     fn pack(&self) -> Vec<u8>;
-    fn unpack(data: &Vec<u8>) -> Self;
+    fn unpack(data: &[u8]) -> Self;
 }
 
 impl<T: Transferable> Packed for T {
@@ -50,7 +50,7 @@ impl<T: Transferable> Packed for T {
         bincode::serialize(&self).expect("can't serialize a transferable object")
     }
 
-    fn unpack(data: &Vec<u8>) -> Self {
+    fn unpack(data: &[u8]) -> Self {
         bincode::deserialize(&data).expect("can't deserialize a transferable object")
     }
 }
@@ -66,7 +66,7 @@ impl From<usize> for HandlerId {
 }
 
 impl HandlerId {
-    fn raw_id(&self) -> usize {
+    fn raw_id(self) -> usize {
         self.0
     }
 }
@@ -224,7 +224,7 @@ impl Discoverer for Context {
             let upd = AgentUpdate::Create(agent_link);
             scope.send(upd);
         }
-        let upd = AgentUpdate::Connected(bridge.id.into());
+        let upd = AgentUpdate::Connected(bridge.id);
         bridge.scope.send(upd);
         Box::new(bridge)
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,15 @@ pub struct App<COMP: Component> {
     scope: Scope<COMP>,
 }
 
+impl<COMP> Default for App<COMP>
+where
+    COMP: Component + Renderable<COMP>,
+{
+    fn default() -> Self {
+        App::new()
+    }
+}
+
 impl<COMP> App<COMP>
 where
     COMP: Component + Renderable<COMP>,

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -168,6 +168,15 @@ where
     }
 }
 
+impl<COMP> Default for Scope<COMP>
+where
+    COMP: Component + Renderable<COMP>,
+{
+    fn default() -> Self {
+        Scope::new()
+    }
+}
+
 struct CreateComponent<COMP>
 where
     COMP: Component,

--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -245,8 +245,9 @@ where
         .map(|(k, v)| {
             (
                 k.as_str(),
-                v.to_str()
-                    .expect(format!("Unparsable request header {}: {:?}", k.as_str(), v).as_str()),
+                v.to_str().unwrap_or_else(|_| {
+                    panic!("Unparsable request header {}: {:?}", k.as_str(), v)
+                }),
             )
         })
         .collect();

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -38,6 +38,6 @@ pub trait Task: Drop {
 
 #[doc(hidden)]
 fn to_ms(duration: Duration) -> u32 {
-    let ms = duration.subsec_nanos() / 1_000_000;
+    let ms = duration.subsec_millis();
     ms + duration.as_secs() as u32 * 1000
 }

--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -84,7 +84,7 @@ impl WebSocketTask {
         IN: Into<Text>,
     {
         if let Ok(body) = data.into() {
-            if let Err(_) = self.ws.send_text(&body) {
+            if self.ws.send_text(&body).is_err() {
                 self.notification.emit(WebSocketStatus::Error);
             }
         }
@@ -96,7 +96,7 @@ impl WebSocketTask {
         IN: Into<Binary>,
     {
         if let Ok(body) = data.into() {
-            if let Err(_) = self.ws.send_bytes(&body) {
+            if self.ws.send_bytes(&body).is_err() {
                 self.notification.emit(WebSocketStatus::Error);
             }
         }

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -82,7 +82,7 @@ impl<COMP: Component> VComp<COMP> {
                     }
 
                     let mut scope = unsafe {
-                        let raw: *mut Scope<CHILD> = ::std::mem::transmute(scope);
+                        let raw: *mut Scope<CHILD> = scope as *mut Scope<CHILD>;
                         *Box::from_raw(raw)
                     };
 

--- a/src/virtual_dom/vlist.rs
+++ b/src/virtual_dom/vlist.rs
@@ -9,6 +9,12 @@ pub struct VList<COMP: Component> {
     pub childs: Vec<VNode<COMP>>,
 }
 
+impl<COMP: Component> Default for VList<COMP> {
+    fn default() -> Self {
+        VList::new()
+    }
+}
+
 impl<COMP: Component> VList<COMP> {
     /// Creates a new `VTag` instance with `tag` name (cannot be changed later in DOM).
     pub fn new() -> Self {


### PR DESCRIPTION
Clippy had some small changes that it preferred

`fn unpack(data: &[u8]) -> Self;`: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
Because `&Vec<u8>` and `&[u8]` are identical enough, and this doesn't break code, Clippy likes the slice more because it's flexible

`fn raw_id(self) -> usize {`: https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref
`HandlerId` is small enough (8 bytes) that Clippy thinks it's trivially copied, rather than passing a pointer around (this might be not relevant because it's WASM)

`AgentUpdate::Connected(bridge.id);`: https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
`bridge.id` is already a `HandlerId` so no point in using `.into()`

`v.to_str().unwrap_or_else(|_| {`: https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call
With the `expect`, the error string is always allocated, even when the error doesn't occur. Using an `unwrap_or_else` makes sure the error string only gets allocated when it fails

`duration.subsec_millis();`: https://rust-lang.github.io/rust-clippy/master/index.html#duration_subsec
Stable since rust 1.27

`self.ws.send_text(&body).is_err()`: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
The `Err` is not used, so `.is_err()` is more concise

`scope as *mut Scope<CHILD>;`: https://rust-lang.github.io/rust-clippy/master/index.html#transmute_ptr_to_ptr
A cast can be used instead of a transmute
