### PR TITLE
Expose parent element in mounted

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -12,6 +12,7 @@ pub use scope::{NodeCell, Scope};
 
 use crate::callback::Callback;
 use crate::virtual_dom::VNode;
+use stdweb::web::Element;
 
 /// This type indicates that component should be rendered again.
 pub type ShouldRender = bool;
@@ -27,7 +28,7 @@ pub trait Component: Sized + 'static {
     /// Called after the component has been attached to the VDOM and it is safe to receive messages
     /// from agents but before the browser updates the screen. If true is returned, the view will
     /// be re-rendered and the user will not see the initial render.
-    fn mounted(&mut self) -> ShouldRender {
+    fn mounted(&mut self, _: &Element) -> ShouldRender {
         false
     }
     /// Called everytime when a messages of `Msg` type received. It also takes a

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -114,7 +114,7 @@ struct CreatedState<COMP: Component> {
 impl<COMP: Component + Renderable<COMP>> CreatedState<COMP> {
     /// Called once immediately after the component is created.
     fn mounted(mut self) -> Self {
-        if self.component.mounted() {
+        if self.component.mounted(&self.element) {
             self.update()
         } else {
             self


### PR DESCRIPTION
Change adds parent element to mounted.

```rust
fn mounted(&mut self, parent: &Element) -> ShouldRender
```
Addresses https://github.com/yewstack/yew/issues/616