### PR TITLE
fix deserialize error of fetch example in yewtil

### DIFF
--- a/yewtil/examples/fetch/src/lib.rs
+++ b/yewtil/examples/fetch/src/lib.rs
@@ -110,7 +110,7 @@ impl Component for Model {
                 html! {<button onclick=self.link.callback(|_| Msg::GetMarkdown)>{"Get employees"}</button>}
             }
             FetchState::Fetching(_) => html! {"Fetching"},
-            FetchState::Fetched(data) => data.data.iter().map(render_employee).collect(),
+            FetchState::Fetched(body) => body.data.iter().map(render_employee).collect(),
             FetchState::Failed(_, err) => html! {&err},
         }
     }

--- a/yewtil/examples/fetch/src/lib.rs
+++ b/yewtil/examples/fetch/src/lib.rs
@@ -11,12 +11,13 @@ pub fn run_app() {
 }
 
 struct Model {
-    markdown: Fetch<Request, Vec<Employee>>,
+    markdown: Fetch<Request, RequestBody>,
     link: ComponentLink<Self>,
 }
 
 #[derive(Default, Debug, Clone)]
 pub struct Request;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Employee {
     id: String,
@@ -26,9 +27,24 @@ pub struct Employee {
     profile_image: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RequestBody {
+    status: String,
+    data: Vec<Employee>
+}
+
+impl Default for RequestBody {
+    fn default() -> RequestBody {
+        RequestBody {
+            status: String::from(""),
+            data: vec![]
+        }
+    }
+}
+
 impl FetchRequest for Request {
     type RequestBody = ();
-    type ResponseBody = Vec<Employee>;
+    type ResponseBody = RequestBody;
     type Format = Json;
 
     fn url(&self) -> String {
@@ -51,7 +67,7 @@ impl FetchRequest for Request {
 }
 
 enum Msg {
-    SetMarkdownFetchState(FetchAction<Vec<Employee>>),
+    SetMarkdownFetchState(FetchAction<RequestBody>),
     GetMarkdown,
 }
 
@@ -94,7 +110,7 @@ impl Component for Model {
                 html! {<button onclick=self.link.callback(|_| Msg::GetMarkdown)>{"Get employees"}</button>}
             }
             FetchState::Fetching(_) => html! {"Fetching"},
-            FetchState::Fetched(data) => data.iter().map(render_employee).collect(),
+            FetchState::Fetched(data) => data.data.iter().map(render_employee).collect(),
             FetchState::Failed(_, err) => html! {&err},
         }
     }

--- a/yewtil/examples/fetch/src/lib.rs
+++ b/yewtil/examples/fetch/src/lib.rs
@@ -30,14 +30,14 @@ pub struct Employee {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RequestBody {
     status: String,
-    data: Vec<Employee>
+    data: Vec<Employee>,
 }
 
 impl Default for RequestBody {
     fn default() -> RequestBody {
         RequestBody {
             status: String::from(""),
-            data: vec![]
+            data: vec![],
         }
     }
 }


### PR DESCRIPTION
#### Description

fix deserialize error of fetch example in yewtil

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [x] I have done the test
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
