### PR TITLE
Update pulldown cmark

### DIFF
--- a/examples/crm/Cargo.toml
+++ b/examples/crm/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 serde = "1"
 serde_derive = "1"
 yew = { path = "../../yew" }
-pulldown-cmark = "0.1.2"
+pulldown-cmark = { version = "0.7.0", default-features = false }
 
 [features]
 std_web = ["yew/std_web"]

--- a/examples/crm/src/markdown.rs
+++ b/examples/crm/src/markdown.rs
@@ -1,6 +1,6 @@
 /// Original author of this code is [Nathan Ringo](https://github.com/remexre)
 /// Source: https://github.com/acmumn/mentoring/blob/master/web-client/src/view/markdown.rs
-use pulldown_cmark::{Alignment, Event, Parser, Tag, OPTION_ENABLE_TABLES};
+use pulldown_cmark::{Alignment, Event, Parser, Tag, Options};
 use yew::virtual_dom::{VNode, VTag, VText};
 use yew::{html, Html};
 
@@ -18,7 +18,10 @@ pub fn render_markdown(src: &str) -> Html {
         }};
     }
 
-    for ev in Parser::new_ext(src, OPTION_ENABLE_TABLES) {
+   let mut options = Options::empty();
+   options.insert(Options::ENABLE_TABLES);
+
+    for ev in Parser::new_ext(src, options) {
         match ev {
             Event::Start(tag) => {
                 spine.push(make_tag(tag));

--- a/examples/crm/src/markdown.rs
+++ b/examples/crm/src/markdown.rs
@@ -159,5 +159,10 @@ fn make_tag(t: Tag) -> VTag {
             el
         }
         Tag::FootnoteDefinition(ref _footnote_id) => VTag::new("span"), // Footnotes are not rendered as anything special
+        Tag::Strikethrough => {
+            let mut el = VTag::new("span");
+            el.add_class("text-decoration-strikethrough");
+            el
+        }
     }
 }

--- a/examples/crm/src/markdown.rs
+++ b/examples/crm/src/markdown.rs
@@ -149,11 +149,12 @@ fn make_tag(t: Tag) -> VTag {
             }
             el
         }
-        Tag::Image(ref src, ref title) => {
+        Tag::Image(_link_type, ref src, ref title) => {
             let mut el = VTag::new("img");
             el.add_attribute("src", src);
+            let title = title.clone().into_string();
             if title != "" {
-                el.add_attribute("title", title);
+                el.add_attribute("title", &title);
             }
             el
         }

--- a/examples/crm/src/markdown.rs
+++ b/examples/crm/src/markdown.rs
@@ -1,6 +1,6 @@
 /// Original author of this code is [Nathan Ringo](https://github.com/remexre)
 /// Source: https://github.com/acmumn/mentoring/blob/master/web-client/src/view/markdown.rs
-use pulldown_cmark::{Alignment, Event, Parser, Tag, Options, CodeBlockKind};
+use pulldown_cmark::{Alignment, CodeBlockKind, Event, Options, Parser, Tag};
 use yew::virtual_dom::{VNode, VTag, VText};
 use yew::{html, Html};
 
@@ -18,8 +18,8 @@ pub fn render_markdown(src: &str) -> Html {
         }};
     }
 
-   let mut options = Options::empty();
-   options.insert(Options::ENABLE_TABLES);
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
 
     for ev in Parser::new_ext(src, options) {
         match ev {

--- a/examples/crm/src/markdown.rs
+++ b/examples/crm/src/markdown.rs
@@ -136,7 +136,6 @@ fn make_tag(t: Tag) -> VTag {
             el.add_class("font-weight-bold");
             el
         }
-        Tag::Code => VTag::new("code"),
         Tag::Link(_link_type, ref href, ref title) => {
             let mut el = VTag::new("a");
             el.add_attribute("href", href);

--- a/examples/crm/src/markdown.rs
+++ b/examples/crm/src/markdown.rs
@@ -85,7 +85,7 @@ pub fn render_markdown(src: &str) -> Html {
 fn make_tag(t: Tag) -> VTag {
     match t {
         Tag::Paragraph => VTag::new("p"),
-        Tag::Header(n) => {
+        Tag::Heading(n) => {
             assert!(n > 0);
             assert!(n < 7);
             VTag::new(format!("h{}", n))

--- a/examples/crm/src/markdown.rs
+++ b/examples/crm/src/markdown.rs
@@ -66,6 +66,7 @@ pub fn render_markdown(src: &str) -> Html {
                 }
             }
             Event::Text(text) => add_child!(VText::new(text.to_string()).into()),
+            Event::Rule => add_child!(VTag::new("hr").into()),
             Event::SoftBreak => add_child!(VText::new("\n".to_string()).into()),
             Event::HardBreak => add_child!(VTag::new("br").into()),
             _ => println!("Unknown event: {:#?}", ev),
@@ -84,7 +85,6 @@ pub fn render_markdown(src: &str) -> Html {
 fn make_tag(t: Tag) -> VTag {
     match t {
         Tag::Paragraph => VTag::new("p"),
-        Tag::Rule => VTag::new("hr"),
         Tag::Header(n) => {
             assert!(n > 0);
             assert!(n < 7);

--- a/examples/crm/src/markdown.rs
+++ b/examples/crm/src/markdown.rs
@@ -1,6 +1,6 @@
 /// Original author of this code is [Nathan Ringo](https://github.com/remexre)
 /// Source: https://github.com/acmumn/mentoring/blob/master/web-client/src/view/markdown.rs
-use pulldown_cmark::{Alignment, Event, Parser, Tag, Options};
+use pulldown_cmark::{Alignment, Event, Parser, Tag, Options, CodeBlockKind};
 use yew::virtual_dom::{VNode, VTag, VText};
 use yew::{html, Html};
 
@@ -95,19 +95,23 @@ fn make_tag(t: Tag) -> VTag {
             el.add_class("blockquote");
             el
         }
-        Tag::CodeBlock(lang) => {
+        Tag::CodeBlock(code_block_kind) => {
             let mut el = VTag::new("code");
-            // Different color schemes may be used for different code blocks,
-            // but a different library (likely js based at the moment) would be necessary to actually provide the
-            // highlighting support by locating the language classes and applying dom transforms
-            // on their contents.
-            match lang.as_ref() {
-                "html" => el.add_class("html-language"),
-                "rust" => el.add_class("rust-language"),
-                "java" => el.add_class("java-language"),
-                "c" => el.add_class("c-language"),
-                _ => {} // Add your own language highlighting support
-            };
+
+            if let CodeBlockKind::Fenced(lang) = code_block_kind {
+                // Different color schemes may be used for different code blocks,
+                // but a different library (likely js based at the moment) would be necessary to actually provide the
+                // highlighting support by locating the language classes and applying dom transforms
+                // on their contents.
+                match lang.as_ref() {
+                    "html" => el.add_class("html-language"),
+                    "rust" => el.add_class("rust-language"),
+                    "java" => el.add_class("java-language"),
+                    "c" => el.add_class("c-language"),
+                    _ => {} // Add your own language highlighting support
+                };
+            }
+
             el
         }
         Tag::List(None) => VTag::new("ul"),

--- a/examples/crm/src/markdown.rs
+++ b/examples/crm/src/markdown.rs
@@ -137,11 +137,12 @@ fn make_tag(t: Tag) -> VTag {
             el
         }
         Tag::Code => VTag::new("code"),
-        Tag::Link(ref href, ref title) => {
+        Tag::Link(_link_type, ref href, ref title) => {
             let mut el = VTag::new("a");
             el.add_attribute("href", href);
+            let title = title.clone().into_string();
             if title != "" {
-                el.add_attribute("title", title);
+                el.add_attribute("title", &title);
             }
             el
         }


### PR DESCRIPTION
Closes #1117 

This updates the tags to match the changes in the pulldown-cmark api. I'm not sure if there's a better way to deal with the Cow strings in link and image titles, but if there is I don't know what it is.
 