### PR TITLE
Improve speed of to_string for Classes

### DIFF
--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -84,13 +84,11 @@ impl Classes {
 
 impl ToString for Classes {
     fn to_string(&self) -> String {
-        let mut buf = String::new();
-        for class in &self.set {
-            buf.push_str(class);
-            buf.push(' ');
-        }
-        buf.pop();
-        buf
+        self.set
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<&str>>()
+            .join(" ")
     }
 }
 


### PR DESCRIPTION
The prior code would reallocate for every item in the set that is pushed into the buffer. This should make one bigger allocation for the `Vec<&str>` (assuming it uses the size_hint? - worst case it makes a log_n number of allocations to accommodate the str references) and another for joining it into the final `String` with spaces.
