### PR TITLE
Example build hardening

### DIFF
--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -59,9 +59,9 @@ on_exit() {
 trap on_exit EXIT
 
 if [[ -z "$EXAMPLE" ]]; then
-    fail "$0 requires an example name as argument"
-    info "usage:\n$0 EXAMPLE"
-    exit 1
+    fail "$0 requires the name of the example as the first argument"
+    info "See the README.md file for help"
+    exit
 fi
 
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)" # this source dir

--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -68,8 +68,8 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)" # this so
 
 if [[ ! -d "$SRCDIR/$EXAMPLE" || "$EXAMPLE" = "common" || "$EXAMPLE" = "server" ]]; then
     fail "$EXAMPLE: no such example"
-    info "usage:\n$0 EXAMPLE"
-    exit 1
+    info "See the README.md file for help"
+    exit
 fi
 
 cd "$SRCDIR/$EXAMPLE" # "$SRCDIR" ensures that this script can be run from anywhere.

--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -58,7 +58,19 @@ on_exit() {
 
 trap on_exit EXIT
 
+if [[ -z "$EXAMPLE" ]]; then
+    fail "$0 requires an example name as argument"
+    info "usage:\n$0 EXAMPLE"
+    exit 1
+fi
+
 SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)" # this source dir
+
+if [[ ! -d "$SRCDIR/$EXAMPLE" || "$EXAMPLE" = "common" || "$EXAMPLE" = "server" ]]; then
+    fail "$EXAMPLE: no such example"
+    info "usage:\n$0 EXAMPLE"
+    exit 1
+fi
 
 cd "$SRCDIR/$EXAMPLE" # "$SRCDIR" ensures that this script can be run from anywhere.
 


### PR DESCRIPTION
#### Description

The script [examples/build.sh](https://github.com/yewstack/yew/blob/master/examples/build.sh) should check if approached example (defined by `$1`) exists. It should use `wasm-pack` for [todomvc](https://github.com/yewstack/yew/tree/master/examples/todomvc) example.

I'm aware about [Proposal: Replace bash scripts with a Rust CLI](https://github.com/yewstack/yew/issues/1418), but as long as the script exists in the repository, it should support build of all examples.

#### Testing instructions

`$ for d in ./*; do bn=`basename $d`; if [ ! -d $d ] || [ $bn = "common" ] || [ $bn = "static" ] || [ $bn = "server" ]; then continue; fi; echo ">$bn<"; ./build.sh $bn; done`

I couldn't build `server` example for same of openssl dependencies yet.