### PR TITLE
Make Component::change impl mandatory

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -31,6 +31,10 @@
 //! #         unimplemented!()
 //! #     }
 //! #
+//! #     fn change(&mut self, props: Self::Properties) -> ShouldRender {
+//! #         unimplemented!()
+//! #     }
+//! #
 //! #     fn view(&self) -> Html {
 //! #
 //! // ...

--- a/crates/macro/tests/macro/html-component-fail.rs
+++ b/crates/macro/tests/macro/html-component-fail.rs
@@ -21,6 +21,9 @@ impl Component for Child {
     fn update(&mut self, _: Self::Message) -> ShouldRender {
         unimplemented!()
     }
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        unimplemented!()
+    }
     fn view(&self) -> Html {
         unimplemented!()
     }
@@ -42,6 +45,9 @@ impl Component for ChildContainer {
     fn update(&mut self, _: Self::Message) -> ShouldRender {
         unimplemented!()
     }
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        unimplemented!()
+    }
     fn view(&self) -> Html {
         unimplemented!()
     }
@@ -59,6 +65,9 @@ impl Component for Generic<String> {
         unimplemented!()
     }
     fn update(&mut self, _: Self::Message) -> ShouldRender {
+        unimplemented!()
+    }
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
         unimplemented!()
     }
     fn view(&self) -> Html {

--- a/crates/macro/tests/macro/html-component-fail.stderr
+++ b/crates/macro/tests/macro/html-component-fail.stderr
@@ -1,178 +1,178 @@
 error: this open tag has no corresponding close tag
-  --> $DIR/html-component-fail.rs:70:13
+  --> $DIR/html-component-fail.rs:79:13
    |
-70 |     html! { <Child> };
+79 |     html! { <Child> };
    |             ^^^^^^^
 
 error: expected identifier
-  --> $DIR/html-component-fail.rs:71:22
+  --> $DIR/html-component-fail.rs:80:22
    |
-71 |     html! { <Child:: /> };
+80 |     html! { <Child:: /> };
    |                      ^
 
 error: unexpected end of input, expected identifier
-  --> $DIR/html-component-fail.rs:72:5
+  --> $DIR/html-component-fail.rs:81:5
    |
-72 |     html! { <Child with /> };
+81 |     html! { <Child with /> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unexpected token
-  --> $DIR/html-component-fail.rs:73:20
+  --> $DIR/html-component-fail.rs:82:20
    |
-73 |     html! { <Child props /> };
+82 |     html! { <Child props /> };
    |                    ^^^^^
 
 error: this open tag has no corresponding close tag
-  --> $DIR/html-component-fail.rs:74:13
+  --> $DIR/html-component-fail.rs:83:13
    |
-74 |     html! { <Child with props > };
+83 |     html! { <Child with props > };
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: too many refs set
-  --> $DIR/html-component-fail.rs:75:38
+  --> $DIR/html-component-fail.rs:84:38
    |
-75 |     html! { <Child with props ref=() ref=() /> };
+84 |     html! { <Child with props ref=() ref=() /> };
    |                                      ^^^
 
 error: too many refs set
-  --> $DIR/html-component-fail.rs:76:38
+  --> $DIR/html-component-fail.rs:85:38
    |
-76 |     html! { <Child with props ref=() ref=() value=1 /> };
+85 |     html! { <Child with props ref=() ref=() value=1 /> };
    |                                      ^^^
 
 error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:77:38
+  --> $DIR/html-component-fail.rs:86:38
    |
-77 |     html! { <Child with props ref=() value=1 ref=() /> };
+86 |     html! { <Child with props ref=() value=1 ref=() /> };
    |                                      ^^^^^
 
 error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:78:31
+  --> $DIR/html-component-fail.rs:87:31
    |
-78 |     html! { <Child with props value=1 ref=()  ref=() /> };
+87 |     html! { <Child with props value=1 ref=()  ref=() /> };
    |                               ^^^^^
 
 error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:79:28
+  --> $DIR/html-component-fail.rs:88:28
    |
-79 |     html! { <Child value=1 with props  ref=()  ref=() /> };
+88 |     html! { <Child value=1 with props  ref=()  ref=() /> };
    |                            ^^^^
 
 error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:80:35
+  --> $DIR/html-component-fail.rs:89:35
    |
-80 |     html! { <Child value=1 ref=() with props ref=() /> };
+89 |     html! { <Child value=1 ref=() with props ref=() /> };
    |                                   ^^^^
 
 error: too many refs set
-  --> $DIR/html-component-fail.rs:81:27
+  --> $DIR/html-component-fail.rs:90:27
    |
-81 |     html! { <Child ref=() ref=() value=1  with props  /> };
+90 |     html! { <Child ref=() ref=() value=1  with props  /> };
    |                           ^^^
 
 error: unexpected token
-  --> $DIR/html-component-fail.rs:83:31
+  --> $DIR/html-component-fail.rs:92:31
    |
-83 |     html! { <Child with props () /> };
+92 |     html! { <Child with props () /> };
    |                               ^^
 
 error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:84:28
+  --> $DIR/html-component-fail.rs:93:28
    |
-84 |     html! { <Child value=1 with props /> };
+93 |     html! { <Child value=1 with props /> };
    |                            ^^^^
 
 error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:85:31
+  --> $DIR/html-component-fail.rs:94:31
    |
-85 |     html! { <Child with props value=1 /> };
+94 |     html! { <Child with props value=1 /> };
    |                               ^^^^^
 
 error: expected identifier
-  --> $DIR/html-component-fail.rs:86:20
+  --> $DIR/html-component-fail.rs:95:20
    |
-86 |     html! { <Child type=0 /> };
+95 |     html! { <Child type=0 /> };
    |                    ^^^^
 
 error: expected identifier
-  --> $DIR/html-component-fail.rs:87:20
+  --> $DIR/html-component-fail.rs:96:20
    |
-87 |     html! { <Child invalid-prop-name=0 /> };
+96 |     html! { <Child invalid-prop-name=0 /> };
    |                    ^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected expression
-  --> $DIR/html-component-fail.rs:89:5
+  --> $DIR/html-component-fail.rs:98:5
    |
-89 |     html! { <Child string= /> };
+98 |     html! { <Child string= /> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: too many refs set
-  --> $DIR/html-component-fail.rs:94:33
-   |
-94 |     html! { <Child int=1 ref=() ref=() /> };
-   |                                 ^^^
+   --> $DIR/html-component-fail.rs:103:33
+    |
+103 |     html! { <Child int=1 ref=() ref=() /> };
+    |                                 ^^^
 
 error: this close tag has no corresponding open tag
-  --> $DIR/html-component-fail.rs:97:13
-   |
-97 |     html! { </Child> };
-   |             ^^^^^^^^
+   --> $DIR/html-component-fail.rs:106:13
+    |
+106 |     html! { </Child> };
+    |             ^^^^^^^^
 
 error: this open tag has no corresponding close tag
-  --> $DIR/html-component-fail.rs:98:13
-   |
-98 |     html! { <Child><Child></Child> };
-   |             ^^^^^^^
+   --> $DIR/html-component-fail.rs:107:13
+    |
+107 |     html! { <Child><Child></Child> };
+    |             ^^^^^^^
 
 error: only one root html element allowed
-  --> $DIR/html-component-fail.rs:99:28
-   |
-99 |     html! { <Child></Child><Child></Child> };
-   |                            ^^^^^^^^^^^^^^^
+   --> $DIR/html-component-fail.rs:108:28
+    |
+108 |     html! { <Child></Child><Child></Child> };
+    |                            ^^^^^^^^^^^^^^^
 
 error: this close tag has no corresponding open tag
-   --> $DIR/html-component-fail.rs:108:30
+   --> $DIR/html-component-fail.rs:117:30
     |
-108 |     html! { <Generic<String>></Generic> };
+117 |     html! { <Generic<String>></Generic> };
     |                              ^^^^^^^^^^
 
 error: this close tag has no corresponding open tag
-   --> $DIR/html-component-fail.rs:109:30
+   --> $DIR/html-component-fail.rs:118:30
     |
-109 |     html! { <Generic<String>></Generic<Vec<String>>> };
+118 |     html! { <Generic<String>></Generic<Vec<String>>> };
     |                              ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find value `blah` in this scope
-  --> $DIR/html-component-fail.rs:82:25
+  --> $DIR/html-component-fail.rs:91:25
    |
-82 |     html! { <Child with blah /> };
+91 |     html! { <Child with blah /> };
    |                         ^^^^ not found in this scope
 
 error[E0609]: no field `unknown` on type `ChildProperties`
-  --> $DIR/html-component-fail.rs:88:20
+  --> $DIR/html-component-fail.rs:97:20
    |
-88 |     html! { <Child unknown="unknown" /> };
+97 |     html! { <Child unknown="unknown" /> };
    |                    ^^^^^^^ unknown field
    |
    = note: available fields are: `string`, `int`
 
 error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-  --> $DIR/html-component-fail.rs:88:20
+  --> $DIR/html-component-fail.rs:97:20
    |
 6  | #[derive(Clone, Properties, PartialEq)]
    |                 ---------- method `unknown` not found for this
 ...
-88 |     html! { <Child unknown="unknown" /> };
+97 |     html! { <Child unknown="unknown" /> };
    |                    ^^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<(), std::string::String>` is not satisfied
-  --> $DIR/html-component-fail.rs:90:33
+  --> $DIR/html-component-fail.rs:99:33
    |
-90 |     html! { <Child int=1 string={} /> };
+99 |     html! { <Child int=1 string={} /> };
    |                                 ^^ the trait `yew::virtual_dom::Transformer<(), std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
    |
    = help: the following implementations were found:
@@ -184,84 +184,84 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom:
    = note: required by `yew::virtual_dom::Transformer::transform`
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<{integer}, std::string::String>` is not satisfied
-  --> $DIR/html-component-fail.rs:91:33
-   |
-91 |     html! { <Child int=1 string=3 /> };
-   |                                 ^ the trait `yew::virtual_dom::Transformer<{integer}, std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
-   |
-   = help: the following implementations were found:
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
-           and 3 others
-   = note: required by `yew::virtual_dom::Transformer::transform`
+   --> $DIR/html-component-fail.rs:100:33
+    |
+100 |     html! { <Child int=1 string=3 /> };
+    |                                 ^ the trait `yew::virtual_dom::Transformer<{integer}, std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
+    |
+    = help: the following implementations were found:
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
+            and 3 others
+    = note: required by `yew::virtual_dom::Transformer::transform`
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<{integer}, std::string::String>` is not satisfied
-  --> $DIR/html-component-fail.rs:92:33
-   |
-92 |     html! { <Child int=1 string={3} /> };
-   |                                 ^^^ the trait `yew::virtual_dom::Transformer<{integer}, std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
-   |
-   = help: the following implementations were found:
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
-           and 3 others
-   = note: required by `yew::virtual_dom::Transformer::transform`
+   --> $DIR/html-component-fail.rs:101:33
+    |
+101 |     html! { <Child int=1 string={3} /> };
+    |                                 ^^^ the trait `yew::virtual_dom::Transformer<{integer}, std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
+    |
+    = help: the following implementations were found:
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
+            and 3 others
+    = note: required by `yew::virtual_dom::Transformer::transform`
 
 error[E0308]: mismatched types
-  --> $DIR/html-component-fail.rs:93:30
-   |
-93 |     html! { <Child int=1 ref=() /> };
-   |                              ^^ expected struct `yew::html::NodeRef`, found `()`
+   --> $DIR/html-component-fail.rs:102:30
+    |
+102 |     html! { <Child int=1 ref=() /> };
+    |                              ^^ expected struct `yew::html::NodeRef`, found `()`
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<u32, i32>` is not satisfied
-  --> $DIR/html-component-fail.rs:95:24
-   |
-95 |     html! { <Child int=0u32 /> };
-   |                        ^^^^ the trait `yew::virtual_dom::Transformer<u32, i32>` is not implemented for `yew::virtual_dom::vcomp::VComp`
-   |
-   = help: the following implementations were found:
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
-           and 3 others
-   = note: required by `yew::virtual_dom::Transformer::transform`
+   --> $DIR/html-component-fail.rs:104:24
+    |
+104 |     html! { <Child int=0u32 /> };
+    |                        ^^^^ the trait `yew::virtual_dom::Transformer<u32, i32>` is not implemented for `yew::virtual_dom::vcomp::VComp`
+    |
+    = help: the following implementations were found:
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
+              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
+            and 3 others
+    = note: required by `yew::virtual_dom::Transformer::transform`
 
 error[E0599]: no method named `string` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-  --> $DIR/html-component-fail.rs:96:20
-   |
-6  | #[derive(Clone, Properties, PartialEq)]
-   |                 ---------- method `string` not found for this
+   --> $DIR/html-component-fail.rs:105:20
+    |
+6   | #[derive(Clone, Properties, PartialEq)]
+    |                 ---------- method `string` not found for this
 ...
-96 |     html! { <Child string="abc" /> };
-   |                    ^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
-   |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `string`, perhaps you need to implement it:
-           candidate #1: `proc_macro::bridge::server::Literal`
+105 |     html! { <Child string="abc" /> };
+    |                    ^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
+    |
+    = help: items from traits can only be used if the trait is implemented and in scope
+    = note: the following trait defines an item `string`, perhaps you need to implement it:
+            candidate #1: `proc_macro::bridge::server::Literal`
 
 error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-   --> $DIR/html-component-fail.rs:100:5
+   --> $DIR/html-component-fail.rs:109:5
     |
 6   | #[derive(Clone, Properties, PartialEq)]
     |                 ---------- method `children` not found for this
 ...
-100 |     html! { <Child>{ "Not allowed" }</Child> };
+109 |     html! { <Child>{ "Not allowed" }</Child> };
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
     |
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0599]: no method named `build` found for struct `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
-   --> $DIR/html-component-fail.rs:102:5
+   --> $DIR/html-component-fail.rs:111:5
     |
-29  | #[derive(Clone, Properties)]
+32  | #[derive(Clone, Properties)]
     |                 ---------- method `build` not found for this
 ...
-102 |     html! { <ChildContainer /> };
+111 |     html! { <ChildContainer /> };
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
     |
     = help: items from traits can only be used if the trait is implemented and in scope
@@ -270,12 +270,12 @@ error[E0599]: no method named `build` found for struct `ChildContainerProperties
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0599]: no method named `build` found for struct `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
-   --> $DIR/html-component-fail.rs:103:5
+   --> $DIR/html-component-fail.rs:112:5
     |
-29  | #[derive(Clone, Properties)]
+32  | #[derive(Clone, Properties)]
     |                 ---------- method `build` not found for this
 ...
-103 |     html! { <ChildContainer></ChildContainer> };
+112 |     html! { <ChildContainer></ChildContainer> };
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
     |
     = help: items from traits can only be used if the trait is implemented and in scope
@@ -284,9 +284,9 @@ error[E0599]: no method named `build` found for struct `ChildContainerProperties
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<&str>` is not satisfied
-   --> $DIR/html-component-fail.rs:104:5
+   --> $DIR/html-component-fail.rs:113:5
     |
-104 |     html! { <ChildContainer>{ "Not allowed" }</ChildContainer> };
+113 |     html! { <ChildContainer>{ "Not allowed" }</ChildContainer> };
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<&str>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
     |
     = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `&str`
@@ -294,9 +294,9 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::conv
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied
-   --> $DIR/html-component-fail.rs:105:5
+   --> $DIR/html-component-fail.rs:114:5
     |
-105 |     html! { <ChildContainer><></></ChildContainer> };
+114 |     html! { <ChildContainer><></></ChildContainer> };
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vnode::VNode>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
     |
     = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vnode::VNode`
@@ -304,9 +304,9 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::conv
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied
-   --> $DIR/html-component-fail.rs:106:5
+   --> $DIR/html-component-fail.rs:115:5
     |
-106 |     html! { <ChildContainer><other /></ChildContainer> };
+115 |     html! { <ChildContainer><other /></ChildContainer> };
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vnode::VNode>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
     |
     = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vnode::VNode`

--- a/crates/macro/tests/macro/html-component-pass.rs
+++ b/crates/macro/tests/macro/html-component-pass.rs
@@ -19,6 +19,9 @@ impl Component for Generic<String> {
     fn update(&mut self, _: Self::Message) -> ShouldRender {
         unimplemented!()
     }
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        unimplemented!()
+    }
     fn view(&self) -> Html {
         unimplemented!()
     }
@@ -32,6 +35,9 @@ impl Component for Generic<Vec<String>> {
         unimplemented!()
     }
     fn update(&mut self, _: Self::Message) -> ShouldRender {
+        unimplemented!()
+    }
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
         unimplemented!()
     }
     fn view(&self) -> Html {
@@ -55,6 +61,9 @@ impl Component for Container {
         unimplemented!()
     }
     fn update(&mut self, _: Self::Message) -> ShouldRender {
+        unimplemented!()
+    }
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
         unimplemented!()
     }
     fn view(&self) -> Html {
@@ -113,6 +122,9 @@ impl Component for Child {
     fn update(&mut self, _: Self::Message) -> ShouldRender {
         unimplemented!()
     }
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        unimplemented!()
+    }
     fn view(&self) -> Html {
         unimplemented!()
     }
@@ -127,6 +139,9 @@ impl Component for AltChild {
         unimplemented!()
     }
     fn update(&mut self, _: Self::Message) -> ShouldRender {
+        unimplemented!()
+    }
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
         unimplemented!()
     }
     fn view(&self) -> Html {
@@ -150,6 +165,9 @@ impl Component for ChildContainer {
         unimplemented!()
     }
     fn update(&mut self, _: Self::Message) -> ShouldRender {
+        unimplemented!()
+    }
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
         unimplemented!()
     }
     fn view(&self) -> Html {

--- a/examples/crm/src/lib.rs
+++ b/examples/crm/src/lib.rs
@@ -146,6 +146,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         match self.scene {
             Scene::ClientsList => html! {

--- a/examples/custom_components/src/lib.rs
+++ b/examples/custom_components/src/lib.rs
@@ -46,6 +46,10 @@ impl Component for Model {
         }
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         let counter = |x| {
             html! {

--- a/examples/dashboard/src/lib.rs
+++ b/examples/dashboard/src/lib.rs
@@ -186,6 +186,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div>

--- a/examples/fragments/src/lib.rs
+++ b/examples/fragments/src/lib.rs
@@ -34,6 +34,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <>

--- a/examples/game_of_life/src/lib.rs
+++ b/examples/game_of_life/src/lib.rs
@@ -209,6 +209,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div>

--- a/examples/large_table/src/lib.rs
+++ b/examples/large_table/src/lib.rs
@@ -33,6 +33,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <table>

--- a/examples/showcase/src/main.rs
+++ b/examples/showcase/src/main.rs
@@ -91,6 +91,10 @@ impl Component for Model {
         }
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div id="fullscreen">

--- a/examples/std_web/counter/src/lib.rs
+++ b/examples/std_web/counter/src/lib.rs
@@ -48,6 +48,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div>

--- a/examples/std_web/inner_html/src/lib.rs
+++ b/examples/std_web/inner_html/src/lib.rs
@@ -33,6 +33,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         let js_svg = js! {
             var div = document.createElement("div");

--- a/examples/std_web/mount_point/src/lib.rs
+++ b/examples/std_web/mount_point/src/lib.rs
@@ -29,6 +29,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div>

--- a/examples/std_web/node_refs/src/input.rs
+++ b/examples/std_web/node_refs/src/input.rs
@@ -31,6 +31,11 @@ impl Component for InputComponent {
         false
     }
 
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.props = props;
+        true
+    }
+
     fn view(&self) -> Html {
         html! {
             <input

--- a/examples/std_web/node_refs/src/lib.rs
+++ b/examples/std_web/node_refs/src/lib.rs
@@ -46,6 +46,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div class="main">

--- a/examples/std_web/npm_and_rest/src/lib.rs
+++ b/examples/std_web/npm_and_rest/src/lib.rs
@@ -67,6 +67,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         let view_exchange = |exchange| {
             html! {

--- a/examples/std_web/todomvc/src/lib.rs
+++ b/examples/std_web/todomvc/src/lib.rs
@@ -121,6 +121,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div class="todomvc-wrapper">

--- a/examples/std_web/two_apps/src/lib.rs
+++ b/examples/std_web/two_apps/src/lib.rs
@@ -57,6 +57,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div>

--- a/examples/textarea/src/lib.rs
+++ b/examples/textarea/src/lib.rs
@@ -35,6 +35,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div>

--- a/examples/timer/src/lib.rs
+++ b/examples/timer/src/lib.rs
@@ -97,6 +97,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         let view_message = |message| {
             html! { <p>{ message }</p> }

--- a/examples/web_sys/counter/src/lib.rs
+++ b/examples/web_sys/counter/src/lib.rs
@@ -48,6 +48,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div>

--- a/examples/web_sys/inner_html/src/lib.rs
+++ b/examples/web_sys/inner_html/src/lib.rs
@@ -30,6 +30,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         let js_svg = {
             let div = web_sys::window()

--- a/examples/web_sys/mount_point/src/lib.rs
+++ b/examples/web_sys/mount_point/src/lib.rs
@@ -29,6 +29,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div>

--- a/examples/web_sys/node_refs/src/input.rs
+++ b/examples/web_sys/node_refs/src/input.rs
@@ -31,6 +31,11 @@ impl Component for InputComponent {
         false
     }
 
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.props = props;
+        true
+    }
+
     fn view(&self) -> Html {
         html! {
             <input

--- a/examples/web_sys/node_refs/src/lib.rs
+++ b/examples/web_sys/node_refs/src/lib.rs
@@ -45,6 +45,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div class="main">

--- a/examples/web_sys/npm_and_rest/src/lib.rs
+++ b/examples/web_sys/npm_and_rest/src/lib.rs
@@ -64,6 +64,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         let view_exchange = |exchange| {
             html! {

--- a/examples/web_sys/todomvc/src/lib.rs
+++ b/examples/web_sys/todomvc/src/lib.rs
@@ -121,6 +121,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div class="todomvc-wrapper">

--- a/examples/web_sys/two_apps/src/lib.rs
+++ b/examples/web_sys/two_apps/src/lib.rs
@@ -57,6 +57,10 @@ impl Component for Model {
         true
     }
 
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
     fn view(&self) -> Html {
         html! {
             <div>

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -14,6 +14,7 @@
 //!#     type Message = ();type Properties = ();
 //!#     fn create(props: Self::Properties,link: ComponentLink<Self>) -> Self {unimplemented!()}
 //!#     fn update(&mut self,msg: Self::Message) -> bool {unimplemented!()}
+//!#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
 //!#     fn view(&self) -> Html {unimplemented!()}}
 //! impl ToString for Scene {
 //!     fn to_string(&self) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,10 @@
 //!         true
 //!     }
 //!
+//!     fn change(&mut self, _: Self::Properties) -> ShouldRender {
+//!         false
+//!     }
+//!
 //!     fn view(&self) -> Html {
 //!         html! {
 //!             <div>

--- a/src/services/fetch/std_web.rs
+++ b/src/services/fetch/std_web.rs
@@ -185,7 +185,7 @@ impl FetchService {
     ///     .expect("Failed to build request.");
     /// ```
     ///
-    /// The callback function can build a loop message by passing or analizing the
+    /// The callback function can build a loop message by passing or analyzing the
     /// response body and metadata.
     ///
     /// ```
@@ -197,6 +197,7 @@ impl FetchService {
     ///#     type Message = Msg;type Properties = ();
     ///#     fn create(props: Self::Properties,link: ComponentLink<Self>) -> Self {unimplemented!()}
     ///#     fn update(&mut self,msg: Self::Message) -> bool {unimplemented!()}
+    ///#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
     ///#     fn view(&self) -> Html {unimplemented!()}
     ///# }
     ///# enum Msg {
@@ -236,6 +237,7 @@ impl FetchService {
     ///#     type Message = Msg;type Properties = ();
     ///#     fn create(props: Self::Properties,link: ComponentLink<Self>) -> Self {unimplemented!()}
     ///#     fn update(&mut self,msg: Self::Message) -> bool {unimplemented!()}
+    ///#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
     ///#     fn view(&self) -> Html {unimplemented!()}
     ///# }
     ///# enum Msg {
@@ -289,6 +291,7 @@ impl FetchService {
     ///#     type Properties = ();
     ///#     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {unimplemented!()}
     ///#     fn update(&mut self, msg: Self::Message) -> bool {unimplemented!()}
+    ///#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
     ///#     fn view(&self) -> Html {unimplemented!()}
     ///# }
     ///# pub enum Msg { }

--- a/src/services/fetch/web_sys.rs
+++ b/src/services/fetch/web_sys.rs
@@ -199,6 +199,7 @@ impl FetchService {
     ///#     type Message = Msg;type Properties = ();
     ///#     fn create(props: Self::Properties,link: ComponentLink<Self>) -> Self {unimplemented!()}
     ///#     fn update(&mut self,msg: Self::Message) -> bool {unimplemented!()}
+    ///#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
     ///#     fn view(&self) -> Html {unimplemented!()}
     ///# }
     ///# enum Msg {
@@ -239,6 +240,7 @@ impl FetchService {
     ///#     type Message = Msg;type Properties = ();
     ///#     fn create(props: Self::Properties,link: ComponentLink<Self>) -> Self {unimplemented!()}
     ///#     fn update(&mut self,msg: Self::Message) -> bool {unimplemented!()}
+    ///#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
     ///#     fn view(&self) -> Html {unimplemented!()}
     ///# }
     ///# enum Msg {
@@ -293,6 +295,7 @@ impl FetchService {
     ///#     type Properties = ();
     ///#     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {unimplemented!()}
     ///#     fn update(&mut self, msg: Self::Message) -> bool {unimplemented!()}
+    ///#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
     ///#     fn view(&self) -> Html {unimplemented!()}
     ///# }
     ///# pub enum Msg {}

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -346,6 +346,10 @@ mod tests {
             unimplemented!();
         }
 
+        fn change(&mut self, _: Self::Properties) -> ShouldRender {
+            unimplemented!();
+        }
+
         fn view(&self) -> Html {
             unimplemented!();
         }

--- a/src/virtual_dom/vlist.rs
+++ b/src/virtual_dom/vlist.rs
@@ -146,6 +146,10 @@ mod tests {
             unimplemented!();
         }
 
+        fn change(&mut self, _: Self::Properties) -> ShouldRender {
+            unimplemented!();
+        }
+
         fn view(&self) -> Html {
             unimplemented!();
         }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -575,6 +575,10 @@ mod tests {
             unimplemented!();
         }
 
+        fn change(&mut self, _: Self::Properties) -> ShouldRender {
+            unimplemented!();
+        }
+
         fn view(&self) -> Html {
             unimplemented!();
         }
@@ -594,6 +598,10 @@ mod tests {
             unimplemented!();
         }
 
+        fn change(&mut self, _: Self::Properties) -> ShouldRender {
+            unimplemented!();
+        }
+
         fn view(&self) -> Html {
             unimplemented!();
         }
@@ -610,6 +618,10 @@ mod tests {
         }
 
         fn update(&mut self, _: Self::Message) -> ShouldRender {
+            unimplemented!();
+        }
+
+        fn change(&mut self, _: Self::Properties) -> ShouldRender {
             unimplemented!();
         }
 

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -148,6 +148,10 @@ mod test {
             unimplemented!();
         }
 
+        fn change(&mut self, _: Self::Properties) -> ShouldRender {
+            unimplemented!();
+        }
+
         fn view(&self) -> Html {
             unimplemented!();
         }


### PR DESCRIPTION
#### Problem
A common mistake that Yew devs make is properly handling the `change` lifecycle method. This is mostly because Yew does not require an implementation. Until https://github.com/yewstack/yew/issues/830 is implemented, implementing `change` should be required.