### PR TITLE
Re-export web-sys

### DIFF
--- a/yew/src/lib.rs
+++ b/yew/src/lib.rs
@@ -114,6 +114,9 @@ pub mod agent;
 #[cfg(feature = "services")]
 pub mod services;
 
+#[cfg(feature = "web_sys")]
+pub use web_sys;
+
 /// The module that contains all events available in the framework.
 pub mod events {
     use cfg_if::cfg_if;


### PR DESCRIPTION
This would allow users to use web-sys functions such
as console.log without having to add the web-sys
dependency to their Cargo.toml.