### PR TITLE
Use wasm-bindgen-futures' spawn_local

### DIFF
--- a/yewtil/Cargo.toml
+++ b/yewtil/Cargo.toml
@@ -15,7 +15,7 @@ all = ["stable", "experimental"]
 # Broad features
 ## All features MUST be stable or experimental
 stable = ["neq", "pure", "history", "mrc_irc", "effect", "future"]
-experimental = ["dsl", "lrc", "with_callback", "fetch" ]
+experimental = ["dsl", "lrc", "with_callback", "fetch"]
 
 # Some pointers are stable, some experimental.
 # This makes sure you get all the pointers
@@ -29,7 +29,7 @@ history = []
 dsl = []
 effect = []
 fetch = ["serde", "serde_json", "neq", "future"]
-future = ["wasm-bindgen-futures", "wasm-bindgen", "stdweb", "futures", "web-sys"]
+future = ["wasm-bindgen-futures", "wasm-bindgen", "futures"]
 
 # Ptr features
 lrc = []

--- a/yewtil/Cargo.toml
+++ b/yewtil/Cargo.toml
@@ -28,7 +28,7 @@ with_callback = []
 history = []
 dsl = []
 effect = []
-fetch = ["serde", "serde_json", "neq", "future"]
+fetch = ["serde", "serde_json", "neq", "future", "web-sys"]
 future = ["wasm-bindgen-futures", "wasm-bindgen", "futures"]
 
 # Ptr features

--- a/yewtil/src/future.rs
+++ b/yewtil/src/future.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use stdweb::spawn_local;
+use wasm_bindgen_futures::spawn_local;
 use yew::{
     agent::{Agent, AgentLink},
     Component, ComponentLink,


### PR DESCRIPTION
Removes dependency on `stdweb` when it's not wanted.

Fixes #1166 