### PR TITLE
Implement Clone for ComponentLink

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -369,6 +369,7 @@ impl EmptyBuilder {
 }
 
 /// Link to component's scope for creating callbacks.
+#[derive(Clone)]
 pub struct ComponentLink<COMP: Component> {
     scope: Scope<COMP>,
 }


### PR DESCRIPTION
Fixes: https://github.com/yewstack/yew/issues/739

#### Problem
Users cannot currently clone component links for Futures

