### PR TITLE
Add class, id and placeholder properties to Select

### DIFF
--- a/yew-components/src/select.rs
+++ b/yew-components/src/select.rs
@@ -66,6 +66,15 @@ pub struct Props<T: Clone> {
     /// Options are available to choose.
     #[prop_or_default]
     pub options: Vec<T>,
+    /// Classes applied to the `<select>` tag
+    #[prop_or_default]
+    pub classes: String,
+    /// ID for the `<select>` tag
+    #[prop_or_default]
+    pub id: String,
+    /// Placeholder value, shown at the top as a disabled option
+    #[prop_or(String::from("↪"))]
+    pub placeholder: String,
     /// Callback to handle changes.
     pub on_change: Callback<T>,
 }
@@ -124,9 +133,15 @@ where
         };
 
         html! {
-            <select ref=self.select_ref.clone() disabled=self.props.disabled onchange=self.on_change()>
+            <select
+                ref=self.select_ref.clone()
+                id=self.props.id.clone()
+                class=self.props.classes.clone()
+                disabled=self.props.disabled
+                onchange=self.on_change()
+            >
                 <option value="" disabled=true selected=selected.is_none()>
-                    { "↪" }
+                    { self.props.placeholder.clone() }
                 </option>
                 { for self.props.options.iter().map(view_option) }
             </select>
@@ -158,6 +173,32 @@ mod tests {
         let on_change = Callback::<u8>::default();
         html! {
             <Select<u8> on_change=on_change />
+        };
+    }
+
+    #[test]
+    fn can_create_select_with_class() {
+        let on_change = Callback::<u8>::default();
+        let class = "form-control";
+        html! {
+            <Select<u8> on_change=on_change classes=class />
+        };
+    }
+
+    #[test]
+    fn can_create_select_with_id() {
+        let on_change = Callback::<u8>::default();
+        let id = "test-select";
+        html! {
+            <Select<u8> on_change=on_change id=id />
+        };
+    }
+
+    #[test]
+    fn can_create_select_with_placeholder() {
+        let on_change = Callback::<u8>::default();
+        html! {
+            <Select<u8> on_change=on_change placeholder="--Please choose an option--" />
         };
     }
 }

--- a/yew-components/src/select.rs
+++ b/yew-components/src/select.rs
@@ -179,18 +179,16 @@ mod tests {
     #[test]
     fn can_create_select_with_class() {
         let on_change = Callback::<u8>::default();
-        let class = "form-control";
         html! {
-            <Select<u8> on_change=on_change classes=class />
+            <Select<u8> on_change=on_change classes="form-control" />
         };
     }
 
     #[test]
     fn can_create_select_with_id() {
         let on_change = Callback::<u8>::default();
-        let id = "test-select";
         html! {
-            <Select<u8> on_change=on_change id=id />
+            <Select<u8> on_change=on_change id="test-select" />
         };
     }
 

--- a/yew-components/src/select.rs
+++ b/yew-components/src/select.rs
@@ -68,7 +68,7 @@ pub struct Props<T: Clone> {
     pub options: Vec<T>,
     /// Classes applied to the `<select>` tag
     #[prop_or_default]
-    pub classes: String,
+    pub class: String,
     /// ID for the `<select>` tag
     #[prop_or_default]
     pub id: String,
@@ -136,7 +136,7 @@ where
             <select
                 ref=self.select_ref.clone()
                 id=self.props.id.clone()
-                class=self.props.classes.clone()
+                class=self.props.class.clone()
                 disabled=self.props.disabled
                 onchange=self.on_change()
             >
@@ -180,7 +180,7 @@ mod tests {
     fn can_create_select_with_class() {
         let on_change = Callback::<u8>::default();
         html! {
-            <Select<u8> on_change=on_change classes="form-control" />
+            <Select<u8> on_change=on_change class="form-control" />
         };
     }
 


### PR DESCRIPTION
Add three new properties to the Select component to enable more customization.

- `id` is necessary to associate a `<label>` with the component.
- `classes` lets users apply custom CSS classes to the component. The reason for
  choosing `classes` over `class` as the name of the property is to mirror `yew-router`'s components: https://github.com/yewstack/yew/blob/0.15.0/yew-router/src/components/mod.rs#L37
- `placeholder` allows users to choose a value for the disabled, empty option shown before making a selection. The original `"↪"` is kept as default.