### PR TITLE
Add link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
   </p>
 
   <h4>
+    <a href="https://docs.rs/yew">Docs</a>
+    <span> | </span>
     <a href="#running-the-examples">Examples</a>
     <span> | </span>
     <a href="https://github.com/yewstack/yew/blob/master/CHANGELOG.md">Changelog</a>


### PR DESCRIPTION
I find myself often at the github repo page and wanting to quickly get to the docs, searching for a link at the top of the readme.

I've omitted the version so that it's always redirected to the latest build. 