### PR TITLE
Split class names on whitespace when using `tuple` or `Vec`

### DIFF
--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -228,3 +228,47 @@ pub trait Transformer<FROM, TO> {
     /// Transforms one type to another.
     fn transform(from: FROM) -> TO;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_is_initially_empty() {
+        let subject = Classes::new();
+        assert!(subject.is_empty());
+    }
+
+    #[test]
+    fn it_pushes_value() {
+        let mut subject = Classes::new();
+        subject.push("foo");
+        assert!(!subject.is_empty());
+        assert!(subject.contains("foo"));
+    }
+
+    #[test]
+    fn it_adds_values_via_extend() {
+        let mut other = Classes::new();
+        other.push("bar");
+        let subject = Classes::new().extend(other);
+        assert!(subject.contains("bar"));
+    }
+
+    #[test]
+    fn it_contains_both_values() {
+        let mut other = Classes::new();
+        other.push("bar");
+        let mut subject = Classes::new().extend(other);
+        subject.push("foo");
+        assert!(subject.contains("foo"));
+        assert!(subject.contains("bar"));
+    }
+
+    #[test]
+    fn it_splits_class_with_spaces() {
+        let mut subject = Classes::new();
+        subject.push("foo bar");
+        assert!(subject.contains("foo bar"));
+    }
+}

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -76,10 +76,8 @@ impl Classes {
     ///
     /// Prevents duplication of class names.
     pub fn push(&mut self, class: &str) {
-        let class = class.trim();
-        if !class.is_empty() {
-            self.set.insert(class.into());
-        }
+        let classes_to_add: Classes = class.into();
+        self.set.extend(classes_to_add.set);
     }
 
     /// Check the set contains a class.
@@ -269,6 +267,7 @@ mod tests {
     fn it_splits_class_with_spaces() {
         let mut subject = Classes::new();
         subject.push("foo bar");
-        assert!(subject.contains("foo bar"));
+        assert!(subject.contains("foo"));
+        assert!(subject.contains("bar"));
     }
 }

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -146,7 +146,9 @@ impl<T: AsRef<str>> From<Vec<T>> for Classes {
     fn from(t: Vec<T>) -> Self {
         let set = t
             .iter()
-            .map(|x| x.as_ref().to_string())
+            .map(|x| x.as_ref())
+            .flat_map(|s| s.split_whitespace())
+            .map(String::from)
             .filter(|c| !c.is_empty())
             .collect();
         Self { set }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -756,6 +756,22 @@ mod tests {
     }
 
     #[test]
+    fn supports_multiple_non_unique_classes_tuple() {
+        let a = html! {
+            <div class=("class-1", "class-1 class-2")></div>
+        };
+
+        if let VNode::VTag(vtag) = a {
+            println!("{:?}", vtag.classes);
+            assert!(vtag.classes.contains("class-1"));
+            assert!(vtag.classes.contains("class-2"));
+            assert!(!vtag.classes.contains("class-3"));
+        } else {
+            panic!("vtag expected");
+        }
+    }
+
+    #[test]
     fn supports_multiple_classes_string() {
         let a = html! {
             <div class="class-1 class-2   class-3"></div>
@@ -781,6 +797,23 @@ mod tests {
     fn supports_multiple_classes_vec() {
         let mut classes = vec!["class-1"];
         classes.push("class-2");
+        let a = html! {
+            <div class=classes></div>
+        };
+
+        if let VNode::VTag(vtag) = a {
+            println!("{:?}", vtag.classes);
+            assert!(vtag.classes.contains("class-1"));
+            assert!(vtag.classes.contains("class-2"));
+            assert!(!vtag.classes.contains("class-3"));
+        } else {
+            panic!("vtag expected");
+        }
+    }
+
+    #[test]
+    fn supports_multiple_classes_one_value_vec() {
+        let classes = vec!["class-1 class-2", "class-1"];
         let a = html! {
             <div class=classes></div>
         };


### PR DESCRIPTION
Change `Classes::push` to use the existing `From<&str> for Classes` implementation which uses `str::split_whitespace`. The `impl<T: AsRef<str>> From<Vec<T>> for Classes` has likewise been changed to use `str::split_whitespace` on each of the members of the incoming `Vec`.

Add tests to cover the new expected behavior of the functions related to the `Classes` struct.

Fixes #935