### PR TITLE
Make examples compile with wasm-pack

### DIFF
--- a/examples/crm/Cargo.toml
+++ b/examples/crm/Cargo.toml
@@ -13,3 +13,6 @@ pulldown-cmark = { version = "0.7.0", default-features = false }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/custom_components/Cargo.toml
+++ b/examples/custom_components/Cargo.toml
@@ -10,3 +10,6 @@ yew = { path = "../../yew" }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/dashboard/Cargo.toml
+++ b/examples/dashboard/Cargo.toml
@@ -13,3 +13,6 @@ yew = { path = "../../yew", features = ["toml"] }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/fragments/Cargo.toml
+++ b/examples/fragments/Cargo.toml
@@ -10,3 +10,6 @@ yew = { path = "../../yew" }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -15,3 +15,6 @@ yew = { path = "../../yew" }
 [features]
 std_web = ["rand/stdweb", "yew/std_web"]
 web_sys = ["rand/wasm-bindgen", "yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/large_table/Cargo.toml
+++ b/examples/large_table/Cargo.toml
@@ -10,3 +10,6 @@ yew = { path = "../../yew" }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -10,3 +10,6 @@ yew = { path = "../../yew" }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/nested_list/Cargo.toml
+++ b/examples/nested_list/Cargo.toml
@@ -12,3 +12,6 @@ yew = { path = "../../yew" }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/pub_sub/Cargo.toml
+++ b/examples/pub_sub/Cargo.toml
@@ -12,3 +12,6 @@ yew = { path = "../../yew" }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/textarea/Cargo.toml
+++ b/examples/textarea/Cargo.toml
@@ -10,3 +10,6 @@ yew = { path = "../../yew" }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/timer/Cargo.toml
+++ b/examples/timer/Cargo.toml
@@ -10,3 +10,6 @@ yew = { path = "../../yew" }
 [features]
 std_web = ["yew/std_web"]
 web_sys = ["yew/web_sys"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
Added
```
[lib]
crate-type = ["cdylib" "rlib"]
```
to various `Cargo.toml`s so the examples can be compiled with `wasm-pack build`.