### PR TITLE
Fixed library types in Cargo.toml (for wasm-pack)

### DIFF
--- a/examples/web_sys/counter/Cargo.toml
+++ b/examples/web_sys/counter/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.1"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 js-sys = "0.3"
 yew = { path = "../../..", features = ["services", "web_sys"] }

--- a/examples/web_sys/file_upload/Cargo.toml
+++ b/examples/web_sys/file_upload/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 js-sys = "0.3"
 yew = { path = "../../..", features = ["web_sys"] }

--- a/examples/web_sys/file_upload/src/lib.rs
+++ b/examples/web_sys/file_upload/src/lib.rs
@@ -93,6 +93,10 @@ impl Component for Model {
             </div>
         }
     }
+
+    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
+        false
+    }
 }
 
 impl Model {

--- a/examples/web_sys/inner_html/Cargo.toml
+++ b/examples/web_sys/inner_html/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Garrett Berg <vitiral@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 web-sys = { version = "0.3", features = ["console", "Document", "Element", "Node", "Window"] }
 yew = { path = "../../..", features = ["web_sys"] }

--- a/examples/web_sys/js_callback/Cargo.toml
+++ b/examples/web_sys/js_callback/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Scott Steele <scottlsteele@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 yew = { path = "../../..", features = ["web_sys"] }
 

--- a/examples/web_sys/mount_point/Cargo.toml
+++ b/examples/web_sys/mount_point/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Ben Berman <ben@standardbots.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 wasm-bindgen = "0.2"
 yew = { path = "../../..", features = ["web_sys"] }

--- a/examples/web_sys/multi_thread/Cargo.toml
+++ b/examples/web_sys/multi_thread/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [[bin]]
 name = "multi_thread_app"
 path = "src/bin/app.rs"

--- a/examples/web_sys/multi_thread/src/lib.rs
+++ b/examples/web_sys/multi_thread/src/lib.rs
@@ -79,4 +79,8 @@ impl Component for Model {
             </div>
         }
     }
+
+    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
+        false
+    }
 }

--- a/examples/web_sys/node_refs/Cargo.toml
+++ b/examples/web_sys/node_refs/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Justin Starry <justin.starry@icloud.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 yew = { path = "../../..", features = ["web_sys"] }
 web-sys = { version = "0.3", features = ["HtmlElement", "HtmlInputElement", "Node"] }

--- a/examples/web_sys/npm_and_rest/Cargo.toml
+++ b/examples/web_sys/npm_and_rest/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 anyhow = "1"
 js-sys = "0.3"

--- a/examples/web_sys/todomvc/Cargo.toml
+++ b/examples/web_sys/todomvc/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 strum = "0.13"
 strum_macros = "0.13"

--- a/examples/web_sys/two_apps/Cargo.toml
+++ b/examples/web_sys/two_apps/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 stdweb = "0.4.20"
 yew = { path = "../../..", features = ["web_sys"] }

--- a/examples/web_sys/webgl/Cargo.toml
+++ b/examples/web_sys/webgl/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Miklós Tusz <mdtusz@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 js-sys = "0.3"
 yew = { path = "../../..", features = ["web_sys"] }

--- a/examples/web_sys/webgl/src/lib.rs
+++ b/examples/web_sys/webgl/src/lib.rs
@@ -84,6 +84,10 @@ impl Component for Model {
             <canvas ref={self.node_ref.clone()} />
         }
     }
+
+    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
+        false
+    }
 }
 
 impl Model {


### PR DESCRIPTION
Also added some missing implementations of Component::change.

This allows all examples in `web_sys/` to be built with `wasm-pack build`, with the exception of `file_upload` (see #1087).