### PR TITLE
amendment of todomvc example

### DIFF
--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -9,4 +9,8 @@ strum = "0.18"
 strum_macros = "0.18"
 serde = "1"
 serde_derive = "1"
+wasm-bindgen = "0.2.60"
 yew = { path = "../../yew" }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -6,7 +6,7 @@ Unlike other implementations, this stores the full state of the model,
 including: all entries, entered text and chosen filter.
 
 ### How to run:
-This example requires rustc v1.39.0 or above to compile due to its use of async/.await syntax.
+This example requires rustc v1.39.0 or above to compile due to its use of the `async`/`await` syntax.
 
 ```sh
 wasm-pack build --target web --out-name wasm --out-dir ./static && miniserve ./static --index index.html

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -4,3 +4,13 @@ This is an implementation of [TodoMVC](http://todomvc.com/) app.
 
 Unlike other implementations, this stores the full state of the model,
 including: all entries, entered text and chosen filter.
+
+### How to run:
+This example requires rustc v1.39.0 or above to compile due to its use of async/.await syntax.
+
+```sh
+wasm-pack build --target web --out-name wasm --out-dir ./static && miniserve ./static --index index.html
+```
+This will compile the project, bundle up the compiler output and static assets, and start a http server on port 8080 so you can access the example at [localhost:8080](http://127.0.0.1:8080).
+
+It is expected that you have a setup with [wasm-pack9](https://github.com/rustwasm/wasm-pack) and [miniserve](https://github.com/svenstaro/miniserve) installed.

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -13,4 +13,4 @@ wasm-pack build --target web --out-name wasm --out-dir ./static && miniserve ./s
 ```
 This will compile the project, bundle the compiler output and static assets together, and start a HTTP server running locally on port 8080 (to access the example you can use your browser to navigate to [localhost:8080](http://127.0.0.1:8080)).
 
-It is expected that you have a setup with [wasm-pack9](https://github.com/rustwasm/wasm-pack) and [miniserve](https://github.com/svenstaro/miniserve) installed.
+To run this example you'll need to have [wasm-pack](https://github.com/rustwasm/wasm-pack) and [miniserve](https://github.com/svenstaro/miniserve) installed.

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -11,6 +11,6 @@ This example requires rustc v1.39.0 or above to compile due to its use of the `a
 ```sh
 wasm-pack build --target web --out-name wasm --out-dir ./static && miniserve ./static --index index.html
 ```
-This will compile the project, bundle up the compiler output and static assets, and start a http server on port 8080 so you can access the example at [localhost:8080](http://127.0.0.1:8080).
+This will compile the project, bundle the compiler output and static assets together, and start a HTTP server running locally on port 8080 (to access the example you can use your browser to navigate to [localhost:8080](http://127.0.0.1:8080)).
 
 It is expected that you have a setup with [wasm-pack9](https://github.com/rustwasm/wasm-pack) and [miniserve](https://github.com/svenstaro/miniserve) installed.

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -3,6 +3,7 @@
 use serde_derive::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::{EnumIter, ToString};
+use wasm_bindgen::prelude::*;
 use yew::events::KeyboardEvent;
 use yew::format::Json;
 use yew::services::storage::{Area, StorageService};
@@ -359,4 +360,9 @@ impl State {
         };
         self.entries.remove(idx);
     }
+}
+
+#[wasm_bindgen(start)]
+pub fn run_app() {
+    yew::start_app::<Model>();
 }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    yew::start_app::<todomvc::Model>();
-}

--- a/examples/todomvc/static/index.html
+++ b/examples/todomvc/static/index.html
@@ -7,6 +7,9 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/todomvc-app-css@2.1.2/index.css" />
     </head>
     <body>
-        <script src="/todomvc.js"></script>
+        <script type="module">
+            import init from "./wasm.js"
+            init()
+        </script>
     </body>
 </html>


### PR DESCRIPTION
makes it ready for `wasm-pack build`

#### Description

as mentioned in issues  [#1016](https://github.com/yewstack/yew/issues/1016#issuecomment-598292356) wasm-code generated with `wasm-bindgen` runs in `Uncaught SyntaxError: Cannot use 'import.meta' outside a module` exception. This PR aims to solve the issue by switching to `wasm-pack`. #1079 is an other issue, which referred the example.

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
