### PR TITLE
examples/large_table: Fix deprecation warning

### DIFF
--- a/examples/large_table/static/index.html
+++ b/examples/large_table/static/index.html
@@ -6,6 +6,6 @@
         <link rel="stylesheet" href="styles.css">
     </head>
     <body>
-        <script src="js/app.js"></script>
+        <script src="/large_table.js"></script>
     </body>
 </html>


### PR DESCRIPTION
This fixes the `cargo web start` deprecation warning:

```
WARNING: `/js/app.js` is deprecated; you should update your HTML file to use `/large_table.js` instead!
```