### PR TITLE
Implement PartialEq for ChildrenRenderer

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -210,6 +210,12 @@ pub struct ChildrenRenderer<T> {
     children: Vec<T>,
 }
 
+impl<T: PartialEq> PartialEq for ChildrenRenderer<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.children == other.children
+    }
+}
+
 impl<T> ChildrenRenderer<T>
 where
     T: Clone + Into<VNode>,

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -146,9 +146,13 @@ impl fmt::Debug for VNode {
 impl PartialEq for VNode {
     fn eq(&self, other: &VNode) -> bool {
         match (self, other) {
-            (VNode::VTag(vtag_a), VNode::VTag(vtag_b)) => vtag_a == vtag_b,
-            (VNode::VText(vtext_a), VNode::VText(vtext_b)) => vtext_a == vtext_b,
-            _ => false, // TODO: Implement other variants
+            (VNode::VTag(a), VNode::VTag(b)) => a == b,
+            (VNode::VText(a), VNode::VText(b)) => a == b,
+            (VNode::VList(a), VNode::VList(b)) => a == b,
+            (VNode::VRef(a), VNode::VRef(b)) => a == b,
+            // Need to improve PartialEq for VComp before enabling
+            (VNode::VComp(_), VNode::VComp(_)) => false,
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/yewstack/yew/issues/907

#### Problem
It's not easy to check that the children of a component didn't change.

#### Changes
* Expand `PartialEq` for `VNode` to include `VRef` and `VList`
* Implement `PartialEq` for `ChildrenRenderer<T: PartialEq>` (This will implement it for `Children` because it's just an alias for `ChildrenRenderer<VNode>`
