### PR TITLE
Bugfix: Fix wasm-bindgen to v0.2.58, v0.2.59 breaks test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ slab = "0.4"
 stdweb = { version = "0.4.20", optional = true }
 thiserror = "1"
 toml = { version = "0.5", optional = true }
-wasm-bindgen = { version = "0.2.58", optional = true }
+wasm-bindgen = { version = "= 0.2.58", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 yew-macro = { version = "0.13.0", path = "crates/macro" }
 


### PR DESCRIPTION
I noticed then when trying to get the test suite for pr #992 to pass. Updating to `wasm-bindgen` 0.2.58 causes the test suite to panic.

## Replicate

1. Update crates and run tests on master.
```bash
cargo update
./ci/run_tests.sh
```
2. See test suite panic
3. Fix `wasm-bindgen` to v0.258 and re-run test suite.
4. see Test suite pass.

----

Here is the stack trace from the panic.

```bash
> $ RUST_BACKTRACE=1  ./ci/run_tests.sh                                                        ⬡ 12.9.1 [±master ✓]
+ '[' 1 == 0 ']'
+ cargo test --target wasm32-unknown-unknown --features wasm_test,std_web
   Compiling yew v0.13.0 (/mnt/hybrid/Code/yew)
   Compiling wasm-bindgen-test-macro v0.3.9
   Compiling yew-macro v0.13.0 (/mnt/hybrid/Code/yew/crates/macro)
   Compiling wasm-bindgen-test v0.3.9
    Finished test [unoptimized + debuginfo] target(s) in 8.02s
     Running target/wasm32-unknown-unknown/debug/deps/yew-f52688e53998f017.wasm
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', /mnt/hybrid/dependency-managers/cargo/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-cli-support-0.2.58/src/descriptor.rs:198:15
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.44/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.44/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1053
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1428
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:204
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:224
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:470
  11: rust_begin_unwind
             at src/libstd/panicking.rs:378
  12: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
  13: core::panicking::panic_bounds_check
             at src/libcore/panicking.rs:63
  14: wasm_bindgen_cli_support::descriptor::Descriptor::_decode
  15: wasm_bindgen_cli_support::descriptor::Descriptor::_decode
  16: wasm_bindgen_cli_support::descriptor::Function::decode
  17: wasm_bindgen_cli_support::descriptor::Descriptor::_decode
  18: wasm_bindgen_cli_support::descriptors::execute
  19: wasm_bindgen_cli_support::Bindgen::generate_output
  20: wasm_bindgen_cli_support::Bindgen::generate
  21: wasm_bindgen_test_runner::main
  22: std::rt::lang_start::{{closure}}
  23: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
  24: std::panicking::try::do_call
             at src/libstd/panicking.rs:303
  25: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:86
  26: std::panicking::try
             at src/libstd/panicking.rs:281
  27: std::panic::catch_unwind
             at src/libstd/panic.rs:394
  28: std::rt::lang_start_internal
             at src/libstd/rt.rs:51
  29: main
  30: __libc_start_main
  31: _start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
error: test failed, to rerun pass '--lib'         
                                             
```