### PR TITLE
Remove special 'for' syntax (WIP)

### DIFF
--- a/examples/large_table/src/lib.rs
+++ b/examples/large_table/src/lib.rs
@@ -57,10 +57,9 @@ fn view_row(selected: Option<(u32, u32)>, row: u32) -> Html<Model> {
 
 impl Renderable<Model> for Model {
     fn view(&self) -> Html<Self> {
-        use yew::virtual_dom::vnode::ToHtmlAdaptor;
         html! {
             <table>
-                { (0..99).map(|row| view_row(self.selected, row)).html() }
+                { (0..99).map(|row| view_row(self.selected, row)).collect::<Html<Self>>() }
             </table>
         }
     }

--- a/examples/large_table/src/lib.rs
+++ b/examples/large_table/src/lib.rs
@@ -57,11 +57,10 @@ fn view_row(selected: Option<(u32, u32)>, row: u32) -> Html<Model> {
 
 impl Renderable<Model> for Model {
     fn view(&self) -> Html<Self> {
+        use yew::virtual_dom::vnode::ToHtmlAdaptor;
         html! {
             <table>
-                {for (0..99).map(|row| {
-                    view_row(self.selected, row)
-                })}
+                { (0..99).map(|row| view_row(self.selected, row)).html() }
             </table>
         }
     }

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -117,55 +117,6 @@ impl <COMP: Component, A: Into<VNode<COMP>>> FromIterator<A> for VNode<COMP> {
         VNode::VList(vlist)
     }
 }
-//
-///// Iterator adaptor for displaying html.
-//pub struct HtmlAdaptor<I> {
-//    it: I,
-//}
-///// Trait to convert to html adaptor.
-//pub trait ToHtmlAdaptor<I> {
-//    /// Converts existing iterator to an html adaptor
-//    fn html(self) -> HtmlAdaptor<I>;
-//}
-//
-//impl<I, II, T> ToHtmlAdaptor<I> for II
-//where
-//    II: IntoIterator<Item = T, IntoIter = I>,
-//    I: Iterator<Item = T>,
-//{
-//    fn html(self) -> HtmlAdaptor<I> {
-//        HtmlAdaptor {
-//            it: self.into_iter(),
-//        }
-//    }
-//}
-//
-//impl<'a, I, T: 'a> Iterator for HtmlAdaptor<I>
-//where
-//    I: Iterator<Item = T>,
-//{
-//    type Item = T;
-//
-//    fn next(&mut self) -> Option<Self::Item> {
-//        self.it.next()
-//    }
-//}
-//
-//impl<COMP, I, T> From<HtmlAdaptor<I>> for VNode<COMP>
-//where
-//    COMP: Component,
-//    I: Iterator<Item = T>,
-//    T: Into<VNode<COMP>>,
-//{
-//    fn from(i: HtmlAdaptor<I>) -> Self {
-//        let vlist = i.into_iter().fold(VList::new(), |mut acc, x| {
-//            // TODO, adding a VList::with_size(usize) might improve performance via eliminating reallocation as the vec grows.
-//            acc.add_child(x.into());
-//            acc
-//        });
-//        VNode::VList(vlist)
-//    }
-//}
 
 impl<COMP: Component> fmt::Debug for VNode<COMP> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -5,6 +5,7 @@ use crate::html::{Component, Renderable, Scope};
 use std::cmp::PartialEq;
 use std::fmt;
 use stdweb::web::{Element, INode, Node};
+use std::iter::FromIterator;
 
 /// Bind virtual element to a DOM reference.
 pub enum VNode<COMP: Component> {
@@ -107,54 +108,64 @@ impl<'a, COMP: Component> From<&'a dyn Renderable<COMP>> for VNode<COMP> {
     }
 }
 
-/// Iterator adaptor for displaying html.
-pub struct HtmlAdaptor<I> {
-    it: I,
-}
-/// Trait to convert to html adaptor.
-pub trait ToHtmlAdaptor<I> {
-    /// Converts existing iterator to an html adaptor
-    fn html(self) -> HtmlAdaptor<I>;
-}
-
-impl<I, II, T> ToHtmlAdaptor<I> for II
-where
-    II: IntoIterator<Item = T, IntoIter = I>,
-    I: Iterator<Item = T>,
-{
-    fn html(self) -> HtmlAdaptor<I> {
-        HtmlAdaptor {
-            it: self.into_iter(),
-        }
-    }
-}
-
-impl<'a, I, T: 'a> Iterator for HtmlAdaptor<I>
-where
-    I: Iterator<Item = T>,
-{
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.it.next()
-    }
-}
-
-impl<COMP, I, T> From<HtmlAdaptor<I>> for VNode<COMP>
-where
-    COMP: Component,
-    I: Iterator<Item = T>,
-    T: Into<VNode<COMP>>,
-{
-    fn from(i: HtmlAdaptor<I>) -> Self {
-        let vlist = i.into_iter().fold(VList::new(), |mut acc, x| {
-            // TODO, adding a VList::with_size(usize) might improve performance via eliminating reallocation as the vec grows.
+impl <COMP: Component, A: Into<VNode<COMP>>> FromIterator<A> for VNode<COMP> {
+    fn from_iter<T: IntoIterator<Item=A>>(iter: T) -> Self {
+        let vlist = iter.into_iter().fold(VList::new(), |mut acc, x| {
             acc.add_child(x.into());
             acc
         });
         VNode::VList(vlist)
     }
 }
+//
+///// Iterator adaptor for displaying html.
+//pub struct HtmlAdaptor<I> {
+//    it: I,
+//}
+///// Trait to convert to html adaptor.
+//pub trait ToHtmlAdaptor<I> {
+//    /// Converts existing iterator to an html adaptor
+//    fn html(self) -> HtmlAdaptor<I>;
+//}
+//
+//impl<I, II, T> ToHtmlAdaptor<I> for II
+//where
+//    II: IntoIterator<Item = T, IntoIter = I>,
+//    I: Iterator<Item = T>,
+//{
+//    fn html(self) -> HtmlAdaptor<I> {
+//        HtmlAdaptor {
+//            it: self.into_iter(),
+//        }
+//    }
+//}
+//
+//impl<'a, I, T: 'a> Iterator for HtmlAdaptor<I>
+//where
+//    I: Iterator<Item = T>,
+//{
+//    type Item = T;
+//
+//    fn next(&mut self) -> Option<Self::Item> {
+//        self.it.next()
+//    }
+//}
+//
+//impl<COMP, I, T> From<HtmlAdaptor<I>> for VNode<COMP>
+//where
+//    COMP: Component,
+//    I: Iterator<Item = T>,
+//    T: Into<VNode<COMP>>,
+//{
+//    fn from(i: HtmlAdaptor<I>) -> Self {
+//        let vlist = i.into_iter().fold(VList::new(), |mut acc, x| {
+//            // TODO, adding a VList::with_size(usize) might improve performance via eliminating reallocation as the vec grows.
+//            acc.add_child(x.into());
+//            acc
+//        });
+//        VNode::VList(vlist)
+//    }
+//}
 
 impl<COMP: Component> fmt::Debug for VNode<COMP> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -109,7 +109,7 @@ impl<'a, COMP: Component> From<&'a dyn Renderable<COMP>> for VNode<COMP> {
 
 /// Iterator adaptor for displaying html.
 pub struct HtmlAdaptor<I> {
-    it: I
+    it: I,
 }
 /// Trait to convert to html adaptor.
 pub trait ToHtmlAdaptor<I> {
@@ -117,20 +117,21 @@ pub trait ToHtmlAdaptor<I> {
     fn html(self) -> HtmlAdaptor<I>;
 }
 
-impl <I, II, T> ToHtmlAdaptor<I> for II
-    where
-        II: IntoIterator<Item=T, IntoIter=I>,
-        I: Iterator<Item=T>
- {
+impl<I, II, T> ToHtmlAdaptor<I> for II
+where
+    II: IntoIterator<Item = T, IntoIter = I>,
+    I: Iterator<Item = T>,
+{
     fn html(self) -> HtmlAdaptor<I> {
         HtmlAdaptor {
-            it: self.into_iter()
+            it: self.into_iter(),
         }
     }
 }
 
 impl<'a, I, T: 'a> Iterator for HtmlAdaptor<I>
-where I: Iterator<Item=T>,
+where
+    I: Iterator<Item = T>,
 {
     type Item = T;
 
@@ -139,20 +140,18 @@ where I: Iterator<Item=T>,
     }
 }
 
-
 impl<COMP, I, T> From<HtmlAdaptor<I>> for VNode<COMP>
 where
     COMP: Component,
-    I: Iterator<Item=T>,
-    T: Into<VNode<COMP>>
+    I: Iterator<Item = T>,
+    T: Into<VNode<COMP>>,
 {
     fn from(i: HtmlAdaptor<I>) -> Self {
-        let vlist = i
-            .into_iter()
-            .fold(VList::new(), |mut acc, x| {
-                acc.add_child(x.into());
-                acc
-            });
+        let vlist = i.into_iter().fold(VList::new(), |mut acc, x| {
+            // TODO, adding a VList::with_size(usize) might improve performance via eliminating reallocation as the vec grows.
+            acc.add_child(x.into());
+            acc
+        });
         VNode::VList(vlist)
     }
 }

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -4,8 +4,8 @@ use super::{VComp, VDiff, VList, VTag, VText};
 use crate::html::{Component, Renderable, Scope};
 use std::cmp::PartialEq;
 use std::fmt;
-use stdweb::web::{Element, INode, Node};
 use std::iter::FromIterator;
+use stdweb::web::{Element, INode, Node};
 
 /// Bind virtual element to a DOM reference.
 pub enum VNode<COMP: Component> {
@@ -108,8 +108,8 @@ impl<'a, COMP: Component> From<&'a dyn Renderable<COMP>> for VNode<COMP> {
     }
 }
 
-impl <COMP: Component, A: Into<VNode<COMP>>> FromIterator<A> for VNode<COMP> {
-    fn from_iter<T: IntoIterator<Item=A>>(iter: T) -> Self {
+impl<COMP: Component, A: Into<VNode<COMP>>> FromIterator<A> for VNode<COMP> {
+    fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
         let vlist = iter.into_iter().fold(VList::new(), |mut acc, x| {
             acc.add_child(x.into());
             acc

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -107,6 +107,56 @@ impl<'a, COMP: Component> From<&'a dyn Renderable<COMP>> for VNode<COMP> {
     }
 }
 
+/// Iterator adaptor for displaying html.
+pub struct HtmlAdaptor<I> {
+    it: I
+}
+/// Trait to convert to html adaptor.
+pub trait ToHtmlAdaptor<I> {
+    /// Converts existing iterator to an html adaptor
+    fn html(self) -> HtmlAdaptor<I>;
+}
+
+impl <I, II, T> ToHtmlAdaptor<I> for II
+    where
+        II: IntoIterator<Item=T, IntoIter=I>,
+        I: Iterator<Item=T>
+ {
+    fn html(self) -> HtmlAdaptor<I> {
+        HtmlAdaptor {
+            it: self.into_iter()
+        }
+    }
+}
+
+impl<'a, I, T: 'a> Iterator for HtmlAdaptor<I>
+where I: Iterator<Item=T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.it.next()
+    }
+}
+
+
+impl<COMP, I, T> From<HtmlAdaptor<I>> for VNode<COMP>
+where
+    COMP: Component,
+    I: Iterator<Item=T>,
+    T: Into<VNode<COMP>>
+{
+    fn from(i: HtmlAdaptor<I>) -> Self {
+        let vlist = i
+            .into_iter()
+            .fold(VList::new(), |mut acc, x| {
+                acc.add_child(x.into());
+                acc
+            });
+        VNode::VList(vlist)
+    }
+}
+
 impl<COMP: Component> fmt::Debug for VNode<COMP> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {


### PR DESCRIPTION
Attempts to address https://github.com/yewstack/yew/issues/606

I'm running into coherence issues and conflicting implementations with `ToString` and `IntoIterator` when I try to do a blanket impl for `impl <T: IntoIterator<etc...> From<T> for VNode<COMP>`. If I replace the `ToString` blanket impl with concrete impls for `String` and `&str`, I still run into coherence issues where downstream crates might provide a conflicting impl.

I figured that the easiest path forward is to create my own iterator and implement `Into<VNode<COMP>>` for it via an impl for `From`.

So this PR thusfar gets us from:
#### Before
```rust
html! {
   for self.props.items.iter().map(renderItem)
}
```

#### To the start of this PR.
 ```rust
html! {
   self.props.items.iter().map(renderItem).html()
}
```

#### To now
 ```rust
html! {
   self.props.items.iter().map(renderItem).collect::<Html<Self>>()
}
```

Which strictly speaking, is _better_, as it frees up a keyword, but isn't anywhere near what you ideally want:
#### Ideal
```rust
html! {
   self.props.items.iter().map(renderItem)
}
```
-------
Any feedback on how to achieve this design goal would be appreciated.
