### PR TITLE
More yew examples compiling

### DIFF
--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Martin Matusiak <numerodix@gmail.com>"]
 edition = "2018"
 description="A useful utility for handing markdown which is used by other examples – not an example in itself!"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
-yew = { path = "../../yew" }
 pulldown-cmark = { version = "0.7.0", default-features = false }
+wasm-bindgen = "0.2.64"
+yew = { path = "../../yew" }

--- a/examples/crm/Cargo.toml
+++ b/examples/crm/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
+common = { path = "../common" }
 serde = "1"
 serde_derive = "1"
 yew = { path = "../../yew" }
-common = { path = "../common" }

--- a/examples/crm/src/lib.rs
+++ b/examples/crm/src/lib.rs
@@ -1,9 +1,9 @@
 #![recursion_limit = "256"]
 
-#[macro_use]
-extern crate serde_derive;
+extern crate common;
 
 use common::markdown;
+use serde::{Deserialize, Serialize};
 use yew::format::Json;
 use yew::services::storage::Area;
 use yew::services::{DialogService, StorageService};

--- a/examples/crm/src/main.rs
+++ b/examples/crm/src/main.rs
@@ -3,8 +3,8 @@
 mod lib;
 use lib::Model;
 
-extern crate serde_derive;
 extern crate common;
+extern crate serde_derive;
 
 fn main() {
     yew::start_app::<Model>();

--- a/examples/crm/src/main.rs
+++ b/examples/crm/src/main.rs
@@ -1,3 +1,11 @@
+#![recursion_limit = "256"]
+
+mod lib;
+use lib::Model;
+
+extern crate serde_derive;
+extern crate common;
+
 fn main() {
-    yew::start_app::<crm::Model>();
+    yew::start_app::<Model>();
 }

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 yew = { path = "../../yew" }
-
+wasm-bindgen = "0.2.64"

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -1,3 +1,6 @@
-fn main() {
-    yew::start_app::<minimal::Model>();
+mod lib;
+use lib::Model;
+
+pub fn main() {
+    yew::start_app::<Model>();
 }


### PR DESCRIPTION
#### Description

Relates to #1289

Allows some Yew examples that weren't building via `examples/build.sh` to be built successfully. Was able to get every example compiling except for `server`.

One thing that came up when running `ci/run_stable_checks.sh` is that for some reason, a warning appears on the `crm` example yet "fixing" the warnings leads to a compilation error. Without both of these attributes, there is a recursion limit exceeded error when compiling. Maybe this warning should be silenced? This is on Rust 1.44.1.

```
error: unused attribute
 --> examples/crm/src/lib.rs:1:1
  |
1 | #![recursion_limit = "256"]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `-D unused-attributes` implied by `-D warnings`

error: crate-level attribute should be in the root module
 --> examples/crm/src/lib.rs:1:1
  |
1 | #![recursion_limit = "256"]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to 2 previous errors
```

#### Checklist:

- [ ] I have run `./ci/run_stable_checks.sh`
- [ ] I have reviewed my own code
- [NA] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
