### PR TITLE
[yew-macro] Do not allow void elements to have children

### DIFF
--- a/yew-macro/tests/macro/html-tag-fail.rs
+++ b/yew-macro/tests/macro/html-tag-fail.rs
@@ -36,6 +36,8 @@ fn compile_fail() {
 
     html! { <input ref=() /> };
     html! { <input ref=() ref=() /> };
+
+    html! { <br></br> };
 }
 
 fn main() {}

--- a/yew-macro/tests/macro/html-tag-fail.rs
+++ b/yew-macro/tests/macro/html-tag-fail.rs
@@ -37,7 +37,7 @@ fn compile_fail() {
     html! { <input ref=() /> };
     html! { <input ref=() ref=() /> };
 
-    html! { <br></br> };
+    html! { <input type="text"></input> };
 }
 
 fn main() {}

--- a/yew-macro/tests/macro/html-tag-fail.stderr
+++ b/yew-macro/tests/macro/html-tag-fail.stderr
@@ -142,11 +142,11 @@ error: the attribute `ref` can only be specified once
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the tag `<br>` is a void element and cannot have children (hint: rewrite this as `<br/>`)
-  --> $DIR/html-tag-fail.rs:40:16
+error: the tag `<input>` is a void element and cannot have children (hint: rewrite this as `<input/>`)
+  --> $DIR/html-tag-fail.rs:40:13
    |
-40 |     html! { <br></br> };
-   |                ^
+40 |     html! { <input type="text"></input> };
+   |             ^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/yew-macro/tests/macro/html-tag-fail.stderr
+++ b/yew-macro/tests/macro/html-tag-fail.stderr
@@ -142,6 +142,14 @@ error: the attribute `ref` can only be specified once
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: the tag `<br>` is a void element and cannot have children (hint: rewrite this as `<br/>`)
+  --> $DIR/html-tag-fail.rs:40:16
+   |
+40 |     html! { <br></br> };
+   |                ^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0308]: mismatched types
   --> $DIR/html-tag-fail.rs:25:28
    |


### PR DESCRIPTION
Ensure HTML void element like <br> to be self-closed.

Fixes https://github.com/yewstack/yew/issues/1182