### PR TITLE
Input current value sync

### DIFF
--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -379,6 +379,27 @@ impl VDiff for VTag {
                     if self.tag == vtag.tag {
                         // If tags are equal, preserve the reference that already exists.
                         self.reference = vtag.reference.take();
+                        if let Some(element) = self.reference.as_ref() {
+                            if let Some(input) = {
+                                cfg_match! {
+                                    feature = "std_web" => InputElement::try_from(element.clone()).ok(),
+                                    feature = "web_sys" => element.dyn_ref::<InputElement>(),
+                                }
+                            } {
+                                let current_value = cfg_match! {
+                                    feature = "std_web" => input.raw_value(),
+                                    feature = "web_sys" => input.value(),
+                                };
+                                vtag.set_value(&current_value)
+                            } else if let Some(tae) = {
+                                cfg_match! {
+                                    feature = "std_web" => TextAreaElement::try_from(element.clone()).ok(),
+                                    feature = "web_sys" => element.dyn_ref::<TextAreaElement>(),
+                                }
+                            } {
+                                vtag.set_value(&tae.value())
+                            }
+                        }
                         (Reform::Keep, Some(vtag))
                     } else {
                         // We have to create a new reference, remove ancestor.

--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -1247,7 +1247,10 @@ mod tests {
             feature = "std_web" => InputElement::try_from(input_ref.clone()).ok(),
             feature = "web_sys" => input_ref.dyn_ref::<InputElement>(),
         };
-        input.unwrap().set_value("User input");
+        cfg_match! {
+            feature = "std_web" => input.unwrap().set_raw_value("User input"),
+            feature = "web_sys" => input.unwrap().set_value("User input"),
+        };
 
         let ancestor = vtag;
         // Same state after onInput or onChange event


### PR DESCRIPTION
Places input current value into last tag state before comparing it with new one

Fixes #233

#### Checklist:

- [x] I have ran `./ci/run_stable_checks.sh`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works