### PR TITLE
Prevent events per default on RouteAnchor/Button

### DIFF
--- a/yew-router/CHANGELOG.md
+++ b/yew-router/CHANGELOG.md
@@ -21,7 +21,7 @@ END TEMPLATE-->
 - #### 🛠 Fixes
   - None
 - #### 🚨 Breaking changes
-  - `AnchorButton` now prevents default events per default @TheNeikos
+  - `RouterButton` now prevents default events per default @TheNeikos
 
 ## ✨ **0.14.0** *2020-6-30*
 

--- a/yew-router/CHANGELOG.md
+++ b/yew-router/CHANGELOG.md
@@ -21,7 +21,7 @@ END TEMPLATE-->
 - #### 🛠 Fixes
   - None
 - #### 🚨 Breaking changes
-  - None
+  - `AnchorButton` now prevents default events per default @TheNeikos
 
 ## ✨ **0.14.0** *2020-6-30*
 

--- a/yew-router/src/components/router_button.rs
+++ b/yew-router/src/components/router_button.rs
@@ -47,11 +47,20 @@ impl<SW: Switch + Clone + 'static, STATE: RouterState> Component for RouterButto
     }
 
     fn view(&self) -> VNode {
-        let cb = |x| self.link.callback(x);
+        #[cfg(feature = "std_web")]
+        let cb = self.link.callback(|event: ClickEvent| {
+            event.prevent_default();
+            Msg::Clicked
+        });
+        #[cfg(feature = "web_sys")]
+        let cb = self.link.callback(|event: MouseEvent| {
+            event.prevent_default();
+            Msg::Clicked
+        });
         html! {
             <button
                 class=self.props.classes.clone(),
-                onclick=cb(|_| Msg::Clicked),
+                onclick=cb,
                 disabled=self.props.disabled,
             >
                 {

--- a/yew-router/src/components/router_link.rs
+++ b/yew-router/src/components/router_link.rs
@@ -58,6 +58,7 @@ impl<SW: Switch + Clone + 'static, STATE: RouterState> Component for RouterAncho
 
         let route: Route<STATE> = Route::from(self.props.route.clone());
         let target: &str = route.as_str();
+
         #[cfg(feature = "std_web")]
         let cb = self.link.callback(|event: ClickEvent| {
             event.prevent_default();


### PR DESCRIPTION
#### Description

This PR adds the ability to toggle whether the callback of a `RouteAnchor` or `RouteButton` calls `prevent_default` on its event. It is per default turn on. Which changes the behavior for `RouteButton` but not for `RouteAnchor` as it was already in place there. 

Fixes #1280 

#### Checklist:

- [x] I have ran `./ci/run_stable_checks.sh`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works

I would love to add tests, but I am not sure how such a change could be tested, or if it needs to be.