### PR TITLE
Fix pub_sub example that no longer compiles in 0.13

### DIFF
--- a/examples/pub_sub/Cargo.toml
+++ b/examples/pub_sub/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 log = "0.4"
 web_logger = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-yew = { path = "../.." }
+yew = { path = "../..", features = ["std_web"] }
 stdweb = "0.4.20"

--- a/examples/pub_sub/src/event_bus.rs
+++ b/examples/pub_sub/src/event_bus.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::fmt::Debug;
 use yew::worker::*;
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/examples/pub_sub/src/lib.rs
+++ b/examples/pub_sub/src/lib.rs
@@ -5,7 +5,7 @@ mod producer;
 mod subscriber;
 
 use producer::Producer;
-use subscriber::Subsciber;
+use subscriber::Subscriber;
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
 
 pub struct Model {}
@@ -26,7 +26,7 @@ impl Component for Model {
         html! {
             <div>
                 <Producer />
-                <Subsciber />
+                <Subscriber />
             </div>
         }
     }

--- a/examples/pub_sub/src/producer.rs
+++ b/examples/pub_sub/src/producer.rs
@@ -28,7 +28,7 @@ impl Component for Producer {
         match msg {
             Msg::Clicked => {
                 self.event_bus
-                    .send(Request::EventBusMsg(format!("Message receieved")));
+                    .send(Request::EventBusMsg(format!("Message received")));
                 false
             }
         }

--- a/examples/pub_sub/src/subscriber.rs
+++ b/examples/pub_sub/src/subscriber.rs
@@ -6,20 +6,20 @@ pub enum Msg {
     NewMessage(String),
 }
 
-pub struct Subsciber {
+pub struct Subscriber {
     message: String,
     _producer: Box<dyn Bridge<EventBus>>,
 }
 
-impl Component for Subsciber {
+impl Component for Subscriber {
     type Message = Msg;
     type Properties = ();
 
     fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
         let callback = link.callback(|s| Msg::NewMessage(s));
         let _producer = EventBus::bridge(callback);
-        Subsciber {
-            message: format!("No message yet"),
+        Subscriber {
+            message: format!("No message yet."),
             _producer,
         }
     }
@@ -33,7 +33,7 @@ impl Component for Subsciber {
 
     fn view(&self) -> Html {
         html! {
-            <h1>{self.message.clone()}</h1>
+            <h1>{ &self.message }</h1>
         }
     }
 }


### PR DESCRIPTION
The pub_sub example is no longer compiling with yew 0.13, because it is missing the `"std_web"` feature. This PR fixes this. I also took the opportunity to fix some typos and unneeded code.