### PR TITLE
Add `default` value for properties

### DIFF
--- a/crates/macro/src/derive_props/field.rs
+++ b/crates/macro/src/derive_props/field.rs
@@ -1,6 +1,6 @@
 use super::generics::GenericArguments;
 use proc_macro2::{Ident, Span};
-use quote::quote;
+use quote::{quote, quote_spanned};
 use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::convert::TryFrom;
 use syn::parse::Result;
@@ -83,8 +83,13 @@ impl PropField {
             }
             PropAttr::Default { default_value } => {
                 let name = &self.name;
-                quote! {
-                    #name: #default_value,
+                let ty = &self.ty;
+                let span = default_value.span();
+                quote_spanned! {span=>
+                    #name: {
+                        let none: Option<#ty> = None;
+                        if false { none } else { Some(#default_value) }.unwrap()
+                    },
                 }
             }
             PropAttr::None => {

--- a/crates/macro/src/derive_props/field.rs
+++ b/crates/macro/src/derive_props/field.rs
@@ -5,19 +5,29 @@ use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::convert::TryFrom;
 use syn::parse::Result;
 use syn::spanned::Spanned;
-use syn::{Error, Field, Meta, MetaList, NestedMeta, Type, Visibility};
+use syn::{Error, Expr, Field, Lit, Meta, MetaList, MetaNameValue, NestedMeta, Type, Visibility};
+
+#[derive(PartialEq, Eq)]
+enum PropAttr {
+    Required { wrapped_name: Ident },
+    Default { default_value: Expr },
+    None,
+}
 
 #[derive(Eq)]
 pub struct PropField {
     ty: Type,
     name: Ident,
-    wrapped_name: Option<Ident>,
+    attr: PropAttr,
 }
 
 impl PropField {
     /// All required property fields are wrapped in an `Option`
     pub fn is_required(&self) -> bool {
-        self.wrapped_name.is_some()
+        match self.attr {
+            PropAttr::Required { .. } => true,
+            _ => false,
+        }
     }
 
     /// This step name is descriptive to help a developer realize they missed a required prop
@@ -31,13 +41,16 @@ impl PropField {
     /// Used to transform the `PropWrapper` struct into `Properties`
     pub fn to_field_setter(&self) -> proc_macro2::TokenStream {
         let name = &self.name;
-        if let Some(wrapped_name) = &self.wrapped_name {
-            quote! {
-                #name: self.wrapped.#wrapped_name.unwrap(),
+        match &self.attr {
+            PropAttr::Required { wrapped_name } => {
+                quote! {
+                    #name: self.wrapped.#wrapped_name.unwrap(),
+                }
             }
-        } else {
-            quote! {
-                #name: self.wrapped.#name,
+            _ => {
+                quote! {
+                    #name: self.wrapped.#name,
+                }
             }
         }
     }
@@ -45,28 +58,40 @@ impl PropField {
     /// Wrap all required props in `Option`
     pub fn to_field_def(&self) -> proc_macro2::TokenStream {
         let ty = &self.ty;
-        if let Some(wrapped_name) = &self.wrapped_name {
-            quote! {
-                #wrapped_name: ::std::option::Option<#ty>,
+        match &self.attr {
+            PropAttr::Required { wrapped_name } => {
+                quote! {
+                    #wrapped_name: ::std::option::Option<#ty>,
+                }
             }
-        } else {
-            let name = &self.name;
-            quote! {
-                #name: #ty,
+            _ => {
+                let name = &self.name;
+                quote! {
+                    #name: #ty,
+                }
             }
         }
     }
 
     /// All optional props must implement the `Default` trait
     pub fn to_default_setter(&self) -> proc_macro2::TokenStream {
-        if let Some(wrapped_name) = &self.wrapped_name {
-            quote! {
-                #wrapped_name: ::std::default::Default::default(),
+        match &self.attr {
+            PropAttr::Required { wrapped_name } => {
+                quote! {
+                    #wrapped_name: ::std::option::Option::None,
+                }
             }
-        } else {
-            let name = &self.name;
-            quote! {
-                #name: ::std::default::Default::default(),
+            PropAttr::Default { default_value } => {
+                let name = &self.name;
+                quote! {
+                    #name: #default_value,
+                }
+            }
+            PropAttr::None => {
+                let name = &self.name;
+                quote! {
+                    #name: ::std::default::Default::default(),
+                }
             }
         }
     }
@@ -78,64 +103,77 @@ impl PropField {
         generic_arguments: &GenericArguments,
         vis: &Visibility,
     ) -> proc_macro2::TokenStream {
-        let Self {
-            name,
-            ty,
-            wrapped_name,
-        } = self;
-        if let Some(wrapped_name) = wrapped_name {
-            quote! {
-                #[doc(hidden)]
-                #vis fn #name(mut self, #name: #ty) -> #builder_name<#generic_arguments> {
-                    self.wrapped.#wrapped_name = ::std::option::Option::Some(#name);
-                    #builder_name {
-                        wrapped: self.wrapped,
-                        _marker: ::std::marker::PhantomData,
+        let Self { name, ty, attr } = self;
+        match attr {
+            PropAttr::Required { wrapped_name } => {
+                quote! {
+                    #[doc(hidden)]
+                    #vis fn #name(mut self, #name: #ty) -> #builder_name<#generic_arguments> {
+                        self.wrapped.#wrapped_name = ::std::option::Option::Some(#name);
+                        #builder_name {
+                            wrapped: self.wrapped,
+                            _marker: ::std::marker::PhantomData,
+                        }
                     }
                 }
             }
-        } else {
-            quote! {
-                #[doc(hidden)]
-                #vis fn #name(mut self, #name: #ty) -> #builder_name<#generic_arguments> {
-                    self.wrapped.#name = #name;
-                    self
+            _ => {
+                quote! {
+                    #[doc(hidden)]
+                    #vis fn #name(mut self, #name: #ty) -> #builder_name<#generic_arguments> {
+                        self.wrapped.#name = #name;
+                        self
+                    }
                 }
             }
         }
     }
 
-    // Detect the `#[props(required)]` attribute which denotes required fields
-    fn required_wrapper(named_field: &syn::Field) -> Result<Option<Ident>> {
+    // Detect `#[props(required)]` or `#[props(default="...")]` attribute
+    fn attribute(named_field: &syn::Field) -> Result<PropAttr> {
         let meta_list = if let Some(meta_list) = Self::find_props_meta_list(named_field) {
             meta_list
         } else {
-            return Ok(None);
+            return Ok(PropAttr::None);
         };
 
-        let expected_required = syn::Error::new(meta_list.span(), "expected `props(required)`");
+        let expected_attr = syn::Error::new(
+            meta_list.span(),
+            "expected `props(required)` or `#[props(default=\"...\")]`",
+        );
         let first_nested = if let Some(first_nested) = meta_list.nested.first() {
             first_nested
         } else {
-            return Err(expected_required);
+            return Err(expected_attr);
         };
+        match first_nested {
+            NestedMeta::Meta(Meta::Path(word_path)) => {
+                if !word_path.is_ident("required") {
+                    return Err(expected_attr);
+                }
 
-        let word_path = match first_nested {
-            NestedMeta::Meta(Meta::Path(path)) => path,
-            _ => return Err(expected_required),
-        };
+                if let Some(ident) = &named_field.ident {
+                    let wrapped_name = Ident::new(&format!("{}_wrapper", ident), Span::call_site());
+                    Ok(PropAttr::Required { wrapped_name })
+                } else {
+                    unreachable!()
+                }
+            }
+            NestedMeta::Meta(Meta::NameValue(name_value)) => {
+                let MetaNameValue { path, lit, .. } = name_value;
 
-        if !word_path.is_ident("required") {
-            return Err(expected_required);
-        }
+                if !path.is_ident("default") {
+                    return Err(expected_attr);
+                }
 
-        if let Some(ident) = &named_field.ident {
-            Ok(Some(Ident::new(
-                &format!("{}_wrapper", ident),
-                Span::call_site(),
-            )))
-        } else {
-            unreachable!()
+                if let Lit::Str(lit_str) = lit {
+                    let default_value = lit_str.parse()?;
+                    Ok(PropAttr::Default { default_value })
+                } else {
+                    Err(expected_attr)
+                }
+            }
+            _ => Err(expected_attr),
         }
     }
 
@@ -161,7 +199,7 @@ impl TryFrom<Field> for PropField {
 
     fn try_from(field: Field) -> Result<Self> {
         Ok(PropField {
-            wrapped_name: Self::required_wrapper(&field)?,
+            attr: Self::attribute(&field)?,
             ty: field.ty,
             name: field.ident.unwrap(),
         })

--- a/tests/derive_props/fail.rs
+++ b/tests/derive_props/fail.rs
@@ -50,4 +50,34 @@ mod t4 {
     }
 }
 
+mod t5 {
+    use super::*;
+    #[derive(Clone, Properties)]
+    pub struct Props {
+        // ERROR: default must be given a value
+        #[props(default)]
+        value: String,
+    }
+}
+
+mod t6 {
+    use super::*;
+    #[derive(Clone, Properties)]
+    pub struct Props {
+        // ERROR: the value must be a string
+        #[props(default = 123)]
+        value: i32,
+    }
+}
+
+mod t7 {
+    use super::*;
+    #[derive(Clone, Properties)]
+    pub struct Props {
+        // ERROR: the value must be parsed as a String
+        #[props(default = "123")]
+        value: String,
+    }
+}
+
 fn main() {}

--- a/tests/derive_props/fail.stderr
+++ b/tests/derive_props/fail.stderr
@@ -42,14 +42,14 @@ error[E0599]: no method named `b` found for type `t4::PropsBuilder<t4::PropsBuil
 49 |         Props::builder().b(1).a(2).build();
    |                          ^ help: there is a method with a similar name: `a`
 
-error[E0308]: mismatched types
+error[E0308]: if and else have incompatible types
   --> $DIR/fail.rs:78:27
    |
 78 |         #[props(default = "123")]
    |                           ^^^^^
    |                           |
    |                           expected struct `std::string::String`, found integer
-   |                           help: try using a conversion method: `"123".to_string()`
+   |                           expected because of this
    |
-   = note: expected type `std::string::String`
-              found type `{integer}`
+   = note: expected type `std::option::Option<std::string::String>`
+              found type `std::option::Option<{integer}>`

--- a/tests/derive_props/fail.stderr
+++ b/tests/derive_props/fail.stderr
@@ -1,7 +1,19 @@
-error: expected `props(required)`
+error: expected `props(required)` or `#[props(default="...")]`
   --> $DIR/fail.rs:21:11
    |
 21 |         #[props(optional)]
+   |           ^^^^^
+
+error: expected `props(required)` or `#[props(default="...")]`
+  --> $DIR/fail.rs:58:11
+   |
+58 |         #[props(default)]
+   |           ^^^^^
+
+error: expected `props(required)` or `#[props(default="...")]`
+  --> $DIR/fail.rs:68:11
+   |
+68 |         #[props(default = 123)]
    |           ^^^^^
 
 error[E0277]: the trait bound `t1::Value: std::default::Default` is not satisfied
@@ -29,3 +41,15 @@ error[E0599]: no method named `b` found for type `t4::PropsBuilder<t4::PropsBuil
 ...
 49 |         Props::builder().b(1).a(2).build();
    |                          ^ help: there is a method with a similar name: `a`
+
+error[E0308]: mismatched types
+  --> $DIR/fail.rs:78:27
+   |
+78 |         #[props(default = "123")]
+   |                           ^^^^^
+   |                           |
+   |                           expected struct `std::string::String`, found integer
+   |                           help: try using a conversion method: `"123".to_string()`
+   |
+   = note: expected type `std::string::String`
+              found type `{integer}`

--- a/tests/derive_props/pass.rs
+++ b/tests/derive_props/pass.rs
@@ -107,16 +107,22 @@ mod t6 {
 mod t7 {
     use super::*;
 
-    #[derive(Clone, Properties)]
-    pub struct Props {
-        #[props(default = "123 + 456")]
-        value: i32,
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub enum Foo {
+        One,
+        Two,
     }
 
-    fn required_prop_generics_should_work() {
+    #[derive(Clone, Properties)]
+    pub struct Props {
+        #[props(default = "Foo::One")]
+        value: Foo,
+    }
+
+    fn default_value_should_work() {
         let props = Props::builder().build();
-        assert_eq!(props.value, 579);
-        Props::builder().value(456).build();
+        assert_eq!(props.value, Foo::One);
+        Props::builder().value(Foo::Two).build();
     }
 }
 

--- a/tests/derive_props/pass.rs
+++ b/tests/derive_props/pass.rs
@@ -91,14 +91,32 @@ mod t6 {
     #[derive(Properties, Clone)]
     pub struct Props<T: FromStr + Clone>
     where
-    <T as FromStr>::Err: Clone,
+        <T as FromStr>::Err: Clone,
     {
         #[props(required)]
         value: Result<T, <T as FromStr>::Err>,
     }
 
     fn required_prop_generics_with_where_clause_should_work() {
-        Props::<String>::builder().value(Ok(String::from(""))).build();
+        Props::<String>::builder()
+            .value(Ok(String::from("")))
+            .build();
+    }
+}
+
+mod t7 {
+    use super::*;
+
+    #[derive(Clone, Properties)]
+    pub struct Props {
+        #[props(default = "123 + 456")]
+        value: i32,
+    }
+
+    fn required_prop_generics_should_work() {
+        let props = Props::builder().build();
+        assert_eq!(props.value, 579);
+        Props::builder().value(456).build();
     }
 }
 


### PR DESCRIPTION
Fix #775

We will be able to provide default values to properties, using a syntax like:

```rust
#[derive(Properties)]
struct MyProps {
    #[props(default = "50 + 50")]
    value: u32,
    #[props(default = "true")]
    enabled: bool
}
```

The syntax is based on @mdtusz's suggestion, but it takes an expression instead of a path to a function. 