### PR TITLE
Added `NeqAssignBy` trait

### DIFF
--- a/yewtil/src/lib.rs
+++ b/yewtil/src/lib.rs
@@ -28,7 +28,7 @@ mod history;
 pub use history::History;
 
 #[cfg(feature = "neq")]
-pub use not_equal_assign::NeqAssign;
+pub use not_equal_assign::{NeqAssign, NeqAssignBy};
 
 #[deprecated]
 #[cfg(feature = "pure")]

--- a/yewtil/src/not_equal_assign.rs
+++ b/yewtil/src/not_equal_assign.rs
@@ -43,13 +43,74 @@ pub trait NeqAssign<NEW> {
     ///#         unimplemented!()
     ///#     }
     ///  }
+    ///
+    /// let mut foo = 1;
+    ///
+    /// assert_eq!(foo.neq_assign(42), true);
+    /// assert_eq!(foo, 42);
+    ///
+    /// assert_eq!(foo.neq_assign(42), false);
     /// ```
     fn neq_assign(&mut self, new: NEW) -> ShouldRender;
 }
 
 impl<T: BorrowMut<U>, U: PartialEq> NeqAssign<U> for T {
     fn neq_assign(&mut self, new: U) -> bool {
-        if self.borrow() != &new {
+        self.neq_assign_by(new, |x, y| x == y)
+    }
+}
+/// Blanket trait to provide a convenience method for assigning props in `changed` or updating values in `update`.
+///
+/// Like `neq_assign`, but for cases where `self` doesn't impl `PartialEq` or a nonstandard equality comparison is needed.
+///
+/// Useful for `Result<T, E: !PartialEq>`.
+pub trait NeqAssignBy<NEW> {
+    /// ```
+    /// # use yewtil::{NeqAssign, NeqAssignBy};
+    /// ##[derive(Clone, Debug)]
+    /// struct NonComparableError;
+    ///
+    /// fn eq_by_ok<T, E>(a: &Result<T, E>, b: &Result<T, E>) -> bool
+    /// where
+    ///     T: PartialEq,
+    /// {
+    ///     match (a, b) {
+    ///         (Ok(_), Err(_))
+    ///         | (Err(_), Ok(_))
+    ///         | (Err(_), Err(_)) => false,
+    ///         (Ok(a), Ok(b)) => a == b,
+    ///     }
+    /// }
+    ///
+    /// let mut foo: Result<u32, NonComparableError> = Ok(1);
+    ///
+    /// // Won't compile
+    /// // assert_eq!(foo.neq_assign(Ok(42)), true)
+    ///
+    /// assert_eq!(foo.neq_assign_by(Ok(42), eq_by_ok), true);
+    /// assert_eq!(foo.clone().unwrap(), 42);
+    ///
+    /// assert_eq!(foo.neq_assign_by(Err(NonComparableError), eq_by_ok), true);
+    /// assert!(foo.is_err());
+    ///
+    /// // The tradeoff: all assignments of an `Err` value will count as updates, even if they are
+    /// // "the same" for all practical intents and purposes.
+    /// assert_eq!(foo.neq_assign_by(Err(NonComparableError), eq_by_ok), true);
+    /// assert_eq!(foo.neq_assign_by(Err(NonComparableError), eq_by_ok), true);
+    /// assert_eq!(foo.neq_assign_by(Err(NonComparableError), eq_by_ok), true);
+    /// ```
+    ///
+    fn neq_assign_by<F>(&mut self, new: NEW, eq: F) -> ShouldRender
+    where
+        F: FnOnce(&NEW, &NEW) -> bool;
+}
+
+impl<T: BorrowMut<U>, U> NeqAssignBy<U> for T {
+    fn neq_assign_by<F>(&mut self, new: U, eq: F) -> ShouldRender
+    where
+        F: FnOnce(&U, &U) -> bool,
+    {
+        if !eq(self.borrow(), &new) {
             *self.borrow_mut() = new;
             true
         } else {


### PR DESCRIPTION
#### Description

Added `NeqAssignBy` trait to `yewtil` crate. It behaves similar to `NeqAssign`, but accepts a `FnOnce(&U, &U) -> bool` instead of relying on the `PartialEq` impl.

I was using `reqwest::Client` for fetching in my app, and was frustrated that `reqwest::Result` didn't play well with `NeqAssign` (glorious boilerplate reduction!) because `reqwest::Error: !PartialEq`. I understand the design decision, similar to why `std::io::Error` also doesn't impl `PartialEq`. I figured I could split the difference and just treat all `Err` variants as unequal with a custom equality function. This proved satisfactory, so I thought I'd share my solution.

I also reimplemented `NeqAssign` in terms of `NeqAssignBy`, in the spirit of similar `*_by` functions in `std` (e.g. `Iterator::eq_by`).

I am fairly comfortable with Rust, but still really new to OSS contribution. Feedback greatly appreciated!

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [x] I have added tests
- [x] If this is a feature, my tests prove that the feature works


