### PR TITLE
Add default mounted() method to Component trait

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -25,9 +25,9 @@ pub trait Component: Sized + 'static {
     /// Initialization routine which could use a context.
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self;
     /// Called after the component has been attached to the VDOM and it is safe to receive messages
-    /// from agents. Any changes made to the state that `view` relies on will not be apparent
-    /// immediately as this method does not trigger a rerender.
-    fn on_mount(&mut self) {}
+    /// from agents but before the browser updates the screen. If true is returned, the view will
+    /// be re-rendered and the user will not see the initial render.
+    fn mounted(&mut self) -> ShouldRender { false }
     /// Called everytime when a messages of `Msg` type received. It also takes a
     /// reference to a context.
     fn update(&mut self, msg: Self::Message) -> ShouldRender;

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -24,6 +24,10 @@ pub trait Component: Sized + 'static {
     type Properties: Properties;
     /// Initialization routine which could use a context.
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self;
+    /// Called after the component has been attached to the VDOM and it is safe to receive messages
+    /// from agents. Any changes made to the state that `view` relies on will not be apparent
+    /// immediately as this method does not trigger a rerender.
+    fn on_mount(&mut self) {}
     /// Called everytime when a messages of `Msg` type received. It also takes a
     /// reference to a context.
     fn update(&mut self, msg: Self::Message) -> ShouldRender;

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -112,6 +112,11 @@ struct CreatedState<COMP: Component> {
 }
 
 impl<COMP: Component + Renderable<COMP>> CreatedState<COMP> {
+    /// Called once immediately after the component is created.
+    fn mounted(mut self) -> Self {
+        self.component.on_mount();
+        self
+    }
     fn update(mut self) -> Self {
         let mut next_frame = self.component.view();
         let node = next_frame.apply(&self.element, None, self.last_frame, &self.env);
@@ -178,7 +183,9 @@ where
     fn run(self: Box<Self>) {
         let current_state = self.shared_state.replace(ComponentState::Processing);
         self.shared_state.replace(match current_state {
-            ComponentState::Ready(state) => ComponentState::Created(state.create().update()),
+            ComponentState::Ready(state) => {
+                ComponentState::Created(state.create().update().mounted())
+            },
             ComponentState::Created(_) | ComponentState::Destroyed => current_state,
             ComponentState::Empty | ComponentState::Processing => {
                 panic!("unexpected component state: {}", current_state);

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -125,11 +125,8 @@ impl<COMP: Component + Renderable<COMP>> CreatedState<COMP> {
         }
 
         Self {
-            env: self.env,
-            component: self.component,
             last_frame: Some(next_frame),
-            element: self.element,
-            occupied: self.occupied,
+            ..self
         }
     }
 }

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -114,9 +114,13 @@ struct CreatedState<COMP: Component> {
 impl<COMP: Component + Renderable<COMP>> CreatedState<COMP> {
     /// Called once immediately after the component is created.
     fn mounted(mut self) -> Self {
-        self.component.on_mount();
-        self
+        if self.component.mounted() {
+            self.update()
+        } else {
+            self
+        }
     }
+
     fn update(mut self) -> Self {
         let mut next_frame = self.component.view();
         let node = next_frame.apply(&self.element, None, self.last_frame, &self.env);
@@ -124,10 +128,8 @@ impl<COMP: Component + Renderable<COMP>> CreatedState<COMP> {
             *cell.borrow_mut() = node;
         }
 
-        Self {
-            last_frame: Some(next_frame),
-            ..self
-        }
+        self.last_frame = Some(next_frame);
+        self
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/yewstack/yew/issues/572

I made the choice to have `on_mount()` not return a `ShouldRender` bool, because I don't think there is a situation where altering parts of a component state relevant to the `view()` should ever take place in `on_mount()` instead of `create()`. Let me know your thoughts, because its an easy enough change to make.