### PR TITLE
Mark re-exports with doc(no_inline) for clarity

### DIFF
--- a/yew/src/lib.rs
+++ b/yew/src/lib.rs
@@ -122,6 +122,7 @@ pub mod events {
 
     cfg_if! {
         if #[cfg(feature = "std_web")] {
+            #[doc(no_inline)]
             pub use stdweb::web::event::{
                 BlurEvent, ClickEvent, ContextMenuEvent, DoubleClickEvent, DragDropEvent, DragEndEvent,
                 DragEnterEvent, DragEvent, DragExitEvent, DragLeaveEvent, DragOverEvent, DragStartEvent,
@@ -133,6 +134,7 @@ pub mod events {
                 ScrollEvent, SubmitEvent, TouchCancel, TouchEnd, TouchEnter, TouchMove, TouchStart,
             };
         } else if #[cfg(feature = "web_sys")] {
+            #[doc(no_inline)]
             pub use web_sys::{
                 DragEvent, Event, FocusEvent, KeyboardEvent, MouseEvent, PointerEvent, TouchEvent, UiEvent,
                 WheelEvent,

--- a/yew/src/services/fetch/web_sys.rs
+++ b/yew/src/services/fetch/web_sys.rs
@@ -21,6 +21,7 @@ use web_sys::{
     Response as WebResponse,
 };
 
+#[doc(no_inline)]
 pub use web_sys::{
     RequestCache as Cache, RequestCredentials as Credentials, RequestMode as Mode,
     RequestRedirect as Redirect, Window, WorkerGlobalScope,

--- a/yew/src/services/reader/std_web.rs
+++ b/yew/src/services/reader/std_web.rs
@@ -6,6 +6,7 @@ use crate::services::Task;
 use std::cmp;
 use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::web::event::LoadEndEvent;
+#[doc(no_inline)]
 pub use stdweb::web::{Blob, File, IBlob};
 use stdweb::web::{FileReader, FileReaderReadyState, FileReaderResult, IEventTarget, TypedArray};
 #[allow(unused_imports)]


### PR DESCRIPTION
Fix #1142

### Before
<img width="645" alt="Screenshot 2020-04-27 15 58 28" src="https://user-images.githubusercontent.com/1076145/80348260-1d8ac500-88a0-11ea-938c-4469b90ddf05.png">

---

### After
<img width="617" alt="Screenshot 2020-04-27 16 00 33" src="https://user-images.githubusercontent.com/1076145/80348343-3c895700-88a0-11ea-8013-f7ff6aec6329.png">

<img width="588" alt="Screenshot 2020-04-27 15 58 51" src="https://user-images.githubusercontent.com/1076145/80348271-1fed1f00-88a0-11ea-972c-273bcc52afc6.png">
