### PR TITLE
Removed method destroy, replaced it with a drop implementation

### DIFF
--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -96,8 +96,13 @@ where
 
         ret
     }
+}
 
-    fn destroy(&mut self) {
+impl<T> Drop for FunctionComponent<T>
+where
+    T: FunctionProvider,
+{
+    fn drop(&mut self) {
         if let Some(hook_state) = self.hook_state.borrow_mut().deref_mut() {
             for hook in hook_state.destroy_listeners.drain(..) {
                 hook()

--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -122,9 +122,6 @@ pub trait Component: Sized + 'static {
     /// }
     ///# }
     fn rendered(&mut self, _first_render: bool) {}
-
-    /// The `destroy` method is called right before a Component is unmounted.
-    fn destroy(&mut self) {} // TODO(#941): Replace with `Drop`
 }
 
 /// A type which expected as a result of `view` function implementation.

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -386,7 +386,7 @@ where
     fn run(self: Box<Self>) {
         match self.state.replace(ComponentState::Destroyed) {
             ComponentState::Created(mut this) => {
-                this.component.destroy();
+                drop(this.component);
                 if let Some(last_frame) = &mut this.last_frame {
                     last_frame.detach(&this.element);
                 }


### PR DESCRIPTION
This small change removes the "destroy" method of the component trait, replacing it with a drop implementation where it was needed (in the Component implementation of FunctionComponent).

Fixes: https://github.com/yewstack/yew/issues/941