### PR TITLE
Implement Default for VNode

### DIFF
--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -72,6 +72,12 @@ impl<COMP: Component> VDiff for VNode<COMP> {
     }
 }
 
+impl <COMP: Component> Default for VNode<COMP> {
+    fn default() -> Self {
+        VNode::VList(VList::new())
+    }
+}
+
 impl<COMP: Component> From<VText<COMP>> for VNode<COMP> {
     fn from(vtext: VText<COMP>) -> Self {
         VNode::VText(vtext)

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -72,7 +72,7 @@ impl<COMP: Component> VDiff for VNode<COMP> {
     }
 }
 
-impl <COMP: Component> Default for VNode<COMP> {
+impl<COMP: Component> Default for VNode<COMP> {
     fn default() -> Self {
         VNode::VList(VList::new())
     }


### PR DESCRIPTION
This is can provide ergonomic benefits by enabling `.unwrap_or_default()` to be called on `Option<Html<Self>>`, which might reduce the pain of having to write `else {html!{}}` blocks.