### PR TITLE
fix native_worker.js 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ if you tell the `cargo-web` to build for them using the `--target` parameter.
 
 ### Code Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CODE_OF_CONDUCT.md)].
+This project exists thanks to all the people who contribute.
 <a href="https://github.com/yewstack/yew/graphs/contributors"><img src="https://opencollective.com/yew/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors

--- a/README.md
+++ b/README.md
@@ -477,10 +477,10 @@ cargo build --target wasm32-unknown-unknown
 ```
 
 ### Running Tests
-For the tests to work one have to ensure that `wasm-bindgen-cli` is installed. 
+For the tests to work one have to ensure that `wasm-bindgen-cli` is installed.
 [Instructions](https://rustwasm.github.io/docs/wasm-bindgen/wasm-bindgen-test/usage.html#install-the-test-runner)
 
-Additionally a webdriver must be installed locally and configured to be on the 
+Additionally a webdriver must be installed locally and configured to be on the
 `PATH`. Currently supports `geckodriver`, `chromedriver`, and `safaridriver`,
 although more driver support may be added! You can download these at:
 
@@ -537,7 +537,7 @@ if you tell the `cargo-web` to build for them using the `--target` parameter.
 
 ### Code Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute. [[Contribute](CODE_OF_CONDUCT.md)].
 <a href="https://github.com/yewstack/yew/graphs/contributors"><img src="https://opencollective.com/yew/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors

--- a/examples/multi_thread/static/bin
+++ b/examples/multi_thread/static/bin
@@ -1,1 +1,1 @@
-../../../target/wasm32-unknown-unknown/release
+../../target/wasm32-unknown-unknown/release


### PR DESCRIPTION
I was trying to compile the `multi_thread` example but I was receiving the error:
> GET http://localhost:8000/bin/native_worker.js 404 (Not Found)

Turns out it was a problem in the link that pointed to the `native_worker` target folder. 

PS: Just fixed the Contribute link to the Code of Conduct page since it's my first PR and clicking there I got to a GitHub not found page :)