### PR TITLE
Enable Agents to send messages to themselves.

### DIFF
--- a/examples/npm_and_rest/src/gravatar.rs
+++ b/examples/npm_and_rest/src/gravatar.rs
@@ -38,7 +38,6 @@ impl GravatarService {
             if meta.status.is_success() {
                 callback.emit(data)
             } else {
-                // format_err! is a macro in crate `failure`
                 callback.emit(Err(anyhow!(
                     "{}: error getting profile https://gravatar.com/",
                     meta.status

--- a/yew/src/agent/link.rs
+++ b/yew/src/agent/link.rs
@@ -48,13 +48,14 @@ impl<AGN: Agent> AgentLink<AGN> {
     }
 
     /// Create a callback which will send a message to the agent when invoked.
-    pub fn callback<F, IN>(&self, function: F) -> Callback<IN>
+    pub fn callback<F, IN, M>(&self, function: F) -> Callback<IN>
     where
-        F: Fn(IN) -> AGN::Message + 'static,
+        M: Into<AGN::Message>,
+        F: Fn(IN) -> M + 'static,
     {
         let scope = self.scope.clone();
         let closure = move |input| {
-            let output = function(input);
+            let output = function(input).into();
             scope.send(AgentLifecycleEvent::Message(output));
         };
         closure.into()

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -183,7 +183,10 @@ impl<COMP: Component> Scope<COMP> {
         self.rendered(false);
     }
 
-    /// Send a batch of messages to the component
+    /// Send a batch of messages to the component.
+    ///
+    /// This is useful for reducing re-renders of the components because the messages are handled
+    /// together and the view function is called only once if needed.
     pub fn send_message_batch(&self, messages: Vec<COMP::Message>) {
         self.update(ComponentUpdate::MessageBatch(messages));
         self.rendered(false);


### PR DESCRIPTION
Add methods on `AgentLink` to allow sending messages to itself, as ComponentLink can do. What do you think? :slightly_smiling_face: 

Related to: https://github.com/yewstack/yew/issues/1209