### PR TITLE
Allow binary-only formats (e.g., CBOR) with websockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ agent = ["bincode"]
 yaml = ["serde_yaml"]
 msgpack = ["rmp-serde"]
 cbor = ["serde_cbor"]
+cbor_packed = ["serde_cbor"]
 
 [workspace]
 members = [

--- a/src/format/bincode.rs
+++ b/src/format/bincode.rs
@@ -16,7 +16,9 @@ use bincode;
 /// let Bincode(data) = dump;
 ///# }
 /// ```
+/// This is a binary only format.
 #[derive(Debug)]
 pub struct Bincode<T>(pub T);
 
 binary_format!(Bincode, bincode::serialize, bincode::deserialize);
+text_format_is_an_error!(Bincode);

--- a/src/format/cbor.rs
+++ b/src/format/cbor.rs
@@ -16,7 +16,9 @@ use serde_cbor;
 /// let Cbor(data) = dump;
 ///# }
 /// ```
+/// This is a binary only format.
 #[derive(Debug)]
 pub struct Cbor<T>(pub T);
 
 binary_format!(Cbor based on serde_cbor);
+text_format_is_an_error!(Cbor);

--- a/src/format/cbor_packed.rs
+++ b/src/format/cbor_packed.rs
@@ -1,0 +1,29 @@
+//! Contains an implementation of CBOR serialization format that uses a
+//! packed representation.
+
+use serde_cbor;
+
+/// A packed representation of a CBOR data. Use it as wrapper to
+/// set a format you want to use for conversion:
+///
+/// ```
+/// // Converts (lazy) data to a Cbor
+///# use yew::format::CborPacked;
+///# fn dont_execute() {
+///# let data: String = unimplemented!();
+/// let dump = CborPacked(&data);
+///
+/// // Converts CBOR string to a data (lazy).
+/// let CborPacked(data) = dump;
+///# }
+/// ```
+/// This is a binary only format.
+#[derive(Debug)]
+pub struct CborPacked<T>(pub T);
+
+binary_format!(
+    CborPacked,
+    serde_cbor::ser::to_vec_packed,
+    serde_cbor::from_slice
+);
+text_format_is_an_error!(CborPacked);

--- a/src/format/macros.rs
+++ b/src/format/macros.rs
@@ -52,3 +52,19 @@ macro_rules! binary_format {
         }
     };
 }
+
+macro_rules! text_format_is_an_error {
+    ($type:ident) => {
+        use $crate::format::FormatError;
+
+        fn to_string<T>(_value: T) -> Result<String, failure::Error> {
+            Err(FormatError::CantEncodeBinaryAsText.into())
+        }
+
+        fn from_str<T>(_s: &str) -> Result<T, failure::Error> {
+            Err(FormatError::ReceivedTextForBinary.into())
+        }
+
+        text_format!($type based on self);
+    }
+}

--- a/src/format/msgpack.rs
+++ b/src/format/msgpack.rs
@@ -17,7 +17,9 @@ use rmp_serde;
 /// let MsgPack(data) = dump;
 ///# }
 /// ```
+/// This is a binary only protocol.
 #[derive(Debug)]
 pub struct MsgPack<T>(pub T);
 
 binary_format!(MsgPack based on rmp_serde);
+text_format_is_an_error!(MsgPack);


### PR DESCRIPTION
Fixes: #389

This allows the various formats that can't be converted in or out of Text to be used in the callback that a websocket will use.