### PR TITLE
Simplify component state

### DIFF
--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -260,7 +260,7 @@ where
     }
     use_hook(
         move |state: &mut UseEffectState<Dependents, Destructor>, hook_update| {
-            let mut should_update = !(*state.deps == *deps);
+            let mut should_update = *state.deps != *deps;
 
             move || {
                 hook_update(move |state: &mut UseEffectState<Dependents, Destructor>| {

--- a/yew-functional/tests/lib.rs
+++ b/yew-functional/tests/lib.rs
@@ -151,10 +151,20 @@ fn use_effect_destroys_on_component_drop() {
     struct UseEffectFunction {}
     struct UseEffectWrapper {}
     #[derive(Properties, Clone)]
-    struct DestroyCalledProps {
+    struct WrapperProps {
         destroy_called: Rc<dyn Fn()>,
     }
-    impl PartialEq for DestroyCalledProps {
+    impl PartialEq for WrapperProps {
+        fn eq(&self, _other: &Self) -> bool {
+            false
+        }
+    }
+    #[derive(Properties, Clone)]
+    struct FunctionProps {
+        effect_called: Rc<dyn Fn()>,
+        destroy_called: Rc<dyn Fn()>,
+    }
+    impl PartialEq for FunctionProps {
         fn eq(&self, _other: &Self) -> bool {
             false
         }
@@ -162,15 +172,15 @@ fn use_effect_destroys_on_component_drop() {
     type UseEffectComponent = FunctionComponent<UseEffectFunction>;
     type UseEffectWrapperComponent = FunctionComponent<UseEffectWrapper>;
     impl FunctionProvider for UseEffectFunction {
-        type TProps = DestroyCalledProps;
+        type TProps = FunctionProps;
 
         fn run(props: &Self::TProps) -> Html {
+            let effect_called = props.effect_called.clone();
             let destroy_called = props.destroy_called.clone();
             use_effect_with_deps(
                 move |_| {
-                    move || {
-                        destroy_called();
-                    }
+                    effect_called();
+                    move || destroy_called()
                 },
                 (),
             );
@@ -178,21 +188,14 @@ fn use_effect_destroys_on_component_drop() {
         }
     }
     impl FunctionProvider for UseEffectWrapper {
-        type TProps = DestroyCalledProps;
+        type TProps = WrapperProps;
 
         fn run(props: &Self::TProps) -> Html {
             let (show, set_show) = use_state(|| true);
-            use_effect_with_deps(
-                move |_| {
-                    set_show(false);
-                    || {}
-                },
-                (),
-            );
-
             if *show {
+                let effect_called: Rc<dyn Fn()> = Rc::new(move || set_show(false));
                 return html! {
-                    <UseEffectComponent destroy_called=props.destroy_called.clone() />
+                    <UseEffectComponent destroy_called=props.destroy_called.clone() effect_called=effect_called />
                 };
             } else {
                 return html! {
@@ -206,7 +209,7 @@ fn use_effect_destroys_on_component_drop() {
     let destroy_counter_c = destroy_counter.clone();
     app.mount_with_props(
         yew::utils::document().get_element_by_id("output").unwrap(),
-        DestroyCalledProps {
+        WrapperProps {
             destroy_called: Rc::new(move || *destroy_counter_c.borrow_mut().deref_mut() += 1),
         },
     );

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -17,6 +17,8 @@ cfg_if! {
 
 /// Updates for a `Component` instance. Used by scope sender.
 pub(crate) enum ComponentUpdate<COMP: Component> {
+    /// Force update
+    Force,
     /// Wraps messages for a component.
     Message(COMP::Message),
     /// Wraps batch of messages for a component.
@@ -28,19 +30,9 @@ pub(crate) enum ComponentUpdate<COMP: Component> {
 /// Untyped scope used for accessing parent scope
 #[derive(Debug, Clone)]
 pub struct AnyScope {
-    type_id: TypeId,
-    parent: Option<Rc<AnyScope>>,
-    state: Rc<dyn Any>,
-}
-
-impl Default for AnyScope {
-    fn default() -> Self {
-        Self {
-            type_id: TypeId::of::<()>(),
-            parent: None,
-            state: Rc::new(()),
-        }
-    }
+    pub(crate) type_id: TypeId,
+    pub(crate) parent: Option<Rc<AnyScope>>,
+    pub(crate) state: Rc<dyn Any>,
 }
 
 impl<COMP: Component> From<Scope<COMP>> for AnyScope {
@@ -70,7 +62,7 @@ impl AnyScope {
             parent: self.parent,
             state: self
                 .state
-                .downcast_ref::<Shared<ComponentState<COMP>>>()
+                .downcast_ref::<Shared<Option<ComponentState<COMP>>>>()
                 .expect("unexpected component type")
                 .clone(),
         }
@@ -80,7 +72,7 @@ impl AnyScope {
 /// A context which allows sending messages to a component.
 pub struct Scope<COMP: Component> {
     parent: Option<Rc<AnyScope>>,
-    state: Shared<ComponentState<COMP>>,
+    state: Shared<Option<ComponentState<COMP>>>,
 }
 
 impl<COMP: Component> fmt::Debug for Scope<COMP> {
@@ -107,14 +99,16 @@ impl<COMP: Component> Scope<COMP> {
     /// Returns the linked component if available
     pub fn get_component(&self) -> Option<impl Deref<Target = COMP> + '_> {
         self.state.try_borrow().ok().and_then(|state_ref| {
-            state_ref.component()?;
-            Some(Ref::map(state_ref, |this| this.component().unwrap()))
+            state_ref.as_ref()?;
+            Some(Ref::map(state_ref, |state| {
+                state.as_ref().unwrap().component.as_ref()
+            }))
         })
     }
 
     pub(crate) fn new(parent: Option<AnyScope>) -> Self {
         let parent = parent.map(Rc::new);
-        let state = Rc::new(RefCell::new(ComponentState::Empty));
+        let state = Rc::new(RefCell::new(None));
         Scope { parent, state }
     }
 
@@ -126,35 +120,25 @@ impl<COMP: Component> Scope<COMP> {
         node_ref: NodeRef,
         props: COMP::Properties,
     ) -> Scope<COMP> {
-        let mut scope = self;
-        let ready_state = ReadyState {
+        *self.state.borrow_mut() = Some(ComponentState::new(
             element,
-            node_ref,
-            scope: scope.clone(),
-            props,
             ancestor,
-        };
-        *scope.state.borrow_mut() = ComponentState::Ready(ready_state);
-        scope.create();
-        scope
+            node_ref,
+            self.clone(),
+            props,
+        ));
+        self.update(ComponentUpdate::Force, true);
+        self
     }
 
-    /// Schedules a task to create and render a component and then mount it to the DOM
-    pub(crate) fn create(&mut self) {
-        let state = self.state.clone();
-        let create = CreateComponent { state };
-        scheduler().push_comp(ComponentRunnableType::Create, Box::new(create));
-        self.rendered(true);
-    }
-
-    /// Schedules a task to send a message or new props to a component
-    pub(crate) fn update(&self, update: ComponentUpdate<COMP>) {
+    /// Schedules a task to send an update to a component
+    pub(crate) fn update(&self, update: ComponentUpdate<COMP>, first_update: bool) {
         let update = UpdateComponent {
             state: self.state.clone(),
             update,
         };
         scheduler().push_comp(ComponentRunnableType::Update, Box::new(update));
-        self.rendered(false);
+        self.rendered(first_update);
     }
 
     /// Schedules a task to call the rendered method on a component
@@ -179,14 +163,12 @@ impl<COMP: Component> Scope<COMP> {
     where
         T: Into<COMP::Message>,
     {
-        self.update(ComponentUpdate::Message(msg.into()));
-        self.rendered(false);
+        self.update(ComponentUpdate::Message(msg.into()), false);
     }
 
     /// Send a batch of messages to the component
     pub fn send_message_batch(&self, messages: Vec<COMP::Message>) {
-        self.update(ComponentUpdate::MessageBatch(messages));
-        self.rendered(false);
+        self.update(ComponentUpdate::MessageBatch(messages), false);
     }
 
     /// Creates a `Callback` which will send a message to the linked component's
@@ -234,171 +216,32 @@ impl<COMP: Component> Scope<COMP> {
     }
 }
 
-enum ComponentState<COMP: Component> {
-    Empty,
-    Ready(ReadyState<COMP>),
-    Created(CreatedState<COMP>),
-    Processing,
-    Destroyed,
+struct ComponentState<COMP: Component> {
+    element: Element,
+    node_ref: NodeRef,
+    scope: Scope<COMP>,
+    component: Box<COMP>,
+    last_root: Option<VNode>,
+    rendered: bool,
 }
 
 impl<COMP: Component> ComponentState<COMP> {
-    fn component(&self) -> Option<&COMP> {
-        match self {
-            ComponentState::Created(state) => Some(&state.component),
-            _ => None,
-        }
-    }
-}
-
-impl<COMP: Component> fmt::Display for ComponentState<COMP> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = match self {
-            ComponentState::Empty => "empty",
-            ComponentState::Ready(_) => "ready",
-            ComponentState::Created(_) => "created",
-            ComponentState::Processing => "processing",
-            ComponentState::Destroyed => "destroyed",
-        };
-        write!(f, "{}", name)
-    }
-}
-
-struct ReadyState<COMP: Component> {
-    element: Element,
-    node_ref: NodeRef,
-    props: COMP::Properties,
-    scope: Scope<COMP>,
-    ancestor: Option<VNode>,
-}
-
-impl<COMP: Component> ReadyState<COMP> {
-    fn create(self) -> CreatedState<COMP> {
-        CreatedState {
+    fn new(
+        element: Element,
+        ancestor: Option<VNode>,
+        node_ref: NodeRef,
+        scope: Scope<COMP>,
+        props: COMP::Properties,
+    ) -> Self {
+        let component = Box::new(COMP::create(props, scope.clone()));
+        Self {
+            element,
+            node_ref,
+            scope,
+            component,
+            last_root: ancestor,
             rendered: false,
-            component: COMP::create(self.props, self.scope.clone()),
-            element: self.element,
-            last_frame: self.ancestor,
-            node_ref: self.node_ref,
-            scope: self.scope,
         }
-    }
-}
-
-struct CreatedState<COMP: Component> {
-    rendered: bool,
-    element: Element,
-    component: COMP,
-    last_frame: Option<VNode>,
-    node_ref: NodeRef,
-    scope: Scope<COMP>,
-}
-
-impl<COMP: Component> CreatedState<COMP> {
-    /// Called after a component and all of its children have been rendered.
-    fn rendered(mut self, first_render: bool) -> Self {
-        self.rendered = true;
-        self.component.rendered(first_render);
-        self
-    }
-
-    fn update(mut self) -> Self {
-        let mut root = self.component.render();
-        if let Some(node) = root.apply(
-            &self.scope.clone().into(),
-            &self.element,
-            None,
-            self.last_frame,
-        ) {
-            self.node_ref.set(Some(node));
-        } else if let VNode::VComp(child) = &root {
-            // If the root VNode is a VComp, we won't have access to the rendered DOM node
-            // because components render asynchronously. In order to bubble up the DOM node
-            // from the VComp, we need to link the currently rendering component with its
-            // root child component.
-            self.node_ref.link(child.node_ref.clone());
-        }
-        self.last_frame = Some(root);
-        self
-    }
-}
-
-struct RenderedComponent<COMP>
-where
-    COMP: Component,
-{
-    state: Shared<ComponentState<COMP>>,
-    first_render: bool,
-}
-
-impl<COMP> Runnable for RenderedComponent<COMP>
-where
-    COMP: Component,
-{
-    fn run(self: Box<Self>) {
-        let current_state = self.state.replace(ComponentState::Processing);
-        self.state.replace(match current_state {
-            ComponentState::Created(s) if !s.rendered => {
-                ComponentState::Created(s.rendered(self.first_render))
-            }
-            ComponentState::Destroyed | ComponentState::Created(_) => current_state,
-            ComponentState::Empty | ComponentState::Processing | ComponentState::Ready(_) => {
-                panic!("unexpected component state: {}", current_state);
-            }
-        });
-    }
-}
-
-struct CreateComponent<COMP>
-where
-    COMP: Component,
-{
-    state: Shared<ComponentState<COMP>>,
-}
-
-impl<COMP> Runnable for CreateComponent<COMP>
-where
-    COMP: Component,
-{
-    fn run(self: Box<Self>) {
-        let current_state = self.state.replace(ComponentState::Processing);
-        self.state.replace(match current_state {
-            ComponentState::Ready(s) => ComponentState::Created(s.create().update()),
-            ComponentState::Created(_) | ComponentState::Destroyed => current_state,
-            ComponentState::Empty | ComponentState::Processing => {
-                panic!("unexpected component state: {}", current_state);
-            }
-        });
-    }
-}
-
-struct DestroyComponent<COMP>
-where
-    COMP: Component,
-{
-    state: Shared<ComponentState<COMP>>,
-}
-
-impl<COMP> Runnable for DestroyComponent<COMP>
-where
-    COMP: Component,
-{
-    fn run(self: Box<Self>) {
-        match self.state.replace(ComponentState::Destroyed) {
-            ComponentState::Created(mut this) => {
-                drop(this.component);
-                if let Some(last_frame) = &mut this.last_frame {
-                    last_frame.detach(&this.element);
-                }
-            }
-            ComponentState::Ready(mut this) => {
-                if let Some(ancestor) = &mut this.ancestor {
-                    ancestor.detach(&this.element);
-                }
-            }
-            ComponentState::Empty | ComponentState::Destroyed => {}
-            s @ ComponentState::Processing => panic!("unexpected component state: {}", s),
-        };
     }
 }
 
@@ -406,7 +249,7 @@ struct UpdateComponent<COMP>
 where
     COMP: Component,
 {
-    state: Shared<ComponentState<COMP>>,
+    state: Shared<Option<ComponentState<COMP>>>,
     update: ComponentUpdate<COMP>,
 }
 
@@ -415,33 +258,81 @@ where
     COMP: Component,
 {
     fn run(self: Box<Self>) {
-        let current_state = self.state.replace(ComponentState::Processing);
-        self.state.replace(match current_state {
-            ComponentState::Created(mut this) => {
-                let should_update = match self.update {
-                    ComponentUpdate::Message(message) => this.component.update(message),
-                    ComponentUpdate::MessageBatch(messages) => messages
-                        .into_iter()
-                        .fold(false, |acc, msg| this.component.update(msg) || acc),
-                    ComponentUpdate::Properties(props, node_ref) => {
-                        // When components are updated, they receive a new node ref that
-                        // must be linked to previous one.
-                        node_ref.link(this.node_ref.clone());
-                        this.component.change(props)
-                    }
-                };
-                let next_state = if should_update {
-                    this.rendered = false;
-                    this.update()
-                } else {
-                    this
-                };
-                ComponentState::Created(next_state)
+        if let Some(mut state) = self.state.borrow_mut().as_mut() {
+            let should_update = match self.update {
+                ComponentUpdate::Force => true,
+                ComponentUpdate::Message(message) => state.component.update(message),
+                ComponentUpdate::MessageBatch(messages) => messages
+                    .into_iter()
+                    .fold(false, |acc, msg| state.component.update(msg) || acc),
+                ComponentUpdate::Properties(props, node_ref) => {
+                    // When components are updated, they receive a new node ref that
+                    // must be linked to previous one.
+                    node_ref.link(state.node_ref.clone());
+                    state.component.change(props)
+                }
+            };
+
+            if should_update {
+                state.rendered = false;
+                let mut root = state.component.render();
+                let last_root = state.last_root.take();
+                if let Some(node) =
+                    root.apply(&state.scope.clone().into(), &state.element, None, last_root)
+                {
+                    state.node_ref.set(Some(node));
+                } else if let VNode::VComp(child) = &root {
+                    // If the root VNode is a VComp, we won't have access to the rendered DOM node
+                    // because components render asynchronously. In order to bubble up the DOM node
+                    // from the VComp, we need to link the currently rendering component with its
+                    // root child component.
+                    state.node_ref.link(child.node_ref.clone());
+                }
+                state.last_root = Some(root);
+            };
+        }
+    }
+}
+
+struct RenderedComponent<COMP>
+where
+    COMP: Component,
+{
+    state: Shared<Option<ComponentState<COMP>>>,
+    first_render: bool,
+}
+
+impl<COMP> Runnable for RenderedComponent<COMP>
+where
+    COMP: Component,
+{
+    fn run(self: Box<Self>) {
+        if let Some(mut state) = self.state.borrow_mut().as_mut() {
+            if !state.rendered {
+                state.rendered = true;
+                state.component.rendered(self.first_render);
             }
-            ComponentState::Destroyed => current_state,
-            ComponentState::Processing | ComponentState::Ready(_) | ComponentState::Empty => {
-                panic!("unexpected component state: {}", current_state);
+        }
+    }
+}
+
+struct DestroyComponent<COMP>
+where
+    COMP: Component,
+{
+    state: Shared<Option<ComponentState<COMP>>>,
+}
+
+impl<COMP> Runnable for DestroyComponent<COMP>
+where
+    COMP: Component,
+{
+    fn run(self: Box<Self>) {
+        if let Some(mut state) = self.state.borrow_mut().take() {
+            drop(state.component);
+            if let Some(last_frame) = &mut state.last_root {
+                last_frame.detach(&state.element);
             }
-        });
+        }
     }
 }

--- a/yew/src/scheduler.rs
+++ b/yew/src/scheduler.rs
@@ -31,7 +31,6 @@ pub(crate) struct Scheduler {
 
 pub(crate) enum ComponentRunnableType {
     Destroy,
-    Create,
     Update,
     Rendered,
 }
@@ -40,7 +39,6 @@ pub(crate) enum ComponentRunnableType {
 struct ComponentScheduler {
     // Queues
     destroy: Shared<VecDeque<Box<dyn Runnable>>>,
-    create: Shared<VecDeque<Box<dyn Runnable>>>,
     update: Shared<VecDeque<Box<dyn Runnable>>>,
 
     // Stack
@@ -51,7 +49,6 @@ impl ComponentScheduler {
     fn new() -> Self {
         ComponentScheduler {
             destroy: Rc::new(RefCell::new(VecDeque::new())),
-            create: Rc::new(RefCell::new(VecDeque::new())),
             update: Rc::new(RefCell::new(VecDeque::new())),
             rendered: Rc::new(RefCell::new(Vec::new())),
         }
@@ -59,7 +56,6 @@ impl ComponentScheduler {
 
     fn next_runnable(&self) -> Option<Box<dyn Runnable>> {
         None.or_else(|| self.destroy.borrow_mut().pop_front())
-            .or_else(|| self.create.borrow_mut().pop_front())
             .or_else(|| self.update.borrow_mut().pop_front())
             .or_else(|| self.rendered.borrow_mut().pop())
     }
@@ -79,7 +75,6 @@ impl Scheduler {
             ComponentRunnableType::Destroy => {
                 self.component.destroy.borrow_mut().push_back(runnable)
             }
-            ComponentRunnableType::Create => self.component.create.borrow_mut().push_back(runnable),
             ComponentRunnableType::Update => self.component.update.borrow_mut().push_back(runnable),
             ComponentRunnableType::Rendered => self.component.rendered.borrow_mut().push(runnable),
         };

--- a/yew/src/virtual_dom/vcomp.rs
+++ b/yew/src/virtual_dom/vcomp.rs
@@ -129,10 +129,10 @@ impl VComp {
                 }
                 GeneratorType::Overwrite(any_scope) => {
                     let mut scope: Scope<COMP> = any_scope.downcast();
-                    scope.update(ComponentUpdate::Properties(
-                        props.clone(),
-                        node_ref_clone.clone(),
-                    ));
+                    scope.update(
+                        ComponentUpdate::Properties(props.clone(), node_ref_clone.clone()),
+                        false,
+                    );
 
                     Mounted {
                         node_ref: node_ref_clone.clone(),

--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -507,6 +507,7 @@ where
 mod tests {
     use super::*;
     use crate::{html, Component, ComponentLink, Html, ShouldRender};
+    use std::any::TypeId;
     #[cfg(feature = "std_web")]
     use stdweb::web::{document, IElement};
     #[cfg(feature = "wasm_test")]
@@ -514,6 +515,14 @@ mod tests {
 
     #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
+
+    fn test_scope() -> AnyScope {
+        AnyScope {
+            type_id: TypeId::of::<()>(),
+            parent: None,
+            state: Rc::new(()),
+        }
+    }
 
     struct Comp;
 
@@ -839,7 +848,7 @@ mod tests {
         #[cfg(feature = "web_sys")]
         let document = web_sys::window().unwrap().document().unwrap();
 
-        let scope = AnyScope::default();
+        let scope = test_scope();
         let div_el = document.create_element("div").unwrap();
         let namespace = SVG_NAMESPACE;
         #[cfg(feature = "web_sys")]
@@ -982,7 +991,7 @@ mod tests {
 
     #[test]
     fn it_does_not_set_empty_class_name() {
-        let scope = AnyScope::default();
+        let scope = test_scope();
         let parent = document().create_element("div").unwrap();
 
         #[cfg(feature = "std_web")]
@@ -999,7 +1008,7 @@ mod tests {
 
     #[test]
     fn it_does_not_set_missing_class_name() {
-        let scope = AnyScope::default();
+        let scope = test_scope();
         let parent = document().create_element("div").unwrap();
 
         #[cfg(feature = "std_web")]
@@ -1016,7 +1025,7 @@ mod tests {
 
     #[test]
     fn it_sets_class_name() {
-        let scope = AnyScope::default();
+        let scope = test_scope();
         let parent = document().create_element("div").unwrap();
 
         #[cfg(feature = "std_web")]
@@ -1072,7 +1081,7 @@ mod tests {
 
     #[test]
     fn swap_order_of_classes() {
-        let scope = AnyScope::default();
+        let scope = test_scope();
         let parent = document().create_element("div").unwrap();
 
         #[cfg(feature = "std_web")]
@@ -1123,7 +1132,7 @@ mod tests {
 
     #[test]
     fn add_class_to_the_middle() {
-        let scope = AnyScope::default();
+        let scope = test_scope();
         let parent = document().create_element("div").unwrap();
 
         #[cfg(feature = "std_web")]


### PR DESCRIPTION
#### Problem
The internal component state machine is over complicated. `Empty` state and `Destroyed` state are essentially the same. The `Processing` state is an implementation detail and therefore unnecessary.

#### Changes
- Simplify the component state machine
    - The component state is now option wrapped. `None` means the component doesn't exist (rather than using `Empty` or `Destroyed`).
    - We also eagerly create the component rather than using a delayed create task. I don't anticipate this causing any issues.
    - Lastly, Yew will no longer immediately call `Component::render` after creating a component. This revealed an assumption in a yew-functional test where we expected the component to receive an update event before being destroyed.
- Rework functional tests to not rely on the component rendering before being destroyed
- Add internal "force" component update mechanism