### PR TITLE
Added ChangeEvent to exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub mod events {
     pub use crate::html::{ChangeData, InputData};
 
     pub use stdweb::web::event::{
-        BlurEvent, ClickEvent, ContextMenuEvent, DoubleClickEvent, DragDropEvent, DragEndEvent,
+        BlurEvent, ChangeEvent, ClickEvent, ContextMenuEvent, DoubleClickEvent, DragDropEvent, DragEndEvent,
         DragEnterEvent, DragEvent, DragExitEvent, DragLeaveEvent, DragOverEvent, DragStartEvent,
         FocusEvent, GotPointerCaptureEvent, IKeyboardEvent, IMouseEvent, IPointerEvent,
         KeyDownEvent, KeyPressEvent, KeyUpEvent, LostPointerCaptureEvent, MouseDownEvent,


### PR DESCRIPTION
Seems that ChangeEvent was missing from the import-to-export list of event types. I've added it. Hope nothing else is missing.