### PR TITLE
accept trailing / from argument supplied to examples/build.sh

### DIFF
--- a/examples/build.sh
+++ b/examples/build.sh
@@ -16,7 +16,7 @@ if [ ! -z "$CARGO_TARGET_DIR" ]; then
     TARGET_DIR=$CARGO_TARGET_DIR/wasm32-unknown-unknown/debug
 fi
 
-EXAMPLE=$1
+EXAMPLE=${1%\/}
 cd $EXAMPLE
 
 # wasm-pack build


### PR DESCRIPTION
#### Description

Auto-completion adds a trailing slash because each example is indeed a directory. But the script fails if there is a trailing dash, so, if there is, we remove it from the argument.

#### Checklist:

- [ ] I have ran `./ci/run_stable_checks.sh`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works