### PR TITLE
Fix counter examples

### DIFF
--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -13,7 +13,6 @@ pub struct Model {
 pub enum Msg {
     Increment,
     Decrement,
-    Bulk(Vec<Msg>),
 }
 
 impl Component for Model {
@@ -37,12 +36,6 @@ impl Component for Model {
             Msg::Decrement => {
                 self.value -= 1;
                 self.console.log("minus one");
-            }
-            Msg::Bulk(list) => {
-                for msg in list {
-                    self.update(msg);
-                    self.console.log("Bulk action");
-                }
             }
         }
         true

--- a/yew-stdweb/examples/counter/src/lib.rs
+++ b/yew-stdweb/examples/counter/src/lib.rs
@@ -13,7 +13,6 @@ pub struct Model {
 pub enum Msg {
     Increment,
     Decrement,
-    Bulk(Vec<Msg>),
 }
 
 impl Component for Model {
@@ -37,12 +36,6 @@ impl Component for Model {
             Msg::Decrement => {
                 self.value -= 1;
                 self.console.log("minus one");
-            }
-            Msg::Bulk(list) => {
-                for msg in list {
-                    self.update(msg);
-                    self.console.log("Bulk action");
-                }
             }
         }
         true


### PR DESCRIPTION
I've spent a few minutes trying to figure out why my code in `Bulk` msg handling is doing nothing. Looks like the examples were updated to use `batch_callback` instead of manual `Bulk` handling  in f48bc90edb66df94aaed8f61d99912ffb2bd22de. I've just removed the confusing code.

`grep` found no other `Bulk` in examples, so (probably) there are no other similar mistakes 