### PR TITLE
Implement default for Callback<T>

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -49,6 +49,12 @@ impl<IN> Callback<IN> {
     }
 }
 
+impl<IN> Default for Callback<IN> {
+    fn default() -> Self {
+        Self::noop()
+    }
+}
+
 impl<IN: 'static> Callback<IN> {
     /// Changes input type of the callback to another.
     /// Works like common `map` method but in an opposite direction.


### PR DESCRIPTION
This would make it easier for users to implement their Properties by using `#[derive(Default)]` or `#[prop_or_default]`.

Related to #1041 