### PR TITLE
Forbid missing Debug implementations

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -68,6 +68,13 @@ impl HandlerId {
     }
 }
 
+
+impl fmt::Debug for HandlerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("HandlerId")
+    }
+}
+
 /// This trait allows registering or getting the address of a worker.
 pub trait Bridged: Agent + Sized + 'static {
     /// Creates a messaging bridge between a worker and the component.
@@ -249,6 +256,7 @@ thread_local! {
 }
 
 /// Create a single instance in the current thread.
+#[allow(missing_debug_implementations)]
 pub struct Context;
 
 impl Discoverer for Context {
@@ -344,6 +352,7 @@ impl<AGN: Agent> Drop for ContextBridge<AGN> {
 }
 
 /// Create an instance in the current thread.
+#[allow(missing_debug_implementations)]
 pub struct Job;
 
 impl Discoverer for Job {
@@ -397,6 +406,7 @@ impl<AGN: Agent> Drop for JobBridge<AGN> {
 // <<< SEPARATE THREAD >>>
 
 /// Create a new instance for every bridge.
+#[allow(missing_debug_implementations)]
 pub struct Private;
 
 impl Discoverer for Private {
@@ -436,6 +446,12 @@ impl Discoverer for Private {
 pub struct PrivateBridge<T: Agent> {
     worker: Value,
     _agent: PhantomData<T>,
+}
+
+impl <AGN: Agent> fmt::Debug for PrivateBridge<AGN> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PrivateBridge<_>")
+    }
 }
 
 impl<AGN: Agent> Bridge<AGN> for PrivateBridge<AGN> {
@@ -494,6 +510,7 @@ thread_local! {
 }
 
 /// Create a single instance in a tab.
+#[allow(missing_debug_implementations)]
 pub struct Public;
 
 impl Discoverer for Public {
@@ -555,10 +572,17 @@ impl Discoverer for Public {
 impl Dispatchable for Public {}
 
 /// A connection manager for components interaction with workers.
-pub struct PublicBridge<T: Agent> {
+pub struct PublicBridge<AGN: Agent> {
     worker: Value,
     id: HandlerId,
-    _agent: PhantomData<T>,
+    _agent: PhantomData<AGN>,
+}
+
+
+impl <AGN: Agent> fmt::Debug for PublicBridge<AGN> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PublicBridge<_>")
+    }
 }
 
 impl<AGN: Agent> PublicBridge<AGN> {
@@ -636,6 +660,7 @@ impl<AGN: Agent> Drop for PublicBridge<AGN> {
 }
 
 /// Create a single instance in a browser.
+#[allow(missing_debug_implementations)]
 pub struct Global;
 
 impl Discoverer for Global {}
@@ -679,6 +704,12 @@ pub trait Agent: Sized + 'static {
 /// This struct holds a reference to a component and to a global scheduler.
 pub struct AgentScope<AGN: Agent> {
     shared_agent: Shared<AgentRunnable<AGN>>,
+}
+
+impl <AGN: Agent> fmt::Debug for AgentScope<AGN> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("AgentScope<_>")
+    }
 }
 
 impl<AGN: Agent> Clone for AgentScope<AGN> {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -52,7 +52,7 @@ impl<T: Serialize + for<'de> Deserialize<'de>> Packed for T {
 type SharedOutputSlab<AGN> = Shared<Slab<Option<Callback<<AGN as Agent>::Output>>>>;
 
 /// Id of responses handler.
-#[derive(Serialize, Deserialize, Eq, PartialEq, Hash, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Clone, Copy)]
 pub struct HandlerId(usize, bool);
 
 impl HandlerId {
@@ -65,12 +65,6 @@ impl HandlerId {
     /// Indicates if a handler id corresponds to callback in the Agent runtime.
     pub fn is_respondable(&self) -> bool {
         self.1
-    }
-}
-
-impl fmt::Debug for HandlerId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("HandlerId")
     }
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -68,7 +68,6 @@ impl HandlerId {
     }
 }
 
-
 impl fmt::Debug for HandlerId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("HandlerId")
@@ -448,7 +447,7 @@ pub struct PrivateBridge<T: Agent> {
     _agent: PhantomData<T>,
 }
 
-impl <AGN: Agent> fmt::Debug for PrivateBridge<AGN> {
+impl<AGN: Agent> fmt::Debug for PrivateBridge<AGN> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("PrivateBridge<_>")
     }
@@ -578,8 +577,7 @@ pub struct PublicBridge<AGN: Agent> {
     _agent: PhantomData<AGN>,
 }
 
-
-impl <AGN: Agent> fmt::Debug for PublicBridge<AGN> {
+impl<AGN: Agent> fmt::Debug for PublicBridge<AGN> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("PublicBridge<_>")
     }
@@ -706,7 +704,7 @@ pub struct AgentScope<AGN: Agent> {
     shared_agent: Shared<AgentRunnable<AGN>>,
 }
 
-impl <AGN: Agent> fmt::Debug for AgentScope<AGN> {
+impl<AGN: Agent> fmt::Debug for AgentScope<AGN> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("AgentScope<_>")
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use crate::html::{Component, Renderable, Scope};
 use stdweb::web::{document, Element, INode, IParentNode};
 
 /// An application instance.
+#[derive(Debug)]
 pub struct App<COMP: Component> {
     /// `Scope` holder
     scope: Scope<COMP>,

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -20,18 +20,20 @@ use crate::html::{ChangeData, Component, ComponentLink, Html, Renderable, Should
 use crate::macros::{html, Properties};
 
 /// `Select` component.
+#[derive(Debug)]
 pub struct Select<T> {
     props: Props<T>,
 }
 
 /// Internal message of the component.
+#[derive(Debug)]
 pub enum Msg {
     /// This message indicates the option with id selected.
     Selected(Option<usize>),
 }
 
 /// Properties of `Select` component.
-#[derive(PartialEq, Properties)]
+#[derive(PartialEq, Properties, Debug)]
 pub struct Props<T> {
     /// Initially selected value.
     pub selected: Option<T>,

--- a/src/format/cbor.rs
+++ b/src/format/cbor.rs
@@ -12,6 +12,7 @@ use serde_cbor;
 /// // Converts CBOR string to a data (lazy).
 /// let Cbor(data) = dump;
 /// ```
+#[derive(Debug)]
 pub struct Cbor<T>(pub T);
 
 binary_format!(Cbor based on serde_cbor);

--- a/src/format/json.rs
+++ b/src/format/json.rs
@@ -10,6 +10,7 @@
 /// // Converts JSON string to a data (lazy).
 /// let Json(data) = dump;
 /// ```
+#[derive(Debug)]
 pub struct Json<T>(pub T);
 
 text_format!(Json based on serde_json);

--- a/src/format/msgpack.rs
+++ b/src/format/msgpack.rs
@@ -12,6 +12,7 @@ use rmp_serde;
 /// // Converts MessagePack string to a data (lazy).
 /// let MsgPack(data) = dump;
 /// ```
+#[derive(Debug)]
 pub struct MsgPack<T>(pub T);
 
 binary_format!(MsgPack based on rmp_serde);

--- a/src/format/nothing.rs
+++ b/src/format/nothing.rs
@@ -4,6 +4,7 @@ use super::{Binary, Text};
 use failure::err_msg;
 
 /// A representation of an empty data. Nothing stored. Nothing restored.
+#[derive(Debug)]
 pub struct Nothing;
 
 impl Into<Text> for Nothing {

--- a/src/format/toml.rs
+++ b/src/format/toml.rs
@@ -12,6 +12,7 @@ use toml;
 /// // Converts TOML string to a data (lazy).
 /// let Toml(data) = dump;
 /// ```
+#[derive(Debug)]
 pub struct Toml<T>(pub T);
 
 text_format!(Toml based on toml);

--- a/src/format/yaml.rs
+++ b/src/format/yaml.rs
@@ -12,6 +12,7 @@ use serde_yaml;
 /// // Converts YAML string to a data (lazy).
 /// let Yaml(data) = dump;
 /// ```
+#[derive(Debug)]
 pub struct Yaml<T>(pub T);
 
 text_format!(Yaml based on serde_yaml);

--- a/src/html/listener.rs
+++ b/src/html/listener.rs
@@ -17,6 +17,7 @@ macro_rules! impl_action {
 
             /// A wrapper for a callback.
             /// Listener extracted from here when attached.
+            #[allow(missing_debug_implementations)]
             pub struct Wrapper<F>(Option<F>);
 
             /// And event type which keeps the returned type.

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -193,6 +193,7 @@ pub trait Properties {
 }
 
 /// Builder for when a component has no properties
+#[derive(Debug)]
 pub struct EmptyBuilder;
 
 impl Properties for () {

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -25,6 +25,12 @@ pub struct Scope<COMP: Component> {
     shared_state: Shared<ComponentState<COMP>>,
 }
 
+impl<COMP: Component> fmt::Debug for Scope<COMP> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Scope<_>")
+    }
+}
+
 impl<COMP: Component> Clone for Scope<COMP> {
     fn clone(&self) -> Self {
         Scope {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 
 #![deny(
     missing_docs,
+    missing_debug_implementations,
     bare_trait_objects,
     anonymous_parameters,
     elided_lifetimes_in_paths

--- a/src/services/console.rs
+++ b/src/services/console.rs
@@ -5,7 +5,7 @@ use stdweb::{_js_impl, js};
 
 /// A service to use methods of a
 /// [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console).
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ConsoleService {}
 
 impl ConsoleService {

--- a/src/services/dialog.rs
+++ b/src/services/dialog.rs
@@ -6,7 +6,7 @@ use stdweb::Value;
 use stdweb::{_js_impl, js};
 
 /// A dialog service.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct DialogService {}
 
 impl DialogService {

--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -12,11 +12,12 @@ use stdweb::web::ArrayBuffer;
 use stdweb::{JsSerialize, Value};
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
+use std::fmt;
 
 pub use http::{HeaderMap, Method, Request, Response, StatusCode, Uri};
 
 /// Type to set cache for fetch.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub enum Cache {
     /// `default` value of cache.
@@ -35,7 +36,7 @@ pub enum Cache {
 }
 
 /// Type to set credentials for fetch.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub enum Credentials {
     /// `omit` value of credentials.
@@ -47,7 +48,7 @@ pub enum Credentials {
 }
 
 /// Type to set mode for fetch.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub enum Mode {
     /// `same-origin` value of mode.
@@ -59,7 +60,7 @@ pub enum Mode {
 }
 
 /// Type to set redirect behaviour for fetch.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub enum Redirect {
     /// `follow` value of redirect.
@@ -72,7 +73,7 @@ pub enum Redirect {
 
 /// Init options for `fetch()` function call.
 /// https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
-#[derive(Serialize, Default)]
+#[derive(Serialize, Default, Debug)]
 pub struct FetchOptions {
     /// Cache of a fetch request.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -99,8 +100,15 @@ enum FetchError {
 #[must_use]
 pub struct FetchTask(Option<Value>);
 
+
+impl fmt::Debug for FetchTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("FetchTask")
+    }
+}
+
 /// A service to fetch resources.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct FetchService {}
 
 impl FetchService {

--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -6,13 +6,13 @@ use crate::format::{Binary, Format, Text};
 use failure::Fail;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::fmt;
 use stdweb::serde::Serde;
 use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::web::ArrayBuffer;
 use stdweb::{JsSerialize, Value};
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
-use std::fmt;
 
 pub use http::{HeaderMap, Method, Request, Response, StatusCode, Uri};
 
@@ -99,7 +99,6 @@ enum FetchError {
 /// A handle to control sent requests. Can be canceled with a `Task::cancel` call.
 #[must_use]
 pub struct FetchTask(Option<Value>);
-
 
 impl fmt::Debug for FetchTask {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -3,11 +3,11 @@
 
 use super::{to_ms, Task};
 use crate::callback::Callback;
+use std::fmt;
 use std::time::Duration;
 use stdweb::Value;
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
-use std::fmt;
 
 /// A handle which helps to cancel interval. Uses
 /// [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval).

--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -7,14 +7,21 @@ use std::time::Duration;
 use stdweb::Value;
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
+use std::fmt;
 
 /// A handle which helps to cancel interval. Uses
 /// [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval).
 #[must_use]
 pub struct IntervalTask(Option<Value>);
 
+impl fmt::Debug for IntervalTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("IntervalTask")
+    }
+}
+
 /// A service to send messages on every elapsed interval.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct IntervalService {}
 
 impl IntervalService {

--- a/src/services/keyboard.rs
+++ b/src/services/keyboard.rs
@@ -1,8 +1,8 @@
 //! Service to register key press event listeners on elements.
 use crate::callback::Callback;
+use std::fmt;
 use stdweb::web::event::{KeyDownEvent, KeyPressEvent, KeyUpEvent};
 use stdweb::web::{EventListenerHandle, IEventTarget};
-use std::fmt;
 
 /// Service for registering callbacks on elements to get keystrokes from the user.
 ///

--- a/src/services/keyboard.rs
+++ b/src/services/keyboard.rs
@@ -2,6 +2,7 @@
 use crate::callback::Callback;
 use stdweb::web::event::{KeyDownEvent, KeyPressEvent, KeyUpEvent};
 use stdweb::web::{EventListenerHandle, IEventTarget};
+use std::fmt;
 
 /// Service for registering callbacks on elements to get keystrokes from the user.
 ///
@@ -12,12 +13,19 @@ use stdweb::web::{EventListenerHandle, IEventTarget};
 ///
 /// This service is for adding key event listeners to elements that don't support these attributes,
 /// like the `document` or `<canvas>` elements for example.
+#[derive(Debug)]
 pub struct KeyboardService {}
 
 /// Handle to the key event listener.
 ///
 /// When it goes out of scope, the listener will be removed from the element.
 pub struct KeyListenerHandle(Option<EventListenerHandle>);
+
+impl fmt::Debug for KeyListenerHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("KeyListenerHandle")
+    }
+}
 
 impl KeyboardService {
     /// Registers a callback that listens to KeyPressEvents on a provided element.

--- a/src/services/reader.rs
+++ b/src/services/reader.rs
@@ -9,6 +9,7 @@ pub use stdweb::web::{Blob, File, IBlob};
 use stdweb::web::{FileReader, FileReaderReadyState, FileReaderResult, IEventTarget, TypedArray};
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
+use std::fmt;
 
 /// Struct that represents data of a file.
 #[derive(Clone, Debug)]
@@ -39,7 +40,7 @@ pub enum FileChunk {
 }
 
 /// A reader service attached to a user context.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ReaderService {}
 
 impl ReaderService {
@@ -133,6 +134,12 @@ impl ReaderService {
 #[must_use]
 pub struct ReaderTask {
     file_reader: FileReader,
+}
+
+impl fmt::Debug for ReaderTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ReaderTask")
+    }
 }
 
 impl Task for ReaderTask {

--- a/src/services/reader.rs
+++ b/src/services/reader.rs
@@ -3,13 +3,13 @@
 use super::Task;
 use crate::callback::Callback;
 use std::cmp;
+use std::fmt;
 use stdweb::unstable::TryInto;
 use stdweb::web::event::LoadEndEvent;
 pub use stdweb::web::{Blob, File, IBlob};
 use stdweb::web::{FileReader, FileReaderReadyState, FileReaderResult, IEventTarget, TypedArray};
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
-use std::fmt;
 
 /// Struct that represents data of a file.
 #[derive(Clone, Debug)]

--- a/src/services/render.rs
+++ b/src/services/render.rs
@@ -7,13 +7,20 @@ use stdweb::unstable::TryInto;
 use stdweb::Value;
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
+use std::fmt;
 
 /// A handle to cancel a render task.
 #[must_use]
 pub struct RenderTask(Option<Value>);
 
+impl fmt::Debug for RenderTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("RenderTask")
+    }
+}
+
 /// A service to request animation frames.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RenderService {}
 
 impl RenderService {

--- a/src/services/render.rs
+++ b/src/services/render.rs
@@ -3,11 +3,11 @@
 
 use crate::callback::Callback;
 use crate::services::Task;
+use std::fmt;
 use stdweb::unstable::TryInto;
 use stdweb::Value;
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
-use std::fmt;
 
 /// A handle to cancel a render task.
 #[must_use]

--- a/src/services/resize.rs
+++ b/src/services/resize.rs
@@ -1,11 +1,11 @@
 //! This module contains the implementation of a service that listens for browser window resize events.
+use std::fmt;
 use stdweb::Value;
 use stdweb::{
     js,
     web::{window, Window},
 };
 use yew::callback::Callback;
-use std::fmt;
 
 /// A service that fires events when the browser window resizes.
 #[derive(Default, Debug)]

--- a/src/services/resize.rs
+++ b/src/services/resize.rs
@@ -5,16 +5,24 @@ use stdweb::{
     web::{window, Window},
 };
 use yew::callback::Callback;
+use std::fmt;
 
 /// A service that fires events when the browser window resizes.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ResizeService {}
 
 /// A handle to the event listener for resize events.
 #[must_use]
 pub struct ResizeTask(Option<Value>);
 
+impl fmt::Debug for ResizeTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ResizeTask")
+    }
+}
+
 /// Dimensions of the window.
+#[derive(Debug)]
 pub struct WindowDimensions {
     /// The width of the viewport of the browser window.
     pub width: i32,

--- a/src/services/storage.rs
+++ b/src/services/storage.rs
@@ -3,8 +3,8 @@
 
 use crate::format::Text;
 use failure::Fail;
-use stdweb::web::{window, Storage};
 use std::fmt;
+use stdweb::web::{window, Storage};
 
 /// Represents errors of a storage.
 #[derive(Debug, Fail)]

--- a/src/services/storage.rs
+++ b/src/services/storage.rs
@@ -4,6 +4,7 @@
 use crate::format::Text;
 use failure::Fail;
 use stdweb::web::{window, Storage};
+use std::fmt;
 
 /// Represents errors of a storage.
 #[derive(Debug, Fail)]
@@ -13,6 +14,7 @@ enum StorageError {
 }
 
 /// An area to keep the data in.
+#[derive(Debug)]
 pub enum Area {
     /// Use `localStorage` of a browser.
     Local,
@@ -23,6 +25,12 @@ pub enum Area {
 /// A storage service attached to a context.
 pub struct StorageService {
     storage: Storage,
+}
+
+impl fmt::Debug for StorageService {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("StorageService")
+    }
 }
 
 impl StorageService {

--- a/src/services/timeout.rs
+++ b/src/services/timeout.rs
@@ -3,16 +3,15 @@
 
 use super::{to_ms, Task};
 use crate::callback::Callback;
+use std::fmt;
 use std::time::Duration;
 use stdweb::Value;
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
-use std::fmt;
 
 /// A handle to cancel a timeout task.
 #[must_use]
 pub struct TimeoutTask(Option<Value>);
-
 
 impl fmt::Debug for TimeoutTask {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/services/timeout.rs
+++ b/src/services/timeout.rs
@@ -7,13 +7,21 @@ use std::time::Duration;
 use stdweb::Value;
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
+use std::fmt;
 
 /// A handle to cancel a timeout task.
 #[must_use]
 pub struct TimeoutTask(Option<Value>);
 
+
+impl fmt::Debug for TimeoutTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("TimeoutTask")
+    }
+}
+
 /// An service to set a timeout.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct TimeoutService {}
 
 impl TimeoutService {

--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -4,10 +4,10 @@
 use super::Task;
 use crate::callback::Callback;
 use crate::format::{Binary, Text};
+use std::fmt;
 use stdweb::traits::IMessageEvent;
 use stdweb::web::event::{SocketCloseEvent, SocketErrorEvent, SocketMessageEvent, SocketOpenEvent};
 use stdweb::web::{IEventTarget, SocketBinaryType, SocketReadyState, WebSocket};
-use std::fmt;
 
 /// A status of a websocket connection. Used for status notification.
 #[derive(Debug)]

--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -7,9 +7,10 @@ use crate::format::{Binary, Text};
 use stdweb::traits::IMessageEvent;
 use stdweb::web::event::{SocketCloseEvent, SocketErrorEvent, SocketMessageEvent, SocketOpenEvent};
 use stdweb::web::{IEventTarget, SocketBinaryType, SocketReadyState, WebSocket};
+use std::fmt;
 
-#[derive(Debug)]
 /// A status of a websocket connection. Used for status notification.
+#[derive(Debug)]
 pub enum WebSocketStatus {
     /// Fired when a websocket connection was opened.
     Opened,
@@ -26,8 +27,14 @@ pub struct WebSocketTask {
     notification: Callback<WebSocketStatus>,
 }
 
+impl fmt::Debug for WebSocketTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("WebSocketTask")
+    }
+}
+
 /// A websocket service attached to a user context.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct WebSocketService {}
 
 impl WebSocketService {

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -8,6 +8,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use stdweb::unstable::TryInto;
 use stdweb::web::{document, Element, INode, Node};
+use std::fmt;
 
 struct Hidden;
 
@@ -31,12 +32,25 @@ pub struct VComp<COMP: Component> {
     state: Rc<RefCell<MountState<COMP>>>,
 }
 
+impl <COMP: Component> fmt::Debug for VComp<COMP> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("VComp<_>")
+    }
+}
+
 /// A virtual child component.
 pub struct VChild<SELF: Component, PARENT: Component> {
     /// The component properties
     pub props: SELF::Properties,
     /// The parent component scope
     pub scope: ScopeHolder<PARENT>,
+}
+
+
+impl <SELF: Component, PARENT: Component> fmt::Debug for VChild<SELF, PARENT> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("VChild<_,_>")
+    }
 }
 
 impl<SELF, PARENT> VChild<SELF, PARENT>

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -5,10 +5,10 @@ use crate::callback::Callback;
 use crate::html::{Component, ComponentUpdate, NodeCell, Renderable, Scope};
 use std::any::TypeId;
 use std::cell::RefCell;
+use std::fmt;
 use std::rc::Rc;
 use stdweb::unstable::TryInto;
 use stdweb::web::{document, Element, INode, Node};
-use std::fmt;
 
 struct Hidden;
 
@@ -32,7 +32,7 @@ pub struct VComp<COMP: Component> {
     state: Rc<RefCell<MountState<COMP>>>,
 }
 
-impl <COMP: Component> fmt::Debug for VComp<COMP> {
+impl<COMP: Component> fmt::Debug for VComp<COMP> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("VComp<_>")
     }
@@ -46,8 +46,7 @@ pub struct VChild<SELF: Component, PARENT: Component> {
     pub scope: ScopeHolder<PARENT>,
 }
 
-
-impl <SELF: Component, PARENT: Component> fmt::Debug for VChild<SELF, PARENT> {
+impl<SELF: Component, PARENT: Component> fmt::Debug for VChild<SELF, PARENT> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("VChild<_,_>")
     }

--- a/src/virtual_dom/vlist.rs
+++ b/src/virtual_dom/vlist.rs
@@ -4,6 +4,7 @@ use crate::html::{Component, Scope};
 use stdweb::web::{Element, Node};
 
 /// This struct represents a fragment of the Virtual DOM tree.
+#[derive(Debug)]
 pub struct VList<COMP: Component> {
     /// The list of children nodes. Which also could have their own children.
     pub childs: Vec<VNode<COMP>>,


### PR DESCRIPTION
Denies any public type from missing a debug implementation.

Some exceptions are made for rarely used types, and types that are only used as reach associated type parameters to agents.

This offers the peace of mind that any end-user can just slap a `#[derive(Debug)]` on their component, and it will compile without them having to do a custom debug impl.

The trade off is slightly longer compile times, and likely a more bloated WASM binary.


-----------------
There was a recent addition in rust 1.38.0 of [std::any::type_name](https://blog.rust-lang.org/2019/09/26/Rust-1.38.0.html#std:any::type_name).

This would allow yew to offer better information about what inner types our opaque and generic types correspond to instead of just punting and saying `"Opaque<_>"` for our debug strings.
Since this would require a bump to a higher version of rustc to support this, I didn't include it, because it isn't worth that for marginally better debug diagnostics.

Its just another thing to keep in the back of your mind if the minimum supported version is ever raised.