### PR TITLE
[yew-macro] Improve error message

### DIFF
--- a/yew-macro/src/html_tree/html_component.rs
+++ b/yew-macro/src/html_tree/html_component.rs
@@ -398,7 +398,9 @@ impl Parse for Props {
 
                 input.parse::<Ident>()?;
                 props = Props::With(Box::new(WithProps {
-                    props: input.parse::<Ident>()?,
+                    props: input.parse::<Ident>().map_err(|_| {
+                        syn::Error::new_spanned(&token, "`with` must be followed by an identifier")
+                    })?,
                     node_ref: None,
                     key: None,
                 }));

--- a/yew-macro/src/html_tree/html_prop.rs
+++ b/yew-macro/src/html_tree/html_prop.rs
@@ -1,6 +1,5 @@
 use crate::html_tree::HtmlDashedName as HtmlPropLabel;
 use crate::{Peek, PeekValue};
-use boolinator::Boolinator;
 use proc_macro::TokenStream;
 use proc_macro2::TokenTree;
 use syn::buffer::Cursor;
@@ -14,16 +13,16 @@ pub struct HtmlProp {
 
 impl PeekValue<()> for HtmlProp {
     fn peek(cursor: Cursor) -> Option<()> {
-        let (_, cursor) = HtmlPropLabel::peek(cursor)?;
-        let (punct, _) = cursor.punct()?;
-        (punct.as_char() == '=').as_option()
+        HtmlPropLabel::peek(cursor).map(|_| ())
     }
 }
 
 impl Parse for HtmlProp {
     fn parse(input: ParseStream) -> ParseResult<Self> {
         let label = input.parse::<HtmlPropLabel>()?;
-        input.parse::<Token![=]>()?;
+        input
+            .parse::<Token![=]>()
+            .map_err(|_| syn::Error::new_spanned(&label, "this prop doesn't have a value"))?;
         let value = input.parse::<Expr>()?;
         // backwards compat
         let _ = input.parse::<Token![,]>();

--- a/yew-macro/tests/macro/html-component-fail.stderr
+++ b/yew-macro/tests/macro/html-component-fail.stderr
@@ -14,15 +14,15 @@ error: expected identifier
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: unexpected end of input, expected identifier
-  --> $DIR/html-component-fail.rs:81:5
+error: `with` must be followed by an identifier
+  --> $DIR/html-component-fail.rs:81:20
    |
 81 |     html! { <Child with /> };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: unexpected token
+error: this prop doesn't have a value
   --> $DIR/html-component-fail.rs:82:20
    |
 82 |     html! { <Child props /> };


### PR DESCRIPTION
* [X] missing property value as in `<input autofocus />`
* [X] missing identifier after `with` as in `<Button with>`

Fixes https://github.com/yewstack/yew/issues/1179