### PR TITLE
Implement PartialEq for VChild

### DIFF
--- a/yew/src/virtual_dom/vcomp.rs
+++ b/yew/src/virtual_dom/vcomp.rs
@@ -53,6 +53,15 @@ impl<COMP: Component> Clone for VChild<COMP> {
     }
 }
 
+impl<COMP: Component> PartialEq for VChild<COMP>
+where
+    COMP::Properties: PartialEq,
+{
+    fn eq(&self, other: &VChild<COMP>) -> bool {
+        self.props == other.props
+    }
+}
+
 impl<COMP> VChild<COMP>
 where
     COMP: Component,
@@ -325,8 +334,9 @@ impl<COMP: Component> fmt::Debug for VChild<COMP> {
 
 #[cfg(test)]
 mod tests {
+    use super::VChild;
     use crate::macros::Properties;
-    use crate::{html, Component, ComponentLink, Html, ShouldRender};
+    use crate::{html, Component, ComponentLink, Html, NodeRef, ShouldRender};
     #[cfg(feature = "wasm_test")]
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
@@ -390,5 +400,39 @@ mod tests {
         html! {
             <Comp with props />
         };
+    }
+
+    #[test]
+    fn vchild_partialeq() {
+        let vchild1: VChild<Comp> = VChild::new(
+            Props {
+                field_1: 1,
+                field_2: 1,
+            },
+            NodeRef::default(),
+            None,
+        );
+        
+        let vchild2: VChild<Comp> = VChild::new(
+            Props {
+                field_1: 1,
+                field_2: 1,
+            },
+            NodeRef::default(),
+            None,
+        );
+
+        let vchild3: VChild<Comp> = VChild::new(
+            Props {
+                field_1: 2,
+                field_2: 2,
+            },
+            NodeRef::default(),
+            None,
+        );
+
+        assert_eq!(vchild1, vchild2);
+        assert_ne!(vchild1, vchild3);
+        assert_ne!(vchild2, vchild3);
     }
 }

--- a/yew/src/virtual_dom/vcomp.rs
+++ b/yew/src/virtual_dom/vcomp.rs
@@ -412,7 +412,7 @@ mod tests {
             NodeRef::default(),
             None,
         );
-        
+
         let vchild2: VChild<Comp> = VChild::new(
             Props {
                 field_1: 1,


### PR DESCRIPTION
Fixes #1216

Implement `PartialEq` trait for `VChild` just by comparing the `Component::Properties` when they themselves implement `PartialEq`.