### PR TITLE
Revert "Implement Clone for ComponentLink"

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -369,7 +369,6 @@ impl EmptyBuilder {
 }
 
 /// Link to component's scope for creating callbacks.
-#[derive(Clone)]
 pub struct ComponentLink<COMP: Component> {
     scope: Scope<COMP>,
 }


### PR DESCRIPTION
Reverts yewstack/yew#741

Unintentionally added a `Component: Clone` trait bound 