### PR TITLE
Split update and render operations into seprate tasks

### DIFF
--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -16,7 +16,9 @@ pub trait Hook {
     fn tear_down(&mut self) {}
 }
 
-type ProcessMessage = Rc<dyn Fn(Box<dyn FnOnce() -> bool>)>;
+type Msg = Box<dyn FnOnce() -> bool>;
+type ProcessMessage = Rc<dyn Fn(Msg, bool)>;
+
 struct HookState {
     counter: usize,
     scope: AnyScope,
@@ -30,10 +32,25 @@ pub trait FunctionProvider {
     fn run(props: &Self::TProps) -> Html;
 }
 
-pub struct FunctionComponent<T: FunctionProvider> {
+#[derive(Clone, Default)]
+struct MsgQueue(Rc<RefCell<Vec<Msg>>>);
+
+impl MsgQueue {
+    fn push(&self, msg: Msg) {
+        self.0.borrow_mut().push(msg);
+    }
+
+    fn drain(&self) -> Vec<Msg> {
+        self.0.borrow_mut().drain(..).collect()
+    }
+}
+
+pub struct FunctionComponent<T: FunctionProvider + 'static> {
     _never: std::marker::PhantomData<T>,
     props: T::TProps,
+    link: ComponentLink<Self>,
     hook_state: RefCell<Option<HookState>>,
+    message_queue: MsgQueue,
 }
 
 impl<T> FunctionComponent<T>
@@ -62,16 +79,31 @@ where
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
         let scope = AnyScope::from(link.clone());
+        let message_queue = MsgQueue::default();
         FunctionComponent {
             _never: std::marker::PhantomData::default(),
             props,
+            link: link.clone(),
+            message_queue: message_queue.clone(),
             hook_state: RefCell::new(Some(HookState {
                 counter: 0,
                 scope,
-                process_message: Rc::new(move |msg| link.send_message(msg)),
+                process_message: Rc::new(move |msg, post_render| {
+                    if post_render {
+                        message_queue.push(msg);
+                    } else {
+                        link.send_message(msg);
+                    }
+                }),
                 hooks: vec![],
                 destroy_listeners: vec![],
             })),
+        }
+    }
+
+    fn rendered(&mut self, _first_render: bool) {
+        for msg in self.message_queue.drain() {
+            self.link.send_message(msg);
         }
     }
 
@@ -129,7 +161,7 @@ where
 
     use_hook(
         |state: &mut UseRefState<T>, pretrigger_change_acceptor| {
-            let _ignored = || pretrigger_change_acceptor(|_| false); // we need it to be a specific closure type, even if we never use it
+            let _ignored = || pretrigger_change_acceptor(|_| false, true); // we need it to be a specific closure type, even if we never use it
             state.0.clone()
         },
         move || UseRefState(Rc::new(RefCell::new(initial_value()))),
@@ -175,6 +207,7 @@ where
                             ));
                             true
                         },
+                        false, // run pre render
                     );
                 }),
             )
@@ -200,10 +233,13 @@ where
             (
                 current,
                 Box::new(move |o: T| {
-                    hook_update(|state: &mut UseStateState<T>| {
-                        state.current = Rc::new(o);
-                        true
-                    });
+                    hook_update(
+                        |state: &mut UseStateState<T>| {
+                            state.current = Rc::new(o);
+                            true
+                        },
+                        false, // run pre render
+                    )
                 }),
             )
         },
@@ -231,19 +267,20 @@ where
     }
     use_hook(
         |_: &mut UseEffectState<Destructor>, hook_update| {
-            move || {
-                hook_update(move |state: &mut UseEffectState<Destructor>| {
+            hook_update(
+                move |state: &mut UseEffectState<Destructor>| {
                     if let Some(de) = state.destructor.take() {
                         de();
                     }
                     let new_destructor = callback();
                     state.destructor.replace(Box::new(new_destructor));
                     false
-                });
-            }
+                },
+                true, // run post render
+            )
         },
         || UseEffectState { destructor: None },
-    )();
+    );
 }
 
 pub fn use_effect_with_deps<F, Destructor, Dependents>(callback: F, deps: Dependents)
@@ -271,22 +308,25 @@ where
             let mut should_update = *state.deps != *deps;
 
             move || {
-                hook_update(move |state: &mut UseEffectState<Dependents, Destructor>| {
-                    if should_update {
-                        if let Some(de) = state.destructor.take() {
-                            de();
+                hook_update(
+                    move |state: &mut UseEffectState<Dependents, Destructor>| {
+                        if should_update {
+                            if let Some(de) = state.destructor.take() {
+                                de();
+                            }
+                            let new_destructor = callback(deps.borrow());
+                            state.deps = deps;
+                            state.destructor.replace(Box::new(new_destructor));
+                        } else if state.destructor.is_none() {
+                            should_update = true;
+                            state
+                                .destructor
+                                .replace(Box::new(callback(state.deps.borrow())));
                         }
-                        let new_destructor = callback(deps.borrow());
-                        state.deps = deps;
-                        state.destructor.replace(Box::new(new_destructor));
-                    } else if state.destructor.is_none() {
-                        should_update = true;
-                        state
-                            .destructor
-                            .replace(Box::new(callback(state.deps.borrow())));
-                    }
-                    false
-                })
+                        false
+                    },
+                    true, // run post render
+                )
             }
         },
         || UseEffectState {
@@ -301,7 +341,7 @@ pub fn use_hook<InternalHookState, HookRunner, R, InitialStateProvider, Pretrigg
     initial_state_producer: InitialStateProvider,
 ) -> R
 where
-    HookRunner: FnOnce(&mut InternalHookState, Box<dyn Fn(PretriggerChange)>) -> R,
+    HookRunner: FnOnce(&mut InternalHookState, Box<dyn Fn(PretriggerChange, bool)>) -> R,
     InternalHookState: Hook + 'static,
     InitialStateProvider: FnOnce() -> InternalHookState,
     PretriggerChange: FnOnce(&mut InternalHookState) -> bool,
@@ -334,16 +374,19 @@ where
 
     let trigger = {
         let hook = hook.clone();
-        Box::new(move |pretrigger_change: PretriggerChange| {
+        Box::new(move |pretrigger_change: PretriggerChange, post_render| {
             let hook = hook.clone();
-            process_message(Box::new(move || {
-                let mut hook = hook.borrow_mut();
-                let hook = hook.downcast_mut::<InternalHookState>();
-                let hook = hook.expect(
-                    "Incompatible hook type. Hooks must always be called in the same order",
-                );
-                pretrigger_change(hook)
-            }));
+            process_message(
+                Box::new(move || {
+                    let mut hook = hook.borrow_mut();
+                    let hook = hook.downcast_mut::<InternalHookState>();
+                    let hook = hook.expect(
+                        "Incompatible hook type. Hooks must always be called in the same order",
+                    );
+                    pretrigger_change(hook)
+                }),
+                post_render,
+            );
         })
     };
     let mut hook = hook.borrow_mut();

--- a/yew-functional/src/use_context_hook.rs
+++ b/yew-functional/src/use_context_hook.rs
@@ -131,10 +131,13 @@ pub fn use_context<T: 'static + Clone>() -> Option<Rc<T>> {
     use_hook(
         |state: &mut UseContextState<T>, hook_update| {
             state.callback = Some(Rc::new(Box::new(move |ctx: Rc<T>| {
-                hook_update(|state: &mut UseContextState<T>| {
-                    state.current_context = Some(ctx);
-                    true
-                });
+                hook_update(
+                    |state: &mut UseContextState<T>| {
+                        state.current_context = Some(ctx);
+                        true
+                    },
+                    false,
+                ); // run pre render
             })));
             let weak_cb = Rc::downgrade(state.callback.as_ref().unwrap());
             with_provider_component(&state.provider_scope, |comp| {

--- a/yew-functional/src/use_context_hook.rs
+++ b/yew-functional/src/use_context_hook.rs
@@ -129,15 +129,15 @@ pub fn use_context<T: 'static + Clone>() -> Option<Rc<T>> {
         }
     }
     use_hook(
-        |state: &mut UseContextState<T>, hook_update| {
+        |state: &mut UseContextState<T>, hook_callback| {
             state.callback = Some(Rc::new(Box::new(move |ctx: Rc<T>| {
-                hook_update(
+                hook_callback(
                     |state: &mut UseContextState<T>| {
                         state.current_context = Some(ctx);
                         true
                     },
-                    false,
-                ); // run pre render
+                    false, // run pre render
+                );
             })));
             let weak_cb = Rc::downgrade(state.callback.as_ref().unwrap());
             with_provider_component(&state.provider_scope, |comp| {

--- a/yew-functional/tests/use_context_hook.rs
+++ b/yew-functional/tests/use_context_hook.rs
@@ -283,12 +283,7 @@ fn use_context_update_works() {
     let app: App<TestComponent> = yew::App::new();
     app.mount(yew::utils::document().get_element_by_id("output").unwrap());
 
-    // 1 initial render + 3 update steps
-    assert_eq!(obtain_result("test-0"), "total: 4");
-
-    // 1 initial + 2 context updates
-    assert_eq!(obtain_result("test-1"), "current: hello world!, total: 3");
-
-    // 1 initial + 1 context update + 1 magic update + 1 context update
-    assert_eq!(obtain_result("test-2"), "current: hello world!, total: 4");
+    assert_eq!(obtain_result("test-0"), "total: 1");
+    assert_eq!(obtain_result("test-1"), "current: hello world!, total: 1");
+    assert_eq!(obtain_result("test-2"), "current: hello world!, total: 1");
 }

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -422,6 +422,7 @@ mod tests {
         lifecycle: Rc<RefCell<Vec<String>>>,
         create_message: Option<bool>,
         view_message: RefCell<Option<bool>>,
+        rendered_message: RefCell<Option<bool>>,
     }
 
     struct Comp {
@@ -442,6 +443,9 @@ mod tests {
         }
 
         fn rendered(&mut self, first_render: bool) {
+            if let Some(msg) = self.props.rendered_message.borrow_mut().take() {
+                self.link.send_message(msg);
+            }
             self.props
                 .lifecycle
                 .borrow_mut()
@@ -544,6 +548,36 @@ mod tests {
                 "view".to_string(),
                 "update(false)".to_string(),
                 "rendered(true)".to_string(),
+            ],
+        );
+
+        test_lifecycle(
+            Props {
+                lifecycle: lifecycle.clone(),
+                rendered_message: RefCell::new(Some(false)),
+                ..Props::default()
+            },
+            &vec![
+                "create".to_string(),
+                "view".to_string(),
+                "rendered(true)".to_string(),
+                "update(false)".to_string(),
+            ],
+        );
+
+        test_lifecycle(
+            Props {
+                lifecycle: lifecycle.clone(),
+                rendered_message: RefCell::new(Some(true)),
+                ..Props::default()
+            },
+            &vec![
+                "create".to_string(),
+                "view".to_string(),
+                "rendered(true)".to_string(),
+                "update(true)".to_string(),
+                "view".to_string(),
+                "rendered(false)".to_string(),
             ],
         );
     }

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -144,17 +144,17 @@ impl<COMP: Component> Scope<COMP> {
             update,
         };
         scheduler().push_comp(ComponentRunnableType::Update, Box::new(update));
-        self.rendered(first_update);
+        self.render(first_update);
     }
 
-    /// Schedules a task to call the rendered method on a component
-    pub(crate) fn rendered(&self, first_render: bool) {
+    /// Schedules a task to render the component and call its rendered method
+    pub(crate) fn render(&self, first_render: bool) {
         let state = self.state.clone();
-        let rendered = RenderedComponent {
+        let rendered = RenderComponent {
             state,
             first_render,
         };
-        scheduler().push_comp(ComponentRunnableType::Rendered, Box::new(rendered));
+        scheduler().push_comp(ComponentRunnableType::Render, Box::new(rendered));
     }
 
     /// Schedules a task to destroy a component
@@ -244,9 +244,6 @@ impl<COMP: Component> Scope<COMP> {
     }
 }
 
-type Dirty = bool;
-const DIRTY: Dirty = true;
-
 struct ComponentState<COMP: Component> {
     parent: Element,
     next_sibling: NodeRef,
@@ -254,7 +251,7 @@ struct ComponentState<COMP: Component> {
     scope: Scope<COMP>,
     component: Box<COMP>,
     last_root: Option<VNode>,
-    render_status: Option<Dirty>,
+    new_root: Option<VNode>,
 }
 
 impl<COMP: Component> ComponentState<COMP> {
@@ -276,7 +273,7 @@ impl<COMP: Component> ComponentState<COMP> {
             scope,
             component,
             last_root: ancestor,
-            render_status: None,
+            new_root: None,
         }
     }
 }
@@ -348,21 +345,14 @@ where
             };
 
             if should_update {
-                state.render_status = state.render_status.map(|_| DIRTY);
-                let mut root = state.component.render();
-                let last_root = state.last_root.take();
-                let parent_scope = state.scope.clone().into();
-                let next_sibling = state.next_sibling.clone();
-                let node = root.apply(&parent_scope, &state.parent, next_sibling, last_root);
-                state.node_ref.link(node);
-                state.last_root = Some(root);
+                state.new_root = Some(state.component.render());
             };
         }
     }
 }
 
-/// A `Runnable` task which calls the `rendered()` method on a `Component`.
-struct RenderedComponent<COMP>
+/// A `Runnable` task which renders a `Component` and calls its `rendered()` method.
+struct RenderComponent<COMP>
 where
     COMP: Component,
 {
@@ -370,22 +360,26 @@ where
     first_render: bool,
 }
 
-impl<COMP> Runnable for RenderedComponent<COMP>
+impl<COMP> Runnable for RenderComponent<COMP>
 where
     COMP: Component,
 {
     fn run(self: Box<Self>) {
         if let Some(mut state) = self.state.borrow_mut().as_mut() {
-            if self.first_render && state.render_status.is_some() {
+            // Skip render if we haven't seen the "first render" yet
+            if !self.first_render && state.last_root.is_none() {
                 return;
             }
 
-            if !self.first_render && state.render_status != Some(DIRTY) {
-                return;
+            if let Some(mut new_root) = state.new_root.take() {
+                let last_root = state.last_root.take();
+                let parent_scope = state.scope.clone().into();
+                let next_sibling = state.next_sibling.clone();
+                let node = new_root.apply(&parent_scope, &state.parent, next_sibling, last_root);
+                state.node_ref.link(node);
+                state.last_root = Some(new_root);
+                state.component.rendered(self.first_render);
             }
-
-            state.render_status = Some(!DIRTY);
-            state.component.rendered(self.first_render);
         }
     }
 }
@@ -423,14 +417,16 @@ mod tests {
     #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
 
-    #[derive(Clone, Properties)]
+    #[derive(Clone, Properties, Default)]
     struct Props {
         lifecycle: Rc<RefCell<Vec<String>>>,
         create_message: Option<bool>,
+        view_message: RefCell<Option<bool>>,
     }
 
     struct Comp {
         props: Props,
+        link: ComponentLink<Self>,
     }
 
     impl Component for Comp {
@@ -442,7 +438,7 @@ mod tests {
             if let Some(msg) = props.create_message {
                 link.send_message(msg);
             }
-            Comp { props }
+            Comp { props, link }
         }
 
         fn rendered(&mut self, first_render: bool) {
@@ -466,6 +462,9 @@ mod tests {
         }
 
         fn view(&self) -> Html {
+            if let Some(msg) = self.props.view_message.borrow_mut().take() {
+                self.link.send_message(msg);
+            }
             self.props.lifecycle.borrow_mut().push("view".into());
             html! {}
         }
@@ -477,75 +476,75 @@ mod tests {
         }
     }
 
-    #[test]
-    fn mount() {
+    fn test_lifecycle(props: Props, expected: &[String]) {
         let document = crate::utils::document();
-        let lifecycle: Rc<RefCell<Vec<String>>> = Rc::default();
-        let props = Props {
-            lifecycle: lifecycle.clone(),
-            create_message: None,
-        };
-
         let scope = Scope::<Comp>::new(None);
         let el = document.create_element("div").unwrap();
+        let lifecycle = props.lifecycle.clone();
+
+        lifecycle.borrow_mut().clear();
         scope.mount_in_place(el, NodeRef::default(), None, NodeRef::default(), props);
 
-        assert_eq!(
-            lifecycle.borrow_mut().deref(),
-            &vec![
-                "create".to_string(),
-                "view".to_string(),
-                "rendered(true)".to_string()
-            ]
-        );
+        assert_eq!(&lifecycle.borrow_mut().deref()[..], expected);
     }
 
     #[test]
-    fn mount_with_create_message() {
-        let document = crate::utils::document();
+    fn lifecyle_tests() {
         let lifecycle: Rc<RefCell<Vec<String>>> = Rc::default();
-        let props = Props {
-            lifecycle: lifecycle.clone(),
-            create_message: Some(false),
-        };
 
-        let scope = Scope::<Comp>::new(None);
-        let el = document.create_element("div").unwrap();
-        scope.mount_in_place(el, NodeRef::default(), None, NodeRef::default(), props);
+        test_lifecycle(
+            Props {
+                lifecycle: lifecycle.clone(),
+                ..Props::default()
+            },
+            &vec![
+                "create".to_string(),
+                "view".to_string(),
+                "rendered(true)".to_string(),
+            ],
+        );
 
-        assert_eq!(
-            lifecycle.borrow_mut().deref(),
+        test_lifecycle(
+            Props {
+                lifecycle: lifecycle.clone(),
+                create_message: Some(false),
+                ..Props::default()
+            },
             &vec![
                 "create".to_string(),
                 "update(false)".to_string(),
                 "view".to_string(),
-                "rendered(true)".to_string()
-            ]
+                "rendered(true)".to_string(),
+            ],
         );
-    }
 
-    #[test]
-    fn mount_with_create_render_message() {
-        let document = crate::utils::document();
-        let lifecycle: Rc<RefCell<Vec<String>>> = Rc::default();
-        let props = Props {
-            lifecycle: lifecycle.clone(),
-            create_message: Some(true),
-        };
-
-        let scope = Scope::<Comp>::new(None);
-        let el = document.create_element("div").unwrap();
-        scope.mount_in_place(el, NodeRef::default(), None, NodeRef::default(), props);
-
-        assert_eq!(
-            lifecycle.borrow_mut().deref(),
+        test_lifecycle(
+            Props {
+                lifecycle: lifecycle.clone(),
+                view_message: RefCell::new(Some(true)),
+                ..Props::default()
+            },
             &vec![
                 "create".to_string(),
+                "view".to_string(),
                 "update(true)".to_string(),
                 "view".to_string(),
+                "rendered(true)".to_string(),
+            ],
+        );
+
+        test_lifecycle(
+            Props {
+                lifecycle: lifecycle.clone(),
+                view_message: RefCell::new(Some(false)),
+                ..Props::default()
+            },
+            &vec![
+                "create".to_string(),
                 "view".to_string(),
-                "rendered(true)".to_string()
-            ]
+                "update(false)".to_string(),
+                "rendered(true)".to_string(),
+            ],
         );
     }
 }

--- a/yew/src/scheduler.rs
+++ b/yew/src/scheduler.rs
@@ -34,7 +34,7 @@ pub(crate) enum ComponentRunnableType {
     Destroy,
     Create,
     Update,
-    Rendered,
+    Render,
 }
 
 #[derive(Clone)]
@@ -45,7 +45,7 @@ struct ComponentScheduler {
     update: Shared<VecDeque<Box<dyn Runnable>>>,
 
     // Stack
-    rendered: Shared<Vec<Box<dyn Runnable>>>,
+    render: Shared<Vec<Box<dyn Runnable>>>,
 }
 
 impl ComponentScheduler {
@@ -54,7 +54,7 @@ impl ComponentScheduler {
             destroy: Rc::new(RefCell::new(VecDeque::new())),
             create: Rc::new(RefCell::new(VecDeque::new())),
             update: Rc::new(RefCell::new(VecDeque::new())),
-            rendered: Rc::new(RefCell::new(Vec::new())),
+            render: Rc::new(RefCell::new(Vec::new())),
         }
     }
 
@@ -62,7 +62,7 @@ impl ComponentScheduler {
         None.or_else(|| self.destroy.borrow_mut().pop_front())
             .or_else(|| self.create.borrow_mut().pop_front())
             .or_else(|| self.update.borrow_mut().pop_front())
-            .or_else(|| self.rendered.borrow_mut().pop())
+            .or_else(|| self.render.borrow_mut().pop())
     }
 }
 
@@ -82,7 +82,7 @@ impl Scheduler {
             }
             ComponentRunnableType::Create => self.component.create.borrow_mut().push_back(runnable),
             ComponentRunnableType::Update => self.component.update.borrow_mut().push_back(runnable),
-            ComponentRunnableType::Rendered => self.component.rendered.borrow_mut().push(runnable),
+            ComponentRunnableType::Render => self.component.render.borrow_mut().push(runnable),
         };
         self.start();
     }


### PR DESCRIPTION
#### Description
DOM updates are much more efficient when batched together but Yew does not do so when rendering components. This change moves the DOM updates to the "render" task (formerly "rendered"). This allows the scheduler to render to the DOM in quick succession since the virtual dom has already been created.

Related to https://github.com/yewstack/yew/issues/1153

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [x] I have added tests – if this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again). If this is a feature, my tests prove that the feature works.
