### PR TITLE
Allow to extend agent communication from external crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ ryu = "=1.0.0" # 1.0.1 breaks emscripten
 serde_derive = "1"
 trybuild = "1.0"
 rustversion = "0.1"
+toml = "=0.5.3"
 
 [target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dev-dependencies]
 wasm-bindgen-test = "=0.2.50"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ ryu = "=1.0.0" # 1.0.1 breaks emscripten
 serde_derive = "1"
 trybuild = "1.0"
 rustversion = "0.1"
-toml = "=0.5.3"
 
 [target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dev-dependencies]
 wasm-bindgen-test = "=0.2.50"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -18,23 +18,33 @@ use stdweb::Value;
 #[allow(unused_imports)]
 use stdweb::{_js_impl, js};
 
-#[derive(Serialize, Deserialize)]
-enum ToWorker<T> {
+/// Serializable messages to worker
+#[derive(Serialize, Deserialize, Debug)]
+pub enum ToWorker<T> {
+    /// Client is connected
     Connected(HandlerId),
+    /// Incoming message to Worker
     ProcessInput(HandlerId, T),
+    /// Client is disconnected
     Disconnected(HandlerId),
+    /// Worker should be terminated
     Destroy,
 }
 
-#[derive(Serialize, Deserialize)]
-enum FromWorker<T> {
+/// Serializable messages sent by worker to consumer
+#[derive(Serialize, Deserialize, Debug)]
+pub enum FromWorker<T> {
     /// Worker sends this message when `wasm` bundle has loaded.
     WorkerLoaded,
+    /// Outgoing message to consumer
     ProcessOutput(HandlerId, T),
 }
 
-trait Packed {
+/// Message packager, based on serde::Serialize/Deserialize
+pub trait Packed {
+    /// Pack serializable message into Vec<u8>
     fn pack(&self) -> Vec<u8>;
+    /// Unpack deserializable message of byte slice
     fn unpack(data: &[u8]) -> Self;
 }
 
@@ -713,12 +723,13 @@ impl<AGN: Agent> Clone for AgentScope<AGN> {
 }
 
 impl<AGN: Agent> AgentScope<AGN> {
-    fn new() -> Self {
+    /// Create agent scope
+    pub fn new() -> Self {
         let shared_agent = Rc::new(RefCell::new(AgentRunnable::new()));
         AgentScope { shared_agent }
     }
-
-    fn send(&self, update: AgentUpdate<AGN>) {
+    /// Schedule message for sending to agent
+    pub fn send(&self, update: AgentUpdate<AGN>) {
         let envelope = AgentEnvelope {
             shared_agent: self.shared_agent.clone(),
             update,
@@ -728,7 +739,9 @@ impl<AGN: Agent> AgentScope<AGN> {
     }
 }
 
-trait Responder<AGN: Agent> {
+/// Defines communication from Worker to Consumers
+pub trait Responder<AGN: Agent> {
+    /// Implementation for communication channel from Worker to Consumers
     fn response(&self, id: HandlerId, output: AGN::Output);
 }
 
@@ -753,7 +766,7 @@ pub struct AgentLink<AGN: Agent> {
 
 impl<AGN: Agent> AgentLink<AGN> {
     /// Create link for a scope.
-    fn connect<T>(scope: &AgentScope<AGN>, responder: T) -> Self
+    pub fn connect<T>(scope: &AgentScope<AGN>, responder: T) -> Self
     where
         T: Responder<AGN> + 'static,
     {
@@ -804,12 +817,20 @@ impl<AGN> AgentRunnable<AGN> {
     }
 }
 
-enum AgentUpdate<AGN: Agent> {
+/// Local Agent messages
+#[derive(Debug)]
+pub enum AgentUpdate<AGN: Agent> {
+    /// Request to create link
     Create(AgentLink<AGN>),
+    /// Internal Agent message
     Message(AGN::Message),
+    /// Client connected
     Connected(HandlerId),
+    /// Received mesasge from Client
     Input(AGN::Input, HandlerId),
+    /// Client disconnected
     Disconnected(HandlerId),
+    /// Request to destroy agent
     Destroy,
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -739,6 +739,12 @@ impl<AGN: Agent> AgentScope<AGN> {
     }
 }
 
+impl<AGN: Agent> Default for AgentScope<AGN> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Defines communication from Worker to Consumers
 pub trait Responder<AGN: Agent> {
     /// Implementation for communication channel from Worker to Consumers


### PR DESCRIPTION
Fixed and reopened #719

This PR will open communication data structures to allow external crates to implement custom Agents for their purposes. For example wasi worker implementation which provides ~2x faster execution for wasm target https://github.com/dunnock/wasi-worker.

After opening structures it will be possible to implement custom trait for Agent with Reach=Public to allow custom initialization, also it will allow to provide custom implementation for Responder trait. It should be enough to have custom Agent implementation to be able to communicate with main yew application. Example https://github.com/dunnock/wasi-worker/blob/master/examples/yewworker/src/main.rs