### PR TITLE
Pipe through fetch errors in web-sys

### DIFF
--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -246,6 +246,22 @@ mod tests {
     }
 
     #[test]
+    async fn fetch_fail() {
+        let request = Request::get("https://fetch.fail").body(Nothing).unwrap();
+        let cb_future = CallbackFuture::<Response<Result<String, anyhow::Error>>>::default();
+        let callback: Callback<_> = cb_future.clone().into();
+        let _task = FetchService::new().fetch(request, callback);
+        let resp = cb_future.await;
+        #[cfg(feature = "std_web")]
+        assert!(resp.body().is_err());
+        #[cfg(feature = "web_sys")]
+        assert_eq!(
+            "TypeError: NetworkError when attempting to fetch resource.",
+            resp.body().as_ref().unwrap_err().to_string()
+        );
+    }
+
+    #[test]
     async fn fetch_referrer_policy_no_referrer() {
         let request = Request::get("https://httpbin.org/headers")
             .body(Nothing)

--- a/src/services/fetch/web_sys.rs
+++ b/src/services/fetch/web_sys.rs
@@ -132,8 +132,8 @@ fn header_iter(headers: Headers) -> impl Iterator<Item = (String, String)> {
 enum FetchError {
     #[error("canceled")]
     Canceled,
-    #[error("fetch failed")]
-    FetchFailed,
+    #[error("{0}")]
+    FetchFailed(String),
     #[error("invalid response")]
     InvalidResponse,
     #[error("unexpected error, please report")]
@@ -456,7 +456,8 @@ where
     async fn get_response(&self, fetch_promise: Promise) -> Result<WebResponse, FetchError> {
         let response = JsFuture::from(fetch_promise)
             .await
-            .map_err(|_| FetchError::FetchFailed)?;
+            .map_err(|err| err.unchecked_into::<js_sys::Error>())
+            .map_err(|err| FetchError::FetchFailed(err.to_string().as_string().unwrap()))?;
         if *self.active.borrow() {
             Ok(WebResponse::from(response))
         } else {


### PR DESCRIPTION
#### Problem
No transparency in why a fetch failed

#### Changes
* Convert JS error to string and include it in `FetchError::FetchFailed` enum