### PR TITLE
wasm-bindgen-cli is required now for examples to compile

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -34,4 +34,6 @@ Installation guides: [Rust](https://www.rust-lang.org/learn/get-started) and [wa
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 # wasm-pack install
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh;
+# wasm-bindgen-cli install
+cargo install wasm-bindgen-cli
 ```


### PR DESCRIPTION
#### Description

I was not able to compile examples not having `wasm-bindgen-cli` installed. The one that `wasm-pack` installs and manages is **not** available to be invoked from the command-line.

Fixes #1270 

#### Checklist:

- [ ] I have ran `./ci/run_stable_checks.sh`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
