### PR TITLE
Add get_ref method to ComponentLink (WIP)

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -254,6 +254,11 @@ where
     pub fn send_self(&mut self, msg: COMP::Message) {
         self.scope.send_message(msg);
     }
+
+    /// Gets the reference to the parent element.
+    pub fn get_ref(&self) -> stdweb::web::Element {
+        self.scope.get_element().expect("Component was not in either the created or ready state required to get the parent element.")
+    }
 }
 
 impl<COMP: Component> fmt::Debug for ComponentLink<COMP> {

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -73,10 +73,8 @@ where
             ComponentState::Created(created_state) => {
                 Some(created_state.element.clone()) // Is cloning the element here a good thing?
             }
-            ComponentState::Ready(ready_state) => {
-                Some(ready_state.element.clone())
-            }
-            _ => None
+            ComponentState::Ready(ready_state) => Some(ready_state.element.clone()),
+            _ => None,
         }
     }
 }

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -66,6 +66,19 @@ where
     pub fn send_message_batch(&mut self, messages: Vec<COMP::Message>) {
         self.update(ComponentUpdate::MessageBatch(messages));
     }
+
+    pub(crate) fn get_element(&self) -> Option<Element> {
+        use std::ops::Deref;
+        match self.shared_state.as_ref().borrow().deref() {
+            ComponentState::Created(created_state) => {
+                Some(created_state.element.clone()) // Is cloning the element here a good thing?
+            }
+            ComponentState::Ready(ready_state) => {
+                Some(ready_state.element.clone())
+            }
+            _ => None
+        }
+    }
 }
 
 enum ComponentState<COMP: Component> {


### PR DESCRIPTION
Allows getting the element the component is attached to via the ComponentLink.

This initial commit is rough around the edges, but exists to show an alternative to https://github.com/yewstack/yew/pull/617 so that the same feature can be introduced without a breaking change.

The benefit of this is that you can get a reference to the DOM without having to create a breaking change on `mounted`. 
The drawback is that this may more unintuitive to use, because you cannot meaningfully query the element until the html associated with the component is rendered. So in most use cases, you will get the element in `create` and have to query in in `mounted` in order to find the element you are looking for. If you query in `create` you won't find anything because the html doesn't exist yet in the DOM - this may not be obvious at first glance.