### PR TITLE
Render after each component update

### DIFF
--- a/yew/src/scheduler.rs
+++ b/yew/src/scheduler.rs
@@ -97,6 +97,10 @@ impl Scheduler {
         self.start();
     }
 
+    pub(crate) fn lock(&self) -> Option<std::cell::Ref<'_, ()>> {
+        self.lock.try_borrow().ok()
+    }
+
     fn next_runnable(&self) -> Option<Box<dyn Runnable>> {
         None.or_else(|| self.component.next_runnable())
             .or_else(|| self.main.borrow_mut().pop_front())

--- a/yew/src/virtual_dom/vcomp.rs
+++ b/yew/src/virtual_dom/vcomp.rs
@@ -164,7 +164,7 @@ impl<COMP: Component> Mountable for PropsWrapper<COMP> {
 
     fn reuse(self: Box<Self>, scope: &dyn Scoped, next_sibling: NodeRef) {
         let scope: Scope<COMP> = scope.to_any().downcast();
-        scope.update(ComponentUpdate::Properties(self.props, next_sibling), false);
+        scope.update(ComponentUpdate::Properties(self.props, next_sibling));
     }
 }
 


### PR DESCRIPTION
#### Description
When updating a component, Yew tries to batch updates together for rendering performance. This behavior is not desired when a component wishes to inspect DOM state in between "ShouldRender" update messages. This change ensures that Yew will render a component after each "ShouldRender" update message and will not process messages until the render is complete.

Fixes https://github.com/yewstack/yew/issues/1364

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [x] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
