### PR TITLE
Allow to compile to wasi target without wasm_bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ stdweb = "0.4.20"
 toml = { version = "0.4", optional = true }
 yew-macro = { version = "0.10.1", path = "crates/macro" }
 
-[target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os="wasi"), not(cargo_web)))'.dependencies]
 wasm-bindgen = "0.2.54"
 wasm-bindgen-futures = "0.4.4"
 
-[target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os="wasi"), not(cargo_web)))'.dev-dependencies]
 wasm-bindgen-test = "0.3.4"
 
 [target.'cfg(target_os = "emscripten")'.dependencies]

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -412,7 +412,7 @@ where
         closure.into()
     }
 
-    #[cfg(all(target_arch = "wasm32", not(cargo_web)))]
+    #[cfg(all(target_arch = "wasm32", not(target_os="wasi"), not(cargo_web)))]
     /// This method processes a Future that returns a message and sends it back to the component's
     /// loop.
     ///


### PR DESCRIPTION
I am trying to compile yew worker to wasm32-wasi, though now it also includes wasm_bindgen which is not compatible with wasi environment. Wasi allows to execute POSIX-like compatible services e.g. databases, math, lambdas... IMHO it is quite important that yew supports compilation of its workers to WASI as a transitive dependency.

These are few examples where yew is compiled to WASI target:
https://crates.io/crates/wasi-worker-yew
https://github.com/dunnock/wabench/
http://wabench.com:8080/