### PR TITLE
Add access to the event in InputData

### DIFF
--- a/yew/src/html/listener/listener_stdweb.rs
+++ b/yew/src/html/listener/listener_stdweb.rs
@@ -28,7 +28,7 @@ impl_action! {
     onerror(event: ResourceErrorEvent) -> ResourceErrorEvent => |_, event| { event }
     onfocus(event: FocusEvent) -> FocusEvent => |_, event| { event }
     // onformdata not supported
-    oninput(event: InputEvent) -> InputData => |this: &Element, _| { oninput_handler(this) }
+    oninput(event: InputEvent) -> InputData => |this: &Element, event| { oninput_handler(this, event) }
     // oninvalid not supported
     onkeydown(event: KeyDownEvent) -> KeyDownEvent => |_, event| { event }
     onkeypress(event: KeyPressEvent) -> KeyPressEvent => |_, event| { event }

--- a/yew/src/html/listener/listener_web_sys.rs
+++ b/yew/src/html/listener/listener_web_sys.rs
@@ -27,7 +27,7 @@ impl_action! {
     onfocus(name: "focus", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
     // web_sys doesn't have a struct for `FormDataEvent`
     onformdata(name: "formdata", event: Event) -> web_sys::Event => |_, event| { event }
-    oninput(name: "input", event: InputEvent) -> InputData => |this: &Element, _| { oninput_handler(this) }
+    oninput(name: "input", event: InputEvent) -> InputData => |this: &Element, event| { oninput_handler(this, event) }
     oninvalid(name: "invalid", event: Event) -> web_sys::Event => |_, event| { event }
     onkeydown(name: "keydown", event: KeyboardEvent) -> web_sys::KeyboardEvent => |_, event| { event }
     onkeypress(name: "keypress", event: KeyboardEvent) -> web_sys::KeyboardEvent => |_, event| { event }

--- a/yew/src/html/listener/mod.rs
+++ b/yew/src/html/listener/mod.rs
@@ -12,6 +12,7 @@ cfg_if! {
         use stdweb::unstable::{TryFrom, TryInto};
         use stdweb::web::html_element::{InputElement, SelectElement, TextAreaElement};
         use stdweb::web::{Element, EventListenerHandle, FileList, IElement, INode};
+        use stdweb::web::event::InputEvent;
 
         pub use listener_stdweb::*;
     } else if #[cfg(feature = "web_sys")] {
@@ -21,6 +22,7 @@ cfg_if! {
         use web_sys::{
             Element, FileList, HtmlInputElement as InputElement, HtmlSelectElement as SelectElement,
             HtmlTextAreaElement as TextAreaElement,
+            InputEvent
         };
 
         pub use listener_web_sys::*;
@@ -33,6 +35,8 @@ pub struct InputData {
     /// Inserted characters. Contains value from
     /// [InputEvent](https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/data).
     pub value: String,
+    /// The InputEvent received.
+    pub event: InputEvent,
 }
 
 // There is no '.../Web/API/ChangeEvent/data' (for onchange) similar to
@@ -55,7 +59,7 @@ pub enum ChangeData {
     Files(FileList),
 }
 
-fn oninput_handler(this: &Element) -> InputData {
+fn oninput_handler(this: &Element, event: InputEvent) -> InputData {
     // Normally only InputElement or TextAreaElement can have an oninput event listener. In
     // practice though any element with `contenteditable=true` may generate such events,
     // therefore here we fall back to just returning the text content of the node.
@@ -83,7 +87,7 @@ fn oninput_handler(this: &Element) -> InputData {
     let v3 = this.text_content();
     let value = v1.or(v2).or(v3)
         .expect("only an InputElement or TextAreaElement or an element with contenteditable=true can have an oninput event listener");
-    InputData { value }
+    InputData { value, event }
 }
 
 fn onchange_handler(this: &Element) -> ChangeData {


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and which issue is fixed. -->

Fixes #483 by adding `event` field on `InputData` struct.

I haven't added any tests only because there was no test module on the source I've worked on.
I also have tried to apply the same kind of fix to `ChangeEvent` but failed since the current API of `ChangeData` can't contain the event data.

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [ ] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
