### PR TITLE
Add extend method to Classes

### DIFF
--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -17,7 +17,6 @@ pub use self::vnode::VNode;
 pub use self::vtag::VTag;
 pub use self::vtext::VText;
 use crate::html::{Component, Scope};
-use std::ops::RangeFull;
 
 /// `Listener` trait is an universal implementation of an event listener
 /// which helps to bind Rust-listener to JS-listener (DOM).

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -56,6 +56,8 @@ impl Classes {
     }
 
     /// Adds a class to a set.
+    ///
+    /// Prevents duplication of class names.
     pub fn push(&mut self, class: &str) {
         self.set.insert(class.into());
     }
@@ -65,10 +67,11 @@ impl Classes {
         self.set.contains(class)
     }
 
-    /// Adds other classes to this class; returning itself.
-    pub fn union<T: Into<Classes>>(mut self, other: T) -> Self {
-        let mut other: Classes = other.into();
-        self.set.extend(other.set.drain(RangeFull));
+    /// Adds other classes to this set of classes; returning itself.
+    ///
+    /// Takes the logical union of both `Classes`.
+    pub fn extend<T: Into<Classes>>(mut self, other: T) -> Self {
+        self.set.extend(other.into().set.into_iter());
         self
     }
 }

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -17,6 +17,7 @@ pub use self::vnode::VNode;
 pub use self::vtag::VTag;
 pub use self::vtext::VText;
 use crate::html::{Component, Scope};
+use std::ops::RangeFull;
 
 /// `Listener` trait is an universal implementation of an event listener
 /// which helps to bind Rust-listener to JS-listener (DOM).
@@ -41,7 +42,7 @@ type Listeners<COMP> = Vec<Box<dyn Listener<COMP>>>;
 type Attributes = HashMap<String, String>;
 
 /// A set of classes.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Classes {
     set: IndexSet<String>,
 }
@@ -62,6 +63,13 @@ impl Classes {
     /// Check the set contains a class.
     pub fn contains(&self, class: &str) -> bool {
         self.set.contains(class)
+    }
+
+    /// Adds other classes to this class; returning itself.
+    pub fn extend<T: Into<Classes>>(mut self, other: T) -> Self {
+        let mut other: Classes = other.into();
+        self.set.extend(other.set.drain(RangeFull));
+        self
     }
 }
 

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -66,7 +66,7 @@ impl Classes {
     }
 
     /// Adds other classes to this class; returning itself.
-    pub fn extend<T: Into<Classes>>(mut self, other: T) -> Self {
+    pub fn union<T: Into<Classes>>(mut self, other: T) -> Self {
         let mut other: Classes = other.into();
         self.set.extend(other.set.drain(RangeFull));
         self


### PR DESCRIPTION
Also implement Clone.

Addresses https://github.com/yewstack/yew/issues/621

----
I'm a little off-put by the use of `format!()` having to be used to concatenate strings that are later used as classes.

This change allows for usages like:
```rust
html!{
    <div class=Classes::new().union("some-class").union("other-class") />
}
```
or 
```rust
html!{
    <div class=self.class.clone().union("other-class") />
}
```
