### PR TITLE
Rename NodeRef.try_into to avoid trait conflicts

### DIFF
--- a/examples/node_refs/src/lib.rs
+++ b/examples/node_refs/src/lib.rs
@@ -30,7 +30,7 @@ impl Component for Model {
     }
 
     fn mounted(&mut self) -> ShouldRender {
-        if let Some(input) = self.refs[self.focus_index].try_into::<InputElement>() {
+        if let Some(input) = self.refs[self.focus_index].cast::<InputElement>() {
             input.focus();
         }
         false
@@ -40,7 +40,7 @@ impl Component for Model {
         match msg {
             Msg::HoverIndex(index) => self.focus_index = index,
         }
-        if let Some(input) = self.refs[self.focus_index].try_into::<InputElement>() {
+        if let Some(input) = self.refs[self.focus_index].cast::<InputElement>() {
             input.focus();
         }
         true

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -287,7 +287,7 @@ where
 ///     }
 ///
 ///     fn mounted(&mut self) -> ShouldRender {
-///         if let Some(input) = self.node_ref.try_into::<InputElement>() {
+///         if let Some(input) = self.node_ref.cast::<InputElement>() {
 ///             input.focus();
 ///         }
 ///         false
@@ -313,7 +313,7 @@ impl NodeRef {
     }
 
     /// Try converting the node reference into another form
-    pub fn try_into<INTO: TryFrom<Node>>(&self) -> Option<INTO> {
+    pub fn cast<INTO: TryFrom<Node>>(&self) -> Option<INTO> {
         self.get().and_then(|node| INTO::try_from(node).ok())
     }
 


### PR DESCRIPTION
#### Problem
The `try_into` name on the `NodeRef` struct, conflicts with the standard library `TryInto` trait when it's in scope.

#### Changes
Rename `try_into` to `cast`

Related: https://github.com/yewstack/docs/pull/21