### PR TITLE
add requirement: `wasm-bindgen-cli`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ Note: [Visual Studio Code](https://code.visualstudio.com/) has an extension call
 
 ## Requirements
 
-The default way to build the examples is by using `wasm-bindgen` (this is automatically installed if you've installed `wasm-pack`). If they aren't installed, these tools can be installed by using `cargo` (`cargo install wasm-pack`).
+The default way to build the examples is by using `wasm-bindgen` (this is automatically installed if you've installed `wasm-pack`). If they aren't installed, these tools can be installed by using `cargo` (`cargo install wasm-pack` and `cargo install wasm-bindgen-cli`).
 
 Installation guides: [Rust](https://www.rust-lang.org/learn/get-started) and [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
 


### PR DESCRIPTION
used in `./build.sh`

#### Description

add installation instruction for missing build dependency

Fixes
```
~/.../examples$ ./build.sh minimal
[ Building: minimal using wasm-bindgen ]
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
./build.sh: line 43: wasm-bindgen: command not found
[FAIL] Command: "wasm-bindgen --target web --no-typescript --out-dir $SRCDIR/static/ --out-name wasm $TARGET_DIR/$EXAMPLE.wasm" exited with exit code: 127
```

