### PR TITLE
Emit initial route to router subscribers

### DIFF
--- a/examples/routing/src/router.rs
+++ b/examples/routing/src/router.rs
@@ -173,8 +173,11 @@ where
     }
 
     fn connected(&mut self, id: HandlerId) {
+        self.link
+            .response(id, Route::current_route(&self.route_service));
         self.subscribers.insert(id);
     }
+
     fn disconnected(&mut self, id: HandlerId) {
         self.subscribers.remove(&id);
     }


### PR DESCRIPTION
Update routing example to emit initial route to subscribers.

When you navigated to url.com/**route**, the router previously ignored it when linked with a component and only worked on route updates.