### PR TITLE
Bring back destroy lifecycle method

### DIFF
--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -136,13 +136,8 @@ where
 
         ret
     }
-}
 
-impl<T> Drop for FunctionComponent<T>
-where
-    T: FunctionProvider,
-{
-    fn drop(&mut self) {
+    fn destroy(&mut self) {
         if let Some(hook_state) = self.hook_state.borrow_mut().deref_mut() {
             for hook in hook_state.destroy_listeners.drain(..) {
                 hook()

--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -122,6 +122,9 @@ pub trait Component: Sized + 'static {
     /// }
     ///# }
     fn rendered(&mut self, _first_render: bool) {}
+
+    /// The `destroy` method is called right before a Component is unmounted.
+    fn destroy(&mut self) {}
 }
 
 /// A type which expected as a result of `view` function implementation.

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -428,7 +428,7 @@ where
 {
     fn run(self: Box<Self>) {
         if let Some(mut state) = self.state.borrow_mut().take() {
-            drop(state.component);
+            state.component.destroy();
             if let Some(last_frame) = &mut state.last_root {
                 last_frame.detach(&state.parent);
             }


### PR DESCRIPTION
This reverts #1211

#### Description
I think that `destroy` will be useful for v2 of components where props are not owned by the component. I'd rather delay this breaking change than release it as part of 0.17