### PR TITLE
Remove patreon link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,7 +1,7 @@
 # These are supported funding model platforms
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: deniskolodin
+patreon: # Replace with a single Patreon username
 open_collective: yew
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel


### PR DESCRIPTION
**Yew** is 100% community project today. That's infinitely pleasing 👍 
We don't need to keep the link to the my personal **Patreon** page anymore.
Let's keep the link to the **OpenCollective** page only.