### PR TITLE
fix: link all outstanding TODO items to a ticket

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+report_todo = "Unnumbered"
+report_fixme = "Unnumbered"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -272,7 +272,7 @@ impl Discoverer for Context {
         let bridge = LOCAL_AGENTS_POOL.with(|pool| {
             match pool.borrow_mut().entry::<LocalAgent<AGN>>() {
                 anymap::Entry::Occupied(mut entry) => {
-                    // TODO Insert callback!
+                    // TODO(#940): Insert callback!
                     entry.get_mut().create_bridge(callback)
                 }
                 anymap::Entry::Vacant(entry) => {
@@ -423,7 +423,7 @@ impl Discoverer for Private {
             let msg = FromWorker::<AGN::Output>::unpack(&data);
             match msg {
                 FromWorker::WorkerLoaded => {
-                    // TODO Send `Connected` message
+                    // TODO(#948): Send `Connected` message
                 }
                 FromWorker::ProcessOutput(id, output) => {
                     assert_eq!(id.raw_id(), SINGLETON_ID.raw_id());
@@ -431,7 +431,7 @@ impl Discoverer for Private {
                 }
             }
         };
-        // TODO Need somethig better...
+        // TODO(#947): Need somethig better...
         let name_of_resource = AGN::name_of_resource();
         let worker = js! {
             var worker = new Worker(@{name_of_resource});
@@ -463,7 +463,7 @@ impl<AGN: Agent> fmt::Debug for PrivateBridge<AGN> {
 
 impl<AGN: Agent> Bridge<AGN> for PrivateBridge<AGN> {
     fn send(&mut self, msg: AGN::Input) {
-        // TODO Important! Implement.
+        // TODO(#937): Important! Implement.
         // Use a queue to collect a messages if an instance is not ready
         // and send them to an agent when it will reported readiness.
         let msg = ToWorker::ProcessInput(SINGLETON_ID, msg).pack();
@@ -478,7 +478,7 @@ impl<AGN: Agent> Bridge<AGN> for PrivateBridge<AGN> {
 
 impl<AGN: Agent> Drop for PrivateBridge<AGN> {
     fn drop(&mut self) {
-        // TODO Send `Destroy` message.
+        // TODO(#946): Send `Destroy` message.
     }
 }
 
@@ -525,7 +525,7 @@ impl Discoverer for Public {
         let bridge = REMOTE_AGENTS_POOL.with(|pool| {
             match pool.borrow_mut().entry::<RemoteAgent<AGN>>() {
                 anymap::Entry::Occupied(mut entry) => {
-                    // TODO Insert callback!
+                    // TODO(#945): Insert callback!
                     entry.get_mut().create_bridge(callback)
                 }
                 anymap::Entry::Vacant(entry) => {
@@ -537,7 +537,7 @@ impl Discoverer for Public {
                             let msg = FromWorker::<AGN::Output>::unpack(&data);
                             match msg {
                                 FromWorker::WorkerLoaded => {
-                                    // TODO Send `Connected` message
+                                    // TODO(#944): Send `Connected` message
                                     let _ = REMOTE_AGENTS_LOADED.with(|local| {
                                         local.borrow_mut().insert(TypeId::of::<AGN>())
                                     });
@@ -615,7 +615,7 @@ impl<AGN: Agent> PublicBridge<AGN> {
 }
 
 fn send_to_remote<AGN: Agent>(worker: &Value, msg: ToWorker<AGN::Input>) {
-    // TODO Important! Implement.
+    // TODO(#937): Important! Implement.
     // Use a queue to collect a messages if an instance is not ready
     // and send them to an agent when it will reported readiness.
     let msg = msg.pack();
@@ -822,7 +822,7 @@ impl<AGN: Agent> Clone for AgentLink<AGN> {
 
 struct AgentRunnable<AGN> {
     agent: Option<AGN>,
-    // TODO Use agent field to control create message this flag
+    // TODO(#939): Use agent field to control create message this flag
     destroyed: bool,
 }
 

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -50,7 +50,7 @@ pub trait Component: Sized + 'static {
     /// Called by rendering loop.
     fn view(&self) -> Html;
     /// Called for finalization on the final point of the component's lifetime.
-    fn destroy(&mut self) {} // TODO Replace with `Drop`
+    fn destroy(&mut self) {} // TODO(#941): Replace with `Drop`
 }
 
 /// A type which expected as a result of `view` function implementation.

--- a/src/services/reader.rs
+++ b/src/services/reader.rs
@@ -108,7 +108,7 @@ impl ReaderService {
                 let from = position;
                 let to = cmp::min(position + chunk_size, total_size);
                 position = to;
-                // TODO Implement `slice` method in `stdweb`
+                // TODO(#942): Implement `slice` method in `stdweb`
                 let blob: Blob = (js! {
                     return @{file}.slice(@{from as u32}, @{to as u32});
                 })

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -166,7 +166,7 @@ enum Reform {
     Before(Option<Node>),
 }
 
-// TODO What about to implement `VDiff` for `Element`?
+// TODO(#938): What about to implement `VDiff` for `Element`?
 // In makes possible to include ANY element into the tree.
 // `Ace` editor embedding for example?
 

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -428,7 +428,7 @@ impl VDiff for VTag {
         self.apply_diffs(&ancestor);
 
         // Every render it removes all listeners and attach it back later
-        // TODO Compare references of handler to do listeners update better
+        // TODO(#943): Compare references of handler to do listeners update better
         if let Some(ancestor) = ancestor.as_mut() {
             for handle in ancestor.captured.drain(..) {
                 handle.remove();


### PR DESCRIPTION
closes #800 

Note: as pointed out in #800, `report_todo` and `report_fixme` are only available on the nightly channel. If you're on the stable channel, you will see a ton of error messages any time you run `cargo fmt`. Perhaps these should be commented out? Let me know how you'd like to proceed here.

```
><> rustup default stable
info: using existing install for 'stable-x86_64-apple-darwin'
info: default toolchain set to 'stable-x86_64-apple-darwin'

  stable-x86_64-apple-darwin unchanged - rustc 1.41.0 (5e1a79984 2020-01-27)

><> cargo fmt
Warning: can't set `report_todo = Unnumbered`, unstable features are only available in nightly channel.
Warning: can't set `report_fixme = Unnumbered`, unstable features are only available in nightly channel.
Warning: can't set `report_todo = Unnumbered`, unstable features are only available in nightly channel.
Warning: can't set `report_fixme = Unnumbered`, unstable features are only available in nightly channel.
Warning: can't set `report_todo = Unnumbered`, unstable features are only available in nightly channel.
Warning: can't set `report_fixme = Unnumbered`, unstable features are only available in nightly channel.
Warning: can't set `report_todo = Unnumbered`, unstable features are only available in nightly channel.
Warning: can't set `report_fixme = Unnumbered`, unstable features are only available in nightly channel.
Warning: can't set `report_todo = Unnumbered`, unstable features are only available in nightly channel.
Warning: can't set `report_fixme = Unnumbered`, unstable features are only available in nightly channel.
```

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>