### PR TITLE
Improve error messages for invalid fragments

### DIFF
--- a/yew-macro/src/html_tree/html_component.rs
+++ b/yew-macro/src/html_tree/html_component.rs
@@ -7,7 +7,6 @@ use proc_macro2::Span;
 use quote::{quote, quote_spanned, ToTokens};
 use std::cmp::Ordering;
 use syn::buffer::Cursor;
-use syn::parse;
 use syn::parse::{Parse, ParseStream, Result as ParseResult};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
@@ -275,7 +274,7 @@ impl Parse for HtmlComponentOpen {
         // backwards compat
         let _ = input.parse::<Token![:]>();
         let HtmlPropSuffix { stream, div, gt } = input.parse()?;
-        let props = parse(stream)?;
+        let props = syn::parse2(stream)?;
 
         Ok(HtmlComponentOpen {
             lt,

--- a/yew-macro/src/html_tree/html_prop.rs
+++ b/yew-macro/src/html_tree/html_prop.rs
@@ -1,7 +1,6 @@
 use crate::html_tree::HtmlDashedName as HtmlPropLabel;
 use crate::{Peek, PeekValue};
-use proc_macro::TokenStream;
-use proc_macro2::TokenTree;
+use proc_macro2::{TokenStream, TokenTree};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream, Result as ParseResult};
 use syn::{Expr, Token};
@@ -79,8 +78,7 @@ impl Parse for HtmlPropSuffix {
         }
 
         let gt: Token![>] = gt.ok_or_else(|| input.error("missing tag close"))?;
-        let stream: proc_macro2::TokenStream = trees.into_iter().collect();
-        let stream = TokenStream::from(stream);
+        let stream: TokenStream = trees.into_iter().collect();
 
         Ok(HtmlPropSuffix { stream, div, gt })
     }

--- a/yew-macro/src/html_tree/html_tag/mod.rs
+++ b/yew-macro/src/html_tree/html_tag/mod.rs
@@ -9,7 +9,6 @@ use boolinator::Boolinator;
 use proc_macro2::{Delimiter, Span};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::buffer::Cursor;
-use syn::parse;
 use syn::parse::{Parse, ParseStream, Result as ParseResult};
 use syn::spanned::Spanned;
 use syn::{Block, Ident, Token};
@@ -375,7 +374,7 @@ impl Parse for HtmlTagOpen {
         let lt = input.parse::<Token![<]>()?;
         let tag_name = input.parse::<TagName>()?;
         let TagSuffix { stream, div, gt } = input.parse()?;
-        let mut attributes: TagAttributes = parse(stream)?;
+        let mut attributes: TagAttributes = syn::parse2(stream)?;
 
         match &tag_name {
             TagName::Lit(name) => {

--- a/yew-macro/src/html_tree/mod.rs
+++ b/yew-macro/src/html_tree/mod.rs
@@ -57,14 +57,14 @@ impl PeekValue<HtmlType> for HtmlTree {
     fn peek(cursor: Cursor) -> Option<HtmlType> {
         if cursor.eof() {
             Some(HtmlType::Empty)
+        } else if HtmlList::peek(cursor).is_some() {
+            Some(HtmlType::List)
         } else if HtmlComponent::peek(cursor).is_some() {
             Some(HtmlType::Component)
         } else if HtmlTag::peek(cursor).is_some() {
             Some(HtmlType::Tag)
         } else if HtmlBlock::peek(cursor).is_some() {
             Some(HtmlType::Block)
-        } else if HtmlList::peek(cursor).is_some() {
-            Some(HtmlType::List)
         } else {
             None
         }

--- a/yew-macro/tests/derive_props/fail.stderr
+++ b/yew-macro/tests/derive_props/fail.stderr
@@ -16,7 +16,7 @@ error[E0425]: cannot find value `foo` in this scope
 87 |         #[prop_or_else(foo)]
    |                        ^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 83 |     use crate::t10::foo;
    |

--- a/yew-macro/tests/derive_props_test.rs
+++ b/yew-macro/tests/derive_props_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable, test)]
+#[rustversion::attr(stable(1.45), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_props/pass.rs");

--- a/yew-macro/tests/derive_props_test.rs
+++ b/yew-macro/tests/derive_props_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.44), test)]
+#[rustversion::attr(stable, test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_props/pass.rs");

--- a/yew-macro/tests/macro/html-list-fail.rs
+++ b/yew-macro/tests/macro/html-list-fail.rs
@@ -8,8 +8,11 @@ fn compile_fail() {
     html! { <><></> };
     html! { <></><></> };
     html! { <>invalid</> };
-    html! { <key=></>}
-    html! { <key="key".to_string()>invalid</key>}
+    html! { <key=></> };
+    html! { <key="key".to_string()></key> };
+
+    html! { <key="first key" key="second key" /> };
+    html! { <some_attr="test"></> };
 }
 
 fn main() {}

--- a/yew-macro/tests/macro/html-list-fail.stderr
+++ b/yew-macro/tests/macro/html-list-fail.stderr
@@ -15,10 +15,10 @@ error: this closing fragment has no corresponding opening fragment
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this opening fragment has no corresponding closing fragment
- --> $DIR/html-list-fail.rs:6:13
+ --> $DIR/html-list-fail.rs:6:15
   |
 6 |     html! { <><> };
-  |             ^^
+  |               ^^
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -57,15 +57,31 @@ error: expected a valid html element
 error: expected an expression following this equals sign
   --> $DIR/html-list-fail.rs:11:17
    |
-11 |     html! { <key=></>}
+11 |     html! { <key=></> };
    |                 ^^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: this opening fragment has no corresponding closing fragment
-  --> $DIR/html-list-fail.rs:12:13
+error: this closing tag has no corresponding opening tag
+  --> $DIR/html-list-fail.rs:12:36
    |
-12 |     html! { <key="key".to_string()>invalid</key>}
-   |             ^^^^^^^^^^^^^^^^^^^^^^^
+12 |     html! { <key="key".to_string()></key> };
+   |                                    ^^^^^^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: only a single `key` prop is allowed on a fragment
+  --> $DIR/html-list-fail.rs:14:30
+   |
+14 |     html! { <key="first key" key="second key" /> };
+   |                              ^^^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: fragments only accept the `key` prop
+  --> $DIR/html-list-fail.rs:15:14
+   |
+15 |     html! { <some_attr="test"></> };
+   |              ^^^^^^^^^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/yew-macro/tests/macro_test.rs
+++ b/yew-macro/tests/macro_test.rs
@@ -1,7 +1,7 @@
 use yew::html;
 
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.44), test)]
+#[rustversion::attr(stable, test)]
 fn tests() {
     let t = trybuild::TestCases::new();
 

--- a/yew-macro/tests/macro_test.rs
+++ b/yew-macro/tests/macro_test.rs
@@ -1,7 +1,7 @@
 use yew::html;
 
 #[allow(dead_code)]
-#[rustversion::attr(stable, test)]
+#[rustversion::attr(stable(1.45), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
 


### PR DESCRIPTION
#### Description
That took a lot more time than I expected...

<!-- Please include a summary of the change and which issue is fixed. -->


Fixes #1444

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [x] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
