### PR TITLE
SSR: Stringify VNodes (experimental)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ anymap = "0.12"
 bincode = { version = "~1.2.1", optional = true }
 failure = "0.1"
 http = "0.2"
+htmlescape = { version = "0.3.1", optional = true }
 indexmap = "1.0.2"
 log = "0.4"
 proc-macro-hack = "0.5"
@@ -57,6 +58,7 @@ doc_test = []
 web_test = []
 wasm_test = []
 services = []
+ssr = ["htmlescape"]
 agent = ["bincode"]
 yaml = ["serde_yaml"]
 msgpack = ["rmp-serde"]

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -9,7 +9,7 @@ if [ "$emscripten_supported" == "0" ]; then
   cargo web test --features web_test --target wasm32-unknown-emscripten
 fi
 
-cargo test --features wasm_test --target wasm32-unknown-unknown
+cargo test --features wasm_test --features ssr --target wasm32-unknown-unknown
 cargo test --test macro_test
 cargo test --test derive_props_test
 

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -27,6 +27,14 @@ pub trait Listener {
     fn attach(&self, element: &Element) -> EventListenerHandle;
 }
 
+/// Represents that a node can be stringified to HTML.
+pub trait ToHtml {
+    /// Outputs an HTML string corresponding to the node. This output
+    /// is not necessarily deterministic due to the serialization of
+    /// structures (e.g. props) which do not have a particular ordering.
+    fn to_html(&self) -> String;
+}
+
 impl fmt::Debug for dyn Listener {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Listener {{ kind: {} }}", self.kind())

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -1,7 +1,8 @@
 //! This module contains the implementation of a virtual component `VComp`.
 
-use super::{Transformer, VDiff, VNode};
+use super::{ToHtml, Transformer, VDiff, VNode};
 use crate::html::{Component, ComponentUpdate, HiddenScope, NodeRef, Scope};
+use htmlescape;
 use std::any::TypeId;
 use std::cell::RefCell;
 use std::fmt;
@@ -198,7 +199,10 @@ impl VDiff for VComp {
                     }
                     Reform::Before(next_sibling) => {
                         // Temporary node which will be replaced by a component's root node.
-                        let dummy_node = document().create_text_node("");
+                        let dummy_node = parent
+                            .owner_document()
+                            .unwrap("Parent node not attached to a document")
+                            .create_text_node("");
                         if let Some(next_sibling) = next_sibling {
                             parent
                                 .insert_before(&dummy_node, &next_sibling)
@@ -264,5 +268,16 @@ impl fmt::Debug for VComp {
 impl<COMP: Component> fmt::Debug for VChild<COMP> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("VChild<_>")
+    }
+}
+
+impl ToHtml for VComp {
+    fn to_html(&self) -> String {
+        // htmlescape
+
+        match *((*self.state).borrow()) {
+            MountState::Mounted(mounted) => mounted.to_string(),
+            _ => panic!("to_html() called on a component that is not mounted"),
+        }
     }
 }

--- a/src/virtual_dom/vlist.rs
+++ b/src/virtual_dom/vlist.rs
@@ -1,5 +1,5 @@
 //! This module contains fragments implementation.
-use super::{VDiff, VNode, VText};
+use super::{ToHtml, VDiff, VNode, VText};
 use std::ops::{Deref, DerefMut};
 use stdweb::web::{Element, Node};
 
@@ -113,5 +113,12 @@ impl VDiff for VList {
             }
         }
         previous_sibling
+    }
+}
+
+impl ToHtml for VList {
+    fn to_html(&self) -> String {
+        let parts: Vec<String> = self.children.iter().map(|child| child.to_html()).collect();
+        parts.join("")
     }
 }

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -1,6 +1,6 @@
 //! This module contains the implementation of abstract virtual node.
 
-use super::{VChild, VComp, VDiff, VList, VTag, VText};
+use super::{VChild, VComp, VDiff, VList, VTag, VText, ToHtml};
 use crate::html::{Component, Renderable};
 use std::cmp::PartialEq;
 use std::fmt;

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -1,6 +1,6 @@
 //! This module contains the implementation of abstract virtual node.
 
-use super::{VChild, VComp, VDiff, VList, VTag, VText};
+use super::{ToHtml, VChild, VComp, VDiff, VList, VTag, VText};
 use crate::html::{Component, Renderable};
 use std::cmp::PartialEq;
 use std::fmt;
@@ -150,6 +150,18 @@ impl PartialEq for VNode {
             (VNode::VText(vtext_a), VNode::VText(vtext_b)) => vtext_a == vtext_b,
             (VNode::VList(vlist_a), VNode::VList(vlist_b)) => *vlist_a == *vlist_b,
             _ => false, // TODO: Implement other variants
+        }
+    }
+}
+
+impl ToHtml for VNode {
+    fn to_html(&self) -> String {
+        match self {
+            VNode::VTag(vtag) => vtag.to_html(),
+            VNode::VText(vtext) => vtext.to_html(),
+            VNode::VList(vlist) => vlist.to_html(),
+            VNode::VComp(vcomp) => vcomp.to_html(),
+            _ => "".to_string(), // TODO: Implement other variants
         }
     }
 }

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -1,6 +1,6 @@
 //! This module contains the implementation of abstract virtual node.
 
-use super::{VChild, VComp, VDiff, VList, VTag, VText, ToHtml};
+use super::{VChild, VComp, VDiff, VList, VTag, VText};
 use crate::html::{Component, Renderable};
 use std::cmp::PartialEq;
 use std::fmt;

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -148,6 +148,7 @@ impl PartialEq for VNode {
         match (self, other) {
             (VNode::VTag(vtag_a), VNode::VTag(vtag_b)) => vtag_a == vtag_b,
             (VNode::VText(vtext_a), VNode::VText(vtext_b)) => vtext_a == vtext_b,
+            (VNode::VList(vlist_a), VNode::VList(vlist_b)) => *vlist_a == *vlist_b,
             _ => false, // TODO: Implement other variants
         }
     }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -404,6 +404,10 @@ impl ToHtml for VTag {
         }
 
         parts.push(">".to_string());
+        let children_html = match tag_name {
+            "textarea" => VText::new(self.value).to_html(),
+            _ => ""
+        };
         // TODO parts.push(self.children.to_html());
         // TODO handle textareas
         parts.push(format!("</{}>", tag_name).to_string());

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -2,6 +2,7 @@
 
 use super::{
     Attributes, Classes, Listener, Listeners, Patch, Reform, Transformer, VDiff, VList, VNode,
+    ToHtml
 };
 use crate::html::NodeRef;
 use log::warn;
@@ -357,6 +358,12 @@ impl VTag {
                 tae.set_value(value);
             }
         }
+    }
+}
+
+impl ToHtml for VTag {
+    fn to_html(&self) -> String {
+        format!("<{}></{}>", self.tag, self.tag).to_string()
     }
 }
 

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -1,6 +1,6 @@
 //! This module contains the implementation of a virtual text node `VText`.
 
-use super::{Reform, VDiff, VNode};
+use super::{Reform, VDiff, VNode, ToHtml};
 use log::warn;
 use std::cmp::PartialEq;
 use std::fmt;
@@ -87,6 +87,11 @@ impl VDiff for VText {
             }
         }
         self.reference.as_ref().map(|t| t.as_node().to_owned())
+    }
+}
+
+impl ToHtml for VText {
+    fn to_html(&self) -> String {
     }
 }
 

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -1,6 +1,7 @@
 //! This module contains the implementation of a virtual text node `VText`.
 
-use super::{Reform, VDiff, VNode, ToHtml};
+use super::{Reform, ToHtml, VDiff, VNode};
+use htmlescape;
 use log::warn;
 use std::cmp::PartialEq;
 use std::fmt;
@@ -71,7 +72,10 @@ impl VDiff for VText {
         match reform {
             Reform::Keep => {}
             Reform::Before(next_sibling) => {
-                let element = document().create_text_node(&self.text);
+                let element = parent
+                    .owner_document()
+                    .unwrap("Parent node not attached to a document")
+                    .create_text_node(&self.text);
                 if let Some(next_sibling) = next_sibling {
                     parent
                         .insert_before(&element, &next_sibling)
@@ -92,6 +96,7 @@ impl VDiff for VText {
 
 impl ToHtml for VText {
     fn to_html(&self) -> String {
+        htmlescape::encode_minimal(&self.text)
     }
 }
 

--- a/tests/vlist_test.rs
+++ b/tests/vlist_test.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
+use yew::virtual_dom::{VNode, VList};
 
 #[cfg(feature = "wasm_test")]
 wasm_bindgen_test_configure!(run_in_browser);
@@ -30,9 +31,15 @@ fn check_fragments() {
         <>
         </>
     };
-    html! {
+    let div_with_fragment = html! {
         <div>
-            { fragment }
+            { fragment.clone() }
         </div>
     };
+
+    let expected_tree = VNode::VList(
+        VList::new_with_children(vec![])
+    );
+
+    assert_eq!(fragment, expected_tree);
 }

--- a/tests/vlist_test.rs
+++ b/tests/vlist_test.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+use yew::virtual_dom::{VList, VNode};
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
-use yew::virtual_dom::{VNode, VList};
 
 #[cfg(feature = "wasm_test")]
 wasm_bindgen_test_configure!(run_in_browser);
@@ -37,9 +37,7 @@ fn check_fragments() {
         </div>
     };
 
-    let expected_tree = VNode::VList(
-        VList::new_with_children(vec![])
-    );
+    let expected_tree = VNode::VList(VList::new_with_children(vec![]));
 
     assert_eq!(fragment, expected_tree);
 }

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -3,7 +3,7 @@ use stdweb::web::{document, IElement};
 #[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::virtual_dom::vtag::{VTag, HTML_NAMESPACE, SVG_NAMESPACE};
-use yew::virtual_dom::{VDiff, VNode, ToHtml};
+use yew::virtual_dom::{ToHtml, VDiff, VNode};
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
 
 #[cfg(feature = "wasm_test")]
@@ -408,7 +408,6 @@ fn it_checks_misleading_gt() {
     html! { <div><a data-val=Box::<u32>::default() /></div> };
 }
 
-
 #[test]
 fn it_stringifies_complex() {
     let p = html! {
@@ -420,7 +419,7 @@ fn it_stringifies_complex() {
     if let VNode::VTag(p) = p {
         let p_html = (*p).to_html();
 
-        assert_eq!(p_html, "<p aria-controls=\"it-works\">test</p>");
+        assert_eq!(p_html, "<p aria-controls=\"it&#x2D;works\">test</p>");
     } else {
         assert!(false);
     }

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -3,7 +3,7 @@ use stdweb::web::{document, IElement};
 #[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::virtual_dom::vtag::{VTag, HTML_NAMESPACE, SVG_NAMESPACE};
-use yew::virtual_dom::{VDiff, VNode};
+use yew::virtual_dom::{VDiff, VNode, ToHtml};
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
 
 #[cfg(feature = "wasm_test")]
@@ -406,4 +406,22 @@ fn it_checks_misleading_gt() {
 
     html! { <div><a data-val=<u32 as Default>::default() /> </div> };
     html! { <div><a data-val=Box::<u32>::default() /></div> };
+}
+
+
+#[test]
+fn it_stringifies_complex() {
+    let p = html! {
+        <p aria-controls="it-works">
+            { "test" }
+        </p>
+    };
+
+    if let VNode::VTag(p) = p {
+        let p_html = (*p).to_html();
+
+        assert_eq!(p_html, "<p aria-controls=\"it-works\">test</p>");
+    } else {
+        assert!(false);
+    }
 }

--- a/tests/vtext_test.rs
+++ b/tests/vtext_test.rs
@@ -36,10 +36,7 @@ fn text_as_root() {
     };
 
     let expected_tree = VNode::VText(
-        VText {
-            text: "Text Node As Root".to_string(),
-            reference: None,
-        }
+        VText::new("Text Node As Root".to_string())
     );
 
     assert_eq!(no_braces, expected_tree);

--- a/tests/vtext_test.rs
+++ b/tests/vtext_test.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+use yew::virtual_dom::{VNode, VText};
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
-use yew::virtual_dom::{VText, VNode};
 
 #[cfg(feature = "wasm_test")]
 wasm_bindgen_test_configure!(run_in_browser);
@@ -35,9 +35,7 @@ fn text_as_root() {
         { "Text Node As Root" }
     };
 
-    let expected_tree = VNode::VText(
-        VText::new("Text Node As Root".to_string())
-    );
+    let expected_tree = VNode::VText(VText::new("Text Node As Root".to_string()));
 
     assert_eq!(no_braces, expected_tree);
     assert_eq!(with_braces, expected_tree);

--- a/tests/vtext_test.rs
+++ b/tests/vtext_test.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
+use yew::virtual_dom::{VText, VNode};
 
 #[cfg(feature = "wasm_test")]
 wasm_bindgen_test_configure!(run_in_browser);
@@ -26,11 +27,21 @@ impl Component for Comp {
 
 #[test]
 fn text_as_root() {
-    html! {
+    let no_braces = html! {
         "Text Node As Root"
     };
 
-    html! {
+    let with_braces = html! {
         { "Text Node As Root" }
     };
+
+    let expected_tree = VNode::VText(
+        VText {
+            text: "Text Node As Root".to_string(),
+            reference: None,
+        }
+    );
+
+    assert_eq!(no_braces, expected_tree);
+    assert_eq!(with_braces, expected_tree);
 }


### PR DESCRIPTION
This work-in-progress PR represents an attempt to statically convert a VNode into an HTML string, for the purposes of SSR support (#41). Please note that I'm not sure this will be the approach I end up going with, as it may turn out infeasible with nodes such as VComp (currently investigating alternative approaches now); it should be considered an experiment.