### PR TITLE
Fix wrong order of classes when reordering or adding classes to the front

### DIFF
--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 use stdweb::web::{Element, EventListenerHandle, Node};
+use std::iter::FusedIterator;
 
 pub use self::vcomp::{VChild, VComp};
 pub use self::vlist::VList;
@@ -38,6 +39,80 @@ type Listeners = Vec<Rc<dyn Listener>>;
 
 /// A map of attributes.
 type Attributes = HashMap<String, String>;
+
+/// An iterator, which will iterate over all patches needed
+/// to be applied to ancestor_iter to archive
+/// the values and order of desired_iter
+///
+/// The ordered set which will be patched only allows for:
+/// - add: adds a value (if not present) at the end of the set
+/// - remove: removes the value from the set (if present)
+///
+/// The solution is to iterate over the desired set and for each value do the following:
+/// - if there is no ancestor value left, add the desired value
+/// - if there is the same ancestor value at the same position, do nothing
+/// - or else remove the ancestor value and check for the next ancestor position
+#[derive(Debug)]
+struct OrderedSetPatchIterator<I, A, B>
+    where I: std::cmp::PartialEq,
+          A: Iterator<Item = I> + FusedIterator,
+          B: Iterator<Item = I> + FusedIterator
+{
+    /// an iterator to the desired ordered set
+    desired_iter: A,
+    /// an iterator to the ancestor ordered set
+    ancestor_iter: B,
+    /// this contains the peeked value of the desired_iter iterator
+    desired: Option<I>,
+}
+
+impl<I, A, B> OrderedSetPatchIterator<I, A, B>
+    where I: std::cmp::PartialEq,
+          A: Iterator<Item = I> + FusedIterator,
+          B: Iterator<Item = I> + FusedIterator
+{
+    fn new(desired_iter: A, ancestor_iter: B) -> Self {
+        OrderedSetPatchIterator {
+            desired_iter,
+            ancestor_iter,
+            desired: None
+        }
+    }
+}
+
+impl<I, A, B> Iterator for OrderedSetPatchIterator<I, A, B>
+    where I: std::cmp::PartialEq,
+          A: Iterator<Item = I> + FusedIterator,
+          B: Iterator<Item = I> + FusedIterator
+{
+    type Item = Patch<I, ()>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // take remembered value or advance iterator
+        let mut desired = self.desired.take()
+                            .or_else(|| self.desired_iter.next());
+
+        loop {
+            let previous = self.ancestor_iter.next();
+
+            return match (desired, previous) {
+                (None, None) => None,
+                (Some(left), None) => Some(Patch::Add(left, ())),
+                (Some(left), Some(right)) if left == right => {
+                    // values equals for the current position
+                    // advance both iterators
+                    desired = self.desired_iter.next();
+                    continue;
+                }
+                (desired, Some(right)) => {
+                    // remember desired value
+                    self.desired = desired;
+                    Some(Patch::Remove(right))
+                }
+            }
+        }
+    }
+}
 
 /// A set of classes.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -137,6 +212,7 @@ impl<T: AsRef<str>> From<Vec<T>> for Classes {
 }
 
 /// Patch for DOM node modification.
+#[derive(Debug)]
 enum Patch<ID, T> {
     Add(ID, T),
     Replace(ID, T),

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -9,9 +9,9 @@ pub mod vtext;
 use indexmap::set::IndexSet;
 use std::collections::HashMap;
 use std::fmt;
+use std::iter::FusedIterator;
 use std::rc::Rc;
 use stdweb::web::{Element, EventListenerHandle, Node};
-use std::iter::FusedIterator;
 
 pub use self::vcomp::{VChild, VComp};
 pub use self::vlist::VList;
@@ -54,9 +54,10 @@ type Attributes = HashMap<String, String>;
 /// - or else remove the ancestor value and check for the next ancestor position
 #[derive(Debug)]
 struct OrderedSetPatchIterator<I, A, B>
-    where I: std::cmp::PartialEq,
-          A: Iterator<Item = I> + FusedIterator,
-          B: Iterator<Item = I> + FusedIterator
+where
+    I: std::cmp::PartialEq,
+    A: Iterator<Item = I> + FusedIterator,
+    B: Iterator<Item = I> + FusedIterator,
 {
     /// an iterator to the desired ordered set
     desired_iter: A,
@@ -67,30 +68,31 @@ struct OrderedSetPatchIterator<I, A, B>
 }
 
 impl<I, A, B> OrderedSetPatchIterator<I, A, B>
-    where I: std::cmp::PartialEq,
-          A: Iterator<Item = I> + FusedIterator,
-          B: Iterator<Item = I> + FusedIterator
+where
+    I: std::cmp::PartialEq,
+    A: Iterator<Item = I> + FusedIterator,
+    B: Iterator<Item = I> + FusedIterator,
 {
     fn new(desired_iter: A, ancestor_iter: B) -> Self {
         OrderedSetPatchIterator {
             desired_iter,
             ancestor_iter,
-            desired: None
+            desired: None,
         }
     }
 }
 
 impl<I, A, B> Iterator for OrderedSetPatchIterator<I, A, B>
-    where I: std::cmp::PartialEq,
-          A: Iterator<Item = I> + FusedIterator,
-          B: Iterator<Item = I> + FusedIterator
+where
+    I: std::cmp::PartialEq,
+    A: Iterator<Item = I> + FusedIterator,
+    B: Iterator<Item = I> + FusedIterator,
 {
     type Item = Patch<I, ()>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // take remembered value or advance iterator
-        let mut desired = self.desired.take()
-                            .or_else(|| self.desired_iter.next());
+        let mut desired = self.desired.take().or_else(|| self.desired_iter.next());
 
         loop {
             let previous = self.ancestor_iter.next();
@@ -109,7 +111,7 @@ impl<I, A, B> Iterator for OrderedSetPatchIterator<I, A, B>
                     self.desired = desired;
                     Some(Patch::Remove(right))
                 }
-            }
+            };
         }
     }
 }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -1,7 +1,8 @@
 //! This module contains the implementation of a virtual element node `VTag`.
 
 use super::{
-    Attributes, Classes, Listener, Listeners, Patch, Reform, Transformer, VDiff, VList, VNode, OrderedSetPatchIterator,
+    Attributes, Classes, Listener, Listeners, OrderedSetPatchIterator, Patch, Reform, Transformer,
+    VDiff, VList, VNode,
 };
 use crate::html::NodeRef;
 use log::warn;
@@ -203,7 +204,11 @@ impl VTag {
     ) -> impl Iterator<Item = Patch<&'a str, ()>> + 'a {
         // TODO: remove both usages of fuse() when indexmap::set::IndexSet implements FusedIterator
         let desired_classes = self.classes.set.iter().map(String::as_str).fuse();
-        let ancestor_classes = ancestor.iter().flat_map(|ancestor| ancestor.classes.set.iter()).map(String::as_str).fuse();
+        let ancestor_classes = ancestor
+            .iter()
+            .flat_map(|ancestor| ancestor.classes.set.iter())
+            .map(String::as_str)
+            .fuse();
 
         OrderedSetPatchIterator::new(desired_classes, ancestor_classes)
     }
@@ -298,7 +303,9 @@ impl VTag {
         for change in changes {
             match change {
                 Patch::Add(key, value) | Patch::Replace(key, value) => {
-                    element.set_attribute(&key, &value).expect("invalid attribute key");
+                    element
+                        .set_attribute(&key, &value)
+                        .expect("invalid attribute key");
                 }
                 Patch::Remove(key) => {
                     element.remove_attribute(&key);
@@ -915,52 +922,96 @@ mod tests {
         html! { <div><a data-val=<u32 as Default>::default() /> </div> };
         html! { <div><a data-val=Box::<u32>::default() /></div> };
     }
-    
+
     #[test]
     fn swap_order_of_classes() {
         let parent = document().create_element("div").unwrap();
         document().body().unwrap().append_child(&parent);
-        
+
         let mut elem = html! { <div class=("class-1", "class-2", "class-3")></div> };
         elem.apply(&parent, None, None);
-        
-        let vtag = if let VNode::VTag(vtag) = elem { vtag } else { panic!("should be vtag") };
-        
+
+        let vtag = if let VNode::VTag(vtag) = elem {
+            vtag
+        } else {
+            panic!("should be vtag")
+        };
+
         let expected = "class-1 class-2 class-3";
         assert_eq!(vtag.classes.to_string(), expected);
-        assert_eq!(vtag.reference.as_ref().unwrap().get_attribute("class").unwrap(), expected);
+        assert_eq!(
+            vtag.reference
+                .as_ref()
+                .unwrap()
+                .get_attribute("class")
+                .unwrap(),
+            expected
+        );
 
         let ancestor = vtag;
         let elem = html! { <div class=("class-3", "class-2", "class-1")></div> };
-        let mut vtag = if let VNode::VTag(vtag) = elem { vtag } else { panic!("should be vtag") };
+        let mut vtag = if let VNode::VTag(vtag) = elem {
+            vtag
+        } else {
+            panic!("should be vtag")
+        };
         vtag.apply(&parent, None, Some(VNode::VTag(ancestor)));
-        
+
         let expected = "class-3 class-2 class-1";
         assert_eq!(vtag.classes.to_string(), expected);
-        assert_eq!(vtag.reference.as_ref().unwrap().get_attribute("class").unwrap(), expected);
+        assert_eq!(
+            vtag.reference
+                .as_ref()
+                .unwrap()
+                .get_attribute("class")
+                .unwrap(),
+            expected
+        );
     }
-    
+
     #[test]
     fn add_class_to_the_middle() {
         let parent = document().create_element("div").unwrap();
         document().body().unwrap().append_child(&parent);
-        
+
         let mut elem = html! { <div class=("class-1", "class-3")></div> };
         elem.apply(&parent, None, None);
-        
-        let vtag = if let VNode::VTag(vtag) = elem { vtag } else { panic!("should be vtag") };
-        
+
+        let vtag = if let VNode::VTag(vtag) = elem {
+            vtag
+        } else {
+            panic!("should be vtag")
+        };
+
         let expected = "class-1 class-3";
         assert_eq!(vtag.classes.to_string(), expected);
-        assert_eq!(vtag.reference.as_ref().unwrap().get_attribute("class").unwrap(), expected);
+        assert_eq!(
+            vtag.reference
+                .as_ref()
+                .unwrap()
+                .get_attribute("class")
+                .unwrap(),
+            expected
+        );
 
         let ancestor = vtag;
         let elem = html! { <div class=("class-1", "class-2", "class-3")></div> };
-        let mut vtag = if let VNode::VTag(vtag) = elem { vtag } else { panic!("should be vtag") };
+        let mut vtag = if let VNode::VTag(vtag) = elem {
+            vtag
+        } else {
+            panic!("should be vtag")
+        };
         vtag.apply(&parent, None, Some(VNode::VTag(ancestor)));
-        
+
         let expected = "class-1 class-2 class-3";
         assert_eq!(vtag.classes.to_string(), expected);
-        assert_eq!(vtag.reference.as_ref().unwrap().get_attribute("class").unwrap(), expected);
+        assert_eq!(
+            vtag.reference
+                .as_ref()
+                .unwrap()
+                .get_attribute("class")
+                .unwrap(),
+            expected
+        );
     }
 }


### PR DESCRIPTION
An implementation with 2 test cases which should fix #926.
I also replaced `set_attribute` and `remove_attribute` with their stdweb equivalents.
Unfortunately the iterator of `indexmap::set::IndexSet` is not fused, this might create some overhead.
This fix might introduce more updates (add, remove) to the class_list.