### PR TITLE
Add missing derives to `yew_router`'s README

### DIFF
--- a/yew-router/README.md
+++ b/yew-router/README.md
@@ -4,7 +4,7 @@ A routing library for the [Yew](https://github.com/yewstack/yew) frontend framew
 
 ### Example
 ```rust
-#[derive(Switch, Debug)]
+#[derive(Switch, Debug, Clone)]
 pub enum AppRoute {
     #[to = "/profile/{id}"]
     Profile(u32),
@@ -14,7 +14,7 @@ pub enum AppRoute {
     Index,
 }
 
-#[derive(Switch, Debug)]
+#[derive(Switch, Debug, Clone)]
 pub enum ForumRoute {
     #[to = "/{subforum}/{thread_slug}"]
     SubForumAndThread{subforum: String, thread_slug: String}


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and which issue is fixed. -->

Fixes # (issue)

#### Checklist:

- [ ] I have run `./ci/run_stable_checks.sh`
- [ ] I have reviewed my own code
- [ ] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
