### PR TITLE
Install wasm-bindgen-cli if it does not exist on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - rustup target add wasm32-unknown-unknown
   - cargo install cargo-update || true
   - cargo install-update-config --version =0.2.58 wasm-bindgen-cli
-  - cargo install-update wasm-bindgen-cli
+  - cargo install-update --allow-no-update wasm-bindgen-cli
   - LATEST_CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"`
   - curl --retry 5 -LO "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
   - unzip chromedriver_linux64.zip


### PR DESCRIPTION
Fixes: https://github.com/yewstack/yew/issues/891

I recently cleared travis ci caches and broke this functionality