### PR TITLE
Some simple proposed renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ impl Agent for Worker {
     fn handle(&mut self, msg: Self::Input, who: HandlerId) {
         match msg {
             Request::Question(_) => {
-                self.link.response(who, Response::Answer("That's cool!".into()));
+                self.link.respond(who, Response::Answer("That's cool!".into()));
             },
         }
     }

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ impl Agent for Worker {
     fn update(&mut self, msg: Self::Message) { /* ... */ }
 
     // Handle incoming messages from components of other agents.
-    fn handle(&mut self, msg: Self::Input, who: HandlerId) {
+    fn handle_input(&mut self, msg: Self::Input, who: HandlerId) {
         match msg {
             Request::Question(_) => {
                 self.link.respond(who, Response::Answer("That's cool!".into()));

--- a/examples/multi_thread/src/context.rs
+++ b/examples/multi_thread/src/context.rs
@@ -55,7 +55,7 @@ impl Agent for Worker {
         }
     }
 
-    fn handle(&mut self, msg: Self::Input, who: HandlerId) {
+    fn handle_input(&mut self, msg: Self::Input, who: HandlerId) {
         info!("Request: {:?}", msg);
         match msg {
             Request::GetDataFromServer => {

--- a/examples/multi_thread/src/context.rs
+++ b/examples/multi_thread/src/context.rs
@@ -59,7 +59,7 @@ impl Agent for Worker {
         info!("Request: {:?}", msg);
         match msg {
             Request::GetDataFromServer => {
-                self.link.response(who, Response::DataFetched);
+                self.link.respond(who, Response::DataFetched);
             }
         }
     }

--- a/examples/multi_thread/src/job.rs
+++ b/examples/multi_thread/src/job.rs
@@ -55,7 +55,7 @@ impl Agent for Worker {
         }
     }
 
-    fn handle(&mut self, msg: Self::Input, who: HandlerId) {
+    fn handle_input(&mut self, msg: Self::Input, who: HandlerId) {
         info!("Request: {:?}", msg);
         match msg {
             Request::GetDataFromServer => {

--- a/examples/multi_thread/src/job.rs
+++ b/examples/multi_thread/src/job.rs
@@ -59,7 +59,7 @@ impl Agent for Worker {
         info!("Request: {:?}", msg);
         match msg {
             Request::GetDataFromServer => {
-                self.link.response(who, Response::DataFetched);
+                self.link.respond(who, Response::DataFetched);
             }
         }
     }

--- a/examples/multi_thread/src/native_worker.rs
+++ b/examples/multi_thread/src/native_worker.rs
@@ -55,7 +55,7 @@ impl Agent for Worker {
         }
     }
 
-    fn handle(&mut self, msg: Self::Input, who: HandlerId) {
+    fn handle_input(&mut self, msg: Self::Input, who: HandlerId) {
         info!("Request: {:?}", msg);
         match msg {
             Request::GetDataFromServer => {

--- a/examples/multi_thread/src/native_worker.rs
+++ b/examples/multi_thread/src/native_worker.rs
@@ -59,7 +59,7 @@ impl Agent for Worker {
         info!("Request: {:?}", msg);
         match msg {
             Request::GetDataFromServer => {
-                self.link.response(who, Response::DataFetched);
+                self.link.respond(who, Response::DataFetched);
             }
         }
     }

--- a/examples/routing/src/router.rs
+++ b/examples/routing/src/router.rs
@@ -143,7 +143,7 @@ where
         }
     }
 
-    fn handle(&mut self, msg: Self::Input, who: HandlerId) {
+    fn handle_input(&mut self, msg: Self::Input, who: HandlerId) {
         info!("Request: {:?}", msg);
         match msg {
             Request::ChangeRoute(route) => {

--- a/examples/routing/src/router.rs
+++ b/examples/routing/src/router.rs
@@ -137,7 +137,7 @@ where
                 let mut route = Route::current_route(&self.route_service);
                 route.state = state;
                 for sub in self.subscribers.iter() {
-                    self.link.response(*sub, route.clone());
+                    self.link.respond(*sub, route.clone());
                 }
             }
         }
@@ -154,7 +154,7 @@ where
                 let route = Route::current_route(&self.route_service);
                 // broadcast it to all listening components
                 for sub in self.subscribers.iter() {
-                    self.link.response(*sub, route.clone());
+                    self.link.respond(*sub, route.clone());
                 }
             }
             Request::ChangeRouteNoBroadcast(route) => {
@@ -163,14 +163,14 @@ where
             }
             Request::GetCurrentRoute => {
                 let route = Route::current_route(&self.route_service);
-                self.link.response(who, route.clone());
+                self.link.respond(who, route.clone());
             }
         }
     }
 
     fn connected(&mut self, id: HandlerId) {
         self.link
-            .response(id, Route::current_route(&self.route_service));
+            .respond(id, Route::current_route(&self.route_service));
         self.subscribers.insert(id);
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -304,7 +304,7 @@ struct SlabResponder<AGN: Agent> {
 }
 
 impl<AGN: Agent> Responder<AGN> for SlabResponder<AGN> {
-    fn response(&self, id: HandlerId, output: AGN::Output) {
+    fn respond(&self, id: HandlerId, output: AGN::Output) {
         locate_callback_and_respond::<AGN>(&self.slab, id, output);
     }
 }
@@ -384,7 +384,7 @@ struct CallbackResponder<AGN: Agent> {
 }
 
 impl<AGN: Agent> Responder<AGN> for CallbackResponder<AGN> {
-    fn response(&self, id: HandlerId, output: AGN::Output) {
+    fn respond(&self, id: HandlerId, output: AGN::Output) {
         assert_eq!(id.raw_id(), SINGLETON_ID.raw_id());
         self.callback.emit(output);
     }
@@ -752,13 +752,13 @@ impl<AGN: Agent> Default for AgentScope<AGN> {
 /// Defines communication from Worker to Consumers
 pub trait Responder<AGN: Agent> {
     /// Implementation for communication channel from Worker to Consumers
-    fn response(&self, id: HandlerId, output: AGN::Output);
+    fn respond(&self, id: HandlerId, output: AGN::Output);
 }
 
 struct WorkerResponder {}
 
 impl<AGN: Agent> Responder<AGN> for WorkerResponder {
-    fn response(&self, id: HandlerId, output: AGN::Output) {
+    fn respond(&self, id: HandlerId, output: AGN::Output) {
         let msg = FromWorker::ProcessOutput(id, output);
         let data = msg.pack();
         js! {
@@ -788,7 +788,7 @@ impl<AGN: Agent> AgentLink<AGN> {
 
     /// Send response to an agent.
     pub fn response(&self, id: HandlerId, output: AGN::Output) {
-        self.responder.response(id, output);
+        self.responder.respond(id, output);
     }
 
     /// Create a callback which will send a message to the agent when invoked.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -692,7 +692,7 @@ pub trait Agent: Sized + 'static {
     fn connected(&mut self, _id: HandlerId) {}
 
     /// This method called on every incoming message.
-    fn handle(&mut self, msg: Self::Input, id: HandlerId);
+    fn handle_input(&mut self, msg: Self::Input, id: HandlerId);
 
     /// This method called on when a new bridge destroyed.
     fn disconnected(&mut self, _id: HandlerId) {}
@@ -877,7 +877,7 @@ where
                 this.agent
                     .as_mut()
                     .expect("agent was not created to process inputs")
-                    .handle(inp, id);
+                    .handle_input(inp, id);
             }
             AgentLifecycleEvent::Disconnected(id) => {
                 this.agent

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -787,7 +787,7 @@ impl<AGN: Agent> AgentLink<AGN> {
     }
 
     /// Send response to an agent.
-    pub fn response(&self, id: HandlerId, output: AGN::Output) {
+    pub fn respond(&self, id: HandlerId, output: AGN::Output) {
         self.responder.respond(id, output);
     }
 


### PR DESCRIPTION
In the process of trying to grok the definitions of types in `agent.rs`, a few renames seemed as though they may assist with reading the existing literature. Some of these I feel more strongly about than others, but it would be interesting to hear thoughts on these renames. Worth noting as well that I do not necessarily have the full context here, so these changes are offered in the spirit of sparking discussion.

Some of these would result in publicly backwards-incompatible changes, though pre-1.0 would probably be the best time to implement them, as such. The renames are as following:

- `AgentUpdate` -> `AgentUpdateEvent`
- `Agent::handle` -> `Agent::handle_msg_from_worker`
- `AgentEnvelope` -> `AgentCarrier` - This one was confusing because arguably an Envelope could be something carried by an agent, as it evokes imagery similar to "packet." With this wording, it's more clear that the agent is being carried by the AgentCarrier.
- `Responder::response` -> `Responder::send_response` - Since this function has no return value, it seems to be necessary for it to trigger a side effect. As such, I would propose a more `verb`-like name.

Any thoughts would be appreciated!