### PR TITLE
Add README for Custom components example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Yew Examples
 
-Use `build.sh` script to build examples. 
+Use `build.sh` script to build examples.
 
 Examples are prepared for `wasm-bindgen` except folders ending with `_wp` which are prepared for `wasm-pack`.
 

--- a/examples/custom_components/README.md
+++ b/examples/custom_components/README.md
@@ -1,0 +1,24 @@
+# Yew custom components demo
+
+This example demonstrates how an application can be structured into
+components defined in separate modules, and how you can use callbacks to send
+messages to a component higher up in the hierarchy.
+
+## The components
+
+[lib.rs](src/lib.rs) defines the root component, named `Model`. It constructs
+`Barrier` and `Counter` elements, and passes them callbacks that send
+messages back to `Model`. The `lib` module also brings the other components
+into the project with `mod` statements at the top of the file.
+
+[button.rs](src/button.rs) defines a `Button` component with an `onsignal`
+property. When the button is clicked, it generates an internal `Clicked`
+message, which is handled in the `update` function by calling
+`self.onsignal.emit`.
+
+[barrier.rs](src/barrier.rs) defines a `Barrier` which contains five
+`Button`s with identical behaviour. The `Barrier` has an `onsignal` property,
+which is emitted if any of its child `Button`s is clicked.
+
+[counter.rs](src/counter.rs) defines a `Counter` component with several
+attributes that can be set using props.

--- a/examples/js_callback/README.md
+++ b/examples/js_callback/README.md
@@ -1,8 +1,7 @@
-(Asynchronous) callback from Javascript
-=======================================
+# (Asynchronous) callback from Javascript
 
 The purpose of this example is to demonstrate a simple case of asynchronously
 sending a message back into the component update loop.
 
-See https://github.com/yewstack/yew/issues/316 for discussion on what
+See <https://github.com/yewstack/yew/issues/316> for discussion on what
 motivated this example.


### PR DESCRIPTION
I believe `custom_components` is an important reference for basic Yew concepts such as callbacks to higher-up components, and should have a Readme to help new users understand the example.

I took the opportunity to commit a couple of nits in other readme files - consistent filenames and Markdown header styles.

I accept suggestions on how the readme can be improved, for example if it's at the wrong level of detail, or misses some important points.