### PR TITLE
Update proc-macro2, syn and quote to 1.0

### DIFF
--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -21,9 +21,9 @@ proc-macro = true
 boolinator = "2.4.0"
 lazy_static = "1.3.0"
 proc-macro-hack = "0.5"
-proc-macro2 = "0.4"
-quote = "0.6"
-syn = { version = "^0.15.34", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 yew = { path = "../.." }

--- a/crates/macro/src/derive_props/builder.rs
+++ b/crates/macro/src/derive_props/builder.rs
@@ -9,7 +9,6 @@ use super::generics::{to_arguments, with_param_bounds, GenericArguments};
 use super::{DerivePropsInput, PropField};
 use proc_macro2::{Ident, Span};
 use quote::{quote, ToTokens};
-use std::iter;
 
 pub struct PropsBuilder<'a> {
     builder_name: &'a Ident,
@@ -36,9 +35,6 @@ impl ToTokens for PropsBuilder<'_> {
             ..
         } = props;
 
-        let step_trait_repeat = iter::repeat(step_trait);
-        let vis_repeat = iter::repeat(&vis);
-
         let build_step = self.build_step();
         let impl_steps = self.impl_steps();
         let set_fields = self.set_fields();
@@ -59,13 +55,13 @@ impl ToTokens for PropsBuilder<'_> {
         let builder = quote! {
             #(
                 #[doc(hidden)]
-                #vis_repeat struct #step_names;
+                #vis struct #step_names;
             )*
 
             #[doc(hidden)]
             #vis trait #step_trait {}
 
-            #(impl #step_trait_repeat for #step_names {})*
+            #(impl #step_trait for #step_names {})*
 
             #[doc(hidden)]
             #vis struct #builder_name#step_generics {
@@ -73,7 +69,7 @@ impl ToTokens for PropsBuilder<'_> {
                 _marker: ::std::marker::PhantomData<#step_generic_param>,
             }
 
-            #(#impl_steps)*
+            #impl_steps
 
             impl#impl_generics #builder_name<#generic_args> #where_clause {
                 #[doc(hidden)]

--- a/crates/macro/src/derive_props/field.rs
+++ b/crates/macro/src/derive_props/field.rs
@@ -4,7 +4,6 @@ use quote::quote;
 use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::convert::TryFrom;
 use syn::parse::Result;
-use syn::punctuated;
 use syn::spanned::Spanned;
 use syn::{Error, Field, Meta, MetaList, NestedMeta, Type, Visibility};
 
@@ -121,12 +120,12 @@ impl PropField {
             return Err(expected_required);
         };
 
-        let word_ident = match first_nested {
-            punctuated::Pair::End(NestedMeta::Meta(Meta::Word(ident))) => ident,
+        let word_path = match first_nested {
+            NestedMeta::Meta(Meta::Path(path)) => path,
             _ => return Err(expected_required),
         };
 
-        if word_ident != "required" {
+        if !word_path.is_ident("required") {
             return Err(expected_required);
         }
 
@@ -149,7 +148,7 @@ impl PropField {
                 _ => None,
             })?;
 
-        if meta_list.ident == "props" {
+        if meta_list.path.is_ident("props") {
             Some(meta_list)
         } else {
             None

--- a/tests/macro/html-node-fail.stderr
+++ b/tests/macro/html-node-fail.stderr
@@ -22,7 +22,7 @@ error: unsupported type
 11 |     html! {  b"str" };
    |              ^^^^^^
 
-error: unsupported type
+error: int literal is too large
   --> $DIR/html-node-fail.rs:12:14
    |
 12 |     html! {  1111111111111111111111111111111111111111111111111111111111111111111111111111 };
@@ -40,7 +40,7 @@ error: unsupported type
 14 |     html! {  <span>{ b"str" }</span> };
    |                      ^^^^^^
 
-error: unsupported type
+error: int literal is too large
   --> $DIR/html-node-fail.rs:15:22
    |
 15 |     html! {  <span>{ 1111111111111111111111111111111111111111111111111111111111111111111111111111 }</span> };


### PR DESCRIPTION
CLOSES #590

I also tried to lift the recursion limits in the examples, but it looks like they are still required (maybe due to macros from stdweb?).