### PR TITLE
Derive Default for Classes

### DIFF
--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -41,7 +41,7 @@ type Listeners<COMP> = Vec<Box<dyn Listener<COMP>>>;
 type Attributes = HashMap<String, String>;
 
 /// A set of classes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Classes {
     set: IndexSet<String>,
 }


### PR DESCRIPTION
Derives Default for Classes.

If classes are to be passed down through props, it would be preferable to not specify that they are required. 

With this change, by default, there will be an empty set of classes passed via props when Classes are specified as a prop field.