### PR TITLE
Replace web_logger with wasm-logger in examples

### DIFF
--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2018"
 [dependencies]
 rand = "0.7.3"
 log = "0.4"
-web_logger = "0.2"
+wasm_logger = "0.2.0"
 yew = { path = "../../yew" }

--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2018"
 [dependencies]
 rand = "0.7.3"
 log = "0.4"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../yew" }

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -3,7 +3,7 @@ use log::trace;
 use yew::App;
 
 fn main() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     trace!("Initializing yew...");
     yew::initialize();
     App::<Model>::new()

--- a/examples/nested_list/Cargo.toml
+++ b/examples/nested_list/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../yew" }

--- a/examples/nested_list/Cargo.toml
+++ b/examples/nested_list/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
-web_logger = "0.2"
+wasm_logger = "0.2.0"
 yew = { path = "../../yew" }

--- a/examples/nested_list/src/main.rs
+++ b/examples/nested_list/src/main.rs
@@ -1,4 +1,4 @@
 fn main() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<nested_list::App>();
 }

--- a/examples/pub_sub/Cargo.toml
+++ b/examples/pub_sub/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
-web_logger = "0.2"
+wasm_logger = "0.2.0"
 serde = { version = "1.0", features = ["derive"] }
 yew = { path = "../../yew" }

--- a/examples/pub_sub/Cargo.toml
+++ b/examples/pub_sub/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 serde = { version = "1.0", features = ["derive"] }
 yew = { path = "../../yew" }

--- a/yew-router/examples/minimal/Cargo.toml
+++ b/yew-router/examples/minimal/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-yew = { path = "../../../yew"  }
+yew = { path = "../../../yew" }
 yew-router = { path = "../..", features = ["service", "web_sys"], default-features = false }
-web_logger = "0.2"
+wasm_logger = "0.2.0"
 log = "0.4.8"
 wee_alloc = "0.4.5"
 wasm-bindgen = "0.2.60"

--- a/yew-router/examples/minimal/Cargo.toml
+++ b/yew-router/examples/minimal/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 yew = { path = "../../../yew" }
 yew-router = { path = "../..", features = ["service", "web_sys"], default-features = false }
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 log = "0.4.8"
 wee_alloc = "0.4.5"
 wasm-bindgen = "0.2.60"

--- a/yew-router/examples/minimal/src/lib.rs
+++ b/yew-router/examples/minimal/src/lib.rs
@@ -10,7 +10,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen(start)]
 pub fn run_app() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<Model>();
 }
 

--- a/yew-router/examples/router_component/Cargo.toml
+++ b/yew-router/examples/router_component/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 yew = { path = "../../../yew" }
 yew-router = { path = "../.." }
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 log = "0.4.8"
 wee_alloc = "0.4.5"
 wasm-bindgen = "0.2.60"

--- a/yew-router/examples/router_component/Cargo.toml
+++ b/yew-router/examples/router_component/Cargo.toml
@@ -2,16 +2,15 @@
 name = "router_component"
 version = "0.1.0"
 authors = ["Henry Zimmerman <zimhen7@gmail.com>"]
-
-edition="2018"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-yew = { path = "../../../yew"}
-yew-router = {path = "../.."}
-web_logger = "0.2"
+yew = { path = "../../../yew" }
+yew-router = { path = "../.." }
+wasm_logger = "0.2.0"
 log = "0.4.8"
 wee_alloc = "0.4.5"
 wasm-bindgen = "0.2.60"

--- a/yew-router/examples/router_component/src/lib.rs
+++ b/yew-router/examples/router_component/src/lib.rs
@@ -21,7 +21,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen(start)]
 pub fn run_app() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<Model>();
 }
 

--- a/yewtil/examples/dsl/Cargo.toml
+++ b/yewtil/examples/dsl/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../..", features = ["dsl"] }

--- a/yewtil/examples/dsl/Cargo.toml
+++ b/yewtil/examples/dsl/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-web_logger = "0.2.0"
+wasm_logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../..", features = ["dsl"] }

--- a/yewtil/examples/dsl/src/main.rs
+++ b/yewtil/examples/dsl/src/main.rs
@@ -44,6 +44,6 @@ impl Component for Model {
 }
 
 fn main() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<Model>();
 }

--- a/yewtil/examples/effect/Cargo.toml
+++ b/yewtil/examples/effect/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.8"
-web_logger = "0.2.0"
+wasm_logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../..", features = ["effect"] }

--- a/yewtil/examples/effect/Cargo.toml
+++ b/yewtil/examples/effect/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.8"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../..", features = ["effect"] }

--- a/yewtil/examples/effect/src/main.rs
+++ b/yewtil/examples/effect/src/main.rs
@@ -44,6 +44,6 @@ impl Component for Model {
 }
 
 fn main() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<Model>();
 }

--- a/yewtil/examples/fetch/Cargo.toml
+++ b/yewtil/examples/fetch/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib", "rlib"]
 log = "0.4.8"
 serde = "1.0.102"
 wasm-bindgen = "0.2.51"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../..", features = ["fetch"] }

--- a/yewtil/examples/fetch/Cargo.toml
+++ b/yewtil/examples/fetch/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib", "rlib"]
 log = "0.4.8"
 serde = "1.0.102"
 wasm-bindgen = "0.2.51"
-web_logger = "0.2.0"
+wasm_logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../..", features = ["fetch"] }

--- a/yewtil/examples/function_component/Cargo.toml
+++ b/yewtil/examples/function_component/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.8"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../.." }
 

--- a/yewtil/examples/function_component/Cargo.toml
+++ b/yewtil/examples/function_component/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.8"
-web_logger = "0.2.0"
+wasm_logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../.." }
 

--- a/yewtil/examples/function_component/src/main.rs
+++ b/yewtil/examples/function_component/src/main.rs
@@ -40,6 +40,6 @@ impl Component for Model {
 }
 
 fn main() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<Model>();
 }

--- a/yewtil/examples/history/Cargo.toml
+++ b/yewtil/examples/history/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-web_logger = "0.2.0"
+wasm_logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../.." }

--- a/yewtil/examples/history/Cargo.toml
+++ b/yewtil/examples/history/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../.." }

--- a/yewtil/examples/history/src/main.rs
+++ b/yewtil/examples/history/src/main.rs
@@ -59,6 +59,6 @@ impl Component for Model {
 }
 
 fn main() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<Model>();
 }

--- a/yewtil/examples/lrc/Cargo.toml
+++ b/yewtil/examples/lrc/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../..", features = ["lrc"] }

--- a/yewtil/examples/lrc/Cargo.toml
+++ b/yewtil/examples/lrc/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-web_logger = "0.2.0"
+wasm_logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../..", features = ["lrc"] }

--- a/yewtil/examples/lrc/src/main.rs
+++ b/yewtil/examples/lrc/src/main.rs
@@ -54,6 +54,6 @@ impl Component for Model {
 }
 
 fn main() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<Model>();
 }

--- a/yewtil/examples/mrc_irc/Cargo.toml
+++ b/yewtil/examples/mrc_irc/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-web_logger = "0.2.0"
+wasm_logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../.." }

--- a/yewtil/examples/mrc_irc/Cargo.toml
+++ b/yewtil/examples/mrc_irc/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../.." }

--- a/yewtil/examples/mrc_irc/src/main.rs
+++ b/yewtil/examples/mrc_irc/src/main.rs
@@ -56,6 +56,6 @@ impl Component for Model {
 }
 
 fn main() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<Model>();
 }

--- a/yewtil/examples/pure_component/Cargo.toml
+++ b/yewtil/examples/pure_component/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-web_logger = "0.2.0"
+wasm_logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../.." }

--- a/yewtil/examples/pure_component/Cargo.toml
+++ b/yewtil/examples/pure_component/Cargo.toml
@@ -7,6 +7,6 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
-wasm_logger = "0.2.0"
+wasm-logger = "0.2.0"
 yew = { path = "../../../yew" }
 yewtil = { path = "../.." }

--- a/yewtil/examples/pure_component/src/main.rs
+++ b/yewtil/examples/pure_component/src/main.rs
@@ -40,6 +40,6 @@ impl Component for Model {
 }
 
 fn main() {
-    web_logger::init();
+    wasm_logger::init(wasm_logger::Config::default());
     yew::start_app::<Model>();
 }


### PR DESCRIPTION
`wasm-logger` is `web-sys` based, and therefore does not implicitly include a `stdweb` dependency in the examples that use `web-sys`.

Examples in yew-stdweb have not been changed, they should keep using `web_logger` for its `stdweb` support.