### PR TITLE
Refactor VComp to allow access to root vnode

### DIFF
--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -7,8 +7,8 @@ mod listener;
 mod scope;
 
 pub use listener::*;
-pub(crate) use scope::ComponentUpdate;
 pub use scope::{AnyScope, Scope};
+pub(crate) use scope::{ComponentUpdate, Scoped};
 
 use crate::callback::Callback;
 use crate::virtual_dom::{VChild, VNode};

--- a/yew/src/virtual_dom/vnode.rs
+++ b/yew/src/virtual_dom/vnode.rs
@@ -39,27 +39,21 @@ impl VNode {
             VNode::VTag(vtag) => vtag
                 .reference
                 .as_ref()
-                .expect("VTag should always wrap a node")
+                .expect("VTag is not mounted")
                 .clone()
                 .into(),
             VNode::VText(vtext) => {
-                let text_node = vtext
-                    .reference
-                    .as_ref()
-                    .expect("VText should always wrap a node");
+                let text_node = vtext.reference.as_ref().expect("VText is not mounted");
                 cfg_match! {
                     feature = "std_web" => text_node.as_node().clone(),
                     feature = "web_sys" => text_node.clone().into(),
                 }
             }
-            VNode::VComp(vcomp) => vcomp
-                .node_ref
-                .get()
-                .expect("VComp should always wrap a node"),
+            VNode::VComp(vcomp) => vcomp.node_ref.get().expect("VComp is not mounted"),
             VNode::VList(vlist) => vlist
                 .children
                 .get(0)
-                .expect("VList should always always have at least one child")
+                .expect("VList is not mounted")
                 .first_node(),
             VNode::VRef(node) => node.clone(),
         }


### PR DESCRIPTION
#### Description
It was not possible to access the root vnode of a mounted component node due to the `AnyScope` type being a black box. This change introduces a new `Scoped` trait which allows access to the inner mounted state.

By removing the closure based approach for mounting components, I was able to avoid cloning properties on mount as well.

Fixes # (issue)

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
