### PR TITLE
fix infinite render which cause browser frozen

### DIFF
--- a/yew-router/src/router.rs
+++ b/yew-router/src/router.rs
@@ -185,8 +185,10 @@ where
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
-        self.router_agent.send(RouteRequest::GetCurrentRoute);
+    fn rendered(&mut self, first_render: bool) {
+        if first_render {
+            self.router_agent.send(RouteRequest::GetCurrentRoute);
+        }
     }
 
     fn update(&mut self, msg: Self::Message) -> ShouldRender {


### PR DESCRIPTION
Currently yew_router generate a infinite render and causes browser frozen. This fix only allow changes in the DOM in the first render