### PR TITLE
Add a method to emit multiple messages in one callback

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -227,8 +227,8 @@ where
     /// This method create an effect that provider a dispatch function to send messages mutiple
     /// times.
     pub fn create_effect<F, IN>(&mut self, function: F) -> Callback<IN>
-        where 
-            F: Fn(IN, &dyn Fn(COMP::Message)) + 'static,
+    where
+        F: Fn(IN, &dyn Fn(COMP::Message)) + 'static,
     {
         let scope = self.scope.clone();
         let dispatch = move |msg: COMP::Message| {

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -11,7 +11,6 @@ pub(crate) use scope::ComponentUpdate;
 pub use scope::{NodeCell, Scope};
 
 use crate::callback::Callback;
-use crate::html::scope::ManyOrSingleMessage::{Many, Single};
 use crate::virtual_dom::{VChild, VList, VNode};
 use std::fmt;
 
@@ -20,31 +19,31 @@ pub type ShouldRender = bool;
 
 /// An interface of a UI-component. Uses `self` as a model.
 pub trait Component: Sized + 'static {
-    /// Control message type which `update` loop get.
-    type Message: 'static;
-    /// Properties type of component implementation.
-    type Properties: Properties;
-    /// Initialization routine which could use a context.
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self;
-    /// Called after the component has been attached to the VDOM and it is safe to receive messages
-    /// from agents but before the browser updates the screen. If true is returned, the view will
-    /// be re-rendered and the user will not see the initial render.
-    fn mounted(&mut self) -> ShouldRender {
-        false
-    }
-    /// Called everytime when a messages of `Msg` type received. It also takes a
-    /// reference to a context.
-    fn update(&mut self, msg: Self::Message) -> ShouldRender;
-    /// Called when the component's parent component re-renders and the
-    /// component's place in the DOM tree remains unchanged. If the component's
-    /// place in the DOM tree changes, calling this method is unnecessary as the
-    /// component is recreated from scratch. It defaults
-    /// to true if not implemented.
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        true
-    }
-    /// Called for finalization on the final point of the component's lifetime.
-    fn destroy(&mut self) {} // TODO Replace with `Drop`
+  /// Control message type which `update` loop get.
+  type Message: 'static;
+  /// Properties type of component implementation.
+  type Properties: Properties;
+  /// Initialization routine which could use a context.
+  fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self;
+  /// Called after the component has been attached to the VDOM and it is safe to receive messages
+  /// from agents but before the browser updates the screen. If true is returned, the view will
+  /// be re-rendered and the user will not see the initial render.
+  fn mounted(&mut self) -> ShouldRender {
+    false
+  }
+  /// Called everytime when a messages of `Msg` type received. It also takes a
+  /// reference to a context.
+  fn update(&mut self, msg: Self::Message) -> ShouldRender;
+  /// Called when the component's parent component re-renders and the
+  /// component's place in the DOM tree remains unchanged. If the component's
+  /// place in the DOM tree changes, calling this method is unnecessary as the
+  /// component is recreated from scratch. It defaults
+  /// to true if not implemented.
+  fn change(&mut self, _: Self::Properties) -> ShouldRender {
+    true
+  }
+  /// Called for finalization on the final point of the component's lifetime.
+  fn destroy(&mut self) {} // TODO Replace with `Drop`
 }
 
 /// A type which expected as a result of `view` function implementation.
@@ -120,172 +119,171 @@ pub type ChildrenWithProps<C, P> = ChildrenRenderer<VChild<C, P>>;
 
 /// A type used for rendering children html.
 pub struct ChildrenRenderer<T> {
-    len: usize,
-    boxed_render: Box<dyn Fn() -> Vec<T>>,
+  len: usize,
+  boxed_render: Box<dyn Fn() -> Vec<T>>,
 }
 
 impl<T> ChildrenRenderer<T> {
-    /// Create children
-    pub fn new(len: usize, boxed_render: Box<dyn Fn() -> Vec<T>>) -> Self {
-        Self { len, boxed_render }
-    }
+  /// Create children
+  pub fn new(len: usize, boxed_render: Box<dyn Fn() -> Vec<T>>) -> Self {
+    Self { len, boxed_render }
+  }
 
-    /// Children list is empty
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
-    }
+  /// Children list is empty
+  pub fn is_empty(&self) -> bool {
+    self.len == 0
+  }
 
-    /// Number of children elements
-    pub fn len(&self) -> usize {
-        self.len
-    }
+  /// Number of children elements
+  pub fn len(&self) -> usize {
+    self.len
+  }
 
-    /// Build children components and return `Vec`
-    pub fn to_vec(&self) -> Vec<T> {
-        (&self.boxed_render)()
-    }
+  /// Build children components and return `Vec`
+  pub fn to_vec(&self) -> Vec<T> {
+    (&self.boxed_render)()
+  }
 
-    /// Render children components and return `Iterator`
-    pub fn iter(&self) -> impl Iterator<Item = T> {
-        (&self.boxed_render)().into_iter()
-    }
+  /// Render children components and return `Iterator`
+  pub fn iter(&self) -> impl Iterator<Item = T> {
+    (&self.boxed_render)().into_iter()
+  }
 }
 
 impl<T> Default for ChildrenRenderer<T> {
-    fn default() -> Self {
-        Self {
-            len: 0,
-            boxed_render: Box::new(|| Vec::new()),
-        }
+  fn default() -> Self {
+    Self {
+      len: 0,
+      boxed_render: Box::new(|| Vec::new()),
     }
+  }
 }
 
 impl<T> fmt::Debug for ChildrenRenderer<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("ChildrenRenderer<_>")
-    }
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("ChildrenRenderer<_>")
+  }
 }
 
 impl<T, COMP: Component> Renderable<COMP> for ChildrenRenderer<T>
 where
-    T: Into<VNode<COMP>>,
+  T: Into<VNode<COMP>>,
 {
-    fn view(&self) -> Html<COMP> {
-        VList {
-            childs: self.iter().map(|c| c.into()).collect(),
-        }
-        .into()
+  fn view(&self) -> Html<COMP> {
+    VList {
+      childs: self.iter().map(|c| c.into()).collect(),
     }
+    .into()
+  }
 }
 
 /// Should be rendered relative to context and component environment.
 pub trait Renderable<COMP: Component> {
-    /// Called by rendering loop.
-    fn view(&self) -> Html<COMP>;
+  /// Called by rendering loop.
+  fn view(&self) -> Html<COMP>;
 }
 
 /// Trait for building properties for a component
 pub trait Properties {
-    /// Builder that will be used to construct properties
-    type Builder;
+  /// Builder that will be used to construct properties
+  type Builder;
 
-    /// Entrypoint for building properties
-    fn builder() -> Self::Builder;
+  /// Entrypoint for building properties
+  fn builder() -> Self::Builder;
 }
 
 /// Builder for when a component has no properties
 pub struct EmptyBuilder;
 
 impl Properties for () {
-    type Builder = EmptyBuilder;
+  type Builder = EmptyBuilder;
 
-    fn builder() -> Self::Builder {
-        EmptyBuilder
-    }
+  fn builder() -> Self::Builder {
+    EmptyBuilder
+  }
 }
 
 impl EmptyBuilder {
-    /// Build empty properties
-    pub fn build(self) {}
+  /// Build empty properties
+  pub fn build(self) {}
 }
 
 /// Link to component's scope for creating callbacks.
 pub struct ComponentLink<COMP: Component> {
-    scope: Scope<COMP>,
+  scope: Scope<COMP>,
 }
 
 impl<COMP> ComponentLink<COMP>
 where
-    COMP: Component + Renderable<COMP>,
+  COMP: Component + Renderable<COMP>,
 {
-    /// Create link for a scope.
-    fn connect(scope: &Scope<COMP>) -> Self {
-        ComponentLink {
-            scope: scope.clone(),
-        }
+  /// Create link for a scope.
+  fn connect(scope: &Scope<COMP>) -> Self {
+    ComponentLink {
+      scope: scope.clone(),
     }
+  }
 
-    /// This method sends a bunch of messages back to the component's loop
-    /// It will trigger a bunch update in one render loop
-    pub fn send_bunch_back<F, IN>(&mut self, function: F) -> Callback<IN>
-    where
-        F: Fn(IN) -> Vec<COMP::Message> + 'static,
-    {
-        let scope = self.scope.clone();
-        let closure = move |input| {
-            let messages = function(input);
-            scope.clone().send_messages(messages);
-        };
-        closure.into()
-    }
+  /// This method sends batch of messages back to the component's loop
+  pub fn send_back_batch<F, IN>(&mut self, function: F) -> Callback<IN>
+  where
+    F: Fn(IN) -> Vec<COMP::Message> + 'static,
+  {
+    let scope = self.scope.clone();
+    let closure = move |input| {
+      let messages = function(input);
+      scope.clone().send_message_batch(messages);
+    };
+    closure.into()
+  }
 
-    /// This method sends messages back to the component's loop.
-    pub fn send_back<F, IN>(&mut self, function: F) -> Callback<IN>
-    where
-        F: Fn(IN) -> COMP::Message + 'static,
-    {
-        let scope = self.scope.clone();
-        let closure = move |input| {
-            let output = function(input);
-            scope.clone().send_message(output);
-        };
-        closure.into()
-    }
+  /// This method sends messages back to the component's loop.
+  pub fn send_back<F, IN>(&mut self, function: F) -> Callback<IN>
+  where
+    F: Fn(IN) -> COMP::Message + 'static,
+  {
+    let scope = self.scope.clone();
+    let closure = move |input| {
+      let output = function(input);
+      scope.clone().send_message(output);
+    };
+    closure.into()
+  }
 
-    /// This method sends a message to this component immediately.
-    pub fn send_self(&mut self, msg: COMP::Message) {
-        self.scope.send_message(msg);
-    }
+  /// This method sends a message to this component immediately.
+  pub fn send_self(&mut self, msg: COMP::Message) {
+    self.scope.send_message(msg);
+  }
 }
 
 impl<COMP: Component> fmt::Debug for ComponentLink<COMP> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("ComponentLink<_>")
-    }
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("ComponentLink<_>")
+  }
 }
 
 /// A bridging type for checking `href` attribute value.
 #[derive(Debug)]
 pub struct Href {
-    link: String,
+  link: String,
 }
 
 impl From<String> for Href {
-    fn from(link: String) -> Self {
-        Href { link }
-    }
+  fn from(link: String) -> Self {
+    Href { link }
+  }
 }
 
 impl<'a> From<&'a str> for Href {
-    fn from(link: &'a str) -> Self {
-        Href {
-            link: link.to_owned(),
-        }
+  fn from(link: &'a str) -> Self {
+    Href {
+      link: link.to_owned(),
     }
+  }
 }
 
 impl ToString for Href {
-    fn to_string(&self) -> String {
-        self.link.to_owned()
-    }
+  fn to_string(&self) -> String {
+    self.link.to_owned()
+  }
 }

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -19,31 +19,31 @@ pub type ShouldRender = bool;
 
 /// An interface of a UI-component. Uses `self` as a model.
 pub trait Component: Sized + 'static {
-  /// Control message type which `update` loop get.
-  type Message: 'static;
-  /// Properties type of component implementation.
-  type Properties: Properties;
-  /// Initialization routine which could use a context.
-  fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self;
-  /// Called after the component has been attached to the VDOM and it is safe to receive messages
-  /// from agents but before the browser updates the screen. If true is returned, the view will
-  /// be re-rendered and the user will not see the initial render.
-  fn mounted(&mut self) -> ShouldRender {
-    false
-  }
-  /// Called everytime when a messages of `Msg` type received. It also takes a
-  /// reference to a context.
-  fn update(&mut self, msg: Self::Message) -> ShouldRender;
-  /// Called when the component's parent component re-renders and the
-  /// component's place in the DOM tree remains unchanged. If the component's
-  /// place in the DOM tree changes, calling this method is unnecessary as the
-  /// component is recreated from scratch. It defaults
-  /// to true if not implemented.
-  fn change(&mut self, _: Self::Properties) -> ShouldRender {
-    true
-  }
-  /// Called for finalization on the final point of the component's lifetime.
-  fn destroy(&mut self) {} // TODO Replace with `Drop`
+    /// Control message type which `update` loop get.
+    type Message: 'static;
+    /// Properties type of component implementation.
+    type Properties: Properties;
+    /// Initialization routine which could use a context.
+    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self;
+    /// Called after the component has been attached to the VDOM and it is safe to receive messages
+    /// from agents but before the browser updates the screen. If true is returned, the view will
+    /// be re-rendered and the user will not see the initial render.
+    fn mounted(&mut self) -> ShouldRender {
+        false
+    }
+    /// Called everytime when a messages of `Msg` type received. It also takes a
+    /// reference to a context.
+    fn update(&mut self, msg: Self::Message) -> ShouldRender;
+    /// Called when the component's parent component re-renders and the
+    /// component's place in the DOM tree remains unchanged. If the component's
+    /// place in the DOM tree changes, calling this method is unnecessary as the
+    /// component is recreated from scratch. It defaults
+    /// to true if not implemented.
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        true
+    }
+    /// Called for finalization on the final point of the component's lifetime.
+    fn destroy(&mut self) {} // TODO Replace with `Drop`
 }
 
 /// A type which expected as a result of `view` function implementation.
@@ -119,171 +119,171 @@ pub type ChildrenWithProps<C, P> = ChildrenRenderer<VChild<C, P>>;
 
 /// A type used for rendering children html.
 pub struct ChildrenRenderer<T> {
-  len: usize,
-  boxed_render: Box<dyn Fn() -> Vec<T>>,
+    len: usize,
+    boxed_render: Box<dyn Fn() -> Vec<T>>,
 }
 
 impl<T> ChildrenRenderer<T> {
-  /// Create children
-  pub fn new(len: usize, boxed_render: Box<dyn Fn() -> Vec<T>>) -> Self {
-    Self { len, boxed_render }
-  }
+    /// Create children
+    pub fn new(len: usize, boxed_render: Box<dyn Fn() -> Vec<T>>) -> Self {
+        Self { len, boxed_render }
+    }
 
-  /// Children list is empty
-  pub fn is_empty(&self) -> bool {
-    self.len == 0
-  }
+    /// Children list is empty
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 
-  /// Number of children elements
-  pub fn len(&self) -> usize {
-    self.len
-  }
+    /// Number of children elements
+    pub fn len(&self) -> usize {
+        self.len
+    }
 
-  /// Build children components and return `Vec`
-  pub fn to_vec(&self) -> Vec<T> {
-    (&self.boxed_render)()
-  }
+    /// Build children components and return `Vec`
+    pub fn to_vec(&self) -> Vec<T> {
+        (&self.boxed_render)()
+    }
 
-  /// Render children components and return `Iterator`
-  pub fn iter(&self) -> impl Iterator<Item = T> {
-    (&self.boxed_render)().into_iter()
-  }
+    /// Render children components and return `Iterator`
+    pub fn iter(&self) -> impl Iterator<Item = T> {
+        (&self.boxed_render)().into_iter()
+    }
 }
 
 impl<T> Default for ChildrenRenderer<T> {
-  fn default() -> Self {
-    Self {
-      len: 0,
-      boxed_render: Box::new(|| Vec::new()),
+    fn default() -> Self {
+        Self {
+            len: 0,
+            boxed_render: Box::new(|| Vec::new()),
+        }
     }
-  }
 }
 
 impl<T> fmt::Debug for ChildrenRenderer<T> {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.write_str("ChildrenRenderer<_>")
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ChildrenRenderer<_>")
+    }
 }
 
 impl<T, COMP: Component> Renderable<COMP> for ChildrenRenderer<T>
 where
-  T: Into<VNode<COMP>>,
+    T: Into<VNode<COMP>>,
 {
-  fn view(&self) -> Html<COMP> {
-    VList {
-      childs: self.iter().map(|c| c.into()).collect(),
+    fn view(&self) -> Html<COMP> {
+        VList {
+            childs: self.iter().map(|c| c.into()).collect(),
+        }
+        .into()
     }
-    .into()
-  }
 }
 
 /// Should be rendered relative to context and component environment.
 pub trait Renderable<COMP: Component> {
-  /// Called by rendering loop.
-  fn view(&self) -> Html<COMP>;
+    /// Called by rendering loop.
+    fn view(&self) -> Html<COMP>;
 }
 
 /// Trait for building properties for a component
 pub trait Properties {
-  /// Builder that will be used to construct properties
-  type Builder;
+    /// Builder that will be used to construct properties
+    type Builder;
 
-  /// Entrypoint for building properties
-  fn builder() -> Self::Builder;
+    /// Entrypoint for building properties
+    fn builder() -> Self::Builder;
 }
 
 /// Builder for when a component has no properties
 pub struct EmptyBuilder;
 
 impl Properties for () {
-  type Builder = EmptyBuilder;
+    type Builder = EmptyBuilder;
 
-  fn builder() -> Self::Builder {
-    EmptyBuilder
-  }
+    fn builder() -> Self::Builder {
+        EmptyBuilder
+    }
 }
 
 impl EmptyBuilder {
-  /// Build empty properties
-  pub fn build(self) {}
+    /// Build empty properties
+    pub fn build(self) {}
 }
 
 /// Link to component's scope for creating callbacks.
 pub struct ComponentLink<COMP: Component> {
-  scope: Scope<COMP>,
+    scope: Scope<COMP>,
 }
 
 impl<COMP> ComponentLink<COMP>
 where
-  COMP: Component + Renderable<COMP>,
+    COMP: Component + Renderable<COMP>,
 {
-  /// Create link for a scope.
-  fn connect(scope: &Scope<COMP>) -> Self {
-    ComponentLink {
-      scope: scope.clone(),
+    /// Create link for a scope.
+    fn connect(scope: &Scope<COMP>) -> Self {
+        ComponentLink {
+            scope: scope.clone(),
+        }
     }
-  }
 
-  /// This method sends batch of messages back to the component's loop
-  pub fn send_back_batch<F, IN>(&mut self, function: F) -> Callback<IN>
-  where
-    F: Fn(IN) -> Vec<COMP::Message> + 'static,
-  {
-    let scope = self.scope.clone();
-    let closure = move |input| {
-      let messages = function(input);
-      scope.clone().send_message_batch(messages);
-    };
-    closure.into()
-  }
+    /// This method sends batch of messages back to the component's loop
+    pub fn send_back_batch<F, IN>(&mut self, function: F) -> Callback<IN>
+    where
+        F: Fn(IN) -> Vec<COMP::Message> + 'static,
+    {
+        let scope = self.scope.clone();
+        let closure = move |input| {
+            let messages = function(input);
+            scope.clone().send_message_batch(messages);
+        };
+        closure.into()
+    }
 
-  /// This method sends messages back to the component's loop.
-  pub fn send_back<F, IN>(&mut self, function: F) -> Callback<IN>
-  where
-    F: Fn(IN) -> COMP::Message + 'static,
-  {
-    let scope = self.scope.clone();
-    let closure = move |input| {
-      let output = function(input);
-      scope.clone().send_message(output);
-    };
-    closure.into()
-  }
+    /// This method sends messages back to the component's loop.
+    pub fn send_back<F, IN>(&mut self, function: F) -> Callback<IN>
+    where
+        F: Fn(IN) -> COMP::Message + 'static,
+    {
+        let scope = self.scope.clone();
+        let closure = move |input| {
+            let output = function(input);
+            scope.clone().send_message(output);
+        };
+        closure.into()
+    }
 
-  /// This method sends a message to this component immediately.
-  pub fn send_self(&mut self, msg: COMP::Message) {
-    self.scope.send_message(msg);
-  }
+    /// This method sends a message to this component immediately.
+    pub fn send_self(&mut self, msg: COMP::Message) {
+        self.scope.send_message(msg);
+    }
 }
 
 impl<COMP: Component> fmt::Debug for ComponentLink<COMP> {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.write_str("ComponentLink<_>")
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ComponentLink<_>")
+    }
 }
 
 /// A bridging type for checking `href` attribute value.
 #[derive(Debug)]
 pub struct Href {
-  link: String,
+    link: String,
 }
 
 impl From<String> for Href {
-  fn from(link: String) -> Self {
-    Href { link }
-  }
+    fn from(link: String) -> Self {
+        Href { link }
+    }
 }
 
 impl<'a> From<&'a str> for Href {
-  fn from(link: &'a str) -> Self {
-    Href {
-      link: link.to_owned(),
+    fn from(link: &'a str) -> Self {
+        Href {
+            link: link.to_owned(),
+        }
     }
-  }
 }
 
 impl ToString for Href {
-  fn to_string(&self) -> String {
-    self.link.to_owned()
-  }
+    fn to_string(&self) -> String {
+        self.link.to_owned()
+    }
 }

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -224,6 +224,22 @@ where
         }
     }
 
+    /// This method create an effect that provider a dispatch function to send messages mutiple
+    /// times.
+    pub fn create_effect<F, IN>(&mut self, function: F) -> Callback<IN>
+        where 
+            F: Fn(IN, &dyn Fn(COMP::Message)) + 'static,
+    {
+        let scope = self.scope.clone();
+        let dispatch = move |msg: COMP::Message| {
+            scope.clone().send_message(msg);
+        };
+        let closure = move |input| {
+            function(input, &dispatch);
+        };
+        closure.into()
+    }
+
     /// This method sends messages back to the component's loop.
     pub fn send_back<F, IN>(&mut self, function: F) -> Callback<IN>
     where

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -9,270 +9,264 @@ use stdweb::web::{Element, Node};
 /// Holder for the element.
 pub type NodeCell = Rc<RefCell<Option<Node>>>;
 
-pub(crate) enum ManyOrSingleMessage<COMP: Component> {
-    Single(COMP::Message),
-    Many(Vec<COMP::Message>),
-}
 /// Updates for a `Components` instance. Used by scope sender.
 pub(crate) enum ComponentUpdate<COMP: Component> {
-    /// Wraps messages for a component.
-    Message(ManyOrSingleMessage<COMP>),
-    /// Wraps properties for a component.
-    Properties(COMP::Properties),
+  /// Wraps messages for a component.
+  Message(COMP::Message),
+  /// Wraps batch of messages for a component.
+  MessageBatch(Vec<COMP::Message>),
+  /// Wraps properties for a component.
+  Properties(COMP::Properties),
 }
 
 /// A context which contains a bridge to send a messages to a loop.
 /// Mostly services uses it.
 pub struct Scope<COMP: Component> {
-    shared_state: Shared<ComponentState<COMP>>,
+  shared_state: Shared<ComponentState<COMP>>,
 }
 
 impl<COMP: Component> Clone for Scope<COMP> {
-    fn clone(&self) -> Self {
-        Scope {
-            shared_state: self.shared_state.clone(),
-        }
+  fn clone(&self) -> Self {
+    Scope {
+      shared_state: self.shared_state.clone(),
     }
+  }
 }
 
 impl<COMP> Scope<COMP>
 where
-    COMP: Component + Renderable<COMP>,
+  COMP: Component + Renderable<COMP>,
 {
-    pub(crate) fn create(&mut self) {
-        let shared_state = self.shared_state.clone();
-        let create = CreateComponent { shared_state };
-        scheduler().put_and_try_run(Box::new(create));
-    }
+  pub(crate) fn create(&mut self) {
+    let shared_state = self.shared_state.clone();
+    let create = CreateComponent { shared_state };
+    scheduler().put_and_try_run(Box::new(create));
+  }
 
-    pub(crate) fn update(&mut self, update: ComponentUpdate<COMP>) {
-        let update = UpdateComponent {
-            shared_state: self.shared_state.clone(),
-            update,
-        };
-        scheduler().put_and_try_run(Box::new(update));
-    }
+  pub(crate) fn update(&mut self, update: ComponentUpdate<COMP>) {
+    let update = UpdateComponent {
+      shared_state: self.shared_state.clone(),
+      update,
+    };
+    scheduler().put_and_try_run(Box::new(update));
+  }
 
-    pub(crate) fn destroy(&mut self) {
-        let shared_state = self.shared_state.clone();
-        let destroy = DestroyComponent { shared_state };
-        scheduler().put_and_try_run(Box::new(destroy));
-    }
+  pub(crate) fn destroy(&mut self) {
+    let shared_state = self.shared_state.clone();
+    let destroy = DestroyComponent { shared_state };
+    scheduler().put_and_try_run(Box::new(destroy));
+  }
 
-    /// Send a message to the component
-    pub fn send_message(&mut self, msg: COMP::Message) {
-        self.update(ComponentUpdate::Message(Single(msg)));
-    }
+  /// Send a message to the component
+  pub fn send_message(&mut self, msg: COMP::Message) {
+    self.update(ComponentUpdate::Message(msg));
+  }
 
-    /// send many messages to the component
-    pub fn send_messages(&mut self, msgs: Vec<COMP::Message>) {
-        self.update(ComponentUpdate::Message(Many(msgs)));
-    }
+  /// send batch of messages to the component
+  pub fn send_message_batch(&mut self, messages: Vec<COMP::Message>) {
+    self.update(ComponentUpdate::MessageBatch(messages));
+  }
 }
 
 enum ComponentState<COMP: Component> {
-    Empty,
-    Ready(ReadyState<COMP>),
-    Created(CreatedState<COMP>),
-    Processing,
-    Destroyed,
+  Empty,
+  Ready(ReadyState<COMP>),
+  Created(CreatedState<COMP>),
+  Processing,
+  Destroyed,
 }
 
 impl<COMP: Component> fmt::Display for ComponentState<COMP> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = match self {
-            ComponentState::Empty => "empty",
-            ComponentState::Ready(_) => "ready",
-            ComponentState::Created(_) => "created",
-            ComponentState::Processing => "processing",
-            ComponentState::Destroyed => "destroyed",
-        };
-        write!(f, "{}", name)
-    }
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let name = match self {
+      ComponentState::Empty => "empty",
+      ComponentState::Ready(_) => "ready",
+      ComponentState::Created(_) => "created",
+      ComponentState::Processing => "processing",
+      ComponentState::Destroyed => "destroyed",
+    };
+    write!(f, "{}", name)
+  }
 }
 
 struct ReadyState<COMP: Component> {
-    env: Scope<COMP>,
-    element: Element,
-    occupied: Option<NodeCell>,
-    props: COMP::Properties,
-    link: ComponentLink<COMP>,
-    ancestor: Option<VNode<COMP>>,
+  env: Scope<COMP>,
+  element: Element,
+  occupied: Option<NodeCell>,
+  props: COMP::Properties,
+  link: ComponentLink<COMP>,
+  ancestor: Option<VNode<COMP>>,
 }
 
 impl<COMP: Component> ReadyState<COMP> {
-    fn create(self) -> CreatedState<COMP> {
-        CreatedState {
-            component: COMP::create(self.props, self.link),
-            env: self.env,
-            element: self.element,
-            last_frame: self.ancestor,
-            occupied: self.occupied,
-        }
+  fn create(self) -> CreatedState<COMP> {
+    CreatedState {
+      component: COMP::create(self.props, self.link),
+      env: self.env,
+      element: self.element,
+      last_frame: self.ancestor,
+      occupied: self.occupied,
     }
+  }
 }
 
 struct CreatedState<COMP: Component> {
-    env: Scope<COMP>,
-    element: Element,
-    component: COMP,
-    last_frame: Option<VNode<COMP>>,
-    occupied: Option<NodeCell>,
+  env: Scope<COMP>,
+  element: Element,
+  component: COMP,
+  last_frame: Option<VNode<COMP>>,
+  occupied: Option<NodeCell>,
 }
 
 impl<COMP: Component + Renderable<COMP>> CreatedState<COMP> {
-    /// Called once immediately after the component is created.
-    fn mounted(mut self) -> Self {
-        if self.component.mounted() {
-            self.update()
-        } else {
-            self
-        }
+  /// Called once immediately after the component is created.
+  fn mounted(mut self) -> Self {
+    if self.component.mounted() {
+      self.update()
+    } else {
+      self
+    }
+  }
+
+  fn update(mut self) -> Self {
+    let mut next_frame = self.component.view();
+    let node = next_frame.apply(&self.element, None, self.last_frame, &self.env);
+    if let Some(ref mut cell) = self.occupied {
+      *cell.borrow_mut() = node;
     }
 
-    fn update(mut self) -> Self {
-        let mut next_frame = self.component.view();
-        let node = next_frame.apply(&self.element, None, self.last_frame, &self.env);
-        if let Some(ref mut cell) = self.occupied {
-            *cell.borrow_mut() = node;
-        }
-
-        self.last_frame = Some(next_frame);
-        self
-    }
+    self.last_frame = Some(next_frame);
+    self
+  }
 }
 
 impl<COMP> Scope<COMP>
 where
-    COMP: Component + Renderable<COMP>,
+  COMP: Component + Renderable<COMP>,
 {
-    /// visible for testing
-    pub fn new() -> Self {
-        let shared_state = Rc::new(RefCell::new(ComponentState::Empty));
-        Scope { shared_state }
-    }
+  /// visible for testing
+  pub fn new() -> Self {
+    let shared_state = Rc::new(RefCell::new(ComponentState::Empty));
+    Scope { shared_state }
+  }
 
-    // TODO Consider to use &Node instead of Element as parent
-    /// Mounts elements in place of previous node (ancestor).
-    pub(crate) fn mount_in_place(
-        self,
-        element: Element,
-        ancestor: Option<VNode<COMP>>,
-        occupied: Option<NodeCell>,
-        props: COMP::Properties,
-    ) -> Scope<COMP> {
-        let mut scope = self.clone();
-        let link = ComponentLink::connect(&scope);
-        let ready_state = ReadyState {
-            env: self.clone(),
-            element,
-            occupied,
-            link,
-            props,
-            ancestor,
-        };
-        *scope.shared_state.borrow_mut() = ComponentState::Ready(ready_state);
-        scope.create();
-        scope
-    }
+  // TODO Consider to use &Node instead of Element as parent
+  /// Mounts elements in place of previous node (ancestor).
+  pub(crate) fn mount_in_place(
+    self,
+    element: Element,
+    ancestor: Option<VNode<COMP>>,
+    occupied: Option<NodeCell>,
+    props: COMP::Properties,
+  ) -> Scope<COMP> {
+    let mut scope = self.clone();
+    let link = ComponentLink::connect(&scope);
+    let ready_state = ReadyState {
+      env: self.clone(),
+      element,
+      occupied,
+      link,
+      props,
+      ancestor,
+    };
+    *scope.shared_state.borrow_mut() = ComponentState::Ready(ready_state);
+    scope.create();
+    scope
+  }
 }
 
 impl<COMP> Default for Scope<COMP>
 where
-    COMP: Component + Renderable<COMP>,
+  COMP: Component + Renderable<COMP>,
 {
-    fn default() -> Self {
-        Scope::new()
-    }
+  fn default() -> Self {
+    Scope::new()
+  }
 }
 
 struct CreateComponent<COMP>
 where
-    COMP: Component,
+  COMP: Component,
 {
-    shared_state: Shared<ComponentState<COMP>>,
+  shared_state: Shared<ComponentState<COMP>>,
 }
 
 impl<COMP> Runnable for CreateComponent<COMP>
 where
-    COMP: Component + Renderable<COMP>,
+  COMP: Component + Renderable<COMP>,
 {
-    fn run(self: Box<Self>) {
-        let current_state = self.shared_state.replace(ComponentState::Processing);
-        self.shared_state.replace(match current_state {
-            ComponentState::Ready(state) => {
-                ComponentState::Created(state.create().update().mounted())
-            }
-            ComponentState::Created(_) | ComponentState::Destroyed => current_state,
-            ComponentState::Empty | ComponentState::Processing => {
-                panic!("unexpected component state: {}", current_state);
-            }
-        });
-    }
+  fn run(self: Box<Self>) {
+    let current_state = self.shared_state.replace(ComponentState::Processing);
+    self.shared_state.replace(match current_state {
+      ComponentState::Ready(state) => ComponentState::Created(state.create().update().mounted()),
+      ComponentState::Created(_) | ComponentState::Destroyed => current_state,
+      ComponentState::Empty | ComponentState::Processing => {
+        panic!("unexpected component state: {}", current_state);
+      }
+    });
+  }
 }
 
 struct DestroyComponent<COMP>
 where
-    COMP: Component,
+  COMP: Component,
 {
-    shared_state: Shared<ComponentState<COMP>>,
+  shared_state: Shared<ComponentState<COMP>>,
 }
 
 impl<COMP> Runnable for DestroyComponent<COMP>
 where
-    COMP: Component + Renderable<COMP>,
+  COMP: Component + Renderable<COMP>,
 {
-    fn run(self: Box<Self>) {
-        match self.shared_state.replace(ComponentState::Destroyed) {
-            ComponentState::Created(mut this) => {
-                this.component.destroy();
-                if let Some(last_frame) = &mut this.last_frame {
-                    last_frame.detach(&this.element);
-                }
-            }
-            ComponentState::Ready(mut this) => {
-                if let Some(ancestor) = &mut this.ancestor {
-                    ancestor.detach(&this.element);
-                }
-            }
-            ComponentState::Empty | ComponentState::Destroyed => {}
-            s @ ComponentState::Processing => panic!("unexpected component state: {}", s),
-        };
-    }
+  fn run(self: Box<Self>) {
+    match self.shared_state.replace(ComponentState::Destroyed) {
+      ComponentState::Created(mut this) => {
+        this.component.destroy();
+        if let Some(last_frame) = &mut this.last_frame {
+          last_frame.detach(&this.element);
+        }
+      }
+      ComponentState::Ready(mut this) => {
+        if let Some(ancestor) = &mut this.ancestor {
+          ancestor.detach(&this.element);
+        }
+      }
+      ComponentState::Empty | ComponentState::Destroyed => {}
+      s @ ComponentState::Processing => panic!("unexpected component state: {}", s),
+    };
+  }
 }
 
 struct UpdateComponent<COMP>
 where
-    COMP: Component,
+  COMP: Component,
 {
-    shared_state: Shared<ComponentState<COMP>>,
-    update: ComponentUpdate<COMP>,
+  shared_state: Shared<ComponentState<COMP>>,
+  update: ComponentUpdate<COMP>,
 }
 
 impl<COMP> Runnable for UpdateComponent<COMP>
 where
-    COMP: Component + Renderable<COMP>,
+  COMP: Component + Renderable<COMP>,
 {
-    fn run(self: Box<Self>) {
-        let current_state = self.shared_state.replace(ComponentState::Processing);
-        self.shared_state.replace(match current_state {
-            ComponentState::Created(mut this) => {
-                let should_update = match self.update {
-                    ComponentUpdate::Message(message) => match message {
-                        Many(msgs) => msgs
-                            .into_iter()
-                            .fold(false, |acc, msg| this.component.update(msg) || acc),
-                        Single(msg) => this.component.update(msg),
-                    },
-                    ComponentUpdate::Properties(props) => this.component.change(props),
-                };
-                let next_state = if should_update { this.update() } else { this };
-                ComponentState::Created(next_state)
-            }
-            ComponentState::Destroyed => current_state,
-            ComponentState::Processing | ComponentState::Ready(_) | ComponentState::Empty => {
-                panic!("unexpected component state: {}", current_state);
-            }
-        });
-    }
+  fn run(self: Box<Self>) {
+    let current_state = self.shared_state.replace(ComponentState::Processing);
+    self.shared_state.replace(match current_state {
+      ComponentState::Created(mut this) => {
+        let should_update = match self.update {
+          ComponentUpdate::Message(message) => this.component.update(message),
+          ComponentUpdate::MessageBatch(messages) => messages
+            .into_iter()
+            .fold(false, |acc, msg| this.component.update(msg) || acc),
+          ComponentUpdate::Properties(props) => this.component.change(props),
+        };
+        let next_state = if should_update { this.update() } else { this };
+        ComponentState::Created(next_state)
+      }
+      ComponentState::Destroyed => current_state,
+      ComponentState::Processing | ComponentState::Ready(_) | ComponentState::Empty => {
+        panic!("unexpected component state: {}", current_state);
+      }
+    });
+  }
 }

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -11,262 +11,264 @@ pub type NodeCell = Rc<RefCell<Option<Node>>>;
 
 /// Updates for a `Components` instance. Used by scope sender.
 pub(crate) enum ComponentUpdate<COMP: Component> {
-  /// Wraps messages for a component.
-  Message(COMP::Message),
-  /// Wraps batch of messages for a component.
-  MessageBatch(Vec<COMP::Message>),
-  /// Wraps properties for a component.
-  Properties(COMP::Properties),
+    /// Wraps messages for a component.
+    Message(COMP::Message),
+    /// Wraps batch of messages for a component.
+    MessageBatch(Vec<COMP::Message>),
+    /// Wraps properties for a component.
+    Properties(COMP::Properties),
 }
 
 /// A context which contains a bridge to send a messages to a loop.
 /// Mostly services uses it.
 pub struct Scope<COMP: Component> {
-  shared_state: Shared<ComponentState<COMP>>,
+    shared_state: Shared<ComponentState<COMP>>,
 }
 
 impl<COMP: Component> Clone for Scope<COMP> {
-  fn clone(&self) -> Self {
-    Scope {
-      shared_state: self.shared_state.clone(),
+    fn clone(&self) -> Self {
+        Scope {
+            shared_state: self.shared_state.clone(),
+        }
     }
-  }
 }
 
 impl<COMP> Scope<COMP>
 where
-  COMP: Component + Renderable<COMP>,
+    COMP: Component + Renderable<COMP>,
 {
-  pub(crate) fn create(&mut self) {
-    let shared_state = self.shared_state.clone();
-    let create = CreateComponent { shared_state };
-    scheduler().put_and_try_run(Box::new(create));
-  }
+    pub(crate) fn create(&mut self) {
+        let shared_state = self.shared_state.clone();
+        let create = CreateComponent { shared_state };
+        scheduler().put_and_try_run(Box::new(create));
+    }
 
-  pub(crate) fn update(&mut self, update: ComponentUpdate<COMP>) {
-    let update = UpdateComponent {
-      shared_state: self.shared_state.clone(),
-      update,
-    };
-    scheduler().put_and_try_run(Box::new(update));
-  }
+    pub(crate) fn update(&mut self, update: ComponentUpdate<COMP>) {
+        let update = UpdateComponent {
+            shared_state: self.shared_state.clone(),
+            update,
+        };
+        scheduler().put_and_try_run(Box::new(update));
+    }
 
-  pub(crate) fn destroy(&mut self) {
-    let shared_state = self.shared_state.clone();
-    let destroy = DestroyComponent { shared_state };
-    scheduler().put_and_try_run(Box::new(destroy));
-  }
+    pub(crate) fn destroy(&mut self) {
+        let shared_state = self.shared_state.clone();
+        let destroy = DestroyComponent { shared_state };
+        scheduler().put_and_try_run(Box::new(destroy));
+    }
 
-  /// Send a message to the component
-  pub fn send_message(&mut self, msg: COMP::Message) {
-    self.update(ComponentUpdate::Message(msg));
-  }
+    /// Send a message to the component
+    pub fn send_message(&mut self, msg: COMP::Message) {
+        self.update(ComponentUpdate::Message(msg));
+    }
 
-  /// send batch of messages to the component
-  pub fn send_message_batch(&mut self, messages: Vec<COMP::Message>) {
-    self.update(ComponentUpdate::MessageBatch(messages));
-  }
+    /// send batch of messages to the component
+    pub fn send_message_batch(&mut self, messages: Vec<COMP::Message>) {
+        self.update(ComponentUpdate::MessageBatch(messages));
+    }
 }
 
 enum ComponentState<COMP: Component> {
-  Empty,
-  Ready(ReadyState<COMP>),
-  Created(CreatedState<COMP>),
-  Processing,
-  Destroyed,
+    Empty,
+    Ready(ReadyState<COMP>),
+    Created(CreatedState<COMP>),
+    Processing,
+    Destroyed,
 }
 
 impl<COMP: Component> fmt::Display for ComponentState<COMP> {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    let name = match self {
-      ComponentState::Empty => "empty",
-      ComponentState::Ready(_) => "ready",
-      ComponentState::Created(_) => "created",
-      ComponentState::Processing => "processing",
-      ComponentState::Destroyed => "destroyed",
-    };
-    write!(f, "{}", name)
-  }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            ComponentState::Empty => "empty",
+            ComponentState::Ready(_) => "ready",
+            ComponentState::Created(_) => "created",
+            ComponentState::Processing => "processing",
+            ComponentState::Destroyed => "destroyed",
+        };
+        write!(f, "{}", name)
+    }
 }
 
 struct ReadyState<COMP: Component> {
-  env: Scope<COMP>,
-  element: Element,
-  occupied: Option<NodeCell>,
-  props: COMP::Properties,
-  link: ComponentLink<COMP>,
-  ancestor: Option<VNode<COMP>>,
+    env: Scope<COMP>,
+    element: Element,
+    occupied: Option<NodeCell>,
+    props: COMP::Properties,
+    link: ComponentLink<COMP>,
+    ancestor: Option<VNode<COMP>>,
 }
 
 impl<COMP: Component> ReadyState<COMP> {
-  fn create(self) -> CreatedState<COMP> {
-    CreatedState {
-      component: COMP::create(self.props, self.link),
-      env: self.env,
-      element: self.element,
-      last_frame: self.ancestor,
-      occupied: self.occupied,
+    fn create(self) -> CreatedState<COMP> {
+        CreatedState {
+            component: COMP::create(self.props, self.link),
+            env: self.env,
+            element: self.element,
+            last_frame: self.ancestor,
+            occupied: self.occupied,
+        }
     }
-  }
 }
 
 struct CreatedState<COMP: Component> {
-  env: Scope<COMP>,
-  element: Element,
-  component: COMP,
-  last_frame: Option<VNode<COMP>>,
-  occupied: Option<NodeCell>,
+    env: Scope<COMP>,
+    element: Element,
+    component: COMP,
+    last_frame: Option<VNode<COMP>>,
+    occupied: Option<NodeCell>,
 }
 
 impl<COMP: Component + Renderable<COMP>> CreatedState<COMP> {
-  /// Called once immediately after the component is created.
-  fn mounted(mut self) -> Self {
-    if self.component.mounted() {
-      self.update()
-    } else {
-      self
-    }
-  }
-
-  fn update(mut self) -> Self {
-    let mut next_frame = self.component.view();
-    let node = next_frame.apply(&self.element, None, self.last_frame, &self.env);
-    if let Some(ref mut cell) = self.occupied {
-      *cell.borrow_mut() = node;
+    /// Called once immediately after the component is created.
+    fn mounted(mut self) -> Self {
+        if self.component.mounted() {
+            self.update()
+        } else {
+            self
+        }
     }
 
-    self.last_frame = Some(next_frame);
-    self
-  }
+    fn update(mut self) -> Self {
+        let mut next_frame = self.component.view();
+        let node = next_frame.apply(&self.element, None, self.last_frame, &self.env);
+        if let Some(ref mut cell) = self.occupied {
+            *cell.borrow_mut() = node;
+        }
+
+        self.last_frame = Some(next_frame);
+        self
+    }
 }
 
 impl<COMP> Scope<COMP>
 where
-  COMP: Component + Renderable<COMP>,
+    COMP: Component + Renderable<COMP>,
 {
-  /// visible for testing
-  pub fn new() -> Self {
-    let shared_state = Rc::new(RefCell::new(ComponentState::Empty));
-    Scope { shared_state }
-  }
+    /// visible for testing
+    pub fn new() -> Self {
+        let shared_state = Rc::new(RefCell::new(ComponentState::Empty));
+        Scope { shared_state }
+    }
 
-  // TODO Consider to use &Node instead of Element as parent
-  /// Mounts elements in place of previous node (ancestor).
-  pub(crate) fn mount_in_place(
-    self,
-    element: Element,
-    ancestor: Option<VNode<COMP>>,
-    occupied: Option<NodeCell>,
-    props: COMP::Properties,
-  ) -> Scope<COMP> {
-    let mut scope = self.clone();
-    let link = ComponentLink::connect(&scope);
-    let ready_state = ReadyState {
-      env: self.clone(),
-      element,
-      occupied,
-      link,
-      props,
-      ancestor,
-    };
-    *scope.shared_state.borrow_mut() = ComponentState::Ready(ready_state);
-    scope.create();
-    scope
-  }
+    // TODO Consider to use &Node instead of Element as parent
+    /// Mounts elements in place of previous node (ancestor).
+    pub(crate) fn mount_in_place(
+        self,
+        element: Element,
+        ancestor: Option<VNode<COMP>>,
+        occupied: Option<NodeCell>,
+        props: COMP::Properties,
+    ) -> Scope<COMP> {
+        let mut scope = self.clone();
+        let link = ComponentLink::connect(&scope);
+        let ready_state = ReadyState {
+            env: self.clone(),
+            element,
+            occupied,
+            link,
+            props,
+            ancestor,
+        };
+        *scope.shared_state.borrow_mut() = ComponentState::Ready(ready_state);
+        scope.create();
+        scope
+    }
 }
 
 impl<COMP> Default for Scope<COMP>
 where
-  COMP: Component + Renderable<COMP>,
+    COMP: Component + Renderable<COMP>,
 {
-  fn default() -> Self {
-    Scope::new()
-  }
+    fn default() -> Self {
+        Scope::new()
+    }
 }
 
 struct CreateComponent<COMP>
 where
-  COMP: Component,
+    COMP: Component,
 {
-  shared_state: Shared<ComponentState<COMP>>,
+    shared_state: Shared<ComponentState<COMP>>,
 }
 
 impl<COMP> Runnable for CreateComponent<COMP>
 where
-  COMP: Component + Renderable<COMP>,
+    COMP: Component + Renderable<COMP>,
 {
-  fn run(self: Box<Self>) {
-    let current_state = self.shared_state.replace(ComponentState::Processing);
-    self.shared_state.replace(match current_state {
-      ComponentState::Ready(state) => ComponentState::Created(state.create().update().mounted()),
-      ComponentState::Created(_) | ComponentState::Destroyed => current_state,
-      ComponentState::Empty | ComponentState::Processing => {
-        panic!("unexpected component state: {}", current_state);
-      }
-    });
-  }
+    fn run(self: Box<Self>) {
+        let current_state = self.shared_state.replace(ComponentState::Processing);
+        self.shared_state.replace(match current_state {
+            ComponentState::Ready(state) => {
+                ComponentState::Created(state.create().update().mounted())
+            }
+            ComponentState::Created(_) | ComponentState::Destroyed => current_state,
+            ComponentState::Empty | ComponentState::Processing => {
+                panic!("unexpected component state: {}", current_state);
+            }
+        });
+    }
 }
 
 struct DestroyComponent<COMP>
 where
-  COMP: Component,
+    COMP: Component,
 {
-  shared_state: Shared<ComponentState<COMP>>,
+    shared_state: Shared<ComponentState<COMP>>,
 }
 
 impl<COMP> Runnable for DestroyComponent<COMP>
 where
-  COMP: Component + Renderable<COMP>,
+    COMP: Component + Renderable<COMP>,
 {
-  fn run(self: Box<Self>) {
-    match self.shared_state.replace(ComponentState::Destroyed) {
-      ComponentState::Created(mut this) => {
-        this.component.destroy();
-        if let Some(last_frame) = &mut this.last_frame {
-          last_frame.detach(&this.element);
-        }
-      }
-      ComponentState::Ready(mut this) => {
-        if let Some(ancestor) = &mut this.ancestor {
-          ancestor.detach(&this.element);
-        }
-      }
-      ComponentState::Empty | ComponentState::Destroyed => {}
-      s @ ComponentState::Processing => panic!("unexpected component state: {}", s),
-    };
-  }
+    fn run(self: Box<Self>) {
+        match self.shared_state.replace(ComponentState::Destroyed) {
+            ComponentState::Created(mut this) => {
+                this.component.destroy();
+                if let Some(last_frame) = &mut this.last_frame {
+                    last_frame.detach(&this.element);
+                }
+            }
+            ComponentState::Ready(mut this) => {
+                if let Some(ancestor) = &mut this.ancestor {
+                    ancestor.detach(&this.element);
+                }
+            }
+            ComponentState::Empty | ComponentState::Destroyed => {}
+            s @ ComponentState::Processing => panic!("unexpected component state: {}", s),
+        };
+    }
 }
 
 struct UpdateComponent<COMP>
 where
-  COMP: Component,
+    COMP: Component,
 {
-  shared_state: Shared<ComponentState<COMP>>,
-  update: ComponentUpdate<COMP>,
+    shared_state: Shared<ComponentState<COMP>>,
+    update: ComponentUpdate<COMP>,
 }
 
 impl<COMP> Runnable for UpdateComponent<COMP>
 where
-  COMP: Component + Renderable<COMP>,
+    COMP: Component + Renderable<COMP>,
 {
-  fn run(self: Box<Self>) {
-    let current_state = self.shared_state.replace(ComponentState::Processing);
-    self.shared_state.replace(match current_state {
-      ComponentState::Created(mut this) => {
-        let should_update = match self.update {
-          ComponentUpdate::Message(message) => this.component.update(message),
-          ComponentUpdate::MessageBatch(messages) => messages
-            .into_iter()
-            .fold(false, |acc, msg| this.component.update(msg) || acc),
-          ComponentUpdate::Properties(props) => this.component.change(props),
-        };
-        let next_state = if should_update { this.update() } else { this };
-        ComponentState::Created(next_state)
-      }
-      ComponentState::Destroyed => current_state,
-      ComponentState::Processing | ComponentState::Ready(_) | ComponentState::Empty => {
-        panic!("unexpected component state: {}", current_state);
-      }
-    });
-  }
+    fn run(self: Box<Self>) {
+        let current_state = self.shared_state.replace(ComponentState::Processing);
+        self.shared_state.replace(match current_state {
+            ComponentState::Created(mut this) => {
+                let should_update = match self.update {
+                    ComponentUpdate::Message(message) => this.component.update(message),
+                    ComponentUpdate::MessageBatch(messages) => messages
+                        .into_iter()
+                        .fold(false, |acc, msg| this.component.update(msg) || acc),
+                    ComponentUpdate::Properties(props) => this.component.change(props),
+                };
+                let next_state = if should_update { this.update() } else { this };
+                ComponentState::Created(next_state)
+            }
+            ComponentState::Destroyed => current_state,
+            ComponentState::Processing | ComponentState::Ready(_) | ComponentState::Empty => {
+                panic!("unexpected component state: {}", current_state);
+            }
+        });
+    }
 }


### PR DESCRIPTION
Currently, the `send_back` method can only trigger one message as the callback return. but there are many common case that need trigger multiple messages, like:
I fetch a post list from server using FetchService, but I cannot fetch all the posts at once,  the common way is using a `pagination` , so suppose I have following two messages:

```rust
pub enum Msg {
   SetPosts(Vec<Post>),
   SetPagination(u32,u32,u32), // page, per_page, last_page
   // ...
}
```
So it's necessary to trigger the two Message when the request is done. `send_back` cannot do this because `Callback` only allow to return one Message， so I create the `create_effect`  method.

```rust
fn update(&mut self, msg: self::Message) -> ShouldRender {
   match msg {
      Msg::FetchPosts => {
          let callback = self.link.create_effect(
              move |response: Response<Json<Result<PostResult, Error>>>, dispatch| {
                  let (header, Json(body)) = response.into_parts();
                 if  let PostResult(posts, page, per_page, last_page) = body {
                      dispatch(Msg::SetPosts(posts));
                      dispatch(Msg::setPagination(page, per_page, last_page));
                 }
              } 
          )
         self.task = Some(self.fetch_service.fetch(request, callback));
      },
     Msg::SetPosts(posts) => {},
     Msg::SetPagination(page, per_page, last_page) => {}
      // ...
   }
}

```
There is a work example in my blog source: [kirk](https://github.com/stkevintan/Kirk/blob/master/src/app/posts.rs#L49)

This solution is much like [redux-thunk](https://github.com/reduxjs/redux-thunk#motivation) 

Besides , I am not sure to determine wether to update the  `send_back` method directly or create a new one. maybe adding a new method is the wise choice which will not cause a break change.
