### PR TITLE
Make fetch service methods static.

### DIFF
--- a/examples/dashboard/src/lib.rs
+++ b/examples/dashboard/src/lib.rs
@@ -90,9 +90,9 @@ impl Model {
         );
         let request = Request::get("/data.json").body(Nothing).unwrap();
         if binary {
-            fetch_service::fetch_binary(request, callback).unwrap()
+            FetchService::fetch_binary(request, callback).unwrap()
         } else {
-            FetchService::new().fetch(request, callback).unwrap()
+            FetchService::fetch(request, callback).unwrap()
         }
     }
 
@@ -112,7 +112,7 @@ impl Model {
         if binary {
             fetch_service::fetch_binary(request, callback).unwrap()
         } else {
-            FetchService::new().fetch(request, callback).unwrap()
+            FetchService::fetch(request, callback).unwrap()
         }
     }
 }

--- a/examples/dashboard/src/lib.rs
+++ b/examples/dashboard/src/lib.rs
@@ -90,7 +90,7 @@ impl Model {
         );
         let request = Request::get("/data.json").body(Nothing).unwrap();
         if binary {
-            FetchService::new().fetch_binary(request, callback).unwrap()
+            fetch_service::fetch_binary(request, callback).unwrap()
         } else {
             FetchService::new().fetch(request, callback).unwrap()
         }
@@ -110,7 +110,7 @@ impl Model {
         );
         let request = Request::get("/data.toml").body(Nothing).unwrap();
         if binary {
-            FetchService::new().fetch_binary(request, callback).unwrap()
+            fetch_service::fetch_binary(request, callback).unwrap()
         } else {
             FetchService::new().fetch(request, callback).unwrap()
         }

--- a/examples/dashboard/src/lib.rs
+++ b/examples/dashboard/src/lib.rs
@@ -110,7 +110,7 @@ impl Model {
         );
         let request = Request::get("/data.toml").body(Nothing).unwrap();
         if binary {
-            fetch_service::fetch_binary(request, callback).unwrap()
+            FetchService::fetch_binary(request, callback).unwrap()
         } else {
             FetchService::fetch(request, callback).unwrap()
         }

--- a/examples/npm_and_rest/src/gravatar.rs
+++ b/examples/npm_and_rest/src/gravatar.rs
@@ -21,13 +21,12 @@ pub struct Entry {
 
 #[derive(Default)]
 pub struct GravatarService {
-    web: FetchService,
 }
 
 impl GravatarService {
     pub fn new() -> Self {
         Self {
-            web: FetchService::new(),
+            
         }
     }
 
@@ -45,6 +44,6 @@ impl GravatarService {
             }
         };
         let request = Request::get(url.as_str()).body(Nothing).unwrap();
-        self.web.fetch(request, handler.into()).unwrap()
+        FetchService::fetch(request, handler.into()).unwrap()
     }
 }

--- a/examples/npm_and_rest/src/gravatar.rs
+++ b/examples/npm_and_rest/src/gravatar.rs
@@ -20,14 +20,11 @@ pub struct Entry {
 }
 
 #[derive(Default)]
-pub struct GravatarService {
-}
+pub struct GravatarService {}
 
 impl GravatarService {
     pub fn new() -> Self {
-        Self {
-            
-        }
+        Self {}
     }
 
     pub fn profile(&mut self, hash: &str, callback: Callback<Result<Profile, Error>>) -> FetchTask {

--- a/yew-stdweb/examples/npm_and_rest/src/gravatar.rs
+++ b/yew-stdweb/examples/npm_and_rest/src/gravatar.rs
@@ -20,13 +20,11 @@ pub struct Entry {
 }
 
 #[derive(Default)]
-pub struct GravatarService {
-}
+pub struct GravatarService {}
 
 impl GravatarService {
     pub fn new() -> Self {
-        Self {
-        }
+        Self {}
     }
 
     pub fn profile(&mut self, hash: &str, callback: Callback<Result<Profile, Error>>) -> FetchTask {

--- a/yew-stdweb/examples/npm_and_rest/src/gravatar.rs
+++ b/yew-stdweb/examples/npm_and_rest/src/gravatar.rs
@@ -21,13 +21,11 @@ pub struct Entry {
 
 #[derive(Default)]
 pub struct GravatarService {
-    web: FetchService,
 }
 
 impl GravatarService {
     pub fn new() -> Self {
         Self {
-            web: FetchService::new(),
         }
     }
 
@@ -45,6 +43,6 @@ impl GravatarService {
             }
         };
         let request = Request::get(url.as_str()).body(Nothing).unwrap();
-        self.web.fetch(request, handler.into()).unwrap()
+        FetchService::fetch(request, handler.into()).unwrap()
     }
 }

--- a/yew/src/services/fetch.rs
+++ b/yew/src/services/fetch.rs
@@ -57,7 +57,7 @@ mod tests {
         let options = FetchOptions::default();
         let cb_future = CallbackFuture::<Response<Json<Result<HttpBin, anyhow::Error>>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(http_bin)) = resp.body() {
@@ -78,7 +78,7 @@ mod tests {
         };
         let cb_future = CallbackFuture::<Response<Json<Result<HttpBin, anyhow::Error>>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(http_bin)) = resp.body() {
@@ -100,7 +100,7 @@ mod tests {
         };
         let cb_future = CallbackFuture::<Response<Json<Result<HttpBin, anyhow::Error>>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(http_bin)) = resp.body() {
@@ -121,7 +121,7 @@ mod tests {
         };
         let cb_future = CallbackFuture::<Response<Json<Result<HttpBin, anyhow::Error>>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(http_bin)) = resp.body() {
@@ -139,7 +139,7 @@ mod tests {
         let options = FetchOptions::default();
         let cb_future = CallbackFuture::<Response<Json<Result<HttpBin, anyhow::Error>>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(http_bin)) = resp.body() {
@@ -160,7 +160,7 @@ mod tests {
         };
         let cb_future = CallbackFuture::<Response<Json<Result<HttpBin, anyhow::Error>>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(http_bin)) = resp.body() {
@@ -181,7 +181,7 @@ mod tests {
         };
         let cb_future = CallbackFuture::<Response<Result<String, anyhow::Error>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::REQUEST_TIMEOUT);
     }
@@ -197,7 +197,7 @@ mod tests {
         };
         let cb_future = CallbackFuture::<Response<Result<String, anyhow::Error>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         // body is empty because the response is opaque for manual redirects
@@ -219,7 +219,7 @@ mod tests {
         };
         let cb_future = CallbackFuture::<Response<Result<String, anyhow::Error>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.body().as_ref().unwrap(), resource);
@@ -240,7 +240,7 @@ mod tests {
         };
         let cb_future = CallbackFuture::<Response<Result<String, anyhow::Error>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert!(resp.body().is_err());
     }
@@ -250,7 +250,7 @@ mod tests {
         let request = Request::get("https://fetch.fail").body(Nothing).unwrap();
         let cb_future = CallbackFuture::<Response<Result<String, anyhow::Error>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch(request, callback);
+        let _task = FetchService::fetch(request, callback);
         let resp = cb_future.await;
         #[cfg(feature = "std_web")]
         assert!(resp.body().is_err());
@@ -273,7 +273,7 @@ mod tests {
         let cb_future =
             CallbackFuture::<Response<Json<Result<HttpBinHeaders, anyhow::Error>>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(httpbin_headers)) = resp.body() {
@@ -295,7 +295,7 @@ mod tests {
         let cb_future =
             CallbackFuture::<Response<Json<Result<HttpBinHeaders, anyhow::Error>>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
-        let _task = FetchService::new().fetch_with_options(request, options, callback);
+        let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(httpbin_headers)) = resp.body() {

--- a/yew/src/services/fetch/std_web.rs
+++ b/yew/src/services/fetch/std_web.rs
@@ -267,7 +267,6 @@ impl FetchService {
     /// ```
     ///
     pub fn fetch<IN, OUT: 'static>(
-        &mut self,
         request: Request<IN>,
         callback: Callback<Response<OUT>>,
     ) -> Result<FetchTask, &str>
@@ -310,7 +309,6 @@ impl FetchService {
     ///# }
     /// ```
     pub fn fetch_with_options<IN, OUT: 'static>(
-        &mut self,
         request: Request<IN>,
         options: FetchOptions,
         callback: Callback<Response<OUT>>,

--- a/yew/src/services/fetch/std_web.rs
+++ b/yew/src/services/fetch/std_web.rs
@@ -207,9 +207,8 @@ impl FetchService {
     ///# }
     ///# fn dont_execute() {
     ///# let link: ComponentLink<Comp> = unimplemented!();
-    ///# let mut fetch_service: FetchService = FetchService::new();
     ///# let post_request: Request<Result<String, anyhow::Error>> = unimplemented!();
-    /// let task = fetch_service::fetch(
+    /// let task = FetchService::fetch(
     ///     post_request,
     ///     link.callback(|response: Response<Result<String, anyhow::Error>>| {
     ///         if response.status().is_success() {

--- a/yew/src/services/fetch/std_web.rs
+++ b/yew/src/services/fetch/std_web.rs
@@ -337,7 +337,7 @@ impl FetchService {
         request: Request<IN>,
         options: FetchOptions,
         callback: Callback<Response<OUT>>,
-    ) -> Result<FetchTask, &str>
+    ) -> Result<FetchTask, &'static str>
     where
         IN: Into<Binary>,
         OUT: From<Binary>,

--- a/yew/src/services/fetch/std_web.rs
+++ b/yew/src/services/fetch/std_web.rs
@@ -269,7 +269,7 @@ impl FetchService {
     pub fn fetch<IN, OUT: 'static>(
         request: Request<IN>,
         callback: Callback<Response<OUT>>,
-    ) -> Result<FetchTask, &str>
+    ) -> Result<FetchTask, &'static str>
     where
         IN: Into<Text>,
         OUT: From<Text>,
@@ -312,7 +312,7 @@ impl FetchService {
         request: Request<IN>,
         options: FetchOptions,
         callback: Callback<Response<OUT>>,
-    ) -> Result<FetchTask, &str>
+    ) -> Result<FetchTask, &'static str>
     where
         IN: Into<Text>,
         OUT: From<Text>,
@@ -324,7 +324,7 @@ impl FetchService {
     pub fn fetch_binary<IN, OUT: 'static>(
         request: Request<IN>,
         callback: Callback<Response<OUT>>,
-    ) -> Result<FetchTask, &str>
+    ) -> Result<FetchTask, &'static str>
     where
         IN: Into<Binary>,
         OUT: From<Binary>,

--- a/yew/src/services/fetch/std_web.rs
+++ b/yew/src/services/fetch/std_web.rs
@@ -209,7 +209,7 @@ impl FetchService {
     ///# let link: ComponentLink<Comp> = unimplemented!();
     ///# let mut fetch_service: FetchService = FetchService::new();
     ///# let post_request: Request<Result<String, anyhow::Error>> = unimplemented!();
-    /// let task = fetch_service.fetch(
+    /// let task = fetch_service::fetch(
     ///     post_request,
     ///     link.callback(|response: Response<Result<String, anyhow::Error>>| {
     ///         if response.status().is_success() {
@@ -262,7 +262,7 @@ impl FetchService {
     ///     Msg::FetchResourceFailed
     /// });
     ///
-    /// let task = FetchService::new().fetch(get_request, callback);
+    /// let task = FetchService::fetch(get_request, callback);
     ///# }
     /// ```
     ///
@@ -305,7 +305,7 @@ impl FetchService {
     ///     credentials: Some(Credentials::SameOrigin),
     ///     ..FetchOptions::default()
     /// };
-    /// let task = FetchService::new().fetch_with_options(request, options, callback);
+    /// let task = FetchService::fetch_with_options(request, options, callback);
     ///# }
     /// ```
     pub fn fetch_with_options<IN, OUT: 'static>(
@@ -322,7 +322,6 @@ impl FetchService {
 
     /// Fetch the data in binary format.
     pub fn fetch_binary<IN, OUT: 'static>(
-        &mut self,
         request: Request<IN>,
         callback: Callback<Response<OUT>>,
     ) -> Result<FetchTask, &str>
@@ -333,9 +332,8 @@ impl FetchService {
         fetch_impl::<IN, OUT, Vec<u8>, ArrayBuffer>(true, request, None, callback)
     }
 
-    /// Fetch the data in binary format.
+    /// Fetch the data in binary format using the provided request options.
     pub fn fetch_binary_with_options<IN, OUT: 'static>(
-        &mut self,
         request: Request<IN>,
         options: FetchOptions,
         callback: Callback<Response<OUT>>,

--- a/yew/src/services/fetch/web_sys.rs
+++ b/yew/src/services/fetch/web_sys.rs
@@ -210,9 +210,8 @@ impl FetchService {
     ///# }
     ///# fn dont_execute() {
     ///# let link: ComponentLink<Comp> = unimplemented!();
-    ///# let mut fetch_service: FetchService = FetchService::new();
     ///# let post_request: Request<Result<String, Error>> = unimplemented!();
-    /// let task = fetch_service.fetch(
+    /// let task = FetchService::fetch(
     ///     post_request,
     ///     link.callback(|response: Response<Result<String, Error>>| {
     ///         if response.status().is_success() {
@@ -266,7 +265,7 @@ impl FetchService {
     ///     Msg::FetchResourceFailed
     /// });
     ///
-    /// let task = FetchService::new().fetch(get_request, callback);
+    /// let task = FetchService::fetch(get_request, callback);
     ///# }
     /// ```
     ///
@@ -310,7 +309,7 @@ impl FetchService {
     ///     credentials: Some(Credentials::SameOrigin),
     ///     ..FetchOptions::default()
     /// };
-    /// let task = FetchService::new().fetch_with_options(request, options, callback);
+    /// let task = FetchService::fetch_with_options(request, options, callback);
     ///# }
     /// ```
     pub fn fetch_with_options<IN, OUT: 'static>(
@@ -327,7 +326,6 @@ impl FetchService {
 
     /// Fetch the data in binary format.
     pub fn fetch_binary<IN, OUT: 'static>(
-        &mut self,
         request: Request<IN>,
         callback: Callback<Response<OUT>>,
     ) -> Result<FetchTask, Error>
@@ -338,9 +336,8 @@ impl FetchService {
         fetch_impl::<IN, OUT, Vec<u8>>(true, request, None, callback)
     }
 
-    /// Fetch the data in binary format.
+    /// Fetch the data in binary format with the provided request options.
     pub fn fetch_binary_with_options<IN, OUT: 'static>(
-        &mut self,
         request: Request<IN>,
         options: FetchOptions,
         callback: Callback<Response<OUT>>,

--- a/yew/src/services/fetch/web_sys.rs
+++ b/yew/src/services/fetch/web_sys.rs
@@ -271,7 +271,6 @@ impl FetchService {
     /// ```
     ///
     pub fn fetch<IN, OUT: 'static>(
-        &mut self,
         request: Request<IN>,
         callback: Callback<Response<OUT>>,
     ) -> Result<FetchTask, Error>
@@ -315,7 +314,6 @@ impl FetchService {
     ///# }
     /// ```
     pub fn fetch_with_options<IN, OUT: 'static>(
-        &mut self,
         request: Request<IN>,
         options: FetchOptions,
         callback: Callback<Response<OUT>>,


### PR DESCRIPTION
This is a breaking change, but I think it makes it easier to understand how to use fetch service works.