### PR TITLE
Update rustc stable to 1.44

### DIFF
--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -277,7 +277,7 @@ where
                             de();
                         }
                         let new_destructor = callback(deps.borrow());
-                        state.deps = deps.clone();
+                        state.deps = deps;
                         state.destructor.replace(Box::new(new_destructor));
                     } else if state.destructor.is_none() {
                         should_update = true;

--- a/yew-macro/src/html_tree/html_list.rs
+++ b/yew-macro/src/html_tree/html_list.rs
@@ -64,12 +64,21 @@ impl ToTokens for HtmlList {
         } else {
             quote! {None}
         };
+        let children_tokens = if !children.is_empty() {
+            quote! {
+                let mut v = ::std::vec::Vec::new();
+                #(v.extend(::yew::utils::NodeSeq::from(#children));)*
+                v
+            }
+        } else {
+            quote! {
+                ::std::vec::Vec::new()
+            }
+        };
         tokens.extend(quote! {
             ::yew::virtual_dom::VNode::VList(
                 ::yew::virtual_dom::VList::new_with_children({
-                    let mut v = ::std::vec::Vec::new();
-                    #(v.extend(::yew::utils::NodeSeq::from(#children));)*
-                    v
+                    #children_tokens
                 },
                 #key)
             )

--- a/yew-macro/tests/derive_props/fail.stderr
+++ b/yew-macro/tests/derive_props/fail.stderr
@@ -52,7 +52,7 @@ error[E0599]: no method named `b` found for struct `t4::PropsBuilder<t4::PropsBu
    |                     ---------- method `b` not found for this
 ...
 48 |         Props::builder().b(1).a(2).build();
-   |                          ^ help: there is a method with a similar name: `a`
+   |                          ^ help: there is an associated function with a similar name: `a`
 
 error[E0308]: mismatched types
   --> $DIR/fail.rs:67:19

--- a/yew-macro/tests/derive_props_test.rs
+++ b/yew-macro/tests/derive_props_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.43), test)]
+#[rustversion::attr(stable(1.44), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_props/pass.rs");

--- a/yew-macro/tests/macro/html-component-fail-unimplemented.rs
+++ b/yew-macro/tests/macro/html-component-fail-unimplemented.rs
@@ -2,8 +2,10 @@
 
 use yew::prelude::*;
 
+struct Unimplemented;
+
 fn compile_fail() {
-    html! { <String /> };
+    html! { <Unimplemented /> };
 }
 
 fn main() {}

--- a/yew-macro/tests/macro/html-component-fail-unimplemented.stderr
+++ b/yew-macro/tests/macro/html-component-fail-unimplemented.stderr
@@ -1,22 +1,20 @@
-error[E0599]: no function or associated item named `new` found for struct `yew::virtual_dom::vcomp::VChild<std::string::String>` in the current scope
-   --> $DIR/html-component-fail-unimplemented.rs:6:5
-    |
-6   |     html! { <String /> };
-    |     ^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `yew::virtual_dom::vcomp::VChild<std::string::String>`
-    | 
-   ::: /Users/jstarry/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/src/liballoc/string.rs:282:1
-    |
-282 | pub struct String {
-    | ----------------- doesn't satisfy `std::string::String: yew::html::Component`
-    |
-    = note: the method `new` exists but the following trait bounds were not satisfied:
-            `std::string::String: yew::html::Component`
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `std::string::String: yew::html::Component` is not satisfied
- --> $DIR/html-component-fail-unimplemented.rs:6:5
+error[E0599]: no function or associated item named `new` found for struct `yew::virtual_dom::vcomp::VChild<Unimplemented>` in the current scope
+ --> $DIR/html-component-fail-unimplemented.rs:8:5
   |
-6 |     html! { <String /> };
-  |     ^^^^^^^^^^^^^^^^^^^^^ the trait `yew::html::Component` is not implemented for `std::string::String`
+5 | struct Unimplemented;
+  | --------------------- doesn't satisfy `Unimplemented: yew::html::Component`
+...
+8 |     html! { <Unimplemented /> };
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `yew::virtual_dom::vcomp::VChild<Unimplemented>`
+  |
+  = note: the method `new` exists but the following trait bounds were not satisfied:
+          `Unimplemented: yew::html::Component`
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Unimplemented: yew::html::Component` is not satisfied
+ --> $DIR/html-component-fail-unimplemented.rs:8:5
+  |
+8 |     html! { <Unimplemented /> };
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `yew::html::Component` is not implemented for `Unimplemented`
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/yew-macro/tests/macro/html-component-fail-unimplemented.stderr
+++ b/yew-macro/tests/macro/html-component-fail-unimplemented.stderr
@@ -1,8 +1,13 @@
 error[E0599]: no function or associated item named `new` found for struct `yew::virtual_dom::vcomp::VChild<std::string::String>` in the current scope
    --> $DIR/html-component-fail-unimplemented.rs:6:5
     |
-6   |       html! { <String /> };
-    |       ^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `yew::virtual_dom::vcomp::VChild<std::string::String>`
+6   |     html! { <String /> };
+    |     ^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `yew::virtual_dom::vcomp::VChild<std::string::String>`
+    | 
+   ::: /Users/jstarry/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/src/liballoc/string.rs:282:1
+    |
+282 | pub struct String {
+    | ----------------- doesn't satisfy `std::string::String: yew::html::Component`
     |
     = note: the method `new` exists but the following trait bounds were not satisfied:
             `std::string::String: yew::html::Component`

--- a/yew-macro/tests/macro_test.rs
+++ b/yew-macro/tests/macro_test.rs
@@ -1,7 +1,7 @@
 use yew::html;
 
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.43), test)]
+#[rustversion::attr(stable(1.44), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
 

--- a/yew-router-route-parser/src/parser.rs
+++ b/yew-router-route-parser/src/parser.rs
@@ -231,7 +231,7 @@ pub fn parse(
             _ => panic!("parser should not be incomplete"),
         })?;
         i = ii;
-        state = state.transition(token.clone()).map_err(|reason| {
+        state = state.transition(token).map_err(|reason| {
             let error = ParseError {
                 reason: Some(reason),
                 expected: vec![],

--- a/yew/src/callback.rs
+++ b/yew/src/callback.rs
@@ -35,6 +35,7 @@ impl<IN> Clone for Callback<IN> {
     }
 }
 
+#[allow(clippy::vtable_address_comparisons)]
 impl<IN> PartialEq for Callback<IN> {
     fn eq(&self, other: &Callback<IN>) -> bool {
         match (&self, &other) {

--- a/yew/src/services/reader/web_sys.rs
+++ b/yew/src/services/reader/web_sys.rs
@@ -26,7 +26,7 @@ impl ReaderService {
             if let Ok(result) = reader.result() {
                 let array = Uint8Array::new(&result);
                 let data = FileData {
-                    name: name,
+                    name,
                     content: array.to_vec(),
                 };
                 callback.emit(data);


### PR DESCRIPTION
#### Description
- Fix rustc 1.44 clippy errors
- Update macro compiler error tests

Fixes # (issue)

#### Checklist:

- [x] I have ran `./ci/run_stable_checks.sh`
- [x] I have performed a self-review of my own code

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
