### PR TITLE
Fix double node removal

### DIFF
--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -161,7 +161,7 @@ enum Reform {
 }
 
 impl VDiff for VComp {
-    fn detach(&mut self, parent: &Element) -> Option<Node> {
+    fn detach(&mut self, _parent: &Element) -> Option<Node> {
         let mut replace_state = MountState::Detached;
         swap(&mut replace_state, &mut self.state);
         match replace_state {

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -167,13 +167,7 @@ impl VDiff for VComp {
         match replace_state {
             MountState::Mounted(this) => {
                 (this.destroyer)();
-                this.node_ref.get().and_then(|node| {
-                    let next_sibling = node.next_sibling();
-                    parent
-                        .remove_child(&node)
-                        .expect("can't remove the component");
-                    next_sibling
-                })
+                this.node_ref.get().and_then(|node| node.next_sibling())
             }
             _ => None,
         }

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -3,6 +3,7 @@
 use super::{VChild, VComp, VDiff, VList, VTag, VText};
 use crate::html::{Component, Renderable};
 use cfg_if::cfg_if;
+use log::warn;
 use std::cmp::PartialEq;
 use std::fmt;
 use std::iter::FromIterator;
@@ -39,9 +40,9 @@ impl VDiff for VNode {
             VNode::VList(ref mut vlist) => vlist.detach(parent),
             VNode::VRef(ref node) => {
                 let sibling = node.next_sibling();
-                parent
-                    .remove_child(node)
-                    .expect("can't remove node by VRef");
+                if parent.remove_child(node).is_err() {
+                    warn!("Node not found to remove VRef");
+                }
                 sibling
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/yewstack/yew/issues/963
Fixes: https://github.com/yewstack/yew/issues/604

#### Problem
When detaching a component from the DOM, the root element of the component is removed from its parent. This is redundant because, immediately after, Yew will recurse through the components sub dom tree and remove all elements (including the root node).

#### Changes
* Remove redundant root element removal from component
* Change VRef double remove from a panic to a warning