### PR TITLE
Update yew-router examples

### DIFF
--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2018"
 
 [dependencies]
 tungstenite = "0.10.1"
+
+[workspace]

--- a/yew-router/examples/minimal/src/lib.rs
+++ b/yew-router/examples/minimal/src/lib.rs
@@ -66,16 +66,8 @@ impl Component for Model {
             Msg::RouteChanged(route) => self.route = route,
             Msg::ChangeRoute(route) => {
                 // This might be derived in the future
-                let route_string = match route {
-                    AppRoute::A(s) => format!("/a/{}", s),
-                    AppRoute::B { anything, number } => format!("/b/{}/{}", anything, number),
-                    AppRoute::C => "/c".to_string(),
-                };
-                self.route_service.set_route(&route_string, ());
-                self.route = Route {
-                    route: route_string,
-                    state: (),
-                };
+                self.route = route.into();
+                self.route_service.set_route(&self.route.route, ());
             }
         }
         true

--- a/yew-router/examples/servers/actix/Cargo.toml
+++ b/yew-router/examples/servers/actix/Cargo.toml
@@ -11,3 +11,5 @@ actix-web = "2.0.0"
 actix-files = "0.2.1"
 actix-rt = "1.1.0"
 env_logger = "0.7.1"
+
+[workspace]

--- a/yew-router/examples/servers/warp/Cargo.toml
+++ b/yew-router/examples/servers/warp/Cargo.toml
@@ -9,3 +9,5 @@ edition = "2018"
 [dependencies]
 warp = "0.2.2"
 tokio = {version = "0.2.19", features = ["macros"]}
+
+[workspace]

--- a/yew-router/examples/static/index.html
+++ b/yew-router/examples/static/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <title>Yew example</title>
         <script type="module">
-			import init from "./wasm.js"
+			import init from "/wasm.js"
 			init()
 		</script>
     </head>


### PR DESCRIPTION
Thanks for Yew!

Just a few small adjustments to the yew-router examples:

- Put the server crates into their own workspace (so they can be run without modifying files)
- Replace duplicated route matching in minimal example with conversion `into` Route
- Import `wasm.js` always from `/` to allow refreshing nested routes