### PR TITLE
Improve html! "for" iterable ergonomics

### DIFF
--- a/crates/macro/src/html_tree/html_iterable.rs
+++ b/crates/macro/src/html_tree/html_iterable.rs
@@ -41,7 +41,7 @@ impl ToTokens for HtmlIterable {
         let expr = &self.0;
         let new_tokens = quote_spanned! {expr.span()=> {
             let mut __yew_vlist = ::yew::virtual_dom::VList::default();
-            for __yew_node in ::std::iter::IntoIterator::into_iter(#expr) {
+            for __yew_node in #expr {
                 __yew_vlist.add_child(__yew_node.into());
             }
             ::yew::virtual_dom::VNode::from(__yew_vlist)

--- a/crates/macro/src/html_tree/html_iterable.rs
+++ b/crates/macro/src/html_tree/html_iterable.rs
@@ -41,8 +41,7 @@ impl ToTokens for HtmlIterable {
         let expr = &self.0;
         let new_tokens = quote_spanned! {expr.span()=> {
             let mut __yew_vlist = ::yew::virtual_dom::VList::default();
-            let __yew_nodes: &mut ::std::iter::Iterator<Item = _> = &mut(#expr);
-            for __yew_node in __yew_nodes.into_iter() {
+            for __yew_node in ::std::iter::IntoIterator::into_iter(#expr) {
                 __yew_vlist.add_child(__yew_node.into());
             }
             ::yew::virtual_dom::VNode::from(__yew_vlist)

--- a/tests/macro/html-iterable-fail.stderr
+++ b/tests/macro/html-iterable-fail.stderr
@@ -11,7 +11,7 @@ error[E0277]: `()` is not an iterator
   |                 ^^ `()` is not an iterator
   |
   = help: the trait `std::iter::Iterator` is not implemented for `()`
-  = note: required for the cast to the object type `dyn std::iter::Iterator<Item = _>`
+  = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `()` is not an iterator
  --> $DIR/html-iterable-fail.rs:6:17
@@ -20,7 +20,7 @@ error[E0277]: `()` is not an iterator
   |                 ^^^^ `()` is not an iterator
   |
   = help: the trait `std::iter::Iterator` is not implemented for `()`
-  = note: required for the cast to the object type `dyn std::iter::Iterator<Item = _>`
+  = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
  --> $DIR/html-iterable-fail.rs:7:17

--- a/tests/macro/html-iterable-pass.rs
+++ b/tests/macro/html-iterable-pass.rs
@@ -3,12 +3,16 @@ use std::iter;
 
 fn compile_pass() {
     html! { for iter::empty::<Html>() };
+    html! { for Vec::<Html>::new() };
     html! { for Vec::<Html>::new().into_iter() };
     html! { for (0..3).map(|num| { html! { <span>{num}</span> } }) };
     html! { for {iter::empty::<Html>()} };
 
     let empty: Vec<Html> = Vec::new();
     html! { for empty.into_iter() };
+
+    let empty: Vec<Html> = Vec::new();
+    html! { for empty };
 }
 
 fn main() {}


### PR DESCRIPTION
Fixes: https://github.com/yewstack/yew/issues/871

#### Problem
Poor ergonomics when using `html! { for .. } `. When passing a local variable into html! as part of { for my_var }, it is an error for that local variable not to be mut.

#### Solution
Use std::iter::IntoIterator::into_iter(#expr) as suggested by @jplatte