### PR TITLE
Add bincode format and make bincode an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "yewstack/yew" }
 
 [dependencies]
 anymap = "0.12"
-bincode = "=1.0.1"
+bincode = { version = "~1.2.1", optional = true }
 failure = "0.1"
 http = "0.1"
 indexmap = "1.0.2"
@@ -58,7 +58,7 @@ doc_test = []
 web_test = []
 wasm_test = []
 services = []
-agent = []
+agent = ["bincode"]
 yaml = ["serde_yaml"]
 msgpack = ["rmp-serde"]
 cbor = ["serde_cbor"]

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -12,5 +12,5 @@ fi
 cargo test --features wasm_test --target wasm32-unknown-unknown
 cargo test --test macro_test
 cargo test --test derive_props_test
-cargo doc_test
+cargo doc_test --all-features
 (cd crates/macro && cargo doc_test)

--- a/src/format/bincode.rs
+++ b/src/format/bincode.rs
@@ -1,0 +1,22 @@
+//! Contains an implementation of Bincode serialization format.
+
+use bincode;
+
+/// A representation of a Bincode data. Use it as wrapper to
+/// set a format you want to use for conversion:
+///
+/// ```rust
+/// // Converts (lazy) data to a Bincode
+///# use yew::format::Bincode;
+///# fn dont_execute() {
+///# let data: String = unimplemented!();
+/// let dump = Bincode(&data);
+///
+/// // Converts Bincode to a data (lazy).
+/// let Bincode(data) = dump;
+///# }
+/// ```
+#[derive(Debug)]
+pub struct Bincode<T>(pub T);
+
+binary_format!(Bincode, bincode::serialize, bincode::deserialize);

--- a/src/format/macros.rs
+++ b/src/format/macros.rs
@@ -27,12 +27,15 @@ macro_rules! text_format {
 
 macro_rules! binary_format {
     ($type:ident based on $format:ident) => {
+        binary_format!($type, $format::to_vec, $format::from_slice);
+    };
+    ($type:ident, $into:path, $from:path) => {
         impl<'a, T> Into<$crate::format::Binary> for $type<&'a T>
         where
             T: ::serde::Serialize,
         {
             fn into(self) -> $crate::format::Binary {
-                $format::to_vec(&self.0).map_err(::failure::Error::from)
+                $into(&self.0).map_err(::failure::Error::from)
             }
         }
 
@@ -42,7 +45,7 @@ macro_rules! binary_format {
         {
             fn from(value: $crate::format::Binary) -> Self {
                 match value {
-                    Ok(data) => $type($format::from_slice(&data).map_err(::failure::Error::from)),
+                    Ok(data) => $type($from(&data).map_err(::failure::Error::from)),
                     Err(reason) => $type(Err(reason)),
                 }
             }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -9,6 +9,8 @@ use failure::Error;
 #[macro_use]
 pub mod macros;
 
+#[cfg(feature = "bincode")]
+pub mod bincode;
 #[cfg(feature = "cbor")]
 pub mod cbor;
 pub mod json;
@@ -20,6 +22,8 @@ pub mod toml;
 #[cfg(feature = "yaml")]
 pub mod yaml;
 
+#[cfg(feature = "bincode")]
+pub use self::bincode::Bincode;
 #[cfg(feature = "cbor")]
 pub use self::cbor::Cbor;
 pub use self::json::Json;


### PR DESCRIPTION
Fixes: https://github.com/yewstack/yew/issues/790
Fixes: https://github.com/yewstack/yew/issues/413
Continuation of https://github.com/yewstack/yew/pull/714

- Adds `Bincode` Format 
- Makes `bincode` an optional dependency