### PR TITLE
Add no-op method for Callback

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -41,6 +41,12 @@ impl<IN> Callback<IN> {
     pub fn emit(&self, value: IN) {
         (self.0)(value);
     }
+
+    /// Creates a no-op callback which can be used when it is not suitable to use an
+    /// `Option<Callback>`.
+    pub fn noop() -> Self {
+        Self::from(|_| {})
+    }
 }
 
 impl<IN: 'static> Callback<IN> {


### PR DESCRIPTION
When a component is created with an optional event handler, it can
be passed as an `Option` prop, however in certain cases, it is useful to
have either a default event handler, rather than passing a `None`.

Replaces #773 