### PR TITLE
Added missing `Component::change` impl for pub_sub example.

### DIFF
--- a/examples/pub_sub/src/lib.rs
+++ b/examples/pub_sub/src/lib.rs
@@ -18,6 +18,10 @@ impl Component for Model {
         Model {}
     }
 
+    fn change(&mut self, _: Self::Properties) -> bool {
+        false
+    }
+
     fn update(&mut self, _: Self::Message) -> ShouldRender {
         false
     }

--- a/examples/pub_sub/src/producer.rs
+++ b/examples/pub_sub/src/producer.rs
@@ -24,6 +24,10 @@ impl Component for Producer {
         Producer { event_bus, link }
     }
 
+     fn change(&mut self, _: Self::Properties) -> bool {
+         false
+     }
+
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
             Msg::Clicked => {

--- a/examples/pub_sub/src/subscriber.rs
+++ b/examples/pub_sub/src/subscriber.rs
@@ -24,6 +24,10 @@ impl Component for Subscriber {
         }
     }
 
+    fn change(&mut self, _: Self::Properties) -> bool {
+        false
+    }
+
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
             Msg::NewMessage(s) => self.message = s,


### PR DESCRIPTION
The pub_sub example is currently broken because it doesn't implement the now required `Component::change` impl. 
This pull request fixes that.