### PR TITLE
Fix ResizeTask drop

### DIFF
--- a/src/services/resize.rs
+++ b/src/services/resize.rs
@@ -54,11 +54,9 @@ impl ResizeService {
             callback.emit(dimensions);
         };
         let handle = js! {
-            var callback = @{callback};
-            var action = function() {
-                callback();
-            };
-            return window.addEventListener("resize", action);
+            var handle = @{callback};
+            window.addEventListener("resize", handle);
+            return handle;
         };
         ResizeTask(Some(handle))
     }
@@ -70,7 +68,7 @@ impl Drop for ResizeTask {
         js! {
             @(no_return)
             var handle = @{handle};
-            handle.callback.drop();
+            window.removeEventListener("resize", handle);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/yewstack/yew/issues/904

#### Problem
The `Drop` method would always fail because handle was `undefined`

#### Solution
* Properly return the callback so that it can be dropped
* Remove the resize listener on drop