### PR TITLE
Tidy up WebSocket service.

### DIFF
--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -183,7 +183,6 @@ impl WebSocketService {
     ) -> Result<ConnectCommon, WebSocketError> {
         let ws = WebSocket::new(url);
 
-        #[cfg(feature = "web_sys")]
         let ws = ws.map_err(
             #[cfg(feature = "web_sys")]
             |ws_error| {
@@ -198,6 +197,8 @@ impl WebSocketService {
             #[cfg(feature = "std_web")]
             |_| WebSocketError::CreationError("Error opening a WebSocket connection.".to_string()),
         )?;
+
+        #[cfg(feature = "std")]
 
         cfg_match! {
             feature = "std_web" => ws.set_binary_type(SocketBinaryType::ArrayBuffer),

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -1,4 +1,4 @@
-//! Service to connect to a servers by
+//! A service to connect to a server through the
 //! [`WebSocket` Protocol](https://tools.ietf.org/html/rfc6455).
 
 use super::Task;
@@ -20,18 +20,18 @@ cfg_if! {
     }
 }
 
-/// A status of a websocket connection. Used for status notification.
+/// The status of a WebSocket connection. Used for status notifications.
 #[derive(Clone, Debug, PartialEq)]
 pub enum WebSocketStatus {
-    /// Fired when a websocket connection was opened.
+    /// Fired when a WebSocket connection has opened.
     Opened,
-    /// Fired when a websocket connection was closed.
+    /// Fired when a WebSocket connection has closed.
     Closed,
-    /// Fired when a websocket connection was failed.
+    /// Fired when a WebSocket connection has failed.
     Error,
 }
 
-/// A handle to control current websocket connection. Implements `Task` and could be canceled.
+/// A handle to control the WebSocket connection. Implements `Task` and could be canceled.
 #[must_use]
 pub struct WebSocketTask {
     ws: WebSocket,
@@ -64,7 +64,7 @@ impl fmt::Debug for WebSocketTask {
     }
 }
 
-/// A websocket service attached to a user context.
+/// A WebSocket service attached to a user context.
 #[derive(Default, Debug)]
 pub struct WebSocketService {}
 
@@ -74,7 +74,7 @@ impl WebSocketService {
         Self {}
     }
 
-    /// Connects to a server by a websocket connection. Needs two functions to generate
+    /// Connects to a server through a WebSocket connection. Needs two functions to generate
     /// data and notification messages.
     pub fn connect<OUT: 'static>(
         &mut self,
@@ -104,7 +104,7 @@ impl WebSocketService {
         }
     }
 
-    /// Connects to a server by a websocket connection, like connect,
+    /// Connects to a server through a WebSocket connection, like connect,
     /// but only processes binary frames. Text frames are silently
     /// ignored. Needs two functions to generate data and notification
     /// messages.
@@ -136,7 +136,7 @@ impl WebSocketService {
         }
     }
 
-    /// Connects to a server by a websocket connection, like connect,
+    /// Connects to a server through a WebSocket connection, like connect,
     /// but only processes text frames. Binary frames are silently
     /// ignored. Needs two functions to generate data and notification
     /// messages.
@@ -175,10 +175,10 @@ impl WebSocketService {
     ) -> Result<ConnectCommon, &str> {
         let ws = WebSocket::new(url);
         if ws.is_err() {
-            return Err("Failed to created websocket with given URL");
+            return Err("Failed to open a WebSocket connection at the given URL.");
         }
 
-        let ws = ws.map_err(|_| "failed to build websocket")?;
+        let ws = ws.map_err(|_| "Failed to build WebSocket")?;
         cfg_match! {
             feature = "std_web" => ws.set_binary_type(SocketBinaryType::ArrayBuffer),
             feature = "web_sys" => ws.set_binary_type(BinaryType::Arraybuffer),
@@ -300,7 +300,7 @@ fn process_both<OUT: 'static>(
 }
 
 impl WebSocketTask {
-    /// Sends data to a websocket connection.
+    /// Sends data to a WebSocket connection.
     pub fn send<IN>(&mut self, data: IN)
     where
         IN: Into<Text>,
@@ -317,7 +317,7 @@ impl WebSocketTask {
         }
     }
 
-    /// Sends binary data to a websocket connection.
+    /// Sends binary data to a WebSocket connection.
     pub fn send_binary<IN>(&mut self, data: IN)
     where
         IN: Into<Binary>,

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -186,20 +186,18 @@ impl WebSocketService {
         let ws = ws.map_err(|ws_error| {
             #[cfg(feature = "web_sys")]
             {
-                Err(WebSocketError::CreationError(
+                WebSocketError::CreationError(
                     ws_error
                         .clone()
                         .unchecked_into::<js_sys::Error>()
                         .to_string()
                         .as_string()
                         .unwrap(),
-                ));
+                )
             }
             #[cfg(feature = "std_web")]
             {
-                Err(WebSocketError::CreationError(
-                    "Error opening a WebSocket connection.".to_string(),
-                ));
+                WebSocketError::CreationError("Error opening a WebSocket connection.".to_string())
             }
         })?;
 

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -82,8 +82,8 @@ impl WebSocketService {
         Self {}
     }
 
-    /// Connects to a server through a WebSocket connection. Needs two functions to generate
-    /// data and notification messages.
+    /// Connects to a server through a WebSocket connection. Needs two callbacks; one is passed
+    /// data, the other is passed updates about the WebSocket's status.
     pub fn connect<OUT: 'static>(
         &mut self,
         url: &str,

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -183,26 +183,21 @@ impl WebSocketService {
     ) -> Result<ConnectCommon, WebSocketError> {
         let ws = WebSocket::new(url);
 
-        let ws = ws.map_err(
-            |#[cfg(feature = "std_web")] _, #[cfg(feature = "web_sys")] ws_error| {
-                #[cfg(feature = "web_sys")]
-                {
-                    WebSocketError::CreationError(
-                        ws_error
-                            .unchecked_into::<js_sys::Error>()
-                            .to_string()
-                            .as_string()
-                            .unwrap(),
-                    )
-                }
-                #[cfg(feature = "std_web")]
-                {
-                    WebSocketError::CreationError(
-                        "Error opening a WebSocket connection.".to_string(),
-                    )
-                }
-            },
-        )?;
+        #[cfg(feature = "std_web")]
+        let ws = ws.map_err(|_| {
+            WebSocketError::CreationError("Error opening a WebSocket connection.".to_string())
+        })?;
+
+        #[cfg(feature = "web_sys")]
+        let ws = ws.map_err(|ws_error| {
+            WebSocketError::CreationError(
+                ws_error
+                    .unchecked_into::<js_sys::Error>()
+                    .to_string()
+                    .as_string()
+                    .unwrap(),
+            )
+        })?;
 
         cfg_match! {
             feature = "std_web" => ws.set_binary_type(SocketBinaryType::ArrayBuffer),

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -197,13 +197,10 @@ impl WebSocketService {
         }
         #[cfg(feature = "std_web")]
         {
-            if let Err(ws_error) = &ws {
-                return Err(match ws_error {
-                    SyntaxError => WebSocketError::CreationError("Syntax error".to_string()),
-                    CreationError::SecurityError => {
-                        WebSocketError::CreationError("Security error".to_string())
-                    }
-                });
+            if ws.is_err() {
+                return Err(WebSocketError::CreationError(
+                    "Error opening a WebSocket connection.".to_string(),
+                ));
             };
         }
 
@@ -446,7 +443,7 @@ mod tests {
             if let WebSocketError::CreationError(some_error) = task_err {
                 assert_eq!(
                     some_error,
-                    "SyntaxError: An invalid or illegal string was specified"
+                    "SyntaxError: The string did not match the expected pattern."
                 )
             }
         }

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -438,6 +438,7 @@ mod tests {
         let cb_future = CallbackFuture::<Json<Result<Message, anyhow::Error>>>::default();
         let callback = cb_future.clone().into();
         let mut ws = WebSocketService::new();
+        let status_future = CallbackFuture::<WebSocketStatus>::default();
         let notification: Callback<_> = status_future.clone().into();
         let task = ws.connect_text(url, callback, notification);
         assert!(task.is_err());

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -183,21 +183,21 @@ impl WebSocketService {
     ) -> Result<ConnectCommon, WebSocketError> {
         let ws = WebSocket::new(url);
 
-        #[cfg(feature = "std_web")]
-        let ws = ws.map_err(|_| {
-            WebSocketError::CreationError("Error opening a WebSocket connection.".to_string())
-        })?;
-
         #[cfg(feature = "web_sys")]
-        let ws = ws.map_err(|ws_error| {
-            WebSocketError::CreationError(
-                ws_error
-                    .unchecked_into::<js_sys::Error>()
-                    .to_string()
-                    .as_string()
-                    .unwrap(),
-            )
-        })?;
+        let ws = ws.map_err(
+            #[cfg(feature = "web_sys")]
+            |ws_error| {
+                WebSocketError::CreationError(
+                    ws_error
+                        .unchecked_into::<js_sys::Error>()
+                        .to_string()
+                        .as_string()
+                        .unwrap(),
+                )
+            },
+            #[cfg(feature = "std_web")]
+            |_| WebSocketError::CreationError("Error opening a WebSocket connection.".to_string()),
+        )?;
 
         cfg_match! {
             feature = "std_web" => ws.set_binary_type(SocketBinaryType::ArrayBuffer),

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -443,7 +443,7 @@ mod tests {
             if let WebSocketError::CreationError(some_error) = task_err {
                 assert_eq!(
                     some_error,
-                    "SyntaxError: The string did not match the expected pattern."
+                    "SyntaxError: An invalid or illegal string was specified"
                 )
             }
         }

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -189,7 +189,6 @@ impl WebSocketService {
                 {
                     WebSocketError::CreationError(
                         ws_error
-                            .clone()
                             .unchecked_into::<js_sys::Error>()
                             .to_string()
                             .as_string()


### PR DESCRIPTION
#### Description

Use `thiserror` to buble up error messages from the WebSocket.

Fixes #1243 and fixes #1240 

#### Checklist:

- [x] I have ran `./ci/run_stable_checks.sh`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
