### PR TITLE
Filter empty string classes

### DIFF
--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -68,6 +68,11 @@ impl Classes {
         self.set.contains(class)
     }
 
+    /// Check the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+
     /// Adds other classes to this set of classes; returning itself.
     ///
     /// Takes the logical union of both `Classes`.

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -72,8 +72,7 @@ impl Classes {
     ///
     /// Takes the logical union of both `Classes`.
     pub fn extend<T: Into<Classes>>(mut self, other: T) -> Self {
-        self.set
-            .extend(other.into().set.into_iter().filter(|c| !c.is_empty()));
+        self.set.extend(other.into().set.into_iter());
         self
     }
 }

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -72,7 +72,8 @@ impl Classes {
     ///
     /// Takes the logical union of both `Classes`.
     pub fn extend<T: Into<Classes>>(mut self, other: T) -> Self {
-        self.set.extend(other.into().set.into_iter().filter(|c| !c.is_empty()));
+        self.set
+            .extend(other.into().set.into_iter().filter(|c| !c.is_empty()));
         self
     }
 }
@@ -91,28 +92,44 @@ impl ToString for Classes {
 
 impl From<&str> for Classes {
     fn from(t: &str) -> Self {
-        let set = t.split_whitespace().map(String::from).filter(|c| !c.is_empty()).collect();
+        let set = t
+            .split_whitespace()
+            .map(String::from)
+            .filter(|c| !c.is_empty())
+            .collect();
         Self { set }
     }
 }
 
 impl From<String> for Classes {
     fn from(t: String) -> Self {
-        let set = t.split_whitespace().map(String::from).filter(|c| !c.is_empty()).collect();
+        let set = t
+            .split_whitespace()
+            .map(String::from)
+            .filter(|c| !c.is_empty())
+            .collect();
         Self { set }
     }
 }
 
 impl From<&String> for Classes {
     fn from(t: &String) -> Self {
-        let set = t.split_whitespace().map(String::from).filter(|c| !c.is_empty()).collect();
+        let set = t
+            .split_whitespace()
+            .map(String::from)
+            .filter(|c| !c.is_empty())
+            .collect();
         Self { set }
     }
 }
 
 impl<T: AsRef<str>> From<Vec<T>> for Classes {
     fn from(t: Vec<T>) -> Self {
-        let set = t.iter().map(|x| x.as_ref().to_string()).filter(|c| !c.is_empty()).collect();
+        let set = t
+            .iter()
+            .map(|x| x.as_ref().to_string())
+            .filter(|c| !c.is_empty())
+            .collect();
         Self { set }
     }
 }

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -58,7 +58,9 @@ impl Classes {
     ///
     /// Prevents duplication of class names.
     pub fn push(&mut self, class: &str) {
-        self.set.insert(class.into());
+        if !class.is_empty() {
+            self.set.insert(class.into());
+        }
     }
 
     /// Check the set contains a class.
@@ -70,7 +72,7 @@ impl Classes {
     ///
     /// Takes the logical union of both `Classes`.
     pub fn extend<T: Into<Classes>>(mut self, other: T) -> Self {
-        self.set.extend(other.into().set.into_iter());
+        self.set.extend(other.into().set.into_iter().filter(|c| !c.is_empty()));
         self
     }
 }
@@ -89,28 +91,28 @@ impl ToString for Classes {
 
 impl From<&str> for Classes {
     fn from(t: &str) -> Self {
-        let set = t.split_whitespace().map(String::from).collect();
+        let set = t.split_whitespace().map(String::from).filter(|c| !c.is_empty()).collect();
         Self { set }
     }
 }
 
 impl From<String> for Classes {
     fn from(t: String) -> Self {
-        let set = t.split_whitespace().map(String::from).collect();
+        let set = t.split_whitespace().map(String::from).filter(|c| !c.is_empty()).collect();
         Self { set }
     }
 }
 
 impl From<&String> for Classes {
     fn from(t: &String) -> Self {
-        let set = t.split_whitespace().map(String::from).collect();
+        let set = t.split_whitespace().map(String::from).filter(|c| !c.is_empty()).collect();
         Self { set }
     }
 }
 
 impl<T: AsRef<str>> From<Vec<T>> for Classes {
     fn from(t: Vec<T>) -> Self {
-        let set = t.iter().map(|x| x.as_ref().to_string()).collect();
+        let set = t.iter().map(|x| x.as_ref().to_string()).filter(|c| !c.is_empty()).collect();
         Self { set }
     }
 }

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -228,6 +228,33 @@ fn supports_multiple_classes_vec() {
     }
 }
 
+#[test]
+fn filter_empty_string_classes_vec() {
+    let mut classes = vec![""];
+    classes.push("class-2");
+    let a: VNode<Comp> = html! { <div class=vec![""]></div> };
+    let b: VNode<Comp> = html! { <div class=("")></div> };
+    let c: VNode<Comp> = html! { <div class=""></div> };
+
+    if let VNode::VTag(vtag) = a {
+        assert!(vtag.classes.is_empty());
+    } else {
+        panic!("vtag expected");
+    }
+
+    if let VNode::VTag(vtag) = b {
+        assert!(vtag.classes.is_empty());
+    } else {
+        panic!("vtag expected");
+    }
+
+    if let VNode::VTag(vtag) = c {
+        assert!(vtag.classes.is_empty());
+    } else {
+        panic!("vtag expected");
+    }
+}
+
 fn assert_vtag(node: &mut VNode<Comp>) -> &mut VTag<Comp> {
     if let VNode::VTag(vtag) = node {
         return vtag;


### PR DESCRIPTION
#### Problem
When an empty string classname is used, Yew does not filter it and allows it to cause this DOMException:

```
Uncaught (in promise) DOMException: Failed to execute 'add' on 'DOMTokenList': The token provided must not be empty.
```

#### Solution
Filter out empty strings when creating `Classes`