### PR TITLE
Add Dispatchers

### DIFF
--- a/examples/routing/src/b_component.rs
+++ b/examples/routing/src/b_component.rs
@@ -6,7 +6,7 @@ use yew::{html, Bridge, Component, ComponentLink, Html, Renderable, ShouldRender
 pub struct BModel {
     number: Option<usize>,
     sub_path: Option<String>,
-    router: Box<Bridge<Router<()>>>,
+    router: Box<dyn Bridge<Router<()>>>,
 }
 
 pub enum Msg {

--- a/examples/routing/src/lib.rs
+++ b/examples/routing/src/lib.rs
@@ -16,6 +16,7 @@ pub enum Child {
     A,
     B,
     PathNotFound(String),
+    Loading
 }
 
 pub struct Model {
@@ -35,7 +36,7 @@ impl Component for Model {
         let callback = link.send_back(|route: Route<()>| Msg::HandleRoute(route));
         let router = router::Router::bridge(callback);
         Model {
-            child: Child::PathNotFound("".to_string()), // This should be quickly overwritten by the actual route.
+            child: Child::Loading, // This should be quickly overwritten by the actual route.
             router,
         }
     }
@@ -87,7 +88,7 @@ impl Renderable<Model> for Model {
 
 impl Renderable<Model> for Child {
     fn view(&self) -> Html<Model> {
-        match *self {
+        match self {
             Child::A => html! {
                 <>
                     {"This corresponds to route 'a'"}
@@ -104,6 +105,9 @@ impl Renderable<Model> for Child {
                     {format!("Invalid path: '{}'", path)}
                 </>
             },
+            Child::Loading => html! {
+                {"Loading"}
+            }
         }
     }
 }

--- a/examples/routing/src/lib.rs
+++ b/examples/routing/src/lib.rs
@@ -3,12 +3,14 @@
 mod b_component;
 mod router;
 mod routing;
+mod router_button;
 use b_component::BModel;
 
 use log::info;
 use router::Route;
 use yew::agent::Bridged;
 use yew::{html, Bridge, Component, ComponentLink, Html, Renderable, ShouldRender};
+use crate::router_button::RouterButton;
 
 pub enum Child {
     A,
@@ -18,11 +20,10 @@ pub enum Child {
 
 pub struct Model {
     child: Child,
-    router: Box<Bridge<router::Router<()>>>,
+    router: Box<dyn Bridge<router::Router<()>>>,
 }
 
 pub enum Msg {
-    NavigateTo(Child),
     HandleRoute(Route<()>),
 }
 
@@ -32,40 +33,21 @@ impl Component for Model {
 
     fn create(_: Self::Properties, mut link: ComponentLink<Self>) -> Self {
         let callback = link.send_back(|route: Route<()>| Msg::HandleRoute(route));
-        let mut router = router::Router::bridge(callback);
-
-        // TODO Not sure if this is technically correct. This should be sent _after_ the component has been created.
-        // I think the `Component` trait should have a hook called `on_mount()`
-        // that is called after the component has been attached to the vdom.
-        // It seems like this only works because the JS engine decides to activate the
-        // router worker logic after the mounting has finished.
-        router.send(router::Request::GetCurrentRoute);
-
+        let router = router::Router::bridge(callback);
         Model {
-            child: Child::A, // This should be quickly overwritten by the actual route.
+            child: Child::PathNotFound("".to_string()), // This should be quickly overwritten by the actual route.
             router,
         }
     }
 
+    fn mounted(&mut self) -> ShouldRender {
+        // Once the component has successfully mounted, it is safe to send messages to agents.
+        self.router.send(router::Request::GetCurrentRoute);
+        false
+    }
+
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
-            Msg::NavigateTo(child) => {
-                let path_segments = match child {
-                    Child::A => vec!["a".into()],
-                    Child::B => vec!["b".into()],
-                    Child::PathNotFound(_) => vec!["path_not_found".into()],
-                };
-
-                let route = router::Route {
-                    path_segments,
-                    query: None,
-                    fragment: None,
-                    state: (),
-                };
-
-                self.router.send(router::Request::ChangeRoute(route));
-                false
-            }
             Msg::HandleRoute(route) => {
                 info!("Routing: {}", route.to_route_string());
                 // Instead of each component selecting which parts of the path are important to it,
@@ -92,8 +74,8 @@ impl Renderable<Model> for Model {
         html! {
             <div>
                 <nav class="menu">
-                    <button onclick=|_| Msg::NavigateTo(Child::A)>{ "Go to A" }</button>
-                    <button onclick=|_| Msg::NavigateTo(Child::B)>{ "Go to B" }</button>
+                    <RouterButton text="Go to A" path="/a" />
+                    <RouterButton text="Go to B" path="/b" />
                 </nav>
                 <div>
                     {self.child.view()}

--- a/examples/routing/src/lib.rs
+++ b/examples/routing/src/lib.rs
@@ -16,7 +16,7 @@ pub enum Child {
     A,
     B,
     PathNotFound(String),
-    Loading
+    Loading,
 }
 
 pub struct Model {
@@ -107,7 +107,7 @@ impl Renderable<Model> for Child {
             },
             Child::Loading => html! {
                 {"Loading"}
-            }
+            },
         }
     }
 }

--- a/examples/routing/src/lib.rs
+++ b/examples/routing/src/lib.rs
@@ -2,15 +2,15 @@
 
 mod b_component;
 mod router;
-mod routing;
 mod router_button;
+mod routing;
 use b_component::BModel;
 
+use crate::router_button::RouterButton;
 use log::info;
 use router::Route;
 use yew::agent::Bridged;
 use yew::{html, Bridge, Component, ComponentLink, Html, Renderable, ShouldRender};
-use crate::router_button::RouterButton;
 
 pub enum Child {
     A,

--- a/examples/routing/src/lib.rs
+++ b/examples/routing/src/lib.rs
@@ -42,7 +42,6 @@ impl Component for Model {
     }
 
     fn mounted(&mut self) -> ShouldRender {
-        // Once the component has successfully mounted, it is safe to send messages to agents.
         self.router.send(router::Request::GetCurrentRoute);
         false
     }

--- a/examples/routing/src/router.rs
+++ b/examples/routing/src/router.rs
@@ -147,7 +147,7 @@ where
         }
     }
 
-    fn handle(&mut self, msg: Self::Input, who: Option<HandlerId>) {
+    fn handle(&mut self, msg: Self::Input, who: HandlerId) {
         info!("Request: {:?}", msg);
         match msg {
             Request::ChangeRoute(route) => {
@@ -167,9 +167,7 @@ where
             }
             Request::GetCurrentRoute => {
                 let route = Route::current_route(&self.route_service);
-                if let Some(who) = who {
-                    self.link.response(who, route.clone());
-                }
+                self.link.response(who, route.clone());
             }
         }
     }

--- a/examples/routing/src/router.rs
+++ b/examples/routing/src/router.rs
@@ -147,7 +147,11 @@ where
         }
     }
 
-    fn handle(&mut self, msg: Self::Input, who: HandlerId) {
+    fn connected(&mut self, id: HandlerId) {
+        self.subscribers.insert(id);
+    }
+
+    fn handle(&mut self, msg: Self::Input, who: Option<HandlerId>) {
         info!("Request: {:?}", msg);
         match msg {
             Request::ChangeRoute(route) => {
@@ -166,14 +170,12 @@ where
                 self.route_service.set_route(&route_string, route.state);
             }
             Request::GetCurrentRoute => {
-                let route = Route::current_route(&self.route_service);
-                self.link.response(who, route.clone());
+                if let Some(who) = who {
+                    let route = Route::current_route(&self.route_service);
+                    self.link.response(who, route.clone());
+                }
             }
         }
-    }
-
-    fn connected(&mut self, id: HandlerId) {
-        self.subscribers.insert(id);
     }
     fn disconnected(&mut self, id: HandlerId) {
         self.subscribers.remove(&id);

--- a/examples/routing/src/router_button.rs
+++ b/examples/routing/src/router_button.rs
@@ -1,0 +1,76 @@
+//! A component wrapping a <button/> tag that changes the route.
+use crate::router::Route;
+use crate::router::Router;
+use yew::prelude::*;
+use yew::agent::Dispatched;
+
+use yew::agent::Dispatcher;
+use crate::router::Request;
+
+/// Changes the route when clicked.
+pub struct RouterButton {
+    router: Box<dyn Dispatcher<Router<()>>>,
+    props: Props,
+}
+
+pub enum Msg {
+    Clicked
+}
+
+
+/// Properties for Routing Components
+#[derive(Properties, Default, Clone, Debug, PartialEq)]
+pub struct Props {
+    /// The route that will be set when the component is clicked.
+    pub path: String,
+    /// The text to display.
+    pub text: String,
+    /// Disable the component.
+    pub disabled: bool,
+    /// Classes to be added to component.
+    pub classes: String,
+}
+
+impl Component for RouterButton {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(props: Self::Properties, _link: ComponentLink<Self>) -> Self {
+        let router = Router::dispatcher();
+
+        RouterButton { router, props }
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            Msg::Clicked => {
+                let route = Route {
+                    path_segments: self.props.path.split("/").skip(1).map(|s| s.to_string()).collect::<Vec<_>>(),
+                    query: None,
+                    state: (),
+                    fragment: None
+                };
+                self.router.send(Request::ChangeRoute(route));
+                false
+            }
+        }
+    }
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.props = props;
+        true
+    }
+}
+
+impl Renderable<RouterButton> for RouterButton {
+    fn view(&self) -> Html<RouterButton> {
+        html! {
+            <button
+                class=self.props.classes.clone(),
+                onclick=|_| Msg::Clicked,
+                disabled=self.props.disabled,
+            >
+                {&self.props.text}
+            </button>
+        }
+    }
+}

--- a/examples/routing/src/router_button.rs
+++ b/examples/routing/src/router_button.rs
@@ -1,11 +1,11 @@
 //! A component wrapping a <button/> tag that changes the route.
 use crate::router::Route;
 use crate::router::Router;
-use yew::prelude::*;
 use yew::agent::Dispatched;
+use yew::prelude::*;
 
-use yew::agent::Dispatcher;
 use crate::router::Request;
+use yew::agent::Dispatcher;
 
 /// Changes the route when clicked.
 pub struct RouterButton {
@@ -14,9 +14,8 @@ pub struct RouterButton {
 }
 
 pub enum Msg {
-    Clicked
+    Clicked,
 }
-
 
 /// Properties for Routing Components
 #[derive(Properties, Default, Clone, Debug, PartialEq)]
@@ -45,10 +44,16 @@ impl Component for RouterButton {
         match msg {
             Msg::Clicked => {
                 let route = Route {
-                    path_segments: self.props.path.split("/").skip(1).map(|s| s.to_string()).collect::<Vec<_>>(),
+                    path_segments: self
+                        .props
+                        .path
+                        .split("/")
+                        .skip(1)
+                        .map(|s| s.to_string())
+                        .collect::<Vec<_>>(),
                     query: None,
                     state: (),
-                    fragment: None
+                    fragment: None,
                 };
                 self.router.send(Request::ChangeRoute(route));
                 false

--- a/examples/routing/src/router_button.rs
+++ b/examples/routing/src/router_button.rs
@@ -9,7 +9,7 @@ use yew::agent::Dispatcher;
 
 /// Changes the route when clicked.
 pub struct RouterButton {
-    router: Box<dyn Dispatcher<Router<()>>>,
+    router: Dispatcher<Router<()>>,
     props: Props,
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -80,7 +80,7 @@ impl HandlerId {
     }
 }
 
-/// This trait allows to get the address of or register a worker.
+/// This trait allows registering or getting the address of a worker.
 pub trait Bridged: Agent + Sized + 'static {
     /// Creates a messaging bridge between a worker and the component.
     fn bridge(callback: Callback<Self::Output>) -> Box<dyn Bridge<Self>>;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -285,10 +285,8 @@ impl Discoverer for Context {
             let upd = AgentUpdate::Create(agent_link);
             scope.send(upd);
         }
-        //        if let Some(id) = bridge.id {
         let upd = AgentUpdate::Connected(bridge.id);
         bridge.scope.send(upd);
-        //        }
         Box::new(bridge)
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -285,10 +285,10 @@ impl Discoverer for Context {
             let upd = AgentUpdate::Create(agent_link);
             scope.send(upd);
         }
-//        if let Some(id) = bridge.id {
-            let upd = AgentUpdate::Connected(bridge.id);
-            bridge.scope.send(upd);
-//        }
+        //        if let Some(id) = bridge.id {
+        let upd = AgentUpdate::Connected(bridge.id);
+        bridge.scope.send(upd);
+        //        }
         Box::new(bridge)
     }
 }
@@ -302,7 +302,8 @@ struct SlabResponder<AGN: Agent> {
 impl<AGN: Agent> Responder<AGN> for SlabResponder<AGN> {
     fn response(&self, id: HandlerId, output: AGN::Output) {
         let callback: Option<Option<Callback<_>>> = self.slab.borrow().get(id.raw_id()).cloned();
-        if let Some(callback) = callback.and_then(std::convert::identity) { // TODO replace with flatten when option_flattening (60258) stabilizes.
+        if let Some(callback) = callback.and_then(std::convert::identity) {
+            // TODO replace with flatten when option_flattening (60258) stabilizes.
             callback.emit(output);
         } else {
             warn!("Id of handler not exists <slab>: {}", id.raw_id());
@@ -520,7 +521,8 @@ impl Discoverer for Public {
                             }
                             FromWorker::ProcessOutput(id, output) => {
                                 let callback = slab.borrow().get(id.raw_id()).cloned();
-                                if let Some(callback) = callback.and_then(std::convert::identity) { // TODO replace with flatten when option_flattening (60258) stabilizes.
+                                if let Some(callback) = callback.and_then(std::convert::identity) {
+                                    // TODO replace with flatten when option_flattening (60258) stabilizes.
                                     callback.emit(output);
                                 } else {
                                     warn!(

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -61,12 +61,6 @@ impl<T: Transferable> Packed for T {
 #[derive(Serialize, Deserialize, Eq, PartialEq, Hash, Clone, Copy)]
 pub struct HandlerId(usize, bool);
 
-impl From<usize> for HandlerId {
-    fn from(id: usize) -> Self {
-        HandlerId(id, false) // TODO should this initialize to false?
-    }
-}
-
 impl HandlerId {
     fn new(id: usize, respondable: bool) -> Self {
         HandlerId(id, respondable)
@@ -240,9 +234,12 @@ impl<AGN: Agent> LocalAgent<AGN> {
     }
 
     fn create_bridge(&mut self, callback: Option<Callback<AGN::Output>>) -> ContextBridge<AGN> {
+        let respondable = callback.is_some();
+        let id: usize = self.slab.borrow_mut().insert(callback);
+        let id = HandlerId::new(id, respondable);
         ContextBridge {
             scope: self.scope.clone(),
-            id: self.slab.borrow_mut().insert(callback).into(),
+            id
         }
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,12 +8,13 @@ use log::warn;
 use serde::{Deserialize, Serialize};
 use slab::Slab;
 use std::cell::RefCell;
+use std::fmt;
 use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 use stdweb::Value;
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
-use std::ops::{Deref, DerefMut};
 
 #[derive(Serialize, Deserialize)]
 enum ToWorker<T> {
@@ -78,7 +79,6 @@ pub trait Bridged: Agent + Sized + 'static {
     fn bridge(callback: Callback<Self::Output>) -> Box<dyn Bridge<Self>>;
 }
 
-
 /// This trait allows the creation of a dispatcher to an existing agent that will not send replies when messages are sent.
 pub trait Dispatched: Agent + Sized + 'static {
     /// Creates a dispatcher to the agent that will not send messages back.
@@ -99,14 +99,21 @@ pub trait Dispatched: Agent + Sized + 'static {
 
 /// A newtype around a bridge to indicate that it is distinct from a normal bridge
 pub struct Dispatcher<T>(Box<dyn Bridge<T>>);
-impl <T> Deref for Dispatcher<T> {
+
+impl<T> fmt::Debug for Dispatcher<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Dispatcher<_>")
+    }
+}
+
+impl<T> Deref for Dispatcher<T> {
     type Target = dyn Bridge<T>;
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
     }
 }
-impl <T> DerefMut for Dispatcher<T> {
+impl<T> DerefMut for Dispatcher<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut()
     }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -154,10 +154,10 @@ where
     }
 }
 
-impl <T> Dispatched for T
+impl<T> Dispatched for T
 where
     T: Agent,
-    <T as Agent>::Reach: Dispatchable
+    <T as Agent>::Reach: Dispatchable,
 {
     fn dispatcher() -> Box<dyn Dispatcher<Self>> {
         Self::Reach::spawn_or_join_without_callback()
@@ -172,7 +172,7 @@ pub trait Discoverer {
         unimplemented!();
     }
 
-    fn spawn_or_join_without_callback<AGN: Agent>() -> Box<dyn Dispatcher<AGN>>{
+    fn spawn_or_join_without_callback<AGN: Agent>() -> Box<dyn Dispatcher<AGN>> {
         unimplemented!();
     }
 }
@@ -185,7 +185,6 @@ pub trait Bridge<AGN: Agent> {
 
 /// A marker trait for Bridges to indicate that they were created without a callback.
 pub trait Dispatcher<AGN: Agent>: Bridge<AGN> {}
-
 
 // <<< SAME THREAD >>>
 
@@ -219,7 +218,7 @@ impl<AGN: Agent> LocalAgent<AGN> {
 
     fn create_dispatcher(&self) -> ContextDispatcher<AGN> {
         ContextDispatcher {
-            scope: self.scope.clone()
+            scope: self.scope.clone(),
         }
     }
 
@@ -317,7 +316,6 @@ struct ContextBridge<AGN: Agent> {
     id: HandlerId,
 }
 
-
 impl<AGN: Agent> Bridge<AGN> for ContextBridge<AGN> {
     fn send(&mut self, msg: AGN::Input) {
         let upd = AgentUpdate::Input(msg, Some(self.id));
@@ -347,7 +345,7 @@ impl<AGN: Agent> Drop for ContextBridge<AGN> {
 }
 
 struct ContextDispatcher<AGN: Agent> {
-    scope: AgentScope<AGN>
+    scope: AgentScope<AGN>,
 }
 
 impl<AGN: Agent> Bridge<AGN> for ContextDispatcher<AGN> {
@@ -357,7 +355,7 @@ impl<AGN: Agent> Bridge<AGN> for ContextDispatcher<AGN> {
     }
 }
 
-impl <AGN: Agent> Dispatcher<AGN> for ContextDispatcher<AGN> {}
+impl<AGN: Agent> Dispatcher<AGN> for ContextDispatcher<AGN> {}
 
 /// Create an instance in the current thread.
 pub struct Job;
@@ -498,9 +496,8 @@ impl<AGN: Agent> RemoteAgent<AGN> {
     fn create_dispatcher(&self) -> PublicDispatcher<AGN> {
         PublicDispatcher {
             worker: self.worker.clone(),
-            _agent: PhantomData
+            _agent: PhantomData,
         }
-
     }
 
     fn remove_bridge(&mut self, bridge: &PublicBridge<AGN>) -> Last {
@@ -590,8 +587,6 @@ impl Discoverer for Public {
     }
 }
 
-
-
 impl Dispatchable for Public {}
 
 /// A connection manager for components interaction with workers.
@@ -654,7 +649,7 @@ impl<AGN: Agent> Bridge<AGN> for PublicDispatcher<AGN> {
     }
 }
 
-impl <AGN: Agent> Dispatcher<AGN> for PublicDispatcher<AGN> {}
+impl<AGN: Agent> Dispatcher<AGN> for PublicDispatcher<AGN> {}
 
 /// Create a single instance in a browser.
 pub struct Global;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -377,7 +377,7 @@ struct JobBridge<AGN: Agent> {
 
 impl<AGN: Agent> Bridge<AGN> for JobBridge<AGN> {
     fn send(&mut self, msg: AGN::Input) {
-        let upd = AgentUpdate::Input(msg, None);
+        let upd = AgentUpdate::Input(msg, Some(SINGLETON_ID));
         self.scope.send(upd);
     }
 }
@@ -440,7 +440,7 @@ impl<AGN: Agent> Bridge<AGN> for PrivateBridge<AGN> {
         // TODO Important! Implement.
         // Use a queue to collect a messages if an instance is not ready
         // and send them to an agent when it will reported readiness.
-        let msg = ToWorker::ProcessInput(None, msg).pack();
+        let msg = ToWorker::ProcessInput(Some(SINGLETON_ID), msg).pack();
         let worker = &self.worker;
         js! {
             var worker = @{worker};

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -77,14 +77,21 @@ pub trait Bridged: Agent + Sized + 'static {
     fn bridge(callback: Callback<Self::Output>) -> Box<dyn Bridge<Self>>;
 }
 
-/// This trait allows the creation of a dispatcher that will not send replies when messages are sent.
+/// This trait allows the creation of a dispatcher to an existing agent that will not send replies when messages are sent.
 pub trait Dispatched: Agent + Sized + 'static {
-    /// Creates a dispatcher between the worker and the component
-    /// that will not send messages back to the component.
+    /// Creates a dispatcher to the agent that will not send messages back.
     ///
     /// # Note
-    /// Dispatchers don't have `HandlerId`s and therefore `Agent::handle` will be supplied `None` for the `id` parameter,
-    /// and Connected and Disconnected will not be called.
+    /// Dispatchers don't have `HandlerId`s and therefore `Agent::handle` will be supplied `None`
+    /// for the `id` parameter, and `connected` and `disconnected` will not be called.
+    ///
+    /// # Important
+    /// Because the Agents using Context or Public reaches use the number of existing bridges to
+    /// keep track of if the agent itself should exist, creating dispatchers will not guarantee that
+    /// an Agent will exist to service requests sent from Dispatchers. You **must** keep at least one
+    /// bridge around if you wish to use a dispatcher. If you are using agents in a write-only manner,
+    /// then it is suggested that you create a bridge that handles no-op responses as high up in the
+    /// component hierarchy as possible - oftentimes the root component for simplicity's sake.
     fn dispatcher() -> Box<dyn Dispatcher<Self>>;
 }
 


### PR DESCRIPTION
Addresses https://github.com/yewstack/yew/issues/307

Dispatchers are similar to bridges, but they don't require a callback to instantiate.

Dispatchers solve the problem of having to create `NoOp` messages that handle responses from `Agents` for components that do not care about them. This is a relatively common occurrence, and this change provides a significant ergonomic improvement over handling these `NoOp` cases.

Dispatchers, when created, will not hook into the typical Component <-> Agent lifecycle. This is because they do not have `HandlerId`s. So `connected` and `disconnected` will not be called when `Agent::dispatcher()` is called. You can send messages through them, which still reach the `handle` method on the Agent.

Because of the lack of `HandlerId`s in dispatchers, a breaking change was required for `Agent::handle` which now takes an `Option<HandlerId>` instead of just a `HandlerId`.

Because it would be pointless to have dispatchers to `Job` and `Private` discoverers, its usage is constrained to just `Context` and `Public` discoverers.