### PR TITLE
Add PureComponent trait

### DIFF
--- a/examples/custom_components/src/button.rs
+++ b/examples/custom_components/src/button.rs
@@ -1,5 +1,4 @@
 use yew::prelude::*;
-use yew::html::PureComponent;
 
 pub enum Msg {
     Clicked,

--- a/examples/custom_components/src/button.rs
+++ b/examples/custom_components/src/button.rs
@@ -1,52 +1,27 @@
 use yew::prelude::*;
-
-pub struct Button {
-    title: String,
-    onsignal: Callback<()>,
-}
+use yew::html::PureComponent;
 
 pub enum Msg {
     Clicked,
 }
 
 #[derive(PartialEq, Properties)]
-pub struct Props {
+pub struct Button {
     pub title: String,
     #[props(required)]
     pub onsignal: Callback<()>,
 }
 
-impl Component for Button {
+impl PureComponent for Button {
     type Message = Msg;
-    type Properties = Props;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Button {
-            title: props.title,
-            onsignal: props.onsignal,
-        }
-    }
-
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
-        match msg {
-            Msg::Clicked => {
-                self.onsignal.emit(());
-            }
-        }
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.title = props.title;
-        self.onsignal = props.onsignal;
-        true
-    }
-}
-
-impl Renderable<Button> for Button {
-    fn view(&self) -> Html<Self> {
+    fn render(&self) -> Html<Self> {
         html! {
             <button onclick=|_| Msg::Clicked>{ &self.title }</button>
         }
+    }
+
+    fn emit(&self, _: Self::Message) {
+        self.onsignal.emit(())
     }
 }

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -46,7 +46,7 @@ pub trait Component: Sized + 'static {
 }
 
 /// A pure component does not hold state, only providing rendering abilities to a set of inputs.
-pub trait PureComponent: Properties + Sized + 'static {
+pub trait PureComponent: Properties + PartialEq + Sized + 'static {
     /// Message type
     type Message: 'static;
     /// A render function for a pure component.
@@ -74,8 +74,12 @@ impl <T: Properties + 'static> Component for T
     }
 
     fn change(&mut self, props: T) -> ShouldRender {
-        *self = props;
-        true
+        if *self != props {
+            *self = props;
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -45,22 +45,24 @@ pub trait Component: Sized + 'static {
     fn destroy(&mut self) {} // TODO Replace with `Drop`
 }
 
-/// A pure component does not hold state, only providing rendering abilities to a set of inputs.
+/// A pure component does not hold state, only providing rendering capability to a collection of properties.
+///
+/// PureComponents should be used instead of Components if the Component in question does not mutate
+/// the state passed to it via props and if it does not own services or connections to agents.
 pub trait PureComponent: Properties + PartialEq + Sized + 'static {
-    /// Message type
+    /// Message type that can be emitted back to Components higher up in the hierarchy.
     type Message: 'static;
-    /// A render function for a pure component.
+
+    /// Produces VDOM nodes that will be rendered to html.
     fn render(&self) -> Html<Self>;
-    /// Override this if the pure component will pass its messages upwards.
+    /// Called when the PureComponent receives a Message.
     ///
-    /// If the implementing struct in question has a callback, this should be overwritten.
+    /// If the PureComponent has a callback, this should be overwritten.
     fn emit(&self, _msg: Self::Message) { }
 }
 
 
-impl <T: Properties + 'static> Component for T
-    where T: PureComponent {
-
+impl <T: PureComponent> Component for T {
     type Message = <T as PureComponent>::Message;
     type Properties = T;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub mod prelude {
     pub use crate::callback::Callback;
     pub use crate::events::*;
     pub use crate::html::{
-        Children, ChildrenWithProps, Component, ComponentLink, Href, Html, Properties, Renderable,
+        Children, ChildrenWithProps, Component, PureComponent, ComponentLink, Href, Html, Properties, Renderable,
         ShouldRender,
     };
     pub use crate::macros::*;


### PR DESCRIPTION
This PR seeks to add a `PureComponent` trait.

This is purely an ergonomic feature that seeks to eliminate boilerplate from components that will not modify their own state. Using this trait, I saved about 25 lines over using `Component` when rewriting the `Button` component.

Instead of implementing `Component`, you can implement `PureComponent` which only requires that a `render` function be implemented. Optionally, if your component will communicate up the component hierarchy using callbacks, a method called `emit` can be overwritten.