### PR TITLE
use origin as base of worker location (#1175)

### DIFF
--- a/yew/src/agent/worker/mod.rs
+++ b/yew/src/agent/worker/mod.rs
@@ -86,9 +86,9 @@ fn send_to_remote<AGN: Agent>(
 
 #[cfg(feature = "web_sys")]
 fn worker_new(name_of_resource: &str, is_module: bool) -> Worker {
-    let href = utils::document().location().unwrap().href().unwrap();
-    let script_url = format!("{}{}", href, name_of_resource);
-    let wasm_url = format!("{}{}", href, name_of_resource.replace(".js", "_bg.wasm"));
+    let origin = utils::origin().unwrap();
+    let script_url = format!("{}/{}", origin, name_of_resource);
+    let wasm_url = format!("{}/{}", origin, name_of_resource.replace(".js", "_bg.wasm"));
     let array = Array::new();
     array.push(
         &format!(


### PR DESCRIPTION
Small fix to use the page `origin` instead of the page `href` to construct the resource location of workers. This fixes #1175. 