### PR TITLE
Fix generic component tags in html macro

### DIFF
--- a/tests/macro/html-component-fail.rs
+++ b/tests/macro/html-component-fail.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "128"]
 
+use std::marker::PhantomData;
 use yew::prelude::*;
 
 #[derive(Clone, Properties, PartialEq)]
@@ -14,21 +15,14 @@ impl Component for Child {
     type Message = ();
     type Properties = ChildProperties;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Child
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        unimplemented!()
-    }
-
-    fn view(&self) -> Html {
-        unimplemented!()
-    }
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { unimplemented!() }
+    fn update(&mut self, _: Self::Message) -> ShouldRender { unimplemented!() }
+    fn view(&self) -> Html { unimplemented!() }
 }
 
 #[derive(Clone, Properties)]
 pub struct ChildContainerProperties {
+    #[props(required)]
     pub children: ChildrenWithProps<Child>,
 }
 
@@ -37,17 +31,22 @@ impl Component for ChildContainer {
     type Message = ();
     type Properties = ChildContainerProperties;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        ChildContainer
-    }
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { unimplemented!() }
+    fn update(&mut self, _: Self::Message) -> ShouldRender { unimplemented!() }
+    fn view(&self) -> Html { unimplemented!() }
+}
 
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        unimplemented!()
-    }
+pub struct Generic<G> {
+    marker: PhantomData<G>,
+}
 
-    fn view(&self) -> Html {
-        unimplemented!()
-    }
+impl Component for Generic<String> {
+    type Message = ();
+    type Properties = ();
+
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { unimplemented!() }
+    fn update(&mut self, _: Self::Message) -> ShouldRender { unimplemented!() }
+    fn view(&self) -> Html { unimplemented!() }
 }
 
 fn compile_fail() {
@@ -75,11 +74,15 @@ fn compile_fail() {
     html! { <Child><Child></Child> };
     html! { <Child></Child><Child></Child> };
     html! { <Child>{ "Not allowed" }</Child> };
+
+    html! { <ChildContainer /> };
+    html! { <ChildContainer></ChildContainer> };
     html! { <ChildContainer>{ "Not allowed" }</ChildContainer> };
     html! { <ChildContainer><></></ChildContainer> };
-    html! { <ChildContainer><ChildContainer /></ChildContainer> };
-    html! { <ChildContainer><ChildContainer /></ChildContainer> };
     html! { <ChildContainer><Child int=1 /><other /></ChildContainer> };
+
+    html! { <Generic<String>></Generic> };
+    html! { <Generic<String>></Generic<Vec<String>>> };
 }
 
 fn main() {}

--- a/tests/macro/html-component-fail.stderr
+++ b/tests/macro/html-component-fail.stderr
@@ -1,133 +1,145 @@
 error: this open tag has no corresponding close tag
-  --> $DIR/html-component-fail.rs:54:13
+  --> $DIR/html-component-fail.rs:53:13
    |
-54 |     html! { <Child> };
+53 |     html! { <Child> };
    |             ^^^^^^^
 
 error: expected identifier
-  --> $DIR/html-component-fail.rs:55:22
+  --> $DIR/html-component-fail.rs:54:22
    |
-55 |     html! { <Child:: /> };
+54 |     html! { <Child:: /> };
    |                      ^
 
 error: unexpected end of input, expected identifier
-  --> $DIR/html-component-fail.rs:56:5
+  --> $DIR/html-component-fail.rs:55:5
    |
-56 |     html! { <Child with /> };
+55 |     html! { <Child with /> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unexpected token
-  --> $DIR/html-component-fail.rs:57:20
+  --> $DIR/html-component-fail.rs:56:20
    |
-57 |     html! { <Child props /> };
+56 |     html! { <Child props /> };
    |                    ^^^^^
 
 error: this open tag has no corresponding close tag
-  --> $DIR/html-component-fail.rs:58:13
+  --> $DIR/html-component-fail.rs:57:13
    |
-58 |     html! { <Child with props > };
+57 |     html! { <Child with props > };
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: unexpected token
-  --> $DIR/html-component-fail.rs:59:38
+  --> $DIR/html-component-fail.rs:58:38
    |
-59 |     html! { <Child with props ref=() ref=() /> };
+58 |     html! { <Child with props ref=() ref=() /> };
    |                                      ^^^
 
 error: unexpected token
-  --> $DIR/html-component-fail.rs:60:27
+  --> $DIR/html-component-fail.rs:59:27
    |
-60 |     html! { <Child ref=() with props /> };
+59 |     html! { <Child ref=() with props /> };
    |                           ^^^^
 
 error: unexpected token
-  --> $DIR/html-component-fail.rs:62:31
+  --> $DIR/html-component-fail.rs:61:31
    |
-62 |     html! { <Child with props () /> };
+61 |     html! { <Child with props () /> };
    |                               ^^
+
+error: expected identifier
+  --> $DIR/html-component-fail.rs:62:20
+   |
+62 |     html! { <Child type=0 /> };
+   |                    ^^^^
 
 error: expected identifier
   --> $DIR/html-component-fail.rs:63:20
    |
-63 |     html! { <Child type=0 /> };
-   |                    ^^^^
-
-error: expected identifier
-  --> $DIR/html-component-fail.rs:64:20
-   |
-64 |     html! { <Child invalid-prop-name=0 /> };
+63 |     html! { <Child invalid-prop-name=0 /> };
    |                    ^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected expression
-  --> $DIR/html-component-fail.rs:66:5
+  --> $DIR/html-component-fail.rs:65:5
    |
-66 |     html! { <Child string= /> };
+65 |     html! { <Child string= /> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: too many refs set
-  --> $DIR/html-component-fail.rs:71:33
+  --> $DIR/html-component-fail.rs:70:33
    |
-71 |     html! { <Child int=1 ref=() ref=() /> };
+70 |     html! { <Child int=1 ref=() ref=() /> };
    |                                 ^^^
 
 error: this close tag has no corresponding open tag
-  --> $DIR/html-component-fail.rs:74:13
+  --> $DIR/html-component-fail.rs:73:13
    |
-74 |     html! { </Child> };
+73 |     html! { </Child> };
    |             ^^^^^^^^
 
 error: this open tag has no corresponding close tag
-  --> $DIR/html-component-fail.rs:75:13
+  --> $DIR/html-component-fail.rs:74:13
    |
-75 |     html! { <Child><Child></Child> };
+74 |     html! { <Child><Child></Child> };
    |             ^^^^^^^
 
 error: only one root html element allowed
-  --> $DIR/html-component-fail.rs:76:28
+  --> $DIR/html-component-fail.rs:75:28
    |
-76 |     html! { <Child></Child><Child></Child> };
+75 |     html! { <Child></Child><Child></Child> };
    |                            ^^^^^^^^^^^^^^^
 
-error[E0425]: cannot find value `blah` in this scope
-  --> $DIR/html-component-fail.rs:61:25
+error: this close tag has no corresponding open tag
+  --> $DIR/html-component-fail.rs:84:30
    |
-61 |     html! { <Child with blah /> };
+84 |     html! { <Generic<String>></Generic> };
+   |                              ^^^^^^^^^^
+
+error: this close tag has no corresponding open tag
+  --> $DIR/html-component-fail.rs:85:30
+   |
+85 |     html! { <Generic<String>></Generic<Vec<String>>> };
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0425]: cannot find value `blah` in this scope
+  --> $DIR/html-component-fail.rs:60:25
+   |
+60 |     html! { <Child with blah /> };
    |                         ^^^^ not found in this scope
 
 error[E0609]: no field `unknown` on type `ChildProperties`
-  --> $DIR/html-component-fail.rs:65:20
+  --> $DIR/html-component-fail.rs:64:20
    |
-65 |     html! { <Child unknown="unknown" /> };
+64 |     html! { <Child unknown="unknown" /> };
    |                    ^^^^^^^ unknown field
    |
    = note: available fields are: `string`, `int`
 
 error[E0599]: no method named `unknown` found for type `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-  --> $DIR/html-component-fail.rs:65:20
+  --> $DIR/html-component-fail.rs:64:20
    |
-5  | #[derive(Clone, Properties, PartialEq)]
+6  | #[derive(Clone, Properties, PartialEq)]
    |                          - method `unknown` not found for this
 ...
-65 |     html! { <Child unknown="unknown" /> };
+64 |     html! { <Child unknown="unknown" /> };
    |                    ^^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
 
 error[E0308]: mismatched types
-  --> $DIR/html-component-fail.rs:67:33
+  --> $DIR/html-component-fail.rs:66:33
    |
-67 |     html! { <Child int=1 string={} /> };
+66 |     html! { <Child int=1 string={} /> };
    |                                 ^^ expected struct `std::string::String`, found ()
    |
    = note: expected type `std::string::String`
               found type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/html-component-fail.rs:68:33
+  --> $DIR/html-component-fail.rs:67:33
    |
-68 |     html! { <Child int=1 string=3 /> };
+67 |     html! { <Child int=1 string=3 /> };
    |                                 ^
    |                                 |
    |                                 expected struct `std::string::String`, found integer
@@ -137,9 +149,9 @@ error[E0308]: mismatched types
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/html-component-fail.rs:69:33
+  --> $DIR/html-component-fail.rs:68:33
    |
-69 |     html! { <Child int=1 string={3} /> };
+68 |     html! { <Child int=1 string={3} /> };
    |                                 ^^^
    |                                 |
    |                                 expected struct `std::string::String`, found integer
@@ -149,79 +161,83 @@ error[E0308]: mismatched types
               found type `{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/html-component-fail.rs:70:30
+  --> $DIR/html-component-fail.rs:69:30
    |
-70 |     html! { <Child int=1 ref=() /> };
+69 |     html! { <Child int=1 ref=() /> };
    |                              ^^ expected struct `yew::html::NodeRef`, found ()
    |
    = note: expected type `yew::html::NodeRef`
               found type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/html-component-fail.rs:72:24
+  --> $DIR/html-component-fail.rs:71:24
    |
-72 |     html! { <Child int=0u32 /> };
+71 |     html! { <Child int=0u32 /> };
    |                        ^^^^ expected i32, found u32
    |
 help: you can convert an `u32` to `i32` and panic if the converted value wouldn't fit
    |
-72 |     html! { <Child int=0u32.try_into().unwrap() /> };
+71 |     html! { <Child int=0u32.try_into().unwrap() /> };
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0599]: no method named `string` found for type `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-  --> $DIR/html-component-fail.rs:73:20
+  --> $DIR/html-component-fail.rs:72:20
    |
-5  | #[derive(Clone, Properties, PartialEq)]
+6  | #[derive(Clone, Properties, PartialEq)]
    |                          - method `string` not found for this
 ...
-73 |     html! { <Child string="abc" /> };
+72 |     html! { <Child string="abc" /> };
    |                    ^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
 
 error[E0599]: no method named `children` found for type `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-  --> $DIR/html-component-fail.rs:77:5
+  --> $DIR/html-component-fail.rs:76:5
    |
-5  | #[derive(Clone, Properties, PartialEq)]
+6  | #[derive(Clone, Properties, PartialEq)]
    |                          - method `children` not found for this
 ...
-77 |     html! { <Child>{ "Not allowed" }</Child> };
+76 |     html! { <Child>{ "Not allowed" }</Child> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<&str>` is not satisfied
+error[E0599]: no method named `build` found for type `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
   --> $DIR/html-component-fail.rs:78:5
    |
-78 |     html! { <ChildContainer>{ "Not allowed" }</ChildContainer> };
+23 | #[derive(Clone, Properties)]
+   |                          - method `build` not found for this
+...
+78 |     html! { <ChildContainer /> };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error[E0599]: no method named `build` found for type `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
+  --> $DIR/html-component-fail.rs:79:5
+   |
+23 | #[derive(Clone, Properties)]
+   |                          - method `build` not found for this
+...
+79 |     html! { <ChildContainer></ChildContainer> };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<&str>` is not satisfied
+  --> $DIR/html-component-fail.rs:80:5
+   |
+80 |     html! { <ChildContainer>{ "Not allowed" }</ChildContainer> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<&str>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
    |
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `&str`
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied
-  --> $DIR/html-component-fail.rs:79:5
+  --> $DIR/html-component-fail.rs:81:5
    |
-79 |     html! { <ChildContainer><></></ChildContainer> };
+81 |     html! { <ChildContainer><></></ChildContainer> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vnode::VNode>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
    |
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vnode::VNode`
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vcomp::VChild<ChildContainer>>` is not satisfied
-  --> $DIR/html-component-fail.rs:80:5
-   |
-80 |     html! { <ChildContainer><ChildContainer /></ChildContainer> };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vcomp::VChild<ChildContainer>>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
-   |
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vcomp::VChild<ChildContainer>`
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vcomp::VChild<ChildContainer>>` is not satisfied
-  --> $DIR/html-component-fail.rs:81:5
-   |
-81 |     html! { <ChildContainer><ChildContainer /></ChildContainer> };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vcomp::VChild<ChildContainer>>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
-   |
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vcomp::VChild<ChildContainer>`
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied

--- a/tests/macro/html-component-pass.rs
+++ b/tests/macro/html-component-pass.rs
@@ -1,77 +1,82 @@
 #![recursion_limit = "256"]
 
+use std::marker::PhantomData;
 use yew::prelude::*;
 use yew::html::ChildrenRenderer;
 use yew::virtual_dom::{VChild, VComp, VNode};
 
-#[derive(Clone, Debug, Properties)]
-pub struct ParentProperties {
-    #[props(required)]
-    pub children: ChildrenRenderer<ParentVariant>,
+pub struct Generic<G> {
+    marker: PhantomData<G>,
 }
 
-pub struct Parent {
-    props: ParentProperties,
-    link:  ComponentLink<Self>,
-}
-
-impl Component for Parent {
+impl Component for Generic<String> {
     type Message = ();
-    type Properties = ParentProperties;
+    type Properties = ();
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        return Parent { props, link };
-    }
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { unimplemented!() }
+    fn update(&mut self, _: Self::Message) -> ShouldRender { unimplemented!() }
+    fn view(&self) -> Html { unimplemented!() }
+}
 
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        unimplemented!()
-    }
+impl Component for Generic<Vec<String>> {
+    type Message = ();
+    type Properties = ();
 
-    fn view(&self) -> Html {
-        unimplemented!()
-    }
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { unimplemented!() }
+    fn update(&mut self, _: Self::Message) -> ShouldRender { unimplemented!() }
+    fn view(&self) -> Html { unimplemented!() }
+}
+
+#[derive(Clone, Properties, Default)]
+pub struct ContainerProperties {
+    #[props(required)]
+    pub int: i32,
+    pub children: Children,
+}
+
+pub struct Container;
+impl Component for Container {
+    type Message = ();
+    type Properties = ContainerProperties;
+
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { unimplemented!() }
+    fn update(&mut self, _: Self::Message) -> ShouldRender { unimplemented!() }
+    fn view(&self) -> Html { unimplemented!() }
 }
 
 #[derive(Clone)]
-pub enum ParentVariants {
+pub enum ChildrenVariants {
     Child(<Child as Component>::Properties),
-    ChildA(<ChildA as Component>::Properties),
+    AltChild(<AltChild as Component>::Properties),
 }
 
-impl From<ChildProperties> for ParentVariants {
+impl From<ChildProperties> for ChildrenVariants {
     fn from(props: ChildProperties) -> Self {
-        ParentVariants::Child(props)
+        ChildrenVariants::Child(props)
     }
 }
 
-impl From<ChildAProperties> for ParentVariants {
-    fn from(props: ChildAProperties) -> Self {
-        ParentVariants::ChildA(props)
+impl From<()> for ChildrenVariants {
+    fn from(props: ()) -> Self {
+        ChildrenVariants::AltChild(props)
     }
 }
 
-#[derive(Clone)]
-pub struct ParentVariant {
-    props: ParentVariants,
-}
-
-impl<CHILD> From<VChild<CHILD>> for ParentVariant
+impl<CHILD> From<VChild<CHILD>> for ChildrenVariants
 where
     CHILD: Component,
-    CHILD::Properties: Into<ParentVariants>,
+    CHILD::Properties: Into<ChildrenVariants>,
 {
     fn from(comp: VChild<CHILD>) -> Self {
-        return ParentVariant {
-            props: comp.props.into(),
-        };
+        comp.props.into()
     }
 }
 
-impl Into<VNode> for ParentVariant {
+impl Into<VNode> for ChildrenVariants {
     fn into(self) -> VNode {
-        match self.props {
-            ParentVariants::Child(props) => VComp::new::<Child>(props, NodeRef::default()).into(),
-            ParentVariants::ChildA(props) => VComp::new::<ChildA>(props, NodeRef::default()).into(),
+        match self {
+            Self::Child(props) => VComp::new::<Child>(props, NodeRef::default()).into(),
+            Self::AltChild(props) => VComp::new::<AltChild>(props, NodeRef::default()).into(),
         }
     }
 }
@@ -90,76 +95,26 @@ impl Component for Child {
     type Message = ();
     type Properties = ChildProperties;
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Child
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        unimplemented!()
-    }
-
-    fn view(&self) -> Html {
-        unimplemented!()
-    }
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { unimplemented!() }
+    fn update(&mut self, _: Self::Message) -> ShouldRender { unimplemented!() }
+    fn view(&self) -> Html { unimplemented!() }
 }
 
-#[derive(Clone, Properties, Default, PartialEq)]
-pub struct ChildAProperties {
-    pub string: String,
-    #[props(required)]
-    pub int: i32,
-    pub vec: Vec<i32>,
-    pub optional_callback: Option<Callback<()>>,
-}
-
-pub struct ChildA;
-impl Component for ChildA {
+pub struct AltChild;
+impl Component for AltChild {
     type Message = ();
-    type Properties = ChildAProperties;
+    type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
-        ChildA
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        unimplemented!()
-    }
-
-    fn view(&self) -> Html {
-        unimplemented!()
-    }
-}
-
-#[derive(Clone, Properties, Default)]
-pub struct ContainerProperties {
-    #[props(required)]
-    pub int: i32,
-    pub children: Children,
-}
-
-pub struct Container;
-impl Component for Container {
-    type Message = ();
-    type Properties = ContainerProperties;
-
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Container
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        unimplemented!()
-    }
-
-    fn view(&self) -> Html {
-        unimplemented!()
-    }
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { unimplemented!() }
+    fn update(&mut self, _: Self::Message) -> ShouldRender { unimplemented!() }
+    fn view(&self) -> Html { unimplemented!() }
 }
 
 #[derive(Clone, Properties, Default)]
 pub struct ChildContainerProperties {
     #[props(required)]
     pub int: i32,
-    pub children: ChildrenWithProps<Child>,
+    pub children: ChildrenRenderer<ChildrenVariants>,
 }
 
 pub struct ChildContainer;
@@ -167,17 +122,9 @@ impl Component for ChildContainer {
     type Message = ();
     type Properties = ChildContainerProperties;
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
-        ChildContainer
-    }
-
-    fn update(&mut self, _: Self::Message) -> ShouldRender {
-        unimplemented!()
-    }
-
-    fn view(&self) -> Html {
-        unimplemented!()
-    }
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { unimplemented!() }
+    fn update(&mut self, _: Self::Message) -> ShouldRender { unimplemented!() }
+    fn view(&self) -> Html { unimplemented!() }
 }
 
 mod scoped {
@@ -280,8 +227,8 @@ fn compile_pass() {
     };
 
     html! {
-        <Parent>
-            <ChildA int=1 />
+        <ChildContainer int=1>
+            <AltChild />
             {
                 html! {
                     <Child int=1 />
@@ -292,7 +239,16 @@ fn compile_pass() {
                     <Child int=1 />
                 }
             }).collect::<Vec<VChild<Child>>>()}
-        </Parent>
+        </ChildContainer>
+    };
+
+    html! {
+        <>
+            <Generic<String> />
+            <Generic<String> ></Generic<String>>
+            <Generic<Vec<String>> />
+            <Generic<Vec<String>>></ Generic<Vec<String>>>
+        </>
     };
 }
 


### PR DESCRIPTION
Fixes https://github.com/yewstack/yew/issues/834

This used to generate an error:
```rust
error: this close tag has no corresponding open tag
  --> src/main.rs:22:40
   |
22 |             <GenericComponent<String>> </GenericComponent>
   |                                        ^^^^^^^^^^^^^^^^^^^
```