### PR TITLE
Add `prompt` function to the dialogue service.

### DIFF
--- a/yew/src/services/dialog.rs
+++ b/yew/src/services/dialog.rs
@@ -1,5 +1,8 @@
 //! This module contains the implementation of a service
 //! to show alerts and confirm dialogs in a browser.
+//!
+//! If you call these methods repeatably browsers tend to disable these options to give users
+//! a better experience.
 
 use cfg_if::cfg_if;
 use cfg_match::cfg_match;
@@ -53,9 +56,14 @@ impl DialogService {
     /// This method will `panic!` if there is an error in the process of trying to carry out this
     /// operation.
     ///
-    /// Bear in mind that this function is blocking; no other code can be run on the thread while
-    /// the user inputs their message.
-    pub fn prompt(message: &str, default: Option<&str>) -> Option<String> {
+    /// Note that this function is blocking; no other code can be run on the thread while
+    /// the user inputs their message which means that the page will appear to have 'frozen'
+    /// while the user types in their message.
+    pub fn prompt(
+        message: &str,
+        #[cfg(feature = "web_sys")] default: Option<&str>,
+        #[cfg(feature = "std_web")] _: Option<&str>,
+    ) -> Option<String> {
         cfg_if! {
             if #[cfg(feature="web_sys")] {
                 if let Some(default) = default {

--- a/yew/src/services/dialog.rs
+++ b/yew/src/services/dialog.rs
@@ -47,9 +47,10 @@ impl DialogService {
 
     /// Prompts the user to input a message. In most browsers this will open an alert box with
     /// an input field where the user can input a message.
-    ///
-    /// It is possible to supply a default value which will be used if the user does not provide
-    /// a value.
+    #[cfg_attr(
+        feature = "web_sys",
+        doc = "A default value can be supplied which will be returned if the user doesn't input anything."
+    )]
     ///
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt)
     ///
@@ -59,10 +60,21 @@ impl DialogService {
     /// Note that this function is blocking; no other code can be run on the thread while
     /// the user inputs their message which means that the page will appear to have 'frozen'
     /// while the user types in their message.
+    ///
+    #[cfg_attr(
+        feature = "web_sys",
+        doc = "This function will return `None` if the value of `default` is `None` and the user \
+        cancels the operation. (normally a 'cancel' button will be displayed to the user, \
+        clicking which cancels the operation)."
+    )]
+    #[cfg_attr(
+        feature = "std_web",
+        doc = "This function will return `None` if the user cancels the operation (normally a \
+        'cancel' button will be displayed to the user, clicking which cancels the operation)."
+    )]
     pub fn prompt(
         message: &str,
         #[cfg(feature = "web_sys")] default: Option<&str>,
-        #[cfg(feature = "std_web")] _: Option<&str>,
     ) -> Option<String> {
         cfg_if! {
             if #[cfg(feature="web_sys")] {

--- a/yew/src/services/dialog.rs
+++ b/yew/src/services/dialog.rs
@@ -41,4 +41,29 @@ impl DialogService {
             feature = "web_sys" => utils::window().confirm_with_message(message).unwrap(),
         }
     }
+
+    /// Prompts the user to input a message. In most browsers this will open an alert box with
+    /// an input field where the user can input a message.
+    ///
+    /// It is possible to supply a default value which will be used if the user does not provide
+    /// a value.
+    ///
+    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt)
+    ///
+    /// This method will `panic!` if there is an error in the process of trying to carry out this
+    /// operation.
+    ///
+    /// Bear in mind that this function is blocking; no other code can be run on the thread while
+    /// the user inputs their message.
+    pub fn prompt(message: &str, default: Option<&str>) -> Option<String> {
+        cfg_match! {
+            feature = "std_web" => compile_error!("The `prompt` method is not supported for `stdweb`."),
+            feature = "web_sys" => if let Some(default) = default {
+                    utils::window().prompt_with_message_and_default(message, default).expect("Couldn't read input.")
+                }
+                else {
+                    utils::window().prompt_with_message(message).expect("Couldn't read input.")
+                }
+        }
+    }
 }

--- a/yew/src/services/dialog.rs
+++ b/yew/src/services/dialog.rs
@@ -58,12 +58,18 @@ impl DialogService {
     pub fn prompt(message: &str, default: Option<&str>) -> Option<String> {
         cfg_match! {
             feature = "std_web" => compile_error!("The `prompt` method is not supported for `stdweb`."),
-            feature = "web_sys" => if let Some(default) = default {
-                    utils::window().prompt_with_message_and_default(message, default).expect("Couldn't read input.")
-                }
-                else {
-                    utils::window().prompt_with_message(message).expect("Couldn't read input.")
-                }
+            feature = "web_sys" => ({
+                    if let Some(default) = default {
+                        utils::window()
+                               .prompt_with_message_and_default(message, default)
+                               .expect("Couldn't read input.")
+                    }
+                    else {
+                        utils::window()
+                               .prompt_with_message(message)
+                               .expect("Couldn't read input.")
+                    }
+            })
         }
     }
 }

--- a/yew/src/services/fetch/web_sys.rs
+++ b/yew/src/services/fetch/web_sys.rs
@@ -555,7 +555,9 @@ impl WindowOrWorker {
         } else if !global.worker().is_undefined() {
             Self::Worker(global.unchecked_into())
         } else {
-            panic!("Yew's `FetchService` only works when a `window` or `worker` object is available.");
+            panic!(
+                "Yew's `FetchService` only works when a `window` or `worker` object is available."
+            );
         }
     }
 }

--- a/yew/src/services/fetch/web_sys.rs
+++ b/yew/src/services/fetch/web_sys.rs
@@ -164,7 +164,7 @@ pub struct FetchService {}
 
 impl FetchService {
     /// Sends a request to a remote server given a Request object and a callback
-    /// fuction to convert a Response object into a loop's message.
+    /// function to convert a Response object into a loop's message.
     ///
     /// You may use a Request builder to build your request declaratively as on the
     /// following examples:
@@ -183,7 +183,7 @@ impl FetchService {
     ///     .expect("Failed to build request.");
     /// ```
     ///
-    /// The callback function can build a loop message by passing or analizing the
+    /// The callback function can build a loop message by passing or analyzing the
     /// response body and metadata.
     ///
     /// ```
@@ -220,8 +220,8 @@ impl FetchService {
     /// ```
     ///
     /// For a full example, you can specify that the response must be in the JSON format,
-    /// and be a specific serialized data type. If the mesage isn't Json, or isn't the specified
-    /// data type, then you will get a message indicating failure.
+    /// and be a specific serialized data type. If the message isn't JSON, or isn't the specified
+    /// data type, then you will get an error message.
     ///
     /// ```
     ///# use yew::format::{Json, Nothing, Format};
@@ -555,7 +555,7 @@ impl WindowOrWorker {
         } else if !global.worker().is_undefined() {
             Self::Worker(global.unchecked_into())
         } else {
-            panic!("Only supported in a browser or web worker");
+            panic!("Yew's `FetchService` only works when a `window` or `worker` object is available.");
         }
     }
 }

--- a/yew/src/services/mod.rs
+++ b/yew/src/services/mod.rs
@@ -37,8 +37,10 @@ pub use self::websocket::WebSocketService;
 
 use std::time::Duration;
 
-/// An universal task of a service.
-/// The task must be handled when it is cancelled.
+/// A task is an ongoing process which is part of a Yew application.
+///
+/// All tasks must be handled when they are cancelled, which is why the `Drop` trait is required.
+/// Tasks should cancel themselves in their implementation of the `Drop` trait.
 pub trait Task: Drop {
     /// Returns `true` if task is active.
     fn is_active(&self) -> bool;

--- a/yew/src/services/reader/web_sys.rs
+++ b/yew/src/services/reader/web_sys.rs
@@ -19,7 +19,7 @@ impl ReaderService {
 
     /// Reads all bytes from a file and returns them with a callback.
     pub fn read_file(&mut self, file: File, callback: Callback<FileData>) -> Result<ReaderTask> {
-        let file_reader = FileReader::new().map_err(|_| anyhow!("couldn't aquire file reader"))?;
+        let file_reader = FileReader::new().map_err(|_| anyhow!("couldn't acquire file reader"))?;
         let reader = file_reader.clone();
         let name = file.name();
         let callback = move |_event: &Event| {


### PR DESCRIPTION
* Improve the clarity of some doc comments
* Fix a typo in a `map_err`

#### Description

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- ~[ ] I have added tests~ doesn't apply
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
