### PR TITLE
Remove mentioning of use of the `async`/`await` syntax from TodoMVC example's readme

### DIFF
--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -6,7 +6,6 @@ Unlike other implementations, this stores the full state of the model,
 including: all entries, entered text and chosen filter.
 
 ### How to run:
-This example requires rustc v1.39.0 or above to compile due to its use of the `async`/`await` syntax.
 
 ```sh
 wasm-pack build --target web --out-name wasm --out-dir ./static && miniserve ./static --index index.html


### PR DESCRIPTION
#### Description
This PR removed the "This example requires rustc v1.39.0 or above to compile due to its use of the `async`/`await` syntax." line from `TodoMVC example's README` because that example does not make use of the `async`/`await` syntax.

#### Checklist:

- [ ] I have run `./ci/run_stable_checks.sh`
- [ ] I have reviewed my own code
- [ ] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
