### PR TITLE
Fix cargo metadata repository links

### DIFF
--- a/yew-router-macro/Cargo.toml
+++ b/yew-router-macro/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Henry Zimmerman <zimhen7@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "Contains macros used with yew-router"
-repository = "https://github.com/yewstack/yew_router"
+repository = "https://github.com/yewstack/yew"
 
 [lib]
 proc-macro = true

--- a/yew-router-route-parser/Cargo.toml
+++ b/yew-router-route-parser/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Henry Zimmerman <zimhen7@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "The parser for the routing syntax used with yew-router"
-repository = "https://github.com/yewstack/yew_router"
+repository = "https://github.com/yewstack/yew"
 
 [dependencies]
 nom = "5.0.0"

--- a/yew-router/Cargo.toml
+++ b/yew-router/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 keywords = ["web", "yew", "router"]
 categories = ["gui", "web-programming"]
 description = "A router implementation for the Yew framework"
-repository = "https://github.com/yewstack/yew_router"
+repository = "https://github.com/yewstack/yew"
 
 [features]
 default = ["web_sys", "core", "unit_alias"]

--- a/yewtil/Cargo.toml
+++ b/yewtil/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Henry Zimmerman <zimhen7@gmail.com>"]
 edition = "2018"
 description = "Utility crate for Yew"
 license = "MIT/Apache-2.0"
-repository = "https://github.com/yewstack/yewtil"
+repository = "https://github.com/yewstack/yew"
 readme = "Readme.md"
 
 [features]


### PR DESCRIPTION
Fixes the repository links for the repos that have been incorporated into this repo.

The old links caused some confusion, as the links for 0.13 on crates.io pointed me to the outdated repo that didn't contain the version (and I hadn't seen the very obvious message about the moved repo 🙈 )