### PR TITLE
Handle text messages properly in web-sys websocket service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ install:
   - unzip chromedriver_linux64.zip
   - ./ci/install_cargo_web.sh
 
+# Prevents intermittent chromedriver issues https://github.com/travis-ci/travis-ci/issues/8361#issuecomment-350090030
+before_script: sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+
 script:
   - ./ci/run_checks.sh
   - CHROMEDRIVER=$(pwd)/chromedriver ./ci/run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ branches:
 
 dist: trusty
 language: rust
-sudo: true
+sudo: false
 addons:
-  chrome: stable
+  firefox: latest
 
 cache: cargo
 before_cache:
@@ -32,15 +32,11 @@ install:
   - cargo install cargo-update || true
   - cargo install-update-config --version =0.2.59 wasm-bindgen-cli
   - cargo install-update --allow-no-update wasm-bindgen-cli
-  - LATEST_CHROMEDRIVER_VERSION=`curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"`
-  - curl --retry 5 -LO "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
-  - unzip chromedriver_linux64.zip
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
+  - tar -xzf geckodriver-v0.26.0-linux64.tar.gz -C bin
   - ./ci/install_cargo_web.sh
-
-# Prevents intermittent chromedriver issues https://github.com/travis-ci/travis-ci/issues/8361#issuecomment-350090030
-before_script: sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
 
 script:
   - ./ci/run_checks.sh
-  - CHROMEDRIVER=$(pwd)/chromedriver ./ci/run_tests.sh
+  - GECKODRIVER=$(pwd)/geckodriver ./ci/run_tests.sh
   - ./ci/check_examples.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - cargo install cargo-update || true
   - cargo install-update-config --version =0.2.59 wasm-bindgen-cli
   - cargo install-update --allow-no-update wasm-bindgen-cli
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
+  - curl --retry 5 -LO https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
   - tar -xzf geckodriver-v0.26.0-linux64.tar.gz -C bin
   - ./ci/install_cargo_web.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 dist: trusty
 language: rust
-sudo: false
+sudo: true
 addons:
   chrome: stable
 
@@ -40,4 +40,4 @@ install:
 script:
   - ./ci/run_checks.sh
   - CHROMEDRIVER=$(pwd)/chromedriver ./ci/run_tests.sh
-  - CHROMEDRIVER=$(pwd)/chromedriver ./ci/check_examples.sh
+  - ./ci/check_examples.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - cargo install-update-config --version =0.2.59 wasm-bindgen-cli
   - cargo install-update --allow-no-update wasm-bindgen-cli
   - curl --retry 5 -LO https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
-  - tar -xzf geckodriver-v0.26.0-linux64.tar.gz -C bin
+  - tar -xzf geckodriver-v0.26.0-linux64.tar.gz
   - ./ci/install_cargo_web.sh
 
 script:

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -3,14 +3,15 @@ echo "$(rustup default)" | grep -q "1.39.0"
 emscripten_supported=$?
 set -euxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
 
+cargo test --target wasm32-unknown-unknown --features wasm_test,std_web
+cargo test --target wasm32-unknown-unknown --features wasm_test,web_sys
+
 if [ "$emscripten_supported" == "0" ]; then
   # TODO - Emscripten builds are broken on rustc > 1.39.0
   cargo web test --target asmjs-unknown-emscripten --features std_web
   cargo web test --target wasm32-unknown-emscripten --features std_web
 fi
 
-cargo test --target wasm32-unknown-unknown --features wasm_test,std_web
-cargo test --target wasm32-unknown-unknown --features wasm_test,web_sys
 cargo test --doc --features doc_test,wasm_test,yaml,msgpack,cbor,std_web
 cargo test --doc --features doc_test,wasm_test,yaml,msgpack,cbor,web_sys
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -82,6 +82,10 @@ pub enum FormatError {
     /// on a WebSocket that is using a binary serialization format, like Cbor.
     #[error("received text for a binary format")]
     ReceivedTextForBinary,
+    /// Received binary for a text format, e.g. someone sending binary
+    /// on a WebSocket that is using a text serialization format, like Json.
+    #[error("received binary for a text format")]
+    ReceivedBinaryForText,
     /// Trying to encode a binary format as text", e.g., trying to
     /// store a Cbor encoded value in a String.
     #[error("trying to encode a binary format as Text")]


### PR DESCRIPTION
Fixes: #1002

#### Problem
Text messages are handled as binary by default

#### Changes
- Check if a message is a string before treating it as binary
- Add test coverage