### PR TITLE
Derive PartialEq for Classes

### DIFF
--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -41,7 +41,7 @@ type Listeners<COMP> = Vec<Box<dyn Listener<COMP>>>;
 type Attributes = HashMap<String, String>;
 
 /// A set of classes.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Classes {
     set: IndexSet<String>,
 }


### PR DESCRIPTION
I want to pass structured classes via props, but not have them interfere with my ability to reassign and rerender those props in `change` using shortcut methods that depend on PartialEq being implemented on my Props.
Adding PartialEq to Classes removes the trouble of having to manually implement PartialEq for the entire Props if Classes is part of it.