### PR TITLE
Move documentation from the module to the struct

### DIFF
--- a/yew-components/src/select.rs
+++ b/yew-components/src/select.rs
@@ -13,6 +13,7 @@ use yew::macros::{html, Properties};
 /// # Example
 ///
 /// ```
+///# use std::fmt;
 ///# use yew::{Html, Component, ComponentLink, html};
 ///# use yew_components::Select;
 /// #[derive(PartialEq, Clone)]
@@ -27,11 +28,11 @@ use yew::macros::{html, Properties};
 ///#     fn update(&mut self,msg: Self::Message) -> bool {unimplemented!()}
 ///#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
 ///#     fn view(&self) -> Html {unimplemented!()}}
-/// impl ToString for Scene {
-///     fn to_string(&self) -> String {
+/// impl fmt::Display for Scene {
+///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 ///         match self {
-///             Scene::First => "First".to_string(),
-///             Scene::Second => "Second".to_string()
+///             Scene::First => write!(f, "{}", "First"),
+///             Scene::Second => write!(f, "{}", "Second"),
 ///         }
 ///     }
 /// }

--- a/yew-components/src/select.rs
+++ b/yew-components/src/select.rs
@@ -1,45 +1,53 @@
-//! This module contains implementation of `Select` component.
-//! You can use it instead `<select>` tag, because the component
-//! helps you to track selected value in an original type. Example:
-//!
-//! ```
-//!# use yew::{Html, Component, ComponentLink, html};
-//!# use yew_components::Select;
-//! #[derive(PartialEq, Clone)]
-//! enum Scene {
-//!     First,
-//!     Second,
-//! }
-//!# struct Model { link: ComponentLink<Self> };
-//!# impl Component for Model {
-//!#     type Message = ();type Properties = ();
-//!#     fn create(props: Self::Properties,link: ComponentLink<Self>) -> Self {unimplemented!()}
-//!#     fn update(&mut self,msg: Self::Message) -> bool {unimplemented!()}
-//!#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
-//!#     fn view(&self) -> Html {unimplemented!()}}
-//! impl ToString for Scene {
-//!     fn to_string(&self) -> String {
-//!         match self {
-//!             Scene::First => "First".to_string(),
-//!             Scene::Second => "Second".to_string()
-//!         }
-//!     }
-//! }
-//!
-//! fn view(link: ComponentLink<Model>) -> Html {
-//!     let scenes = vec![Scene::First, Scene::Second];
-//!     html! {
-//!         <Select<Scene> options=scenes on_change=link.callback(|_| ()) />
-//!     }
-//! }
-//! ```
+//! This module contains the implementation of the `Select` component.
 
 use web_sys::HtmlSelectElement;
 use yew::callback::Callback;
 use yew::html::{ChangeData, Component, ComponentLink, Html, NodeRef, ShouldRender};
 use yew::macros::{html, Properties};
 
-/// `Select` component.
+/// An alternative to the HTML `<select>` tag.
+///
+/// The display of options is handled by the `ToString` implementation on their
+/// type.
+///
+/// # Example
+///
+/// ```
+///# use yew::{Html, Component, ComponentLink, html};
+///# use yew_components::Select;
+/// #[derive(PartialEq, Clone)]
+/// enum Scene {
+///     First,
+///     Second,
+/// }
+///# struct Model { link: ComponentLink<Self> };
+///# impl Component for Model {
+///#     type Message = ();type Properties = ();
+///#     fn create(props: Self::Properties,link: ComponentLink<Self>) -> Self {unimplemented!()}
+///#     fn update(&mut self,msg: Self::Message) -> bool {unimplemented!()}
+///#     fn change(&mut self, _: Self::Properties) -> bool {unimplemented!()}
+///#     fn view(&self) -> Html {unimplemented!()}}
+/// impl ToString for Scene {
+///     fn to_string(&self) -> String {
+///         match self {
+///             Scene::First => "First".to_string(),
+///             Scene::Second => "Second".to_string()
+///         }
+///     }
+/// }
+///
+/// fn view(link: ComponentLink<Model>) -> Html {
+///     let scenes = vec![Scene::First, Scene::Second];
+///     html! {
+///         <Select<Scene> options=scenes on_change=link.callback(|_| ()) />
+///     }
+/// }
+/// ```
+///
+/// # Properties
+///
+/// Only the `on_change` property is obligatory. The other available properties
+/// are `selected`, `disabled`, `options`, `class`, `id`, and `placeholder`.
 #[derive(Debug)]
 pub struct Select<T: ToString + PartialEq + Clone + 'static> {
     props: Props<T>,


### PR DESCRIPTION
The documentation and code example for `Select` is not currently visible on docs.rs. Moving the doc comment to the struct instead of the module makes it visible.

## Questions
- The Props are not documented publicly, since the crate only exports the struct. What is the best way to document them?
- The `std` docs state that the `ToString` trait should not be implemented directly, only implicitly via `Display`. Should the example follow this advice?