### PR TITLE
Implement Debug for ChildRenderer<T>

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -159,7 +159,7 @@ impl<T> Default for ChildrenRenderer<T> {
     }
 }
 
-impl <T> fmt::Debug for ChildrenRenderer<T> {
+impl<T> fmt::Debug for ChildrenRenderer<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("ChildrenRenderer<_>")
     }

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -9,6 +9,7 @@ mod scope;
 pub use listener::*;
 pub(crate) use scope::ComponentUpdate;
 pub use scope::{NodeCell, Scope};
+use std::fmt;
 
 use crate::callback::Callback;
 use crate::virtual_dom::{VChild, VList, VNode};
@@ -155,6 +156,12 @@ impl<T> Default for ChildrenRenderer<T> {
             len: 0,
             boxed_render: Box::new(|| Vec::new()),
         }
+    }
+}
+
+impl <T> fmt::Debug for ChildrenRenderer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("ChildrenRenderer<_>")
     }
 }
 

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -9,7 +9,6 @@ mod scope;
 pub use listener::*;
 pub(crate) use scope::ComponentUpdate;
 pub use scope::{NodeCell, Scope};
-use std::fmt;
 
 use crate::callback::Callback;
 use crate::virtual_dom::{VChild, VList, VNode};

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -160,7 +160,7 @@ impl<T> Default for ChildrenRenderer<T> {
 }
 
 impl <T> fmt::Debug for ChildrenRenderer<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("ChildrenRenderer<_>")
     }
 }


### PR DESCRIPTION
I like to `#![deny(missing_debug_implementations)]`, and in order to reduce the pain of manually implementing `Debug` for all my stuff, I've been submitting these PRs as I encounter publicly facing types that lack `Debug`.

It might be worth opening an Issue/PR to add that lint to this project.