### PR TITLE
Remove Component validation in html! to allow for generic components

### DIFF
--- a/crates/macro/src/html_tree/html_component.rs
+++ b/crates/macro/src/html_tree/html_component.rs
@@ -148,11 +148,6 @@ impl ToTokens for HtmlComponent {
             },
         };
 
-        let validate_comp = quote_spanned! { ty.span()=>
-            trait __yew_validate_comp: ::yew::html::Component {}
-            impl __yew_validate_comp for #ty {}
-        };
-
         let node_ref = if let Some(node_ref) = props.node_ref() {
             quote_spanned! { node_ref.span()=> #node_ref }
         } else {
@@ -163,7 +158,6 @@ impl ToTokens for HtmlComponent {
             // These validation checks show a nice error message to the user.
             // They do not execute at runtime
             if false {
-                #validate_comp
                 #validate_props
             }
 

--- a/crates/macro/tests/macro/html-component-fail-unimplemented.stderr
+++ b/crates/macro/tests/macro/html-component-fail-unimplemented.stderr
@@ -1,5 +1,17 @@
-error[E0277]: the trait bound `std::string::String: yew::html::Component` is not satisfied
- --> $DIR/html-component-fail-unimplemented.rs:6:14
+error[E0599]: no function or associated item named `new` found for struct `yew::virtual_dom::vcomp::VChild<std::string::String>` in the current scope
+ --> $DIR/html-component-fail-unimplemented.rs:6:5
   |
 6 |     html! { <String /> };
-  |              ^^^^^^ the trait `yew::html::Component` is not implemented for `std::string::String`
+  |     ^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `yew::virtual_dom::vcomp::VChild<std::string::String>`
+  |
+  = note: the method `new` exists but the following trait bounds were not satisfied:
+          `std::string::String : yew::html::Component`
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error[E0277]: the trait bound `std::string::String: yew::html::Component` is not satisfied
+ --> $DIR/html-component-fail-unimplemented.rs:6:5
+  |
+6 |     html! { <String /> };
+  |     ^^^^^^^^^^^^^^^^^^^^^ the trait `yew::html::Component` is not implemented for `std::string::String`
+  |
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)


### PR DESCRIPTION
Because this validation check tries to `impl Component` for the component
type, generic components could not have been used, because the `impl` has to define the generic type parameter itself, but it can only see the `<C>` part directly, and thus can not define the type parameters trait bounds properly.

With this change, it is possible to write a component like this, with a generic type parameter with trait bounds.
```
impl<C> Component for TreeView<C>
    where C: Component,
{
    type Message = Msg;
    type Properties = TreeData<<C as Component>::Properties>;
    ...
    fn view(&self) -> Html {
        if self.props.expanded {
            html! {
                <div>{
                    for self.props.children.iter().cloned()
                            .map(|child| html! {
                                <TreeView<C>
                                    element={child.element}
                                    children={child.children}
                                    expanded={child.expanded}
                                />
                            })
                }</div>
            }
        } else {
            html!{}
        }
    }
    ...
}
```

See more details in this issue: #1064 