### PR TITLE
Higher Order Components (WIP)

### DIFF
--- a/src/html/hoc.rs
+++ b/src/html/hoc.rs
@@ -1,8 +1,8 @@
-use crate::html::{Component, Html, ShouldRender, ComponentLink, Renderable};
+use crate::html::{Component, ComponentLink, Html, Renderable, ShouldRender};
+use crate::virtual_dom::vcomp::ScopeHolder;
+use crate::virtual_dom::{VComp, VNode};
 use crate::Properties as PropertiesTrait;
 use serde::export::PhantomData;
-use crate::virtual_dom::vcomp::ScopeHolder;
-use crate::virtual_dom::{VNode, VComp};
 
 // TODO it might make sense to decompose HocData into smaller, interchangeable parts so that props/state behavior can be changed independently of update behavior.
 // Not sure how valuable that would be though?
@@ -15,7 +15,7 @@ pub trait HocData<Parent, ChildProps, Message>
 where
     Parent: Component + Renderable<Parent>,
     <Parent as Component>::Properties: PartialEq,
-    ChildProps: PropertiesTrait
+    ChildProps: PropertiesTrait,
 {
     /// Creates the data for the HOC.
     fn create(props: &Parent::Properties, link: ComponentLink<Parent>) -> Self;
@@ -50,7 +50,7 @@ where
     target: PhantomData<Target>,
 }
 
-impl <Properties, Message, Data, Target> Component for Hoc<Properties, Message, Data, Target>
+impl<Properties, Message, Data, Target> Component for Hoc<Properties, Message, Data, Target>
 where
     Properties: PropertiesTrait + PartialEq + 'static,
     Message: From<Target::Message> + 'static,
@@ -87,13 +87,13 @@ where
     }
 }
 
-
-impl <Properties, Message, Data, Target> Renderable<Hoc<Properties, Message, Data, Target>> for Hoc<Properties, Message, Data, Target>
-    where
-        Properties: PropertiesTrait + PartialEq +  'static,
-        Message: From<Target::Message> + 'static,
-        Data: HocData<Self, Target::Properties, Message> + 'static,
-        Target: Component + Renderable<Target>,
+impl<Properties, Message, Data, Target> Renderable<Hoc<Properties, Message, Data, Target>>
+    for Hoc<Properties, Message, Data, Target>
+where
+    Properties: PropertiesTrait + PartialEq + 'static,
+    Message: From<Target::Message> + 'static,
+    Data: HocData<Self, Target::Properties, Message> + 'static,
+    Target: Component + Renderable<Target>,
 {
     fn view(&self) -> Html<Self> {
         let vcomp_scope: ScopeHolder<_> = Default::default();

--- a/src/html/hoc.rs
+++ b/src/html/hoc.rs
@@ -122,7 +122,7 @@ pub struct Hoc<Properties, Message, Data, Target>
 where
     Properties: PropertiesTrait + 'static,
     Message: From<Target::Message> + 'static,
-    Data: HocData<Self, ChildProperties=Target::Properties, Message=Message> + 'static,
+    Data: HocData<Self, ChildProperties = Target::Properties, Message = Message> + 'static,
     Target: Component + Renderable<Target>,
 {
     data: Data,
@@ -135,7 +135,7 @@ impl<Properties, Message, Data, Target> Component for Hoc<Properties, Message, D
 where
     Properties: PropertiesTrait + 'static,
     Message: From<Target::Message> + 'static,
-    Data: HocData<Self, ChildProperties= Target::Properties, Message = Message> + 'static,
+    Data: HocData<Self, ChildProperties = Target::Properties, Message = Message> + 'static,
     Target: Component + Renderable<Target>,
 {
     type Message = Message;
@@ -173,7 +173,7 @@ impl<Properties, Message, Data, Target> Renderable<Hoc<Properties, Message, Data
 where
     Properties: PropertiesTrait + 'static,
     Message: From<Target::Message> + 'static,
-    Data: HocData<Self, ChildProperties= Target::Properties, Message = Message> + 'static,
+    Data: HocData<Self, ChildProperties = Target::Properties, Message = Message> + 'static,
     Target: Component + Renderable<Target>,
 {
     fn view(&self) -> Html<Self> {

--- a/src/html/hoc.rs
+++ b/src/html/hoc.rs
@@ -14,9 +14,9 @@ use serde::export::PhantomData;
 ///
 /// # Example
 /// ```
-/// use yew::{Component, ComponentLink, ShouldRender, Renderable, Html, Properties};
-/// use yew::html;
-/// use yew::html::{HocData, Hoc};
+///# use yew::{Component, ComponentLink, ShouldRender, Renderable, Html, Properties};
+///# use yew::html;
+///# use yew::html::{HocData, Hoc};
 /// pub struct MyComponent {
 ///     props: Props
 /// }
@@ -54,9 +54,7 @@ use serde::export::PhantomData;
 ///
 /// impl <T> HocData<Hoc<Props, (), Self, T>, Props, ()> for WithLoggingHoc
 /// where
-///     T: Component + Renderable<T>,
-///     (): From<<T as Component>::Message>,
-///     WithLoggingHoc: HocData<Hoc<Props, (), WithLoggingHoc, T>, <T as yew::Component>::Properties, ()>
+///     T: Component<Properties=Props, Message=()> + Renderable<T>,
 /// {
 ///     fn create(props: <Hoc<Props, (), WithLoggingHoc, T> as Component>::Properties, link: ComponentLink<Hoc<Props, (), WithLoggingHoc, T>>) -> Self {
 ///         log::trace!("create: {:?}", props);
@@ -81,10 +79,8 @@ use serde::export::PhantomData;
 ///     }
 /// }
 ///
+/// /// Use this alias in the `html!` macro.
 /// type MyComponentWithLogging = Hoc<Props, (), WithLoggingHoc, MyComponent>;
-///
-///
-///
 /// ```
 pub trait HocData<Parent, ChildProps, Message>
 where

--- a/src/html/hoc.rs
+++ b/src/html/hoc.rs
@@ -56,7 +56,7 @@ use serde::export::PhantomData;
 /// where
 ///     T: Component<Properties=Props, Message=()> + Renderable<T>,
 /// {
-///     fn create(props: <Hoc<Props, (), WithLoggingHoc, T> as Component>::Properties, link: ComponentLink<Hoc<Props, (), WithLoggingHoc, T>>) -> Self {
+///     fn create(props: Props, link: ComponentLink<Hoc<Props, (), WithLoggingHoc, T>>) -> Self {
 ///         log::trace!("create: {:?}", props);
 ///         WithLoggingHoc {
 ///             props

--- a/src/html/hoc.rs
+++ b/src/html/hoc.rs
@@ -1,0 +1,104 @@
+use crate::html::{Component, Html, ShouldRender, ComponentLink, Renderable};
+use crate::Properties as PropertiesTrait;
+use serde::export::PhantomData;
+use crate::virtual_dom::vcomp::ScopeHolder;
+use crate::virtual_dom::{VNode, VComp};
+
+// TODO it might make sense to decompose HocData into smaller, interchangeable parts so that props/state behavior can be changed independently of update behavior.
+// Not sure how valuable that would be though?
+
+/// Abstracts over the data layer of a Higher Order Component without a conception of the
+/// target component it will render.
+///
+/// Specifying the data for the HOC, requires reimplementing methods that are part of the component lifecycle.
+pub trait HocData<Parent, ChildProps, Message>
+where
+    Parent: Component + Renderable<Parent>,
+    <Parent as Component>::Properties: PartialEq,
+    ChildProps: PropertiesTrait
+{
+    /// Creates the data for the HOC.
+    fn create(props: &Parent::Properties, link: ComponentLink<Parent>) -> Self;
+    /// Runs when the HOC is mounted.
+    fn mounted(&mut self) -> ShouldRender {
+        false
+    }
+    /// Runs when the HOC updates.
+    fn update(&self, msg: Message) -> ShouldRender;
+    /// Runs to extract props used to create target components.
+    fn child_props(&self) -> ChildProps;
+    /// Runs when the HOC changes.
+    fn change(&mut self, props: Parent::Properties) -> ShouldRender;
+    /// Runs when the HOC is destroyed.
+    fn destroy(&mut self) {}
+}
+
+/// Higher Order Component.
+///
+/// Data handling logic can be specified in a `HocData` implementation,
+/// while rendering can be shared between a variety of target components.
+pub struct Hoc<Properties, Message, Data, Target>
+where
+    Properties: PropertiesTrait + PartialEq + 'static,
+    Message: From<Target::Message> + 'static,
+    Data: HocData<Self, Target::Properties, Message> + 'static,
+    Target: Component + Renderable<Target>,
+{
+    data: Data,
+    props: PhantomData<Properties>,
+    message: PhantomData<Message>,
+    target: PhantomData<Target>,
+}
+
+impl <Properties, Message, Data, Target> Component for Hoc<Properties, Message, Data, Target>
+where
+    Properties: PropertiesTrait + PartialEq + 'static,
+    Message: From<Target::Message> + 'static,
+    Data: HocData<Self, Target::Properties, Message> + 'static,
+    Target: Component + Renderable<Target>,
+{
+    type Message = Message;
+    type Properties = Properties;
+
+    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        let data = Data::create(&props, link);
+        Hoc {
+            data,
+            props: PhantomData,
+            message: PhantomData,
+            target: PhantomData,
+        }
+    }
+
+    fn mounted(&mut self) -> ShouldRender {
+        <Data as HocData<Self, _, _>>::mounted(&mut self.data)
+    }
+
+    fn update(&mut self, msg: Message) -> ShouldRender {
+        <Data as HocData<Self, _, Message>>::update(&mut self.data, msg)
+    }
+
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        <Data as HocData<Self, Target::Properties, _>>::change(&mut self.data, props)
+    }
+
+    fn destroy(&mut self) {
+        <Data as HocData<Self, _, _>>::destroy(&mut self.data)
+    }
+}
+
+
+impl <Properties, Message, Data, Target> Renderable<Hoc<Properties, Message, Data, Target>> for Hoc<Properties, Message, Data, Target>
+    where
+        Properties: PropertiesTrait + PartialEq +  'static,
+        Message: From<Target::Message> + 'static,
+        Data: HocData<Self, Target::Properties, Message> + 'static,
+        Target: Component + Renderable<Target>,
+{
+    fn view(&self) -> Html<Self> {
+        let vcomp_scope: ScopeHolder<_> = Default::default();
+        let child_props: Target::Properties = self.data.child_props();
+
+        VNode::VComp(VComp::new::<Target>(child_props, vcomp_scope))
+    }
+}

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -5,10 +5,14 @@
 
 mod listener;
 mod scope;
+mod hoc;
+
 
 pub use listener::*;
 pub(crate) use scope::ComponentUpdate;
 pub use scope::{NodeCell, Scope};
+
+pub use hoc::{Hoc, HocData};
 
 use crate::callback::Callback;
 use crate::virtual_dom::{VChild, VList, VNode};

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -3,10 +3,9 @@
 //! Also this module contains declaration of `Component` trait which used
 //! to create own UI-components.
 
+mod hoc;
 mod listener;
 mod scope;
-mod hoc;
-
 
 pub use listener::*;
 pub(crate) use scope::ComponentUpdate;


### PR DESCRIPTION
An abstraction over components that should allow you to generalize the data/update layer over many visualizations, as well as being able to compose behavior by nesting HOCs inside of each other.

~~This is very much a work in progress, and examples would go a long way towards demonstrating the benefit of this addition, but this react documentation may prove useful as a goal for this PR to strive towards: https://reactjs.org/docs/higher-order-components.html.~~

This is an experimental feature, and quite frankly, requires the writing of very ugly code to use it. Deferring to not merge it in favor of a more ergonomic alternative would be entirely understandable.