### PR TITLE
Save code size by using bincode instead of serde-json to store router state

### DIFF
--- a/yew-router/Cargo.toml
+++ b/yew-router/Cargo.toml
@@ -35,6 +35,7 @@ yew = { version = "0.15.0", path = "../yew", features = ["services", "agent"], d
 yew-router-macro = { version = "0.12.0", path = "../yew-router-macro" }
 yew-router-route-parser = { version = "0.12.0", path = "../yew-router-route-parser" }
 
+bincode = { version = "~1.2.1" }
 cfg-if = "0.1.10"
 cfg-match = "0.2"
 gloo = { version = "0.2.0", optional = true }
@@ -42,7 +43,6 @@ js-sys = { version = "0.3.35", optional = true }
 log = "0.4.8"
 nom = "5.1.1"
 serde = { version = "1.0.104", features = ["derive"] }
-serde_json = "1.0.48"
 stdweb = { version = "0.4.20", optional = true }
 wasm-bindgen = { version = "0.2.58", optional = true }
 


### PR DESCRIPTION
When I ran twiggy on a small Yew project, I noticed that a few of the largest functions were from serde_json: `<serde_json::error::Error as serde::de::Error>::custom`, `serde_json::de::Deserializer<R>::peek_invalid_type`, etc., even though I don't use json serialization anywhere. `twiggy paths` pointed me here, where I learned that serde_json generates a lot of error reporting code even if you only deserialize the unit type.

Switching to bincode saves 13k (446k -> 433k) in an `opt-level = "s"` build of my project with `STATE=()`. If I change the state to `struct TestState { some: u64, test: String, fields: HashMap<String, String> }` instead of `()`, then it saves 33k (475k -> 442k) over serde_json.

The obvious downside is that this makes manual debugging harder, since the value in `history.state` is no longer human-readable.