### PR TITLE
Implement From<Option<T>> for VNode where T: Into<VNode>

### DIFF
--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -131,12 +131,6 @@ macro_rules! impl_from_tostring_for_vnode {
     }
 }
 
-impl<COMP: Component> From<()> for VNode<COMP> {
-    fn from(value: ()) -> Self {
-        VNode::VList(VList { childs: vec![] })
-    }
-}
-
 impl_from_tostring_for_vnode!(
     f32,
     f64,

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -131,7 +131,15 @@ macro_rules! impl_from_tostring_for_vnode {
     }
 }
 
+impl<COMP: Component> From<()> for VNode<COMP> {
+    fn from(value: ()) -> Self {
+        VNode::VText(VText::new(value.clone()))
+    }
+}
+
 impl_from_tostring_for_vnode!(
+    f32,
+    f64,
     &str,
     Cow<'_, &str>,
     bool,

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -133,9 +133,7 @@ macro_rules! impl_from_tostring_for_vnode {
 
 impl<COMP: Component> From<()> for VNode<COMP> {
     fn from(value: ()) -> Self {
-        VNode::VList(VList {
-            childs: vec![]
-        })
+        VNode::VList(VList { childs: vec![] })
     }
 }
 

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -119,7 +119,7 @@ impl<COMP: Component> From<&String> for VNode<COMP> {
     }
 }
 /// Macro used to implement From<T> for VNode<COMP> for types that implement to_string.
-macro_rules! impl_from_for_vnode {
+macro_rules! impl_from_tostring_for_vnode {
     ($($t: ty),*) => {
         $(
         impl<COMP: Component> From<$t> for VNode<COMP> {
@@ -131,7 +131,7 @@ macro_rules! impl_from_for_vnode {
     }
 }
 
-impl_from_for_vnode!(
+impl_from_tostring_for_vnode!(
     &str,
     Cow<'_, &str>,
     bool,

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -133,7 +133,9 @@ macro_rules! impl_from_tostring_for_vnode {
 
 impl<COMP: Component> From<()> for VNode<COMP> {
     fn from(value: ()) -> Self {
-        VNode::VText(VText::new(value.clone()))
+        VNode::VList(VList {
+            childs: vec![]
+        })
     }
 }
 

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -109,7 +109,7 @@ where
 
 impl<COMP: Component> From<String> for VNode<COMP> {
     fn from(value: String) -> Self {
-        VNode::VText(VText::new(value.to_string()))
+        VNode::VText(VText::new(value))
     }
 }
 
@@ -118,18 +118,46 @@ impl<COMP: Component> From<&String> for VNode<COMP> {
         VNode::VText(VText::new(value.clone()))
     }
 }
-
-impl<COMP: Component> From<&str> for VNode<COMP> {
-    fn from(value: &str) -> Self {
-        VNode::VText(VText::new(value.to_string()))
+/// Macro used to implement From<T> for VNode<COMP> for types that implement to_string.
+macro_rules! impl_from_for_vnode {
+    ($t: ty) => {
+        impl<COMP: Component> From<$t> for VNode<COMP> {
+            fn from(value: $t) -> Self {
+                VNode::VText(VText::new(value.to_string()))
+            }
+        }
     }
 }
 
-impl<COMP: Component> From<Cow<'_, &str>> for VNode<COMP> {
-    fn from(value: Cow<'_, &str>) -> Self {
-        VNode::VText(VText::new(value.to_string()))
-    }
-}
+impl_from_for_vnode!(&str);
+impl_from_for_vnode!(Cow<'_, &str>);
+impl_from_for_vnode!(bool);
+
+impl_from_for_vnode!(usize);
+impl_from_for_vnode!(u128);
+impl_from_for_vnode!(u64);
+impl_from_for_vnode!(u32);
+impl_from_for_vnode!(u16);
+impl_from_for_vnode!(u8);
+impl_from_for_vnode!(std::num::NonZeroU128);
+impl_from_for_vnode!(std::num::NonZeroU64);
+impl_from_for_vnode!(std::num::NonZeroU32);
+impl_from_for_vnode!(std::num::NonZeroU16);
+impl_from_for_vnode!(std::num::NonZeroU8);
+
+impl_from_for_vnode!(isize);
+impl_from_for_vnode!(i128);
+impl_from_for_vnode!(i64);
+impl_from_for_vnode!(i32);
+impl_from_for_vnode!(i16);
+impl_from_for_vnode!(i8);
+impl_from_for_vnode!(std::num::NonZeroI128);
+impl_from_for_vnode!(std::num::NonZeroI64);
+impl_from_for_vnode!(std::num::NonZeroI32);
+impl_from_for_vnode!(std::num::NonZeroI16);
+impl_from_for_vnode!(std::num::NonZeroI8);
+
+
 
 impl<'a, COMP: Component> From<&'a dyn Renderable<COMP>> for VNode<COMP> {
     fn from(value: &'a dyn Renderable<COMP>) -> Self {

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -120,44 +120,44 @@ impl<COMP: Component> From<&String> for VNode<COMP> {
 }
 /// Macro used to implement From<T> for VNode<COMP> for types that implement to_string.
 macro_rules! impl_from_for_vnode {
-    ($t: ty) => {
+    ($($t: ty),*) => {
+        $(
         impl<COMP: Component> From<$t> for VNode<COMP> {
             fn from(value: $t) -> Self {
                 VNode::VText(VText::new(value.to_string()))
             }
         }
+        )*
     }
 }
 
-impl_from_for_vnode!(&str);
-impl_from_for_vnode!(Cow<'_, &str>);
-impl_from_for_vnode!(bool);
-
-impl_from_for_vnode!(usize);
-impl_from_for_vnode!(u128);
-impl_from_for_vnode!(u64);
-impl_from_for_vnode!(u32);
-impl_from_for_vnode!(u16);
-impl_from_for_vnode!(u8);
-impl_from_for_vnode!(std::num::NonZeroU128);
-impl_from_for_vnode!(std::num::NonZeroU64);
-impl_from_for_vnode!(std::num::NonZeroU32);
-impl_from_for_vnode!(std::num::NonZeroU16);
-impl_from_for_vnode!(std::num::NonZeroU8);
-
-impl_from_for_vnode!(isize);
-impl_from_for_vnode!(i128);
-impl_from_for_vnode!(i64);
-impl_from_for_vnode!(i32);
-impl_from_for_vnode!(i16);
-impl_from_for_vnode!(i8);
-impl_from_for_vnode!(std::num::NonZeroI128);
-impl_from_for_vnode!(std::num::NonZeroI64);
-impl_from_for_vnode!(std::num::NonZeroI32);
-impl_from_for_vnode!(std::num::NonZeroI16);
-impl_from_for_vnode!(std::num::NonZeroI8);
-
-
+impl_from_for_vnode!(
+    &str,
+    Cow<'_, &str>,
+    bool,
+    usize,
+    u128,
+    u64,
+    u32,
+    u16,
+    u8,
+    std::num::NonZeroU128,
+    std::num::NonZeroU64,
+    std::num::NonZeroU32,
+    std::num::NonZeroU16,
+    std::num::NonZeroU8,
+    isize,
+    i128,
+    i64,
+    i32,
+    i16,
+    i8,
+    std::num::NonZeroI128,
+    std::num::NonZeroI64,
+    std::num::NonZeroI32,
+    std::num::NonZeroI16,
+    std::num::NonZeroI8
+);
 
 impl<'a, COMP: Component> From<&'a dyn Renderable<COMP>> for VNode<COMP> {
     fn from(value: &'a dyn Renderable<COMP>) -> Self {

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -132,6 +132,7 @@ macro_rules! impl_from_tostring_for_vnode {
 }
 
 impl_from_tostring_for_vnode!(
+    char,
     f32,
     f64,
     &str,

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -2,6 +2,7 @@
 
 use super::{VChild, VComp, VDiff, VList, VTag, VText};
 use crate::html::{Component, Renderable, Scope};
+use std::borrow::Cow;
 use std::cmp::PartialEq;
 use std::fmt;
 use std::iter::FromIterator;
@@ -106,8 +107,26 @@ where
     }
 }
 
-impl<COMP: Component, T: ToString> From<T> for VNode<COMP> {
-    fn from(value: T) -> Self {
+impl<COMP: Component> From<String> for VNode<COMP> {
+    fn from(value: String) -> Self {
+        VNode::VText(VText::new(value.to_string()))
+    }
+}
+
+impl<COMP: Component> From<&String> for VNode<COMP> {
+    fn from(value: &String) -> Self {
+        VNode::VText(VText::new(value.clone()))
+    }
+}
+
+impl<COMP: Component> From<&str> for VNode<COMP> {
+    fn from(value: &str) -> Self {
+        VNode::VText(VText::new(value.to_string()))
+    }
+}
+
+impl<COMP: Component> From<Cow<'_, &str>> for VNode<COMP> {
+    fn from(value: Cow<'_, &str>) -> Self {
         VNode::VText(VText::new(value.to_string()))
     }
 }
@@ -115,6 +134,15 @@ impl<COMP: Component, T: ToString> From<T> for VNode<COMP> {
 impl<'a, COMP: Component> From<&'a dyn Renderable<COMP>> for VNode<COMP> {
     fn from(value: &'a dyn Renderable<COMP>) -> Self {
         value.view()
+    }
+}
+
+impl<COMP: Component, T: Into<VNode<COMP>>> From<Option<T>> for VNode<COMP> {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(vnode) => vnode.into(),
+            None => VNode::VList(VList { childs: vec![] }),
+        }
     }
 }
 


### PR DESCRIPTION
Another ergonomic change.
Also a breaking change, and because of that, I don't expect it to be merged - Something like this might need to wait until specialization lands.

The breakage is from removing
```rust
impl<COMP: Component, T: ToString> From<T> for VNode<COMP>
```
and replacing it with an impl for ~every string type~ a bunch of stuff in `std`. This won't cause breakages except for in cases where people were relying on non-string items that implemented `ToString` to be automatically turned into text nodes by the `html!` macro. I expect this to be relatively rare. The quick fix for those problems is manually calling `to_string()` on the values where the breakages occur.

The benefit of this change is in allowing patterns like:
```rust
let x: Option<Html<Self>> = self.value.map(|v| html!{<Comp value=value />});

html! {
    // some other html
    x
}
```

instead of:
```rust
let x = if let Some(value) = self.value {
    html!{<Comp value=value />}
} else {
    html!{}
};

html! {
    // some other html
    x
}
```

My loosely held opinion is that the ergonomic benefit of using `Option<VNode<_>>` is more worthwhile than the benefit of avoiding calling `to_string()` on arbitrary stringable types and the breaking change to remove that functionality.


