### PR TITLE
Fix MDN reference for kind attribute

### DIFF
--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -131,7 +131,7 @@ impl VTag {
     }
 
     /// Sets `kind` property of an
-    /// [InputElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
+    /// [TextTrack](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track).
     /// Same as set `type` attribute.
     pub fn set_kind<T: ToString>(&mut self, value: &T) {
         self.kind = Some(value.to_string());


### PR DESCRIPTION
#### Description

Just a code comment fix.

I think this is a copy-paste error and instead of  `InputElement` it should be `TextTrack`
because that's the only reference for a `kind` attribute I could find in MDN


Fixes # (issue)

#### Checklist:

- [ ] I have ran `./ci/run_stable_checks.sh`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works

