### PR TITLE
Add default impl for Callback

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -18,6 +18,12 @@ impl<IN, F: Fn(IN) + 'static> From<F> for Callback<IN> {
     }
 }
 
+impl<IN> Default for Callback<IN> {
+    fn default() -> Self {
+        Callback(Rc::new(|_| {}))
+    }
+}
+
 impl<IN> Clone for Callback<IN> {
     fn clone(&self) -> Self {
         Callback(self.0.clone())


### PR DESCRIPTION
Without a `Default` impl, the `Callback` struct can only be used as a
required passed in prop to components. This change adds a `Default`
no-op implementation.

Relates to #768. 

As far as I can tell, this shouldn't cause any backwards-compatibility issues either - it isn't possible to impl traits for external structs.  