### PR TITLE
Remove allocation in vtag diff

### DIFF
--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -121,19 +121,10 @@ impl<COMP: Component> fmt::Debug for VNode<COMP> {
 
 impl<COMP: Component> PartialEq for VNode<COMP> {
     fn eq(&self, other: &VNode<COMP>) -> bool {
-        match *self {
-            VNode::VTag(ref vtag_a) => match *other {
-                VNode::VTag(ref vtag_b) => vtag_a == vtag_b,
-                _ => false,
-            },
-            VNode::VText(ref vtext_a) => match *other {
-                VNode::VText(ref vtext_b) => vtext_a == vtext_b,
-                _ => false,
-            },
-            _ => {
-                // TODO Implement it
-                false
-            }
+        match (self, other) {
+            (VNode::VTag(vtag_a), VNode::VTag(vtag_b)) => vtag_a == vtag_b,
+            (VNode::VText(vtext_a), VNode::VText(vtext_b)) => vtext_a == vtext_b,
+            _ => false, // TODO: Implement other variants
         }
     }
 }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -252,20 +252,20 @@ impl<COMP: Component> VTag<COMP> {
     }
 
     /// Similar to `diff_attributers` except there is only a single `kind`.
-    fn diff_kind(&mut self, ancestor: &mut Option<Self>) -> Option<Patch<String, ()>> {
+    fn diff_kind<'a>(&'a self, ancestor: &'a Option<Self>) -> Option<Patch<&'a str, ()>> {
         match (
-            &self.kind,
-            ancestor.as_mut().and_then(|anc| anc.kind.take()),
+            &self.kind.as_ref(),
+            ancestor.as_ref().and_then(|anc| anc.kind.as_ref()),
         ) {
             (&Some(ref left), Some(ref right)) => {
                 if left != right {
-                    Some(Patch::Replace(left.to_string(), ()))
+                    Some(Patch::Replace(&**left, ()))
                 } else {
                     None
                 }
             }
-            (&Some(ref left), None) => Some(Patch::Add(left.to_string(), ())),
-            (&None, Some(right)) => Some(Patch::Remove(right)),
+            (&Some(ref left), None) => Some(Patch::Add(&**left, ())),
+            (&None, Some(right)) => Some(Patch::Remove(&**right)),
             (&None, None) => None,
         }
     }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -271,20 +271,20 @@ impl<COMP: Component> VTag<COMP> {
     }
 
     /// Almost identical in spirit to `diff_kind`
-    fn diff_value(&mut self, ancestor: &mut Option<Self>) -> Option<Patch<String, ()>> {
+    fn diff_value<'a>(&'a self, ancestor: &'a Option<Self>) -> Option<Patch<&'a str, ()>> {
         match (
-            &self.value,
-            ancestor.as_mut().and_then(|anc| anc.value.take()),
+            &self.value.as_ref(),
+            ancestor.as_ref().and_then(|anc| anc.value.as_ref()),
         ) {
             (&Some(ref left), Some(ref right)) => {
                 if left != right {
-                    Some(Patch::Replace(left.to_string(), ()))
+                    Some(Patch::Replace(&**left, ()))
                 } else {
                     None
                 }
             }
-            (&Some(ref left), None) => Some(Patch::Add(left.to_string(), ())),
-            (&None, Some(right)) => Some(Patch::Remove(right)),
+            (&Some(ref left), None) => Some(Patch::Add(&**left, ())),
+            (&None, Some(right)) => Some(Patch::Remove(&**right)),
             (&None, None) => None,
         }
     }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -178,9 +178,19 @@ impl<COMP: Component> VTag<COMP> {
     /// - items that are the same stay the same.
     ///
     /// Otherwise just add everything.
-    fn diff_classes<'a>(&'a self, ancestor: &'a Option<Self>) -> impl Iterator<Item = Patch<&'a str, ()>> + 'a {
-        let to_add = self.classes.set.iter()
-            .filter(move |class| ancestor.as_ref().map_or(true, |ancestor| !ancestor.classes.set.contains(&**class)))
+    fn diff_classes<'a>(
+        &'a self,
+        ancestor: &'a Option<Self>,
+    ) -> impl Iterator<Item = Patch<&'a str, ()>> + 'a {
+        let to_add = self
+            .classes
+            .set
+            .iter()
+            .filter(move |class| {
+                ancestor
+                    .as_ref()
+                    .map_or(true, |ancestor| !ancestor.classes.set.contains(&**class))
+            })
             .map(|class| Patch::Add(&**class, ()));
 
         let to_remove = ancestor
@@ -195,14 +205,17 @@ impl<COMP: Component> VTag<COMP> {
     ///
     /// This also handles patching of attributes when the keys are equal but
     /// the values are different.
-    fn diff_attributes<'a>(&'a self, ancestor: &'a Option<Self>) 
-        -> impl Iterator<Item = Patch<&'a str, &'a str>> + 'a 
-    {
+    fn diff_attributes<'a>(
+        &'a self,
+        ancestor: &'a Option<Self>,
+    ) -> impl Iterator<Item = Patch<&'a str, &'a str>> + 'a {
         // Only change what is necessary.
-        let to_add_or_replace = self.attributes
-            .iter()
-            .filter_map(move |(key, value)| {
-                match ancestor.as_ref().and_then(|ancestor| ancestor.attributes.get(&**key)) {
+        let to_add_or_replace =
+            self.attributes.iter().filter_map(move |(key, value)| {
+                match ancestor
+                    .as_ref()
+                    .and_then(|ancestor| ancestor.attributes.get(&**key))
+                {
                     None => Some(Patch::Add(&**key, &**value)),
                     Some(ancestor_value) if value == ancestor_value => {
                         Some(Patch::Replace(&**key, &**value))


### PR DESCRIPTION
**Disclaimer**: I couldn't test it on my system yet.

This PR attempts to remove all allocations (`String`, `Vec` and `HashSet`) used in various vtag diff functions.

I believe this should have an impact both in terms of performance and memory.

