### PR TITLE
Remove event handler debug message

### DIFF
--- a/src/html/listener.rs
+++ b/src/html/listener.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::virtual_dom::Listener;
-use log::debug;
 use stdweb::web::html_element::SelectElement;
 #[allow(unused_imports)]
 use stdweb::web::{EventListenerHandle, FileList, INode};
@@ -47,7 +46,6 @@ macro_rules! impl_action {
                     let handler = self.0.take().expect("tried to attach listener twice");
                     let this = element.clone();
                     let listener = move |event: $type| {
-                        debug!("Event handler: {}", stringify!($type));
                         event.stop_propagation();
                         let handy_event: $ret = $convert(&this, event);
                         let msg = handler(handy_event);


### PR DESCRIPTION
Forgive me if this is overly heavy-handed, but this debug message becomes _quite_ noisy while developing an application with a debug level set.

I can't seem to find any other uses of `debug!` in the yew codebase, so it seems safe and sensible to remove this. 