### PR TITLE
fix(task): remove `cancel` method from `Task` trait(#884)

### DIFF
--- a/examples/dashboard/src/lib.rs
+++ b/examples/dashboard/src/lib.rs
@@ -167,7 +167,7 @@ impl Component for Model {
                     }
                 }
                 WsAction::Disconnect => {
-                    self.ws.take().unwrap().cancel();
+                    self.ws.take();
                 }
                 WsAction::Lost => {
                     self.ws = None;

--- a/examples/timer/src/lib.rs
+++ b/examples/timer/src/lib.rs
@@ -76,9 +76,7 @@ impl Component for Model {
                 self.console.log("Interval started!");
             }
             Msg::Cancel => {
-                if let Some(mut task) = self.job.take() {
-                    task.cancel();
-                }
+                self.job.take();
                 self.messages.push("Canceled!");
                 self.console.warn("Canceled!");
                 self.console.assert(self.job.is_none(), "Job still exists!");

--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -420,29 +420,23 @@ impl Task for FetchTask {
             false
         }
     }
-    fn cancel(&mut self) {
-        // Fetch API doesn't support request cancelling in all browsers
-        // and we should use this workaround with a flag.
-        // In that case, request not canceled, but callback won't be called.
-        let handle = self
-            .0
-            .take()
-            .expect("tried to cancel request fetching twice");
-        js! {  @(no_return)
-            var handle = @{handle};
-            handle.active = false;
-            handle.callback.drop();
-            if (handle.abortController) {
-                handle.abortController.abort();
-            }
-        }
-    }
 }
 
 impl Drop for FetchTask {
     fn drop(&mut self) {
         if self.is_active() {
-            self.cancel();
+            // Fetch API doesn't support request cancelling in all browsers
+            // and we should use this workaround with a flag.
+            // In that case, request not canceled, but callback won't be called.
+            let handle = self.0.take().unwrap();
+            js! {  @(no_return)
+                var handle = @{handle};
+                handle.active = false;
+                handle.callback.drop();
+                if (handle.abortController) {
+                    handle.abortController.abort();
+                }
+            }
         }
     }
 }

--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -56,20 +56,17 @@ impl Task for IntervalTask {
     fn is_active(&self) -> bool {
         self.0.is_some()
     }
-    fn cancel(&mut self) {
-        let handle = self.0.take().expect("tried to cancel interval twice");
-        js! { @(no_return)
-            var handle = @{handle};
-            clearInterval(handle.interval_id);
-            handle.callback.drop();
-        }
-    }
 }
 
 impl Drop for IntervalTask {
     fn drop(&mut self) {
         if self.is_active() {
-            self.cancel();
+            let handle = self.0.take().unwrap();
+            js! { @(no_return)
+                var handle = @{handle};
+                clearInterval(handle.interval_id);
+                handle.callback.drop();
+            }
         }
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -33,8 +33,6 @@ use std::time::Duration;
 pub trait Task: Drop {
     /// Returns `true` if task is active.
     fn is_active(&self) -> bool;
-    /// Cancel current service's routine.
-    fn cancel(&mut self);
 }
 
 #[doc(hidden)]

--- a/src/services/reader.rs
+++ b/src/services/reader.rs
@@ -146,16 +146,12 @@ impl Task for ReaderTask {
     fn is_active(&self) -> bool {
         self.file_reader.ready_state() == FileReaderReadyState::Loading
     }
-
-    fn cancel(&mut self) {
-        self.file_reader.abort();
-    }
 }
 
 impl Drop for ReaderTask {
     fn drop(&mut self) {
         if self.is_active() {
-            self.cancel();
+            self.file_reader.abort();
         }
     }
 }

--- a/src/services/render.rs
+++ b/src/services/render.rs
@@ -57,20 +57,17 @@ impl Task for RenderTask {
     fn is_active(&self) -> bool {
         self.0.is_some()
     }
-    fn cancel(&mut self) {
-        let handle = self.0.take().expect("tried to cancel render twice");
-        js! { @(no_return)
-            var handle = @{handle};
-            cancelAnimationFrame(handle.render_id);
-            handle.callback.drop();
-        }
-    }
 }
 
 impl Drop for RenderTask {
     fn drop(&mut self) {
         if self.is_active() {
-            self.cancel();
+            let handle = self.0.take().unwrap();
+            js! { @(no_return)
+                var handle = @{handle};
+                cancelAnimationFrame(handle.render_id);
+                handle.callback.drop();
+            }
         }
     }
 }

--- a/src/services/timeout.rs
+++ b/src/services/timeout.rs
@@ -55,20 +55,17 @@ impl Task for TimeoutTask {
     fn is_active(&self) -> bool {
         self.0.is_some()
     }
-    fn cancel(&mut self) {
-        let handle = self.0.take().expect("tried to cancel timeout twice");
-        js! { @(no_return)
-            var handle = @{handle};
-            clearTimeout(handle.timeout_id);
-            handle.callback.drop();
-        }
-    }
 }
 
 impl Drop for TimeoutTask {
     fn drop(&mut self) {
         if self.is_active() {
-            self.cancel();
+            let handle = self.0.take().unwrap();
+            js! { @(no_return)
+                var handle = @{handle};
+                clearTimeout(handle.timeout_id);
+                handle.callback.drop();
+            }
         }
     }
 }

--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -119,15 +119,12 @@ impl Task for WebSocketTask {
     fn is_active(&self) -> bool {
         self.ws.ready_state() == SocketReadyState::Open
     }
-    fn cancel(&mut self) {
-        self.ws.close();
-    }
 }
 
 impl Drop for WebSocketTask {
     fn drop(&mut self) {
         if self.is_active() {
-            self.cancel();
+            self.ws.close();
         }
     }
 }


### PR DESCRIPTION
Fixes #884.

In order to avoid misuse It was decided to remove `cancel` from `Task` trait
and delegate such logic to `Drop`.