### PR TITLE
Fix mounted order

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -739,7 +739,7 @@ impl<AGN: Agent> AgentScope<AGN> {
             update,
         };
         let runnable: Box<dyn Runnable> = Box::new(envelope);
-        scheduler().put_and_try_run(runnable);
+        scheduler().put_and_try_run(runnable, false);
     }
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -739,7 +739,7 @@ impl<AGN: Agent> AgentScope<AGN> {
             update,
         };
         let runnable: Box<dyn Runnable> = Box::new(envelope);
-        scheduler().put_and_try_run(runnable, false);
+        scheduler().push(runnable);
     }
 }
 

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -304,12 +304,19 @@ where
 ///     }
 /// }
 #[derive(PartialEq, Debug, Default, Clone)]
-pub struct NodeRef(Rc<RefCell<Option<Node>>>);
+pub struct NodeRef(Rc<RefCell<NodeRefInner>>);
+
+#[derive(PartialEq, Debug, Default, Clone)]
+struct NodeRefInner {
+    node: Option<Node>,
+    link: Option<NodeRef>,
+}
 
 impl NodeRef {
     /// Get the wrapped Node reference if it exists
     pub fn get(&self) -> Option<Node> {
-        self.0.borrow().clone()
+        let inner = self.0.borrow();
+        inner.node.clone().or_else(|| inner.link.as_ref()?.get())
     }
 
     /// Try converting the node reference into another form
@@ -319,7 +326,12 @@ impl NodeRef {
 
     /// Place a Node in a reference for later use
     pub(crate) fn set(&self, node: Option<Node>) {
-        *self.0.borrow_mut() = node;
+        self.0.borrow_mut().node = node;
+    }
+
+    /// Link a downstream `NodeRef`
+    pub(crate) fn link(&self, node_ref: Self) {
+        self.0.borrow_mut().link = Some(node_ref);
     }
 }
 

--- a/src/html/scope.rs
+++ b/src/html/scope.rs
@@ -78,14 +78,14 @@ impl<COMP: Component> Scope<COMP> {
     pub(crate) fn mounted(&mut self) {
         let shared_state = self.shared_state.clone();
         let mounted = Box::new(MountedComponent { shared_state });
-        scheduler().put_and_try_run(mounted);
+        scheduler().put_and_try_run(mounted, false);
     }
 
     /// Schedules a task to create and render a component and then mount it to the DOM
     pub(crate) fn create(&mut self) {
         let shared_state = self.shared_state.clone();
         let create = CreateComponent { shared_state };
-        scheduler().put_and_try_run(Box::new(create));
+        scheduler().put_and_try_run(Box::new(create), true);
     }
 
     /// Schedules a task to send a message or new props to a component
@@ -94,14 +94,14 @@ impl<COMP: Component> Scope<COMP> {
             shared_state: self.shared_state.clone(),
             update,
         };
-        scheduler().put_and_try_run(Box::new(update));
+        scheduler().put_and_try_run(Box::new(update), false);
     }
 
     /// Schedules a task to destroy a component
     pub(crate) fn destroy(&mut self) {
         let shared_state = self.shared_state.clone();
         let destroy = DestroyComponent { shared_state };
-        scheduler().put_and_try_run(Box::new(destroy));
+        scheduler().put_and_try_run(Box::new(destroy), false);
     }
 
     /// Send a message to the component

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -3,7 +3,6 @@
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 pub(crate) type Shared<T> = Rc<RefCell<T>>;
 
@@ -23,49 +22,57 @@ pub(crate) trait Runnable {
 }
 
 /// This is a global scheduler suitable to schedule and run any tasks.
+#[derive(Clone)]
 pub(crate) struct Scheduler {
-    lock: Rc<AtomicBool>,
-    sequence: Shared<VecDeque<Box<dyn Runnable>>>,
-}
-
-impl Clone for Scheduler {
-    fn clone(&self) -> Self {
-        Scheduler {
-            lock: self.lock.clone(),
-            sequence: self.sequence.clone(),
-        }
-    }
+    lock: Rc<RefCell<()>>,
+    main: Shared<VecDeque<Box<dyn Runnable>>>,
+    create_component: Shared<VecDeque<Box<dyn Runnable>>>,
+    mount_component: Shared<Vec<Box<dyn Runnable>>>,
 }
 
 impl Scheduler {
-    /// Creates a new scheduler with a context.
     fn new() -> Self {
-        let sequence = VecDeque::new();
         Scheduler {
-            lock: Rc::new(AtomicBool::new(false)),
-            sequence: Rc::new(RefCell::new(sequence)),
+            lock: Rc::new(RefCell::new(())),
+            main: Rc::new(RefCell::new(VecDeque::new())),
+            create_component: Rc::new(RefCell::new(VecDeque::new())),
+            mount_component: Rc::new(RefCell::new(Vec::new())),
         }
     }
 
-    pub(crate) fn put_and_try_run(&self, runnable: Box<dyn Runnable>, push_front: bool)  {
-        if push_front {
-            self.sequence.borrow_mut().push_front(runnable);
-        } else {
-            self.sequence.borrow_mut().push_back(runnable);
-        }
+    pub(crate) fn push(&self, runnable: Box<dyn Runnable>) {
+        self.main.borrow_mut().push_back(runnable);
+        self.start();
+    }
 
-        if self.lock.compare_and_swap(false, true, Ordering::Relaxed) {
+    pub(crate) fn push_create(&self, runnable: Box<dyn Runnable>) {
+        self.create_component.borrow_mut().push_back(runnable);
+        self.start();
+    }
+
+    pub(crate) fn push_mount(&self, runnable: Box<dyn Runnable>) {
+        self.mount_component.borrow_mut().push(runnable);
+        self.start();
+    }
+
+    pub(crate) fn start(&self) {
+        let lock = self.lock.try_borrow_mut();
+        if lock.is_err() {
             return;
         }
 
         loop {
-            let do_next = self.sequence.borrow_mut().pop_front();
+            let do_next = self
+                .create_component
+                .borrow_mut()
+                .pop_front()
+                .or_else(|| self.mount_component.borrow_mut().pop())
+                .or_else(|| self.main.borrow_mut().pop_front());
             if let Some(runnable) = do_next {
                 runnable.run();
             } else {
                 break;
             }
         }
-        self.lock.store(false, Ordering::Relaxed);
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -47,8 +47,13 @@ impl Scheduler {
         }
     }
 
-    pub(crate) fn put_and_try_run(&self, runnable: Box<dyn Runnable>) {
-        self.sequence.borrow_mut().push_back(runnable);
+    pub(crate) fn put_and_try_run(&self, runnable: Box<dyn Runnable>, push_front: bool)  {
+        if push_front {
+            self.sequence.borrow_mut().push_front(runnable);
+        } else {
+            self.sequence.borrow_mut().push_back(runnable);
+        }
+
         if self.lock.compare_and_swap(false, true, Ordering::Relaxed) {
             return;
         }

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -18,18 +18,11 @@ enum GeneratorType {
 }
 
 /// A virtual component.
+#[derive(Clone)]
 pub struct VComp {
     type_id: TypeId,
     state: Rc<RefCell<MountState>>,
-}
-
-impl Clone for VComp {
-    fn clone(&self) -> Self {
-        VComp {
-            type_id: self.type_id,
-            state: self.state.clone(),
-        }
-    }
+    pub(crate) node_ref: NodeRef,
 }
 
 /// A virtual child component.
@@ -92,6 +85,7 @@ impl VComp {
     where
         COMP: Component,
     {
+        let node_ref_clone = node_ref.clone();
         let generator = move |generator_type: GeneratorType| -> Mounted {
             match generator_type {
                 GeneratorType::Mount(element, dummy_node) => {
@@ -100,12 +94,12 @@ impl VComp {
                     let mut scope = scope.mount_in_place(
                         element,
                         Some(VNode::VRef(dummy_node.into())),
-                        node_ref.clone(),
+                        node_ref_clone.clone(),
                         props.clone(),
                     );
 
                     Mounted {
-                        node_ref: node_ref.clone(),
+                        node_ref: node_ref_clone.clone(),
                         scope: scope.clone().into(),
                         destroyer: Box::new(move || scope.destroy()),
                     }
@@ -115,7 +109,7 @@ impl VComp {
                     scope.update(ComponentUpdate::Properties(props.clone()));
 
                     Mounted {
-                        node_ref: node_ref.clone(),
+                        node_ref: node_ref_clone.clone(),
                         scope: scope.clone().into(),
                         destroyer: Box::new(move || scope.destroy()),
                     }
@@ -128,6 +122,7 @@ impl VComp {
             state: Rc::new(RefCell::new(MountState::Unmounted(Unmounted {
                 generator: Box::new(generator),
             }))),
+            node_ref,
         }
     }
 }
@@ -215,16 +210,13 @@ impl VDiff for VComp {
                         this.mount(parent.to_owned(), dummy_node)
                     }
                 };
-
-                let node = mounted.node_ref.get();
                 self.state.replace(MountState::Mounted(mounted));
-                node
             }
             state => {
                 self.state.replace(state);
-                None
             }
         }
+        None
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/yewstack/yew/issues/896

#### Problem
Parent and children components rendered out of order. The intended behaviour is that `mounted` is not called on a parent component until all of its children have been rendered.

**Broken Scheduler Queue Order:**
1. Create Parent Job (creates and renders component)
2. Mount Parent Job (calls `mounted()`)
3. Create Child Job
4. Mount Child Job

Since the jobs were processed out of order, the child `NodeRef` was not initialized early enough and therefore not accessible to the parent when `mounted()` was called.

#### Changes

* Split scheduler into 3 job queues (comp creation, comp mount, and default (main))
* Always process create jobs first (allows depth first rendering)
* Then process mount jobs in the reverse order they are queued (to ensure root is mounted last)
* Process main queue last (prevents update messages from getting processed before a component is mounted)
* Fix bug preventing node refs from bubbling up if a component renders a node tree with a root node that is also a component. This bug is fixed by linking node refs 

**New Scheduler Queue Order**
1. Create Parent Job (creates and renders component)
2. Create Child Job
3. Mount Child Job
4. Mount Parent Job (calls `mounted()`)
5. Process other messages