### PR TITLE
Fix unreliable CI fetch tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,16 @@ rust:
   - stable
   - beta
 
+services:
+  - docker
+
 matrix:
   allow_failures:
     - rust: beta
   fast_finish: true
+
+before_install:
+  - docker run -d -p 8000:80 kennethreitz/httpbin@sha256:599fe5e5073102dbb0ee3dbb65f049dab44fa9fc251f6835c9990f8fb196a72b
 
 install:
   - nvm install 9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ although more driver support may be added! You can download these at:
 * chromedriver - http://chromedriver.chromium.org/downloads
 * safaridriver - should be preinstalled on OSX
 
-Lastly, the fetch tests require a local httpbin server running on port `8000`. We recommend running with Docker:
+Lastly, the fetch tests require a local httpbin server running on port `8000`. We recommend running this with Docker:
 
 ```bash
 docker run -p 8000:80 kennethreitz/httpbin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,12 @@ although more driver support may be added! You can download these at:
 * chromedriver - http://chromedriver.chromium.org/downloads
 * safaridriver - should be preinstalled on OSX
 
+Lastly, the fetch tests require a local httpbin server running on port `8000`. We recommend running with Docker:
+
+```bash
+docker run -p 8000:80 kennethreitz/httpbin
+```
+
 ##### Macro Tests
 When adding or updating tests, please make sure you have updated the appropriate `stderr` file, which you can find [here](https://github.com/yewstack/yew/tree/master/yew-macro/tests/macro) for the `html!` macro. These files ensure that macro compilation errors are correct and easy to understand.
 

--- a/yew/src/services/fetch.rs
+++ b/yew/src/services/fetch.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     async fn fetch_referrer_default() {
-        let request = Request::get("https://httpbin.org/get")
+        let request = Request::get("http://localhost:8000/get")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions::default();
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     async fn fetch_referrer_same_origin_url() {
-        let request = Request::get("https://httpbin.org/get")
+        let request = Request::get("http://localhost:8000/get")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions {
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     async fn fetch_referrer_about_client() {
-        let request = Request::get("https://httpbin.org/get")
+        let request = Request::get("http://localhost:8000/get")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions {
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     async fn fetch_referrer_empty() {
-        let request = Request::get("https://httpbin.org/get")
+        let request = Request::get("http://localhost:8000/get")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions {
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     async fn fetch_redirect_default() {
-        let request = Request::get("https://httpbin.org/relative-redirect/1")
+        let request = Request::get("http://localhost:8000/relative-redirect/1")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions::default();
@@ -143,7 +143,7 @@ mod tests {
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(http_bin)) = resp.body() {
-            assert_eq!(http_bin.url, String::from("https://httpbin.org/get"));
+            assert_eq!(http_bin.url, String::from("http://localhost:8000/get"));
         } else {
             assert!(false, "unexpected resp: {:#?}", resp);
         }
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     async fn fetch_redirect_follow() {
-        let request = Request::get("https://httpbin.org/relative-redirect/1")
+        let request = Request::get("http://localhost:8000/relative-redirect/1")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions {
@@ -164,7 +164,7 @@ mod tests {
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
         if let Json(Ok(http_bin)) = resp.body() {
-            assert_eq!(http_bin.url, String::from("https://httpbin.org/get"));
+            assert_eq!(http_bin.url, String::from("http://localhost:8000/get"));
         } else {
             assert!(false, "unexpected resp: {:#?}", resp);
         }
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     async fn fetch_redirect_error() {
-        let request = Request::get("https://httpbin.org/relative-redirect/1")
+        let request = Request::get("http://localhost:8000/relative-redirect/1")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions {
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     async fn fetch_redirect_manual() {
-        let request = Request::get("https://httpbin.org/relative-redirect/1")
+        let request = Request::get("http://localhost:8000/relative-redirect/1")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions {
@@ -208,7 +208,7 @@ mod tests {
     async fn fetch_integrity() {
         let resource = "Yew SRI Test";
         let request = Request::get(format!(
-            "https://httpbin.org/base64/{}",
+            "http://localhost:8000/base64/{}",
             base64::encode_config(resource, base64::URL_SAFE)
         ))
         .body(Nothing)
@@ -229,7 +229,7 @@ mod tests {
     async fn fetch_integrity_fail() {
         let resource = "Yew SRI Test";
         let request = Request::get(format!(
-            "https://httpbin.org/base64/{}",
+            "http://localhost:8000/base64/{}",
             base64::encode_config(resource, base64::URL_SAFE)
         ))
         .body(Nothing)
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     async fn fetch_referrer_policy_no_referrer() {
-        let request = Request::get("https://httpbin.org/headers")
+        let request = Request::get("http://localhost:8000/headers")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions {
@@ -285,7 +285,7 @@ mod tests {
 
     #[test]
     async fn fetch_referrer_policy_origin() {
-        let request = Request::get("https://httpbin.org/headers")
+        let request = Request::get("http://localhost:8000/headers")
             .body(Nothing)
             .unwrap();
         let options = FetchOptions {


### PR DESCRIPTION
#### Description
Fetch tests have been unreliable lately

Fixes https://github.com/yewstack/yew/issues/1316

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [x] I have added tests

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
