### PR TITLE
Fix errors in the TwoApps showcase example

### DIFF
--- a/examples/showcase/src/main.rs
+++ b/examples/showcase/src/main.rs
@@ -37,7 +37,7 @@ use strum_macros::{Display, EnumIter, EnumString};
 use textarea::Model as Textarea;
 use timer::Model as Timer;
 use todomvc::Model as Todomvc;
-use two_apps::Model as TwoApps;
+use two_apps::TwoModels as TwoApps;
 use yew::components::Select;
 use yew::{html, App, Component, ComponentLink, Html, ShouldRender};
 

--- a/examples/std_web/two_apps/src/lib.rs
+++ b/examples/std_web/two_apps/src/lib.rs
@@ -1,6 +1,8 @@
 #![recursion_limit = "256"]
 
-use yew::{html, Component, ComponentLink, Html, ShouldRender};
+use stdweb::web::IParentNode;
+use yew::{html, App, Component, ComponentLink, Html, ShouldRender};
+use yew::html::{Scope};
 
 pub struct Model {
     link: ComponentLink<Self>,
@@ -69,6 +71,50 @@ impl Component for Model {
                 <button onclick=self.link.callback(|_| Msg::SendToOpposite("Two".into()))>{ "Two" }</button>
                 <button onclick=self.link.callback(|_| Msg::SendToOpposite("Three".into()))>{ "Three" }</button>
                 <button onclick=self.link.callback(|_| Msg::SendToOpposite("Ping".into()))>{ "Ping" }</button>
+            </div>
+        }
+    }
+}
+
+fn mount_app(selector: &'static str, app: App<Model>) -> Scope<Model> {
+    let document = yew::utils::document();
+    let element = document.query_selector(selector).unwrap().unwrap();
+    app.mount(element)
+}
+
+pub struct TwoModels {}
+
+impl Component for TwoModels {
+    type Message = ();
+    type Properties = ();
+
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+        TwoModels { }
+    }
+
+    fn mounted(&mut self) -> ShouldRender {
+        let first_app = App::new();
+        let second_app = App::new();
+        let to_first = mount_app(".first-app", first_app);
+        let to_second = mount_app(".second-app", second_app);
+        to_first.send_message(Msg::SetOpposite(to_second.clone()));
+        to_second.send_message(Msg::SetOpposite(to_first.clone()));
+        false
+    }
+
+    fn update(&mut self, _: Self::Message) -> ShouldRender {
+        false
+    }
+
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
+    fn view(&self) -> Html {
+        html! {
+            <div>
+                <div class="first-app"></div>
+                <div class="second-app"></div>
             </div>
         }
     }

--- a/examples/std_web/two_apps/src/main.rs
+++ b/examples/std_web/two_apps/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     let second_app = App::new();
     let to_first = mount_app(".first-app", first_app);
     let to_second = mount_app(".second-app", second_app);
-    to_first.send_message(Msg::SetScope(to_second.clone()));
-    to_second.send_message(Msg::SetScope(to_first.clone()));
+    to_first.send_message(Msg::SetOpposite(to_second.clone()));
+    to_second.send_message(Msg::SetOpposite(to_first.clone()));
     yew::run_loop();
 }

--- a/examples/web_sys/two_apps/src/lib.rs
+++ b/examples/web_sys/two_apps/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 
-use yew::{html, Component, ComponentLink, Html, ShouldRender};
+use yew::{html, App, Component, ComponentLink, Html, ShouldRender};
+use yew::html::{Scope};
 
 pub struct Model {
     link: ComponentLink<Self>,
@@ -69,6 +70,50 @@ impl Component for Model {
                 <button onclick=self.link.callback(|_| Msg::SendToOpposite("Two".into()))>{ "Two" }</button>
                 <button onclick=self.link.callback(|_| Msg::SendToOpposite("Three".into()))>{ "Three" }</button>
                 <button onclick=self.link.callback(|_| Msg::SendToOpposite("Ping".into()))>{ "Ping" }</button>
+            </div>
+        }
+    }
+}
+
+fn mount_app(selector: &'static str, app: App<Model>) -> Scope<Model> {
+    let document = yew::utils::document();
+    let element = document.query_selector(selector).unwrap().unwrap();
+    app.mount(element)
+}
+
+pub struct TwoModels {}
+
+impl Component for TwoModels {
+    type Message = ();
+    type Properties = ();
+
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+        TwoModels { }
+    }
+
+    fn mounted(&mut self) -> ShouldRender {
+        let first_app = App::new();
+        let second_app = App::new();
+        let to_first = mount_app(".first-app", first_app);
+        let to_second = mount_app(".second-app", second_app);
+        to_first.send_message(Msg::SetOpposite(to_second.clone()));
+        to_second.send_message(Msg::SetOpposite(to_first.clone()));
+        false
+    }
+
+    fn update(&mut self, _: Self::Message) -> ShouldRender {
+        false
+    }
+
+    fn change(&mut self, _: Self::Properties) -> ShouldRender {
+        false
+    }
+
+    fn view(&self) -> Html {
+        html! {
+            <div>
+                <div class="first-app"></div>
+                <div class="second-app"></div>
             </div>
         }
     }

--- a/examples/web_sys/two_apps/src/main.rs
+++ b/examples/web_sys/two_apps/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
     let second_app = App::new();
     let to_first = mount_app(".first-app", first_app);
     let to_second = mount_app(".second-app", second_app);
-    to_first.send_message(Msg::SetScope(to_second.clone()));
-    to_second.send_message(Msg::SetScope(to_first.clone()));
+    to_first.send_message(Msg::SetOpposite(to_second.clone()));
+    to_second.send_message(Msg::SetOpposite(to_first.clone()));
     yew::run_loop();
 }


### PR DESCRIPTION
The "two apps" part of the `two_apps` example is now implemented in both `two_apps/src/main.rs` and in the `TwoModels` component of `two_apps/src/lib.rs`. The `TwoModels::mounted` implementation mimics the work done in `main.rs` of the example. The `TwoModels` struct and implementation are the same in both the `web_sys` and `std_web` examples.

Fixes #201 