### PR TITLE
Add NeqAssign utility Trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ pub mod callback;
 pub mod components;
 pub mod format;
 pub mod html;
+pub mod neq_assign;
 pub mod scheduler;
 pub mod services;
 pub mod utils;

--- a/src/neq_assign.rs
+++ b/src/neq_assign.rs
@@ -1,0 +1,53 @@
+//! Module for `neq_assign` utility function.
+
+use crate::html::ShouldRender;
+
+/// Blanket trait to provide a convenience method for assigning props in `changed` or updating values in `update`.
+pub trait NeqAssign {
+    /// If `self` and `new` aren't equal, assigns `new` to `self` and returns true, otherwise returns false.
+    ///
+    /// Short for "Not equal assign".
+    ///
+    /// # Example
+    /// ```
+    /// # use yew::{Component, ShouldRender, ComponentLink};
+    /// # use yew::neq_assign::NeqAssign;
+    /// # use yew::Properties;
+    /// ##[derive(Properties, PartialEq)]
+    ///  struct Props {
+    ///     field1: String,
+    ///     field2: usize
+    ///  }
+    ///  struct Model {
+    ///     props: Props
+    ///  }
+    ///  impl Component for Model {
+    /// #    type Message = ();
+    ///     type Properties = Props;
+    ///     // ...
+    /// #
+    /// #    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+    /// #        unimplemented!()
+    /// #    }
+    /// #    fn update(&mut self, msg: ()) -> ShouldRender {
+    /// #        unimplemented!()
+    /// #    }
+    /// #
+    ///     fn change(&mut self, props: Self::Properties) -> ShouldRender{
+    ///         self.props.neq_assign(props)
+    ///     }
+    ///  }
+    /// ```
+    fn neq_assign(&mut self, new: Self) -> ShouldRender;
+}
+
+impl<T: PartialEq> NeqAssign for T {
+    fn neq_assign(&mut self, new: T) -> ShouldRender {
+        if self != &new {
+            *self = new;
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 //! This module contains useful utils to get information about the current document.
 
+use crate::html::ShouldRender;
 use failure::{err_msg, Error};
 use stdweb::web::document;
-use crate::html::ShouldRender;
 
 /// Returns `host` for the current document. Useful to connect to a server that server the app.
 pub fn host() -> Result<String, Error> {
@@ -11,8 +11,6 @@ pub fn host() -> Result<String, Error> {
         .ok_or_else(|| err_msg("can't get location"))
         .and_then(|l| l.host().map_err(Error::from))
 }
-
-
 
 /// Blanket trait to provide a convenience method for assigning props in `changed` or updating values in `update`.
 pub trait NeqAssign {
@@ -53,7 +51,7 @@ pub trait NeqAssign {
     fn neq_assign(&mut self, new: Self) -> ShouldRender;
 }
 
-impl <T: PartialEq> NeqAssign for T {
+impl<T: PartialEq> NeqAssign for T {
     fn neq_assign(&mut self, new: T) -> ShouldRender {
         if self != &new {
             *self = new;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,9 +14,42 @@ pub fn host() -> Result<String, Error> {
 
 
 
-/// Blanket trait to provide a convenience method for assigning props in `changed` or values in `update`
+/// Blanket trait to provide a convenience method for assigning props in `changed` or updating values in `update`
 pub trait NeqAssign {
     /// If `self` and `new` aren't equal, assigns `new` to `self` and returns true, otherwise returns false.
+    ///
+    /// Short for "Not equal assign".
+    ///
+    /// # Example
+    /// ```
+    /// # use yew::{Component, ShouldRender, ComponentLink};
+    /// # use yew::utils::NeqAssign;
+    /// # use yew::Properties;
+    /// ##[derive(Properties, PartialEq)]
+    ///  struct Props {
+    ///     field1: String,
+    ///     field2: usize
+    ///  }
+    ///  struct Model {
+    ///     props: Props
+    ///  }
+    ///  impl Component for Model {
+    /// #    type Message = ();
+    ///     type Properties = Props;
+    ///     // ...
+    /// #
+    /// #    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+    /// #        unimplemented!()
+    /// #    }
+    /// #    fn update(&mut self, msg: ()) -> ShouldRender {
+    /// #        unimplemented!()
+    /// #    }
+    /// #
+    ///     fn change(&mut self, props: Self::Properties) -> ShouldRender{
+    ///         self.props.neq_assign(props)
+    ///     }
+    ///  }
+    /// ```
     fn neq_assign(&mut self, new: Self) -> ShouldRender;
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ pub fn host() -> Result<String, Error> {
 
 
 
-/// Blanket trait to provide a convenience method for assigning props in `changed` or updating values in `update`
+/// Blanket trait to provide a convenience method for assigning props in `changed` or updating values in `update`.
 pub trait NeqAssign {
     /// If `self` and `new` aren't equal, assigns `new` to `self` and returns true, otherwise returns false.
     ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,5 @@
 //! This module contains useful utils to get information about the current document.
 
-use crate::html::ShouldRender;
 use failure::{err_msg, Error};
 use stdweb::web::document;
 
@@ -10,54 +9,4 @@ pub fn host() -> Result<String, Error> {
         .location()
         .ok_or_else(|| err_msg("can't get location"))
         .and_then(|l| l.host().map_err(Error::from))
-}
-
-/// Blanket trait to provide a convenience method for assigning props in `changed` or updating values in `update`.
-pub trait NeqAssign {
-    /// If `self` and `new` aren't equal, assigns `new` to `self` and returns true, otherwise returns false.
-    ///
-    /// Short for "Not equal assign".
-    ///
-    /// # Example
-    /// ```
-    /// # use yew::{Component, ShouldRender, ComponentLink};
-    /// # use yew::utils::NeqAssign;
-    /// # use yew::Properties;
-    /// ##[derive(Properties, PartialEq)]
-    ///  struct Props {
-    ///     field1: String,
-    ///     field2: usize
-    ///  }
-    ///  struct Model {
-    ///     props: Props
-    ///  }
-    ///  impl Component for Model {
-    /// #    type Message = ();
-    ///     type Properties = Props;
-    ///     // ...
-    /// #
-    /// #    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-    /// #        unimplemented!()
-    /// #    }
-    /// #    fn update(&mut self, msg: ()) -> ShouldRender {
-    /// #        unimplemented!()
-    /// #    }
-    /// #
-    ///     fn change(&mut self, props: Self::Properties) -> ShouldRender{
-    ///         self.props.neq_assign(props)
-    ///     }
-    ///  }
-    /// ```
-    fn neq_assign(&mut self, new: Self) -> ShouldRender;
-}
-
-impl<T: PartialEq> NeqAssign for T {
-    fn neq_assign(&mut self, new: T) -> ShouldRender {
-        if self != &new {
-            *self = new;
-            true
-        } else {
-            false
-        }
-    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@
 
 use failure::{err_msg, Error};
 use stdweb::web::document;
+use crate::html::ShouldRender;
 
 /// Returns `host` for the current document. Useful to connect to a server that server the app.
 pub fn host() -> Result<String, Error> {
@@ -9,4 +10,23 @@ pub fn host() -> Result<String, Error> {
         .location()
         .ok_or_else(|| err_msg("can't get location"))
         .and_then(|l| l.host().map_err(Error::from))
+}
+
+
+
+/// Blanket trait to provide a convenience method for assigning props in `changed` or values in `update`
+pub trait NeqAssign {
+    /// If `self` and `new` aren't equal, assigns `new` to `self` and returns true, otherwise returns false.
+    fn neq_assign(&mut self, new: Self) -> ShouldRender;
+}
+
+impl <T: PartialEq> NeqAssign for T {
+    fn neq_assign(&mut self, new: T) -> ShouldRender {
+        if self != &new {
+            *self = new;
+            true
+        } else {
+            false
+        }
+    }
 }


### PR DESCRIPTION
Adds a trait that makes updating values in `changed` and `update` and returning a reasonable `ShouldRender` value more terse.

Addresses https://github.com/yewstack/yew/issues/631