### PR TITLE
Unify and change children logic in the html macro

### DIFF
--- a/examples/nested_list/src/item.rs
+++ b/examples/nested_list/src/item.rs
@@ -60,7 +60,7 @@ impl ListItem {
 
         html! {
             <div class="list-item-details">
-                { self.props.children.render() }
+                { self.props.children.clone() }
             </div>
         }
     }

--- a/yew-functional/src/use_context_hook.rs
+++ b/yew-functional/src/use_context_hook.rs
@@ -4,7 +4,7 @@ use std::any::TypeId;
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 use std::{iter, mem};
-use yew::html::{AnyScope, Renderable, Scope};
+use yew::html::{AnyScope, Scope};
 use yew::{Children, Component, ComponentLink, Html, Properties};
 
 type ConsumerCallback<T> = Box<dyn Fn(Rc<T>)>;
@@ -83,7 +83,7 @@ impl<T: Clone + 'static> Component for ContextProvider<T> {
     }
 
     fn view(&self) -> Html {
-        self.children.render()
+        self.children.clone().into_iter().collect::<Html>()
     }
 }
 

--- a/yew-functional/src/use_context_hook.rs
+++ b/yew-functional/src/use_context_hook.rs
@@ -4,6 +4,7 @@ use std::any::TypeId;
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 use std::{iter, mem};
+use yew::html;
 use yew::html::{AnyScope, Scope};
 use yew::{Children, Component, ComponentLink, Html, Properties};
 
@@ -83,7 +84,7 @@ impl<T: Clone + 'static> Component for ContextProvider<T> {
     }
 
     fn view(&self) -> Html {
-        self.children.clone().into_iter().collect::<Html>()
+        html! { <>{ self.children.clone() }</> }
     }
 }
 

--- a/yew-functional/tests/use_context_hook.rs
+++ b/yew-functional/tests/use_context_hook.rs
@@ -6,7 +6,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 extern crate yew;
 
-use yew::{html, App, Children, Html, Properties, Renderable};
+use yew::{html, App, Children, Html, Properties};
 use yew_functional::{
     use_context, use_effect, use_ref, use_state, ContextProvider, FunctionComponent,
     FunctionProvider,
@@ -198,7 +198,7 @@ fn use_context_update_works() {
                     <div id=props.id.clone()>
                         { format!("total: {}", counter.borrow()) }
                     </div>
-                    { props.children.render() }
+                    { props.children.clone() }
                 </>
             };
         }

--- a/yew-macro/src/html_tree/html_block.rs
+++ b/yew-macro/src/html_tree/html_block.rs
@@ -1,5 +1,6 @@
 use super::html_iterable::HtmlIterable;
 use super::html_node::HtmlNode;
+use super::ToChildrenTokens;
 use crate::PeekValue;
 use proc_macro2::Delimiter;
 use quote::{quote, quote_spanned, ToTokens};
@@ -44,6 +45,25 @@ impl ToTokens for HtmlBlock {
         let new_tokens = match content {
             BlockContent::Iterable(html_iterable) => quote! {#html_iterable},
             BlockContent::Node(html_node) => quote! {#html_node},
+        };
+
+        tokens.extend(quote_spanned! {brace.span=> #new_tokens});
+    }
+}
+
+impl ToChildrenTokens for HtmlBlock {
+    fn single_child(&self) -> bool {
+        match &self.content {
+            BlockContent::Iterable(iterable) => iterable.single_child(),
+            BlockContent::Node(node) => node.single_child(),
+        }
+    }
+
+    fn to_children_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let HtmlBlock { content, brace } = self;
+        let new_tokens = match content {
+            BlockContent::Iterable(iterable) => iterable.to_children_token_stream(),
+            BlockContent::Node(node) => node.to_children_token_stream(),
         };
 
         tokens.extend(quote_spanned! {brace.span=> #new_tokens});

--- a/yew-macro/src/html_tree/html_block.rs
+++ b/yew-macro/src/html_tree/html_block.rs
@@ -1,6 +1,6 @@
 use super::html_iterable::HtmlIterable;
 use super::html_node::HtmlNode;
-use super::ToChildrenTokens;
+use super::ToNodeIterator;
 use crate::PeekValue;
 use proc_macro2::Delimiter;
 use quote::{quote, quote_spanned, ToTokens};
@@ -51,21 +51,14 @@ impl ToTokens for HtmlBlock {
     }
 }
 
-impl ToChildrenTokens for HtmlBlock {
-    fn single_child(&self) -> bool {
-        match &self.content {
-            BlockContent::Iterable(iterable) => iterable.single_child(),
-            BlockContent::Node(node) => node.single_child(),
-        }
-    }
-
-    fn to_children_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+impl ToNodeIterator for HtmlBlock {
+    fn to_node_iterator_stream(&self) -> Option<proc_macro2::TokenStream> {
         let HtmlBlock { content, brace } = self;
         let new_tokens = match content {
-            BlockContent::Iterable(iterable) => iterable.to_children_token_stream(),
-            BlockContent::Node(node) => node.to_children_token_stream(),
-        };
+            BlockContent::Iterable(iterable) => iterable.to_node_iterator_stream(),
+            BlockContent::Node(node) => node.to_node_iterator_stream(),
+        }?;
 
-        tokens.extend(quote_spanned! {brace.span=> #new_tokens});
+        Some(quote_spanned! {brace.span=> #new_tokens})
     }
 }

--- a/yew-macro/src/html_tree/html_component.rs
+++ b/yew-macro/src/html_tree/html_component.rs
@@ -1,6 +1,6 @@
 use super::HtmlProp;
 use super::HtmlPropSuffix;
-use super::HtmlTreeNested;
+use super::HtmlTree;
 use crate::PeekValue;
 use boolinator::Boolinator;
 use proc_macro2::Span;
@@ -19,7 +19,7 @@ use syn::{
 pub struct HtmlComponent {
     ty: Type,
     props: Props,
-    children: Vec<HtmlTreeNested>,
+    children: Vec<HtmlTree>,
 }
 
 impl PeekValue<()> for HtmlComponent {
@@ -52,7 +52,7 @@ impl Parse for HtmlComponent {
             });
         }
 
-        let mut children: Vec<HtmlTreeNested> = vec![];
+        let mut children: Vec<HtmlTree> = vec![];
         loop {
             if input.is_empty() {
                 return Err(syn::Error::new_spanned(

--- a/yew-macro/src/html_tree/html_component.rs
+++ b/yew-macro/src/html_tree/html_component.rs
@@ -157,7 +157,7 @@ impl ToTokens for HtmlComponent {
         let key = if let Some(key) = props.key() {
             quote_spanned! { key.span()=> Some(#key) }
         } else {
-            quote! {None }
+            quote! {None}
         };
 
         tokens.extend(quote! {{

--- a/yew-macro/src/html_tree/html_component.rs
+++ b/yew-macro/src/html_tree/html_component.rs
@@ -109,9 +109,8 @@ impl ToTokens for HtmlComponent {
         };
 
         let set_children = if !children.is_empty() {
-            let children_vec = children.to_vec_token_stream();
             quote! {
-                .children(::yew::html::ChildrenRenderer::new(#children_vec))
+                .children(::yew::html::ChildrenRenderer::new(#children))
             }
         } else {
             quote! {}

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -55,8 +55,6 @@ impl ToChildrenTokens for HtmlIterable {
 
     fn to_children_tokens(&self, tokens: &mut TokenStream) {
         let Self(expr) = self;
-        tokens.extend(quote_spanned! {expr.span()=> {
-            (#expr).into_iter().map(|n| ::yew::virtual_dom::VNode::from(n))
-        }});
+        expr.to_tokens(tokens);
     }
 }

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -1,3 +1,4 @@
+use super::ToChildrenTokens;
 use crate::PeekValue;
 use boolinator::Boolinator;
 use proc_macro2::TokenStream;
@@ -44,5 +45,18 @@ impl ToTokens for HtmlIterable {
         }};
 
         tokens.extend(new_tokens);
+    }
+}
+
+impl ToChildrenTokens for HtmlIterable {
+    fn single_child(&self) -> bool {
+        false
+    }
+
+    fn to_children_tokens(&self, tokens: &mut TokenStream) {
+        let Self(expr) = self;
+        tokens.extend(quote_spanned! {expr.span()=> {
+            (#expr).into_iter().map(|n| n.into())
+        }});
     }
 }

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -1,4 +1,4 @@
-use super::ToChildrenTokens;
+use super::ToNodeIterator;
 use crate::PeekValue;
 use boolinator::Boolinator;
 use proc_macro2::TokenStream;
@@ -48,13 +48,13 @@ impl ToTokens for HtmlIterable {
     }
 }
 
-impl ToChildrenTokens for HtmlIterable {
-    fn single_child(&self) -> bool {
-        false
-    }
-
-    fn to_children_tokens(&self, tokens: &mut TokenStream) {
+impl ToNodeIterator for HtmlIterable {
+    fn to_node_iterator_stream(&self) -> Option<TokenStream> {
         let Self(expr) = self;
-        tokens.extend(quote_spanned! {expr.span()=> (#expr).into_iter().map(|n| n.into())});
+        // #expr can return anything that implements IntoIterator<Item=Into<T>>
+        // so we generate some extra code to turn it into IntoIterator<Item=T>
+        Some(quote_spanned! {expr.span()=>
+             (#expr).into_iter().map(|n| n.into())
+        })
     }
 }

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -55,6 +55,6 @@ impl ToChildrenTokens for HtmlIterable {
 
     fn to_children_tokens(&self, tokens: &mut TokenStream) {
         let Self(expr) = self;
-        expr.to_tokens(tokens);
+        tokens.extend(quote_spanned! {expr.span()=> (#expr).into_iter().map(|n| n.into())});
     }
 }

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -40,11 +40,7 @@ impl ToTokens for HtmlIterable {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let expr = &self.0;
         let new_tokens = quote_spanned! {expr.span()=> {
-            let mut __yew_vlist = ::yew::virtual_dom::VList::default();
-            for __yew_node in #expr {
-                __yew_vlist.add_child(__yew_node.into());
-            }
-            ::yew::virtual_dom::VNode::from(__yew_vlist)
+            (#expr).into_iter().collect::<::yew::virtual_dom::VNode>()
         }};
 
         tokens.extend(new_tokens);

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -56,7 +56,7 @@ impl ToChildrenTokens for HtmlIterable {
     fn to_children_tokens(&self, tokens: &mut TokenStream) {
         let Self(expr) = self;
         tokens.extend(quote_spanned! {expr.span()=> {
-            (#expr).into_iter().map(|n| n.into())
+            (#expr).into_iter().map(|n| ::yew::virtual_dom::VNode::from(n))
         }});
     }
 }

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -40,9 +40,9 @@ impl Parse for HtmlIterable {
 impl ToTokens for HtmlIterable {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let expr = &self.0;
-        let new_tokens = quote_spanned! {expr.span()=> {
-            (#expr).into_iter().collect::<::yew::virtual_dom::VNode>()
-        }};
+        let new_tokens = quote_spanned! {expr.span()=>
+            ::std::iter::Iterator::collect::<::yew::virtual_dom::VNode>(::std::iter::IntoIterator::into_iter(#expr))
+        };
 
         tokens.extend(new_tokens);
     }
@@ -54,7 +54,7 @@ impl ToNodeIterator for HtmlIterable {
         // #expr can return anything that implements IntoIterator<Item=Into<T>>
         // so we generate some extra code to turn it into IntoIterator<Item=T>
         Some(quote_spanned! {expr.span()=>
-             (#expr).into_iter().map(|n| n.into())
+            ::std::iter::Iterator::map(::std::iter::IntoIterator::into_iter(#expr), |n| n.into())
         })
     }
 }

--- a/yew-macro/src/html_tree/html_list.rs
+++ b/yew-macro/src/html_tree/html_list.rs
@@ -1,4 +1,4 @@
-use super::HtmlTree;
+use super::HtmlChildrenTree;
 use crate::html_tree::{HtmlProp, HtmlPropSuffix};
 use crate::PeekValue;
 use boolinator::Boolinator;
@@ -10,8 +10,17 @@ use syn::spanned::Spanned;
 use syn::{Expr, Token};
 
 pub struct HtmlList {
-    pub children: Vec<HtmlTree>,
-    pub key: Option<Expr>,
+    children: HtmlChildrenTree,
+    key: Option<Expr>,
+}
+
+impl HtmlList {
+    pub fn empty() -> Self {
+        Self {
+            children: HtmlChildrenTree::new(),
+            key: None,
+        }
+    }
 }
 
 impl PeekValue<()> for HtmlList {
@@ -42,9 +51,9 @@ impl Parse for HtmlList {
             ));
         }
 
-        let mut children: Vec<HtmlTree> = vec![];
+        let mut children = HtmlChildrenTree::new();
         while HtmlListClose::peek(input.cursor()).is_none() {
-            children.push(input.parse()?);
+            children.parse_child(input)?;
         }
 
         input.parse::<HtmlListClose>()?;
@@ -66,12 +75,7 @@ impl ToTokens for HtmlList {
         };
         tokens.extend(quote! {
             ::yew::virtual_dom::VNode::VList(
-                ::yew::virtual_dom::VList::new_with_children({
-                    let mut v = ::std::vec::Vec::new();
-                    #(v.extend(::yew::utils::NodeSeq::from(#children));)*
-                    v
-                },
-                #key)
+                ::yew::virtual_dom::VList::new_with_children(#children, #key)
             )
         });
     }

--- a/yew-macro/src/html_tree/html_node.rs
+++ b/yew-macro/src/html_tree/html_node.rs
@@ -58,9 +58,9 @@ impl ToChildrenTokens for HtmlNode {
 
     fn to_children_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(match &self {
-            HtmlNode::Literal(lit) => quote_spanned! {lit.span()=> ::std::iter::once(::yew::virtual_dom::VNode::from(#lit))},
+            HtmlNode::Literal(lit) => quote_spanned! {lit.span()=> ::std::iter::once(#lit)},
             HtmlNode::Expression(expr) => {
-                quote_spanned! {expr.span()=> {::yew::utils::NodeSeq::<_, ::yew::virtual_dom::VNode>::from(#expr)} }
+                quote_spanned! {expr.span()=> ::yew::utils::NodeSeq::<_, ::yew::virtual_dom::VNode>::from(#expr)}
             }
         });
     }

--- a/yew-macro/src/html_tree/html_node.rs
+++ b/yew-macro/src/html_tree/html_node.rs
@@ -5,8 +5,7 @@ use quote::{quote, quote_spanned, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;
-use syn::Expr;
-use syn::Lit;
+use syn::{Expr, Lit};
 
 pub enum HtmlNode {
     Literal(Box<Lit>),
@@ -58,9 +57,11 @@ impl ToChildrenTokens for HtmlNode {
 
     fn to_children_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(match &self {
-            HtmlNode::Literal(lit) => quote_spanned! {lit.span()=> ::std::iter::once(#lit)},
+            HtmlNode::Literal(lit) => {
+                quote_spanned! {lit.span()=> ::std::iter::once((#lit).into())}
+            }
             HtmlNode::Expression(expr) => {
-                quote_spanned! {expr.span()=> ::yew::utils::NodeSeq::<_, ::yew::virtual_dom::VNode>::from(#expr)}
+                quote_spanned! {expr.span()=> ::yew::utils::NodeSeq::from(#expr)}
             }
         });
     }

--- a/yew-macro/src/html_tree/html_node.rs
+++ b/yew-macro/src/html_tree/html_node.rs
@@ -58,9 +58,9 @@ impl ToChildrenTokens for HtmlNode {
 
     fn to_children_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(match &self {
-            HtmlNode::Literal(lit) => quote_spanned! {lit.span()=> ::std::iter::once(#lit)},
+            HtmlNode::Literal(lit) => quote_spanned! {lit.span()=> ::std::iter::once(::yew::virtual_dom::VNode::from(#lit))},
             HtmlNode::Expression(expr) => {
-                quote_spanned! {expr.span()=> {::yew::utils::NodeSeq::from(#expr)} }
+                quote_spanned! {expr.span()=> {::yew::utils::NodeSeq::<_, ::yew::virtual_dom::VNode>::from(#expr)} }
             }
         });
     }

--- a/yew-macro/src/html_tree/html_node.rs
+++ b/yew-macro/src/html_tree/html_node.rs
@@ -1,3 +1,4 @@
+use super::ToChildrenTokens;
 use crate::PeekValue;
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned, ToTokens};
@@ -7,7 +8,10 @@ use syn::spanned::Spanned;
 use syn::Expr;
 use syn::Lit;
 
-pub struct HtmlNode(Node);
+pub enum HtmlNode {
+    Literal(Box<Lit>),
+    Expression(Box<Expr>),
+}
 
 impl Parse for HtmlNode {
     fn parse(input: ParseStream) -> Result<Self> {
@@ -17,12 +21,12 @@ impl Parse for HtmlNode {
                 Lit::Str(_) | Lit::Char(_) | Lit::Int(_) | Lit::Float(_) | Lit::Bool(_) => {}
                 _ => return Err(syn::Error::new(lit.span(), "unsupported type")),
             }
-            Node::Literal(Box::new(lit))
+            HtmlNode::Literal(Box::new(lit))
         } else {
-            Node::Expression(Box::new(input.parse()?))
+            HtmlNode::Expression(Box::new(input.parse()?))
         };
 
-        Ok(HtmlNode(node))
+        Ok(node)
     }
 }
 
@@ -40,22 +44,24 @@ impl PeekValue<()> for HtmlNode {
 
 impl ToTokens for HtmlNode {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        self.0.to_tokens(tokens);
+        tokens.extend(match &self {
+            HtmlNode::Literal(lit) => quote! {#lit},
+            HtmlNode::Expression(expr) => quote_spanned! {expr.span()=> {#expr}},
+        });
     }
 }
 
-impl ToTokens for Node {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let node_token = match &self {
-            Node::Literal(lit) => quote! {#lit},
-            Node::Expression(expr) => quote_spanned! {expr.span()=> {#expr} },
-        };
-
-        tokens.extend(node_token);
+impl ToChildrenTokens for HtmlNode {
+    fn single_child(&self) -> bool {
+        matches!(self, HtmlNode::Literal(_))
     }
-}
 
-enum Node {
-    Literal(Box<Lit>),
-    Expression(Box<Expr>),
+    fn to_children_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(match &self {
+            HtmlNode::Literal(lit) => quote_spanned! {lit.span()=> ::std::iter::once(#lit)},
+            HtmlNode::Expression(expr) => {
+                quote_spanned! {expr.span()=> {::yew::utils::NodeSeq::from(#expr)} }
+            }
+        });
+    }
 }

--- a/yew-macro/src/html_tree/html_tag/mod.rs
+++ b/yew-macro/src/html_tree/html_tag/mod.rs
@@ -1,9 +1,9 @@
 mod tag_attributes;
 
+use super::HtmlChildrenTree;
 use super::HtmlDashedName;
 use super::HtmlProp as TagAttribute;
 use super::HtmlPropSuffix as TagSuffix;
-use super::HtmlTree;
 use crate::{non_capitalized_ascii, Peek, PeekValue};
 use boolinator::Boolinator;
 use proc_macro2::{Delimiter, Span};
@@ -18,7 +18,7 @@ use tag_attributes::{ClassesForm, TagAttributes};
 pub struct HtmlTag {
     tag_name: TagName,
     attributes: TagAttributes,
-    children: Vec<HtmlTree>,
+    children: HtmlChildrenTree,
 }
 
 impl PeekValue<()> for HtmlTag {
@@ -47,7 +47,7 @@ impl Parse for HtmlTag {
             return Ok(HtmlTag {
                 tag_name: open.tag_name,
                 attributes: open.attributes,
-                children: Vec::new(),
+                children: HtmlChildrenTree::new(),
             });
         }
 
@@ -66,7 +66,7 @@ impl Parse for HtmlTag {
         }
 
         let open_key = open.tag_name.get_key();
-        let mut children: Vec<HtmlTree> = vec![];
+        let mut children = HtmlChildrenTree::new();
         loop {
             if input.is_empty() {
                 return Err(syn::Error::new_spanned(
@@ -80,7 +80,7 @@ impl Parse for HtmlTag {
                 }
             }
 
-            children.push(input.parse()?);
+            children.parse_child(input)?;
         }
 
         input.parse::<HtmlTagClose>()?;
@@ -244,7 +244,7 @@ impl ToTokens for HtmlTag {
             #(#set_key)*
             #vtag.add_attributes(vec![#(#attr_pairs),*]);
             #vtag.add_listeners(vec![#(::std::rc::Rc::new(#listeners)),*]);
-            #vtag.add_children(vec![#(#children),*]);
+            #vtag.add_children(#children);
             #dyn_tag_runtime_checks
             ::yew::virtual_dom::VNode::from(#vtag)
         }});

--- a/yew-macro/src/html_tree/mod.rs
+++ b/yew-macro/src/html_tree/mod.rs
@@ -129,29 +129,3 @@ impl HtmlTree {
         }
     }
 }
-
-pub struct HtmlRootNested(HtmlTreeNested);
-impl Parse for HtmlRootNested {
-    fn parse(input: ParseStream) -> Result<Self> {
-        Ok(HtmlRootNested(HtmlTreeNested::parse(input)?))
-    }
-}
-
-impl ToTokens for HtmlRootNested {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        self.0.to_tokens(tokens);
-    }
-}
-
-pub struct HtmlTreeNested(HtmlTree);
-impl Parse for HtmlTreeNested {
-    fn parse(input: ParseStream) -> Result<Self> {
-        Ok(HtmlTreeNested(HtmlTree::parse(input)?))
-    }
-}
-
-impl ToTokens for HtmlTreeNested {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        tokens.extend(self.0.token_stream());
-    }
-}

--- a/yew-macro/src/lib.rs
+++ b/yew-macro/src/lib.rs
@@ -66,7 +66,7 @@ mod derive_props;
 mod html_tree;
 
 use derive_props::DerivePropsInput;
-use html_tree::{HtmlRoot, HtmlTree};
+use html_tree::{HtmlRoot, HtmlRootVNode};
 use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;
 use quote::{quote, ToTokens};
@@ -99,12 +99,12 @@ pub fn derive_props(input: TokenStream) -> TokenStream {
 
 #[proc_macro_hack]
 pub fn html_nested(input: TokenStream) -> TokenStream {
-    let root = parse_macro_input!(input as HtmlTree);
+    let root = parse_macro_input!(input as HtmlRoot);
     TokenStream::from(quote! {#root})
 }
 
 #[proc_macro_hack]
 pub fn html(input: TokenStream) -> TokenStream {
-    let root = parse_macro_input!(input as HtmlRoot);
+    let root = parse_macro_input!(input as HtmlRootVNode);
     TokenStream::from(quote! {#root})
 }

--- a/yew-macro/src/lib.rs
+++ b/yew-macro/src/lib.rs
@@ -66,7 +66,7 @@ mod derive_props;
 mod html_tree;
 
 use derive_props::DerivePropsInput;
-use html_tree::{HtmlRoot, HtmlRootNested};
+use html_tree::{HtmlRoot, HtmlTree};
 use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;
 use quote::{quote, ToTokens};
@@ -99,7 +99,7 @@ pub fn derive_props(input: TokenStream) -> TokenStream {
 
 #[proc_macro_hack]
 pub fn html_nested(input: TokenStream) -> TokenStream {
-    let root = parse_macro_input!(input as HtmlRootNested);
+    let root = parse_macro_input!(input as HtmlTree);
     TokenStream::from(quote! {#root})
 }
 

--- a/yew-macro/tests/macro/html-block-fail.stderr
+++ b/yew-macro/tests/macro/html-block-fail.stderr
@@ -8,6 +8,8 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
+  = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
+  = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>`
   = note: required by `std::convert::From::from`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -21,6 +23,8 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required because of the requirements on the impl of `std::string::ToString` for `()`
    = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
+   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
+   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>`
    = note: required by `std::convert::From::from`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/yew-macro/tests/macro/html-component-fail.rs
+++ b/yew-macro/tests/macro/html-component-fail.rs
@@ -116,6 +116,11 @@ fn compile_fail() {
 
     html! { <Generic<String>></Generic> };
     html! { <Generic<String>></Generic<Vec<String>>> };
+
+    html_nested! {
+        <span>{ 1 }</span>
+        <span>{ 2 }</span>
+    };
 }
 
 fn main() {}

--- a/yew-macro/tests/macro/html-component-fail.stderr
+++ b/yew-macro/tests/macro/html-component-fail.stderr
@@ -346,7 +346,6 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::conv
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<&str>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
     |
     = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `&str`
-    = note: required because of the requirements on the impl of `std::iter::IntoIterator` for `yew::utils::NodeSeq<&str, yew::virtual_dom::vcomp::VChild<Child>>`
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied
@@ -356,7 +355,6 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::conv
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vnode::VNode>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
     |
     = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vnode::VNode`
-    = note: required because of the requirements on the impl of `std::iter::IntoIterator` for `yew::utils::NodeSeq<yew::virtual_dom::vnode::VNode, yew::virtual_dom::vcomp::VChild<Child>>`
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied
@@ -366,5 +364,4 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::conv
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vnode::VNode>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
     |
     = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vnode::VNode`
-    = note: required because of the requirements on the impl of `std::iter::IntoIterator` for `yew::utils::NodeSeq<yew::virtual_dom::vnode::VNode, yew::virtual_dom::vcomp::VChild<Child>>`
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/yew-macro/tests/macro/html-component-fail.stderr
+++ b/yew-macro/tests/macro/html-component-fail.stderr
@@ -190,6 +190,14 @@ error: this closing tag has no corresponding opening tag
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
+   --> $DIR/html-component-fail.rs:122:9
+    |
+122 |         <span>{ 2 }</span>
+    |         ^^^^^^^^^^^^^^^^^^
+    |
+    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0425]: cannot find value `blah` in this scope
   --> $DIR/html-component-fail.rs:91:25
    |

--- a/yew-macro/tests/macro/html-component-pass.rs
+++ b/yew-macro/tests/macro/html-component-pass.rs
@@ -300,9 +300,20 @@ fn compile_pass() {
         </ChildContainer>
     };
 
+    let children = vec![html_nested! { <Child int=1 /> }, html_nested! { <Child int=2 /> }];
+    html! {
+        <ChildContainer int=1>
+            { children }
+        </ChildContainer>
+    };
+
     let variants = || -> Vec<ChildrenVariants> {
         vec![
-            ChildrenVariants::Child(VChild::new(ChildProperties::default(), NodeRef::default(), None)),
+            ChildrenVariants::Child(VChild::new(
+                ChildProperties::default(),
+                NodeRef::default(),
+                None,
+            )),
             ChildrenVariants::AltChild(VChild::new((), NodeRef::default(), None)),
         ]
     };

--- a/yew-macro/tests/macro/html-component-pass.rs
+++ b/yew-macro/tests/macro/html-component-pass.rs
@@ -300,7 +300,10 @@ fn compile_pass() {
         </ChildContainer>
     };
 
-    let children = vec![html_nested! { <Child int=1 /> }, html_nested! { <Child int=2 /> }];
+    let children = vec![
+        html_nested! { <Child int=1 /> },
+        html_nested! { <Child int=2 /> },
+    ];
     html! {
         <ChildContainer int=1>
             { children }
@@ -351,6 +354,8 @@ fn compile_pass() {
             <Generic<Vec<String>>></ Generic<Vec<String>>>
         </>
     };
+
+    html_nested! { 1 };
 }
 
 fn main() {}

--- a/yew-macro/tests/macro/html-iterable-fail.rs
+++ b/yew-macro/tests/macro/html-iterable-fail.rs
@@ -11,6 +11,13 @@ fn compile_fail() {
 
     let empty = Vec::<()>::new();
     html! { for empty.iter() };
+
+    html! {
+        <>
+            <div/>
+            { for () }
+        </>
+    };
 }
 
 fn main() {}

--- a/yew-macro/tests/macro/html-iterable-fail.stderr
+++ b/yew-macro/tests/macro/html-iterable-fail.stderr
@@ -6,24 +6,34 @@ error: expected an expression after the keyword `for`
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `()` is not an iterator
+error[E0599]: no method named `into_iter` found for unit type `()` in the current scope
  --> $DIR/html-iterable-fail.rs:5:17
   |
 5 |     html! { for () };
-  |                 ^^ `()` is not an iterator
+  |                 ^^ method not found in `()`
   |
-  = help: the trait `std::iter::Iterator` is not implemented for `()`
-  = note: required by `std::iter::IntoIterator::into_iter`
+  = note: the method `into_iter` exists but the following trait bounds were not satisfied:
+          `(): std::iter::Iterator`
+          which is required by `(): std::iter::IntoIterator`
+          `&(): std::iter::Iterator`
+          which is required by `&(): std::iter::IntoIterator`
+          `&mut (): std::iter::Iterator`
+          which is required by `&mut (): std::iter::IntoIterator`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `()` is not an iterator
+error[E0599]: no method named `into_iter` found for unit type `()` in the current scope
  --> $DIR/html-iterable-fail.rs:6:17
   |
 6 |     html! { for {()} };
-  |                 ^^^^ `()` is not an iterator
+  |                 ^^^^ method not found in `()`
   |
-  = help: the trait `std::iter::Iterator` is not implemented for `()`
-  = note: required by `std::iter::IntoIterator::into_iter`
+  = note: the method `into_iter` exists but the following trait bounds were not satisfied:
+          `(): std::iter::Iterator`
+          which is required by `(): std::iter::IntoIterator`
+          `&(): std::iter::Iterator`
+          which is required by `&(): std::iter::IntoIterator`
+          `&mut (): std::iter::Iterator`
+          which is required by `&mut (): std::iter::IntoIterator`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
@@ -37,6 +47,7 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
+  = note: required because of the requirements on the impl of `std::iter::FromIterator<()>` for `yew::virtual_dom::vnode::VNode`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
@@ -50,6 +61,7 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = note: required because of the requirements on the impl of `std::string::ToString` for `()`
    = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
+   = note: required because of the requirements on the impl of `std::iter::FromIterator<()>` for `yew::virtual_dom::vnode::VNode`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
@@ -64,4 +76,5 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = note: required because of the requirements on the impl of `std::string::ToString` for `&()`
    = note: required because of the requirements on the impl of `std::convert::From<&()>` for `yew::virtual_dom::vnode::VNode`
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `&()`
+   = note: required because of the requirements on the impl of `std::iter::FromIterator<&()>` for `yew::virtual_dom::vnode::VNode`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/yew-macro/tests/macro/html-iterable-fail.stderr
+++ b/yew-macro/tests/macro/html-iterable-fail.stderr
@@ -6,34 +6,24 @@ error: expected an expression after the keyword `for`
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: no method named `into_iter` found for unit type `()` in the current scope
+error[E0277]: `()` is not an iterator
  --> $DIR/html-iterable-fail.rs:5:17
   |
 5 |     html! { for () };
-  |                 ^^ method not found in `()`
+  |                 ^^ `()` is not an iterator
   |
-  = note: the method `into_iter` exists but the following trait bounds were not satisfied:
-          `(): std::iter::Iterator`
-          which is required by `(): std::iter::IntoIterator`
-          `&(): std::iter::Iterator`
-          which is required by `&(): std::iter::IntoIterator`
-          `&mut (): std::iter::Iterator`
-          which is required by `&mut (): std::iter::IntoIterator`
+  = help: the trait `std::iter::Iterator` is not implemented for `()`
+  = note: required by `std::iter::IntoIterator::into_iter`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: no method named `into_iter` found for unit type `()` in the current scope
+error[E0277]: `()` is not an iterator
  --> $DIR/html-iterable-fail.rs:6:17
   |
 6 |     html! { for {()} };
-  |                 ^^^^ method not found in `()`
+  |                 ^^^^ `()` is not an iterator
   |
-  = note: the method `into_iter` exists but the following trait bounds were not satisfied:
-          `(): std::iter::Iterator`
-          which is required by `(): std::iter::IntoIterator`
-          `&(): std::iter::Iterator`
-          which is required by `&(): std::iter::IntoIterator`
-          `&mut (): std::iter::Iterator`
-          which is required by `&mut (): std::iter::IntoIterator`
+  = help: the trait `std::iter::Iterator` is not implemented for `()`
+  = note: required by `std::iter::IntoIterator::into_iter`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
@@ -48,6 +38,7 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
   = note: required because of the requirements on the impl of `std::iter::FromIterator<()>` for `yew::virtual_dom::vnode::VNode`
+  = note: required by `std::iter::Iterator::collect`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
@@ -62,6 +53,7 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
    = note: required because of the requirements on the impl of `std::iter::FromIterator<()>` for `yew::virtual_dom::vnode::VNode`
+   = note: required by `std::iter::Iterator::collect`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
@@ -77,4 +69,15 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = note: required because of the requirements on the impl of `std::convert::From<&()>` for `yew::virtual_dom::vnode::VNode`
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `&()`
    = note: required because of the requirements on the impl of `std::iter::FromIterator<&()>` for `yew::virtual_dom::vnode::VNode`
+   = note: required by `std::iter::Iterator::collect`
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `()` is not an iterator
+  --> $DIR/html-iterable-fail.rs:18:19
+   |
+18 |             { for () }
+   |                   ^^ `()` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `()`
+   = note: required by `std::iter::IntoIterator::into_iter`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/yew-macro/tests/macro/html-list-pass.rs
+++ b/yew-macro/tests/macro/html-list-pass.rs
@@ -13,6 +13,12 @@ fn compile_pass() {
         <key="key".to_string()>
         </>
     };
+
+    let children = vec![
+        html! { <span>{ "Hello" }</span> },
+        html! { <span>{ "World" }</span> },
+    ];
+    html! { <>{children}</> };
 }
 
 fn main() {}

--- a/yew-macro/tests/macro/html-tag-pass.rs
+++ b/yew-macro/tests/macro/html-tag-pass.rs
@@ -60,6 +60,12 @@ fn compile_pass() {
             }/>
         </div>
     };
+
+    let children = vec![
+        html! { <span>{ "Hello" }</span> },
+        html! { <span>{ "World" }</span> },
+    ];
+    html! { <div>{children}</div> };
 }
 
 fn main() {}

--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use scope::ComponentUpdate;
 pub use scope::{AnyScope, Scope};
 
 use crate::callback::Callback;
-use crate::virtual_dom::{VChild, VList, VNode};
+use crate::virtual_dom::{VChild, VNode};
 use cfg_if::cfg_if;
 use cfg_match::cfg_match;
 use std::cell::RefCell;
@@ -163,7 +163,7 @@ pub type Html = VNode;
 /// The Wrapper component must define a `children` property in order to wrap other elements. The
 /// children property can be used to render the wrapped elements.
 /// ```
-///# use yew::{Children, Html, Properties, Renderable, Component, ComponentLink, html};
+///# use yew::{Children, Html, Properties, Component, ComponentLink, html};
 /// #[derive(Clone, Properties)]
 /// struct WrapperProps {
 ///     children: Children,
@@ -180,7 +180,7 @@ pub type Html = VNode;
 ///     fn view(&self) -> Html {
 ///         html! {
 ///             <div id="container">
-///                 { self.props.children.render() }
+///                 { self.props.children.clone() }
 ///             </div>
 ///         }
 ///     }
@@ -313,14 +313,11 @@ where
         self.children.len()
     }
 
-    /// Build children components and return `Vec`
-    pub fn to_vec(&self) -> Vec<T> {
-        self.children.clone()
-    }
-
     /// Render children components and return `Iterator`
-    pub fn iter(&self) -> impl Iterator<Item = T> {
-        self.to_vec().into_iter()
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = T> + 'a {
+        // clone each child lazily.
+        // This way `self.iter().next()` only has to clone a single node.
+        self.children.iter().cloned()
     }
 }
 
@@ -338,12 +335,12 @@ impl<T> fmt::Debug for ChildrenRenderer<T> {
     }
 }
 
-impl<T> Renderable for ChildrenRenderer<T>
-where
-    T: Clone + Into<VNode>,
-{
-    fn render(&self) -> Html {
-        VList::new_with_children(self.iter().map(|c| c.into()).collect(), None).into()
+impl<T> IntoIterator for ChildrenRenderer<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.children.into_iter()
     }
 }
 

--- a/yew/src/utils.rs
+++ b/yew/src/utils.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Error};
 use cfg_if::cfg_if;
 use cfg_match::cfg_match;
 use std::marker::PhantomData;
+use yew::html::ChildrenRenderer;
 cfg_if! {
     if #[cfg(feature = "std_web")] {
         use stdweb::web::{Document, Window};
@@ -79,6 +80,15 @@ impl<IN: Into<OUT>, OUT> From<IN> for NodeSeq<IN, OUT> {
 
 impl<IN: Into<OUT>, OUT> From<Vec<IN>> for NodeSeq<IN, OUT> {
     fn from(val: Vec<IN>) -> Self {
+        Self(
+            val.into_iter().map(|x| x.into()).collect(),
+            PhantomData::default(),
+        )
+    }
+}
+
+impl<IN: Into<OUT>, OUT> From<ChildrenRenderer<IN>> for NodeSeq<IN, OUT> {
+    fn from(val: ChildrenRenderer<IN>) -> Self {
         Self(
             val.into_iter().map(|x| x.into()).collect(),
             PhantomData::default(),

--- a/yew/src/utils.rs
+++ b/yew/src/utils.rs
@@ -86,7 +86,7 @@ impl<IN: Into<OUT>, OUT> From<Vec<IN>> for NodeSeq<IN, OUT> {
     }
 }
 
-impl<IN: Into<OUT>, OUT> IntoIterator for NodeSeq<IN, OUT> {
+impl<IN, OUT> IntoIterator for NodeSeq<IN, OUT> {
     type Item = OUT;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 

--- a/yew/src/virtual_dom/vcomp.rs
+++ b/yew/src/virtual_dom/vcomp.rs
@@ -446,7 +446,10 @@ mod tests {
     }
 
     #[test]
-    fn iterators_produce_same_results() {
+    #[cfg(feature = "web_sys")]
+    /// Test is only run for web_sys because it's a lot easier to test.
+    /// It tests the behaviour of the virtual dom so there won't be a difference between stdweb and web_sys.
+    fn children_blocks_produce_same_results() {
         #[derive(Clone, Properties)]
         struct Props {
             children: Children,
@@ -483,20 +486,17 @@ mod tests {
         let scope = test_scope();
         let parent = document().create_element("div").unwrap();
 
-        #[cfg(feature = "std_web")]
-        document().body().unwrap().append_child(&parent);
-        #[cfg(feature = "web_sys")]
         document().body().unwrap().append_child(&parent).unwrap();
 
-        let mut list_method = html! {
+        let mut direct_method = html! {
             <List>
                 { children.clone() }
             </List>
         };
-        list_method.apply(&scope, &parent, None, None);
-        let list_html = parent.inner_html();
+        direct_method.apply(&scope, &parent, None, None);
+        let direct_html = parent.inner_html();
         assert_eq!(
-            list_html,
+            direct_html,
             "<ul>\
                 <li><span>a</span></li>\
                 <li><span>b</span></li>\
@@ -504,6 +504,7 @@ mod tests {
             </ul>"
         );
 
+        // clear parent
         parent.set_inner_html("");
 
         let mut for_method = html! {
@@ -514,6 +515,6 @@ mod tests {
         for_method.apply(&scope, &parent, None, None);
         let for_html = parent.inner_html();
 
-        assert_eq!(list_html, for_html)
+        assert_eq!(direct_html, for_html)
     }
 }

--- a/yew/src/virtual_dom/vcomp.rs
+++ b/yew/src/virtual_dom/vcomp.rs
@@ -334,23 +334,14 @@ impl<COMP: Component> fmt::Debug for VChild<COMP> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AnyScope, VChild, VDiff};
+    use super::VChild;
     use crate::macros::Properties;
-    use crate::utils::document;
-    use crate::{html, Children, Component, ComponentLink, Html, NodeRef, ShouldRender};
+    use crate::{html, Component, ComponentLink, Html, NodeRef, ShouldRender};
     #[cfg(feature = "wasm_test")]
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
     #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
-
-    fn test_scope() -> AnyScope {
-        AnyScope {
-            type_id: std::any::TypeId::of::<()>(),
-            parent: None,
-            state: std::rc::Rc::new(()),
-        }
-    }
 
     struct Comp;
 
@@ -450,6 +441,9 @@ mod tests {
     /// Test is only run for web_sys because it's a lot easier to test.
     /// It tests the behaviour of the virtual dom so there won't be a difference between stdweb and web_sys.
     fn children_blocks_produce_same_results() {
+        use super::{AnyScope, VDiff};
+        use crate::{utils::document, Children};
+
         #[derive(Clone, Properties)]
         struct Props {
             children: Children,
@@ -483,7 +477,11 @@ mod tests {
             .map(|text| html! {<span>{ text }</span>})
             .collect();
 
-        let scope = test_scope();
+        let scope = AnyScope {
+            type_id: std::any::TypeId::of::<()>(),
+            parent: None,
+            state: std::rc::Rc::new(()),
+        };
         let parent = document().create_element("div").unwrap();
 
         document().body().unwrap().append_child(&parent).unwrap();

--- a/yew/src/virtual_dom/vlist.rs
+++ b/yew/src/virtual_dom/vlist.rs
@@ -65,6 +65,11 @@ impl VList {
     pub fn add_child(&mut self, child: VNode) {
         self.children.push(child);
     }
+
+    /// Add multiple `VNode` children.
+    pub fn add_children(&mut self, children: impl IntoIterator<Item = VNode>) {
+        self.children.extend(children);
+    }
 }
 
 impl VDiff for VList {

--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -118,10 +118,8 @@ impl VTag {
     }
 
     /// Add multiple `VNode` children.
-    pub fn add_children(&mut self, children: Vec<VNode>) {
-        for child in children {
-            self.add_child(child);
-        }
+    pub fn add_children(&mut self, children: impl IntoIterator<Item = VNode>) {
+        self.children.add_children(children);
     }
 
     /// Sets `value` for an


### PR DESCRIPTION
Fixes #1262 

## What and why?
The easiest way to explain the purpose of these changes is to look at some examples.

### Example 1

Let's assume we want to create a `List` component that wraps the contents in a `<ul>` tag and also wraps each child in a `<li>` so that users of this component don't even need to think about it.

The code for such a component looks like this:
```rust
#[derive(Clone, Properties)]
struct Props { children: Children }
struct List(Props);
impl Component for List {
    // boilerplate omitted for brevity.
    fn view(&self) -> Html {
        let item_iter = self.0.children.iter().map(|item| html! { <li>{ item }</li> });
        html! {  <ul>{ for item_iter }</ul> }
}
```

Now let's try to use this component.
If we only use 'literal' html it works as expected:
```rust
html! {
  <List>
    <span>Hello</span>
    <span>World</span>
  </List>
};
```
<details>
<summary>HTML output</summary>
<p>

```html
<ul>
  <li><span>Hello</span></li>
  <li><span>World</span></li>
</ul>
```

</p>
</details>

But of course in a lot of cases (if not most) the list's content will be dynamically generated. Something like this:
```rust
// entries is an iterator yielding Html items.
let entries = vec![
  html! { <span>Hello</span> },
  html! { <span>World</span> },
].into_iter();

html! {
  <List>
    { for entries }
  </List>
};
```

This doesn't generate the same HTML because the expression block is treated as a single child instead of being 'unfolded' into multiple.

<details>
<summary>HTML output</summary>
<p>

```html
<ul>
  <li>
    <span>Hello</span>
    <span>World</span>
  </li>
</ul>
```

</p>
</details>

Currently the only way around this issue is to pass the children as a property or to use an undocumented feature that allows us to use a vector in expressions below components.

The primary goal of this PR was to make this particular case work as expected.

### Example 2
It is now possible to use a vector in an expression block.
```rust
let children = vec![
    html! { <span>{ "Hello" }</span> },
    html! { <span>{ "World" }</span> },
];
html! { <div>{children}</div> };
```

This should be seen as a better alternative to using `.collect::<Html>()`. It has more semantic meaning as an actual list of children and is less verbose in a lot of situations.

This is mostly a side effect of the changes but I'm mentioning it because I would like to remove the recommendation for `.collect::<Html>()`. There may still be a use case for it but it explicitly creates a single vnode thereby circumventing the work done in this PR.
There are certainly times where the 'unwrapping' isn't desired. In those cases I would advocate for the use of fragments:
```rust
html! {
  <List>
    <>{ my_elements }</>
  </List>
}
```

## Technical details

### Refactor of the different Html tree types

Right now there are 4 tree types: `HtmlTree`, `HtmlRoot`, `HtmlRootNested`, and `HtmlTreeNested`.
I noticed the following problems:
- `HtmlTreeNested` is just `HtmlTree` but it doesn't wrap the code in `::yew::virtual_dom::VNode::from`.
- `HtmlRootNested` is just `HtmlTreeNested`. That's it. There's no difference.
- `HtmlRoot` is just `HtmlTree` but the parse function is extended to handle `HtmlIterable` and `HtmlNode`.
- `HtmlTree` contains the two variants mentioned above but it will never parse them (only `HtmlRoot` can create an `HtmlTree` with those variants).

This PR changes it so that there's only `HtmlTree` and `HtmlRoot`.
`HtmlTree` is basically `HtmlTreeNested` in that it no longer wraps the code in `::yew::virtual_dom::VNode::from`. `HtmlTree` also no longer contains the `HtmlIterable` and `HtmlNode`, both were moved to `HtmlRoot`.
Speaking of which, `HtmlRoot` behaves exactly like it did before but it now does a lot of the work that `HtmlTree` did itself.

### Unified node children behaviour.

There are 3 node types that support children: `HtmlTag`, `HtmlList`, and `HtmlComponent`.
All of them currently have their own implementation of the whole children thing and all of them are slightly different.
`HtmlList` and `HtmlComponent` are very close. They both use `NodeSeq` for more flexibility, which is why they already support passing children in a vector. The difference is that `HtmlComponent` collects `HtmlTreeNested` nodes while `HtmlList` uses `HtmlTree` (note that I'm referring to the old types here, not the refactored ones).
`HtmlTag` on the other hand is totally different because it doesn't use `NodeSeq`. Instead it collects `HtmlTree` and just puts all of them in a vector. Unlike the other two methods, which accept any expression that implements `Into<VNode>`, here expressions have to resolve to `VNode` directly.

This PR makes it so all three behave exactly the same. It introduces the new type `HtmlChildrenTree` which does all of the work.

### `ChildrenRenderer` no longer implements `Renderable` (breaking change)

The reason for this is the same as for why I think we should discourage `.collect::<Html>()` - it explicitly creates a single node.

There is one case where this results in a bit more verbosity: when the user actually wants to create a single node. I can only think of one use case for this though and that is for components that want to return their children unchanged. The `ContextProvider` is one such example.
The code for doing this just looks like this now:
```rust
self.children.iter().collect::<Html>()
```