### PR TITLE
Fix VNode orphaning inside of VTags

### DIFF
--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -352,7 +352,7 @@ impl<COMP: Component> VDiff for VTag<COMP> {
             .expect("tried to remove not rendered VTag from DOM");
 
         // recursively remove its children
-        self.childs.drain(..).for_each(|mut v|{
+        self.childs.drain(..).for_each(|mut v| {
             v.detach(&node);
         });
 

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -352,8 +352,8 @@ impl<COMP: Component> VDiff for VTag<COMP> {
             .expect("tried to remove not rendered VTag from DOM");
 
         // recursively remove its children
-        self.childs.drain(..).for_each(|mut v| {
-            v.detach(&node);
+        self.childs.drain(..).for_each(|mut child| {
+            child.detach(&node);
         });
 
         let sibling = node.next_sibling();

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -350,6 +350,12 @@ impl<COMP: Component> VDiff for VTag<COMP> {
             .reference
             .take()
             .expect("tried to remove not rendered VTag from DOM");
+
+        // recursively remove its children
+        self.childs.drain(..).for_each(|mut v|{
+            v.detach(&node);
+        });
+
         let sibling = node.next_sibling();
         if parent.remove_child(&node).is_err() {
             warn!("Node not found to remove VTag");


### PR DESCRIPTION
Fixes https://github.com/yewstack/yew/issues/643

VTags now recursively detach their children when they are detached themselves. This means that Components nested within `<div>`s or other elements will now properly run their `destroy` function and be dropped by the framework.

Its nice to finally squash a bug that's bothered me for more than a year.