### PR TITLE
Fix new clippy warnings in yew-functional crate

### DIFF
--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -300,11 +300,10 @@ where
         }
     }
     use_hook(
-        move |state: &mut UseEffectState<Dependents, Destructor>, hook_callback| {
-            let mut should_update = *state.deps != *deps;
+        move |_state: &mut UseEffectState<Dependents, Destructor>, hook_callback| {
             hook_callback(
                 move |state: &mut UseEffectState<Dependents, Destructor>| {
-                    if should_update {
+                    if state.deps != deps {
                         if let Some(de) = state.destructor.take() {
                             de();
                         }
@@ -312,7 +311,6 @@ where
                         state.deps = deps;
                         state.destructor.replace(Box::new(new_destructor));
                     } else if state.destructor.is_none() {
-                        should_update = true;
                         state
                             .destructor
                             .replace(Box::new(callback(state.deps.borrow())));


### PR DESCRIPTION
#### Description

With the new stable Rust release clippy generates a warning for the `yew-functional` crate.
The first commit (https://github.com/yewstack/yew/commit/d0632916cb7f127bbd76959d27a9c8c85b389f9b) provides a fix for that warning.
I'm very unsure whether my interpretation of the original intent is correct. It would be great if you could verify that everything is in order, @ZainlessBrombie.

While I was at it I also ran the code against the `pedantic` and `nursery` clippy sets to future-proof the code.
These changes are all part of the second commit and they don't change the semantics of the code.

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [ ] I have added tests
