### PR TITLE
Fix VComp NodeRef self linking issue

### DIFF
--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -515,3 +515,26 @@ impl ToString for Href {
         self.link.to_owned()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::document;
+
+    #[cfg(feature = "wasm_test")]
+    use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+    #[cfg(feature = "wasm_test")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[test]
+    fn self_linking_node_ref() {
+        let node: Node = document().create_text_node("test node").into();
+        let node_ref = NodeRef::new(node.clone());
+        let node_ref_clone = node_ref.clone();
+
+        node_ref.link(node_ref_clone);
+
+        assert_eq!(node, node_ref.get().unwrap());
+    }
+}

--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -430,13 +430,21 @@ impl NodeRef {
 
     /// Place a Node in a reference for later use
     pub(crate) fn set(&self, node: Option<Node>) {
-        self.0.borrow_mut().node = node;
+        let mut this = self.0.borrow_mut();
+        this.node = node;
+        this.link = None;
     }
 
     /// Link a downstream `NodeRef`
     pub(crate) fn link(&self, node_ref: Self) {
-        self.0.borrow_mut().node = None;
-        self.0.borrow_mut().link = Some(node_ref);
+        // Don't link to self
+        if node_ref.0.as_ptr() == self.0.as_ptr() {
+            return;
+        }
+
+        let mut this = self.0.borrow_mut();
+        this.node = None;
+        this.link = Some(node_ref);
     }
 }
 


### PR DESCRIPTION
#### Description
Prevents a `NodeRef` from linking to itself, causing infinite recursion.

Fixes https://github.com/yewstack/yew/issues/1158

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [x] I have added tests – if this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again). If this is a feature, my tests prove that the feature works.

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
