### PR TITLE
Support passing callbacks to elements

### DIFF
--- a/crates/macro/src/html_tree/html_component.rs
+++ b/crates/macro/src/html_tree/html_component.rs
@@ -140,7 +140,7 @@ impl ToTokens for HtmlComponent {
             Props::List(ListProps { props, .. }) => {
                 let set_props = props.iter().map(|HtmlProp { label, value }| {
                     quote_spanned! { value.span()=>
-                        .#label(<::yew::virtual_dom::vcomp::VComp<_> as ::yew::virtual_dom::vcomp::Transformer<_, _, _>>::transform(#vcomp_scope.clone(), #value))
+                        .#label(<::yew::virtual_dom::vcomp::VComp<_> as ::yew::virtual_dom::Transformer<_, _, _>>::transform(#vcomp_scope.clone(), #value))
                     }
                 });
 
@@ -181,7 +181,7 @@ impl ToTokens for HtmlComponent {
                 #validate_props
             }
 
-            let #vcomp_scope: ::yew::virtual_dom::vcomp::ScopeHolder<_> = ::std::default::Default::default();
+            let #vcomp_scope: ::yew::html::ScopeHolder<_> = ::std::default::Default::default();
             let __yew_node_ref: ::yew::html::NodeRef = #node_ref;
             ::yew::virtual_dom::VChild::<#ty, _>::new(#init_props, #vcomp_scope, __yew_node_ref)
         }});

--- a/examples/nested_list/src/list.rs
+++ b/examples/nested_list/src/list.rs
@@ -1,9 +1,8 @@
 use crate::{header::Props as HeaderProps, ListHeader};
 use crate::{item::Props as ItemProps, ListItem};
 use std::fmt;
-use yew::html::{ChildrenRenderer, NodeRef};
+use yew::html::{ChildrenRenderer, NodeRef, ScopeHolder};
 use yew::prelude::*;
-use yew::virtual_dom::vcomp::ScopeHolder;
 use yew::virtual_dom::{VChild, VComp, VNode};
 
 #[derive(Debug)]

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -7,8 +7,8 @@ mod listener;
 mod scope;
 
 pub use listener::*;
-pub use scope::Scope;
 pub(crate) use scope::{ComponentUpdate, HiddenScope};
+pub use scope::{Scope, ScopeHolder};
 
 use crate::callback::Callback;
 use crate::virtual_dom::{VChild, VList, VNode};

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -16,6 +16,9 @@ pub(crate) enum ComponentUpdate<COMP: Component> {
     Properties(COMP::Properties),
 }
 
+/// A reference to the parent's scope which will be used later to send messages.
+pub type ScopeHolder<PARENT> = Rc<RefCell<Option<Scope<PARENT>>>>;
+
 /// A context which allows sending messages to a component.
 pub struct Scope<COMP: Component> {
     shared_state: Shared<ComponentState<COMP>>,

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -16,26 +16,25 @@ pub use self::vlist::VList;
 pub use self::vnode::VNode;
 pub use self::vtag::VTag;
 pub use self::vtext::VText;
-use crate::html::{Component, Scope};
+use crate::html::{Component, Scope, ScopeHolder};
 
 /// `Listener` trait is an universal implementation of an event listener
 /// which helps to bind Rust-listener to JS-listener (DOM).
-pub trait Listener<COMP: Component> {
+pub trait Listener {
     /// Returns standard name of DOM's event.
     fn kind(&self) -> &'static str;
-    /// Attaches listener to the element and uses scope instance to send
-    /// prepared event back to the yew main loop.
-    fn attach(&mut self, element: &Element, scope: Scope<COMP>) -> EventListenerHandle;
+    /// Attaches a listener to the element.
+    fn attach(&self, element: &Element) -> EventListenerHandle;
 }
 
-impl<COMP: Component> fmt::Debug for dyn Listener<COMP> {
+impl fmt::Debug for dyn Listener {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Listener {{ kind: {} }}", self.kind())
     }
 }
 
 /// A list of event listeners.
-type Listeners<COMP> = Vec<Box<dyn Listener<COMP>>>;
+type Listeners = Vec<Box<dyn Listener>>;
 
 /// A map of attributes.
 type Attributes = HashMap<String, String>;
@@ -200,4 +199,10 @@ pub trait VDiff {
         ancestor: Option<VNode<Self::Component>>,
         parent_scope: &Scope<Self::Component>,
     ) -> Option<Node>;
+}
+
+/// Transforms properties and attaches a parent scope holder to callbacks for sending messages.
+pub trait Transformer<PARENT: Component, FROM, TO> {
+    /// Transforms one type to another.
+    fn transform(scope_holder: ScopeHolder<PARENT>, from: FROM) -> TO;
 }

--- a/tests/macro/html-tag-fail.stderr
+++ b/tests/macro/html-tag-fail.stderr
@@ -102,12 +102,6 @@ error: only one `class` attribute allowed
 23 |     html! { <div class="first" class="second" /> };
    |                                ^^^^^
 
-error: `onclick` attribute value should be a closure
-  --> $DIR/html-tag-fail.rs:32:20
-   |
-32 |     html! { <input onclick=1 /> };
-   |                    ^^^^^^^
-
 error: there must be one closure argument
   --> $DIR/html-tag-fail.rs:33:28
    |
@@ -189,6 +183,15 @@ error[E0277]: the trait bound `yew::html::Href: std::convert::From<()>` is not s
              <yew::html::Href as std::convert::From<&'a str>>
              <yew::html::Href as std::convert::From<std::string::String>>
    = note: required because of the requirements on the impl of `std::convert::Into<yew::html::Href>` for `()`
+
+error[E0308]: mismatched types
+  --> $DIR/html-tag-fail.rs:32:20
+   |
+32 |     html! { <input onclick=1 /> };
+   |                    ^^^^^^^ expected struct `yew::callback::Callback`, found integer
+   |
+   = note: expected type `yew::callback::Callback<stdweb::webapi::events::mouse::ClickEvent>`
+              found type `{integer}`
 
 error[E0599]: no method named `to_string` found for type `NotToString` in the current scope
   --> $DIR/html-tag-fail.rs:37:27

--- a/tests/macro/html-tag-pass.rs
+++ b/tests/macro/html-tag-pass.rs
@@ -4,6 +4,7 @@
 mod helpers;
 
 pass_helper! {
+    let onclick = Callback::from(|_: ClickEvent| ());
     let parent_ref = NodeRef::default();
     html! {
         <div>
@@ -37,6 +38,8 @@ pass_helper! {
             <img class=("avatar", "hidden") src="http://pic.com" />
             <img class="avatar hidden", />
             <button onclick=|e| panic!(e) />
+            <button onclick=&onclick />
+            <button onclick=onclick />
             <a href="http://google.com" />
             <custom-tag-a>
                 <custom-tag-b />


### PR DESCRIPTION
#### Problem
The only way to specify listeners for elements is with the magical closure syntax. That approach is not very flexible and is inconsistent with the <Component> syntax so this change allows setting a callback struct as a listener.

New syntax:

```rust
use yew::{html, Callback, ClickEvent, Component, ComponentLink, Html, ShouldRender};

struct Model {
    onclick: Callback<ClickEvent>,
}

enum Msg {
    Click,
}

impl Component for Model {
    type Message = Msg;
    type Properties = ();

    fn create(_: Self::Properties, mut link: ComponentLink<Self>) -> Self {
        Model {
            onclick: link.send_back(|_| Msg::Click }
        }
    }

    fn update(&mut self, msg: Self::Message) -> ShouldRender {
        match msg {
            Msg::Click => true,
        }
    }

    fn view(&self) -> Html<Self> {
        html! {
            <button onclick=self.onclick>{ "Click me!" }</button>
        }
    }
}

```