### PR TITLE
Point docs contribution link at new location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Yew is a community effort and we welcome all kinds of contributions, big or smal
 
 #### 🤓 New to Yew?
 
-Start learning about the framework by helping us improve our [Documentation](https://github.com/yewstack/docs). Pull requests which improve test coverage are also very welcome.
+Start learning about the framework by helping us improve our [Documentation](https://github.com/yewstack/yew/tree/master/docs). Pull requests which improve test coverage are also very welcome.
 
 #### 😎 Looking for inspiration?
 


### PR DESCRIPTION
#### Description

https://github.com/yewstack/docs points at https://github.com/yewstack/yew which points back to the first thing. :)

I think the rest of the PR template is not applicable, as this is not a code change.