### PR TITLE
Add keyboard service

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Implemented:
 * `DialogService`
 * `FetchService`
 * `WebSocketService`
+* `KeyboardService`
 
 ```rust
 use yew::services::{ConsoleService, TimeoutService};

--- a/src/services/keyboard.rs
+++ b/src/services/keyboard.rs
@@ -1,6 +1,6 @@
 //! Service to register key press event listeners on elements.
 use crate::callback::Callback;
-use stdweb::web::event::KeyPressEvent;
+use stdweb::web::event::{KeyDownEvent, KeyPressEvent, KeyUpEvent};
 use stdweb::web::{EventListenerHandle, IEventTarget};
 
 /// Service for registering callbacks on elements to get keystrokes from the user.
@@ -19,12 +19,35 @@ pub struct KeyboardService {}
 /// When it goes out of scope, the listener will be removed from the element.
 pub struct KeyListenerHandle(Option<EventListenerHandle>);
 
-
-
 impl KeyboardService {
     /// Registers a callback that listens to KeyPressEvents on a provided element.
-    pub fn register<T: IEventTarget>(element: &T, callback: Callback<KeyPressEvent>) -> KeyListenerHandle {
+    pub fn register_key_press<T: IEventTarget>(
+        element: &T,
+        callback: Callback<KeyPressEvent>,
+    ) -> KeyListenerHandle {
         let handle = element.add_event_listener(move |event: KeyPressEvent| {
+            callback.emit(event);
+        });
+        KeyListenerHandle(Some(handle))
+    }
+
+    /// Registers a callback that listens to KeyDownEvents on a provided element.
+    pub fn register_key_down<T: IEventTarget>(
+        element: &T,
+        callback: Callback<KeyDownEvent>,
+    ) -> KeyListenerHandle {
+        let handle = element.add_event_listener(move |event: KeyDownEvent| {
+            callback.emit(event);
+        });
+        KeyListenerHandle(Some(handle))
+    }
+
+    /// Registers a callback that listens to KeyUpEvents on a provided element.
+    pub fn register_key_up<T: IEventTarget>(
+        element: &T,
+        callback: Callback<KeyUpEvent>,
+    ) -> KeyListenerHandle {
+        let handle = element.add_event_listener(move |event: KeyUpEvent| {
             callback.emit(event);
         });
         KeyListenerHandle(Some(handle))

--- a/src/services/keyboard.rs
+++ b/src/services/keyboard.rs
@@ -21,6 +21,13 @@ pub struct KeyListenerHandle(Option<EventListenerHandle>);
 
 impl KeyboardService {
     /// Registers a callback that listens to KeyPressEvents on a provided element.
+    ///
+    /// # Documentation
+    /// [keypress event](https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event)
+    ///
+    /// # Warning
+    /// This API has been deprecated in the HTML standard and it is not recommended for use in new projects.
+    /// Consult with the browser compatibility chart in the linked MDN documentation.
     pub fn register_key_press<T: IEventTarget>(
         element: &T,
         callback: Callback<KeyPressEvent>,
@@ -32,6 +39,14 @@ impl KeyboardService {
     }
 
     /// Registers a callback that listens to KeyDownEvents on a provided element.
+    ///
+    /// # Documentation
+    /// [keydown event](https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event)
+    ///
+    /// # Note
+    /// This browser feature is relatively new and is set to replace keypress events.
+    /// Not all browsers may support it completely.
+    /// Consult with the browser compatibility chart in the linked MDN documentation.
     pub fn register_key_down<T: IEventTarget>(
         element: &T,
         callback: Callback<KeyDownEvent>,
@@ -43,6 +58,14 @@ impl KeyboardService {
     }
 
     /// Registers a callback that listens to KeyUpEvents on a provided element.
+    ///
+    /// # Documentation
+    /// [keyup event](https://developer.mozilla.org/en-US/docs/Web/API/Document/keyup_event)
+    ///
+    /// # Note
+    /// This browser feature is relatively new and is set to replace keypress events.
+    /// Not all browsers may support it completely.
+    /// Consult with the browser compatibility chart in the linked MDN documentation.
     pub fn register_key_up<T: IEventTarget>(
         element: &T,
         callback: Callback<KeyUpEvent>,

--- a/src/services/keyboard.rs
+++ b/src/services/keyboard.rs
@@ -1,0 +1,35 @@
+use stdweb::web::{document, IEventTarget, EventListenerHandle};
+use stdweb::web::event::KeyPressEvent;
+
+/// Service for registering callbacks on elements to get keystrokes from the user.
+///
+/// # Note
+/// Elements that natively support keyboard input (input or textarea) can set an
+/// `onkeypress` or `oninput` attribute within the html macro. You **should** use those events instead of
+/// locating the element and registering it with this service.
+///
+/// This service is for adding key event listeners to elements that don't support these attributes,
+/// like the `document` or `<canvas>` elements for example.
+pub struct KeyboardService {}
+
+/// Handle to the key event listener.
+///
+/// When it goes out of scope, the listener will be removed from the element.
+pub struct KeyListenerHandle(EventListenerHandle);
+
+impl KeyboardService {
+    /// Registers a callback that listens to KeyPressEvents on a provided element.
+    pub fn register(element: &IEventTarget, callback: Callback<String>) -> KeyListenerHandle {
+        let handle = element.add_event_listener(move |event: KeyPressEvent| {
+            let key = event.key();
+            callback.emit(key);
+        });
+        KeyListenerHandle(handle)
+    }
+}
+
+impl Drop for KeyListenerHandle {
+    fn drop(&mut self) {
+        self.0.remove()
+    }
+}

--- a/src/services/keyboard.rs
+++ b/src/services/keyboard.rs
@@ -1,6 +1,5 @@
 //! Service to register key press event listeners on elements.
 use crate::callback::Callback;
-use crate::events::IKeyboardEvent;
 use stdweb::web::event::KeyPressEvent;
 use stdweb::web::{EventListenerHandle, IEventTarget};
 
@@ -20,12 +19,13 @@ pub struct KeyboardService {}
 /// When it goes out of scope, the listener will be removed from the element.
 pub struct KeyListenerHandle(Option<EventListenerHandle>);
 
+
+
 impl KeyboardService {
     /// Registers a callback that listens to KeyPressEvents on a provided element.
-    pub fn register<T: IEventTarget>(element: &T, callback: Callback<String>) -> KeyListenerHandle {
+    pub fn register<T: IEventTarget>(element: &T, callback: Callback<KeyPressEvent>) -> KeyListenerHandle {
         let handle = element.add_event_listener(move |event: KeyPressEvent| {
-            let key = event.key();
-            callback.emit(key);
+            callback.emit(event);
         });
         KeyListenerHandle(Some(handle))
     }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -7,13 +7,13 @@ pub mod console;
 pub mod dialog;
 pub mod fetch;
 pub mod interval;
+pub mod keyboard;
 pub mod reader;
 pub mod render;
 pub mod resize;
 pub mod storage;
 pub mod timeout;
 pub mod websocket;
-pub mod keyboard;
 
 pub use self::console::ConsoleService;
 pub use self::dialog::DialogService;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -13,6 +13,7 @@ pub mod resize;
 pub mod storage;
 pub mod timeout;
 pub mod websocket;
+pub mod keyboard;
 
 pub use self::console::ConsoleService;
 pub use self::dialog::DialogService;


### PR DESCRIPTION
Adds a keyboard service so key events can be registered on elements like `document`.

Thanks to cradee (@cradee_gitlab on the yew gitter) for making it apparent something like this might be useful and for implementing a prototype.

-------
Edit: a thought related to this feature.
This service is pretty simple, and could be done in someone's own project without too much difficulty. Should there be a bar that must be cleared for service additions? Would it make sense to create another project within yewstack for accessory services - ones that aren't core to most applications, but are common enough to justify sticking them in a library for reuse? Should all services be moved to another crate and be reexported from yew but gated by a default "on" feature flag?

