### PR TITLE
ComponentLink: Allow send_message and send_message_batch through shared references

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -425,7 +425,7 @@ where
 
     /// This method sends a message to this component to be processed immediately after the
     /// component has been updated and/or rendered.
-    pub fn send_message(&mut self, msg: COMP::Message) {
+    pub fn send_message(&self, msg: COMP::Message) {
         self.scope.send_message(msg);
     }
 
@@ -434,7 +434,7 @@ where
     ///
     /// All messages will first be processed by `update`, and if _any_ of them return `true`,
     /// then re-render will occur.
-    pub fn send_message_batch(&mut self, msgs: Vec<COMP::Message>) {
+    pub fn send_message_batch(&self, msgs: Vec<COMP::Message>) {
         self.scope.send_message_batch(msgs)
     }
 }


### PR DESCRIPTION
I don't know why these functions had `&mut self` parameters before, but the implementation doesn't need it and it can be worked around by using `link.callback(|_| message).emit(())` instead of `link.send_message(message)` (or by cloning) so it seems very unlikely this is intended.

Example:

```rust
let _key_listener_handle = KeyboardService::register_key_press(
    &document(),
    (move |e: KeyPressEvent| {
        if e.key().as_str() == "s" {
            link2.callback(|_| Msg::FocusInput).emit(());
        }
    })
    .into(),
);
```