### PR TITLE
Use trait objects with explicit `dyn` in examples

### DIFF
--- a/examples/game_of_life/src/lib.rs
+++ b/examples/game_of_life/src/lib.rs
@@ -23,7 +23,7 @@ pub struct Model {
     cellules_width: usize,
     cellules_height: usize,
     #[allow(unused)]
-    job: Box<Task>,
+    job: Box<dyn Task>,
 }
 
 impl Cellule {

--- a/examples/multi_thread/src/context.rs
+++ b/examples/multi_thread/src/context.rs
@@ -24,7 +24,7 @@ pub enum Msg {
 pub struct Worker {
     link: AgentLink<Worker>,
     interval: IntervalService,
-    task: Box<Task>,
+    task: Box<dyn Task>,
     fetch: FetchService,
 }
 

--- a/examples/multi_thread/src/job.rs
+++ b/examples/multi_thread/src/job.rs
@@ -24,7 +24,7 @@ pub enum Msg {
 pub struct Worker {
     link: AgentLink<Worker>,
     interval: IntervalService,
-    task: Box<Task>,
+    task: Box<dyn Task>,
     fetch: FetchService,
 }
 

--- a/examples/multi_thread/src/lib.rs
+++ b/examples/multi_thread/src/lib.rs
@@ -9,10 +9,10 @@ use yew::worker::*;
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
 
 pub struct Model {
-    worker: Box<Bridge<native_worker::Worker>>,
-    job: Box<Bridge<job::Worker>>,
-    context: Box<Bridge<context::Worker>>,
-    context_2: Box<Bridge<context::Worker>>,
+    worker: Box<dyn Bridge<native_worker::Worker>>,
+    job: Box<dyn Bridge<job::Worker>>,
+    context: Box<dyn Bridge<context::Worker>>,
+    context_2: Box<dyn Bridge<context::Worker>>,
 }
 
 pub enum Msg {

--- a/examples/multi_thread/src/native_worker.rs
+++ b/examples/multi_thread/src/native_worker.rs
@@ -24,7 +24,7 @@ pub enum Msg {
 pub struct Worker {
     link: AgentLink<Worker>,
     interval: IntervalService,
-    task: Box<Task>,
+    task: Box<dyn Task>,
     fetch: FetchService,
 }
 

--- a/examples/timer/src/lib.rs
+++ b/examples/timer/src/lib.rs
@@ -10,9 +10,9 @@ pub struct Model {
     console: ConsoleService,
     callback_tick: Callback<()>,
     callback_done: Callback<()>,
-    job: Option<Box<Task>>,
+    job: Option<Box<dyn Task>>,
     messages: Vec<&'static str>,
-    _standalone: Box<Task>,
+    _standalone: Box<dyn Task>,
 }
 
 pub enum Msg {


### PR DESCRIPTION
Fixes #685

Address deprecations warnings in the examples directory:

warning: trait objects without an explicit `dyn` are deprecated