### PR TITLE
Derive Clone on props in Yewtil doctest

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -16,3 +16,5 @@ set -euxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_
   && cargo test --doc)
 
 (cd yew-stdweb && cargo test --target wasm32-unknown-unknown --features wasm_test)
+
+(cd yewtil && cargo test)

--- a/yewtil/src/not_equal_assign.rs
+++ b/yewtil/src/not_equal_assign.rs
@@ -15,7 +15,7 @@ pub trait NeqAssign<NEW> {
     /// # use yewtil::NeqAssign;
     /// # use yew::Properties;
     ///# use yew::virtual_dom::VNode;
-    /// ##[derive(Properties, PartialEq)]
+    /// ##[derive(Clone, Properties, PartialEq)]
     ///  struct Props {
     ///     field1: String,
     ///     field2: usize

--- a/yewtil/src/pure.rs
+++ b/yewtil/src/pure.rs
@@ -23,7 +23,7 @@ pub trait PureComponent: Properties + PartialEq + Sized + 'static {
 /// use yew::Html;
 /// use yewtil::{PureComponent, Pure};
 ///
-/// #[derive(Properties, PartialEq)]
+/// #[derive(Clone, Properties, PartialEq)]
 /// pub struct PureMyComponent {
 ///     pub data: String
 /// }


### PR DESCRIPTION
This fixes two failing tests due to the `Clone` trait bound not being satisfied in order to derive `Properties`.