### PR TITLE
Remove proc-macro-hack and bump MSRV to 1.45

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="https://crates.io/crates/yew"><img alt="Crate Info" src="https://img.shields.io/crates/v/yew.svg"/></a>
     <a href="https://docs.rs/yew/"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-yew-green"/></a>
     <a href="https://discord.gg/VQck8X4"><img alt="Discord Chat" src="https://img.shields.io/discord/701068342760570933"/></a>
-    <a href="https://blog.rust-lang.org/2020/03/12/Rust-1.42.html"><img alt="Rustc Version 1.42+" src="https://img.shields.io/badge/rustc-1.42%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html"><img alt="Rustc Version 1.45+" src="https://img.shields.io/badge/rustc-1.45%2B-lightgrey.svg"/></a>
     <a href="https://github.com/jetli/awesome-yew"><img alt="Yew Awesome" src="https://raw.githubusercontent.com/sindresorhus/awesome/master/media/badge.svg"/></a>
   </p>
 

--- a/examples/file_upload/src/lib.rs
+++ b/examples/file_upload/src/lib.rs
@@ -76,7 +76,6 @@ impl Component for Model {
                                 let files = js_sys::try_iter(&files)
                                     .unwrap()
                                     .unwrap()
-                                    .into_iter()
                                     .map(|v| File::from(v.unwrap()));
                                 result.extend(files);
                             }

--- a/examples/nested_list/src/app.rs
+++ b/examples/nested_list/src/app.rs
@@ -46,7 +46,7 @@ impl Component for App {
                 <List on_hover=on_hover weak_link=list_link>
                     <ListHeader text="Calling all Rusties!" on_hover=on_hover list_link=list_link />
                     <ListItem name="Rustin" on_hover=on_hover />
-                    <ListItem hide={true} name="Rustaroo" on_hover=on_hover />
+                    <ListItem hide=true name="Rustaroo" on_hover=on_hover />
                     <ListItem name="Rustifer" on_hover=on_hover>
                         <div class="sublist">{"Sublist!"}</div>
                         {
@@ -54,7 +54,7 @@ impl Component for App {
                                 <List on_hover=on_hover weak_link=sub_list_link>
                                     <ListHeader text="Sub Rusties!" on_hover=on_hover list_link=sub_list_link/>
                                     <ListItem name="Sub Rustin" on_hover=on_hover />
-                                    <ListItem hide={true} name="Sub Rustaroo" on_hover=on_hover />
+                                    <ListItem hide=true name="Sub Rustaroo" on_hover=on_hover />
                                     <ListItem name="Sub Rustifer" on_hover=on_hover />
                                 </List>
                             }

--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -78,7 +78,7 @@ impl Component for Model {
 
     fn view(&self) -> Html {
         html! {
-            <canvas ref={self.node_ref.clone()} />
+            <canvas ref=self.node_ref.clone() />
         }
     }
 

--- a/yew-components/src/select.rs
+++ b/yew-components/src/select.rs
@@ -137,14 +137,14 @@ where
         let view_option = |value: &T| {
             let flag = selected == Some(value);
             html! {
-                <option value=value.to_string() selected=flag>{ value.to_string() }</option>
+                <option value=value selected=flag>{ value.to_string() }</option>
             }
         };
 
         html! {
             <select
                 ref=self.select_ref.clone()
-                id=self.props.id.clone()
+                id=self.props.id
                 class=self.props.class.clone()
                 disabled=self.props.disabled
                 onchange=self.on_change()

--- a/yew-functional/tests/use_context_hook.rs
+++ b/yew-functional/tests/use_context_hook.rs
@@ -270,7 +270,7 @@ fn use_context_update_works() {
             });
 
             return html! {
-                <MyContextProvider context=ctx.clone()>
+                <MyContextProvider context=ctx>
                     <RenderCounter id="test-0">
                         <ContextOutlet id="test-1"/>
                         <ContextOutlet id="test-2" magic=magic/>

--- a/yew-macro/Cargo.toml
+++ b/yew-macro/Cargo.toml
@@ -17,7 +17,6 @@ proc-macro = true
 [dependencies]
 boolinator = "2.4.0"
 lazy_static = "1.3.0"
-proc-macro-hack = "0.5"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }

--- a/yew-macro/src/html_tree/html_component.rs
+++ b/yew-macro/src/html_tree/html_component.rs
@@ -119,6 +119,7 @@ impl ToTokens for HtmlComponent {
             PropType::List(list_props) => {
                 let set_props = list_props.iter().map(|HtmlProp { label, value }| {
                     quote_spanned! { value.span()=> .#label(
+                        #[allow(unused_braces)]
                         <::yew::virtual_dom::VComp as ::yew::virtual_dom::Transformer<_, _>>::transform(
                             #value
                         )

--- a/yew-macro/src/html_tree/html_component.rs
+++ b/yew-macro/src/html_tree/html_component.rs
@@ -150,7 +150,10 @@ impl ToTokens for HtmlComponent {
         };
 
         let key = if let Some(key) = &props.key {
-            quote_spanned! { key.span()=> Some(::yew::virtual_dom::Key::from(#key)) }
+            quote_spanned! { key.span()=>
+                #[allow(clippy::useless_conversion)]
+                Some(::yew::virtual_dom::Key::from(#key))
+            }
         } else {
             quote! {None}
         };

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -52,9 +52,9 @@ impl ToNodeIterator for HtmlIterable {
     fn to_node_iterator_stream(&self) -> Option<TokenStream> {
         let Self(expr) = self;
         // #expr can return anything that implements IntoIterator<Item=Into<T>>
-        // so we generate some extra code to turn it into IntoIterator<Item=T>
+        // We use a util method to avoid clippy warnings and cut down on generated code size
         Some(quote_spanned! {expr.span()=>
-            ::std::iter::Iterator::map(::std::iter::IntoIterator::into_iter(#expr), |n| n.into())
+            ::yew::utils::into_node_iter(#expr)
         })
     }
 }

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -52,7 +52,7 @@ impl ToNodeIterator for HtmlIterable {
     fn to_node_iterator_stream(&self) -> Option<TokenStream> {
         let Self(expr) = self;
         // #expr can return anything that implements IntoIterator<Item=Into<T>>
-        // We use a util method to avoid clippy warnings and cut down on generated code size
+        // We use a util method to avoid clippy warnings and reduce generated code size
         Some(quote_spanned! {expr.span()=>
             ::yew::utils::into_node_iter(#expr)
         })

--- a/yew-macro/src/html_tree/html_iterable.rs
+++ b/yew-macro/src/html_tree/html_iterable.rs
@@ -41,6 +41,7 @@ impl ToTokens for HtmlIterable {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let expr = &self.0;
         let new_tokens = quote_spanned! {expr.span()=>
+            #[allow(unused_braces)]
             ::std::iter::Iterator::collect::<::yew::virtual_dom::VNode>(::std::iter::IntoIterator::into_iter(#expr))
         };
 

--- a/yew-macro/src/html_tree/html_node.rs
+++ b/yew-macro/src/html_tree/html_node.rs
@@ -45,7 +45,7 @@ impl ToTokens for HtmlNode {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(match &self {
             HtmlNode::Literal(lit) => quote! {#lit},
-            HtmlNode::Expression(expr) => quote_spanned! {expr.span()=> {#expr}},
+            HtmlNode::Expression(expr) => quote_spanned! {expr.span()=> #expr},
         });
     }
 }

--- a/yew-macro/src/html_tree/html_tag/mod.rs
+++ b/yew-macro/src/html_tree/html_tag/mod.rs
@@ -191,13 +191,11 @@ impl ToTokens for HtmlTag {
             let name = &listener.label.name;
             let callback = &listener.value;
 
-            quote_spanned! {name.span()=> {
-                ::yew::html::#name::Wrapper::new(
-                    <::yew::virtual_dom::VTag as ::yew::virtual_dom::Transformer<_, _>>::transform(
-                        #callback
-                    )
+            quote_spanned! {name.span()=> ::yew::html::#name::Wrapper::new(
+                <::yew::virtual_dom::VTag as ::yew::virtual_dom::Transformer<_, _>>::transform(
+                    #callback
                 )
-            }}
+            )}
         });
 
         // These are the runtime-checks exclusive to dynamic tags.

--- a/yew-macro/src/html_tree/html_tag/mod.rs
+++ b/yew-macro/src/html_tree/html_tag/mod.rs
@@ -142,11 +142,7 @@ impl ToTokens for HtmlTag {
         });
         let set_booleans = booleans.iter().map(|TagAttribute { label, value }| {
             let label_str = label.to_string();
-            quote_spanned! {value.span()=>
-                if #value {
-                    #vtag.add_attribute(&#label_str, &#label_str);
-                }
-            }
+            quote_spanned! {value.span()=> #vtag.set_boolean_attribute(&#label_str, #value); }
         });
         let set_kind = kind.iter().map(|kind| {
             quote_spanned! {kind.span()=> #vtag.set_kind(&(#kind)); }

--- a/yew-macro/src/html_tree/html_tag/mod.rs
+++ b/yew-macro/src/html_tree/html_tag/mod.rs
@@ -111,6 +111,7 @@ impl ToTokens for HtmlTag {
                 let vtag_name = Ident::new("__yew_vtag_name", expr.span());
                 // this way we get a nice error message (with the correct span) when the expression doesn't return a valid value
                 quote_spanned! {expr.span()=> {
+                    #[allow(unused_braces)]
                     let mut #vtag_name = ::std::borrow::Cow::<'static, str>::from(#expr);
                     if !#vtag_name.is_ascii() {
                         ::std::panic!("a dynamic tag returned a tag name containing non ASCII characters: `{}`", #vtag_name);
@@ -142,6 +143,8 @@ impl ToTokens for HtmlTag {
         });
         let set_booleans = booleans.iter().map(|TagAttribute { label, value }| {
             let label_str = label.to_string();
+            // We use `set_boolean_attribute` instead of inlining an if statement to avoid
+            // the `suspicious_else_formatting` clippy warning.
             quote_spanned! {value.span()=> #vtag.set_boolean_attribute(&#label_str, #value); }
         });
         let set_kind = kind.iter().map(|kind| {
@@ -235,6 +238,7 @@ impl ToTokens for HtmlTag {
             #(#set_classes)*
             #(#set_node_ref)*
             #(#set_key)*
+            #[allow(redundant_clone, unused_braces)]
             #vtag.add_attributes(vec![#(#attr_pairs),*]);
             #vtag.add_listeners(vec![#(::std::rc::Rc::new(#listeners)),*]);
             #vtag.add_children(#children);

--- a/yew-macro/src/lib.rs
+++ b/yew-macro/src/lib.rs
@@ -2,11 +2,7 @@
 //! for generating html and the `Properties` derive macro for deriving the `Properties` trait
 //! for components.
 //!
-//! The `html!` macro uses [proc_macro_hack](https://github.com/dtolnay/proc-macro-hack) in order
-//! to be used in the expression position.
-//!
 //! ```
-//! # #[macro_use] extern crate yew;
 //! use yew::prelude::*;
 //!
 //! struct Component {
@@ -60,7 +56,6 @@
 //! Please refer to [https://github.com/yewstack/yew](https://github.com/yewstack/yew) for how to set this up.
 
 #![recursion_limit = "128"]
-extern crate proc_macro;
 
 mod derive_props;
 mod html_tree;
@@ -68,7 +63,6 @@ mod html_tree;
 use derive_props::DerivePropsInput;
 use html_tree::{HtmlRoot, HtmlRootVNode};
 use proc_macro::TokenStream;
-use proc_macro_hack::proc_macro_hack;
 use quote::{quote, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse_macro_input;
@@ -97,13 +91,13 @@ pub fn derive_props(input: TokenStream) -> TokenStream {
     TokenStream::from(input.into_token_stream())
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn html_nested(input: TokenStream) -> TokenStream {
     let root = parse_macro_input!(input as HtmlRoot);
     TokenStream::from(quote! {#root})
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn html(input: TokenStream) -> TokenStream {
     let root = parse_macro_input!(input as HtmlRootVNode);
     TokenStream::from(quote! {#root})

--- a/yew-macro/tests/macro/html-block-fail.stderr
+++ b/yew-macro/tests/macro/html-block-fail.stderr
@@ -11,7 +11,6 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>`
   = note: required by `std::convert::From::from`
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/html-block-fail.rs:12:16
@@ -26,17 +25,20 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
    = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>`
    = note: required by `std::convert::From::from`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/html-block-fail.rs:15:17
    |
 15 |         <>{ for (0..3).map(|_| not_tree()) }</>
-   |                 ^^^^^^ `()` cannot be formatted with the default formatter
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` cannot be formatted with the default formatter
+   |
+  ::: $WORKSPACE/yew/src/utils.rs:77:8
+   |
+77 |     U: Into<VNode>,
+   |        ----------- required by this bound in `yew::utils::into_node_iter`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required because of the requirements on the impl of `std::string::ToString` for `()`
    = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/yew-macro/tests/macro/html-component-fail.stderr
+++ b/yew-macro/tests/macro/html-component-fail.stderr
@@ -3,208 +3,156 @@ error: this opening tag has no corresponding closing tag
    |
 79 |     html! { <Child> };
    |             ^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected identifier
   --> $DIR/html-component-fail.rs:80:22
    |
 80 |     html! { <Child:: /> };
    |                      ^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `with` must be followed by an identifier
   --> $DIR/html-component-fail.rs:81:20
    |
 81 |     html! { <Child with /> };
    |                    ^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this prop doesn't have a value
   --> $DIR/html-component-fail.rs:82:20
    |
 82 |     html! { <Child props /> };
    |                    ^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this opening tag has no corresponding closing tag
   --> $DIR/html-component-fail.rs:83:13
    |
 83 |     html! { <Child with props > };
    |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: too many refs set
   --> $DIR/html-component-fail.rs:84:38
    |
 84 |     html! { <Child with props ref=() ref=() /> };
    |                                      ^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: too many refs set
   --> $DIR/html-component-fail.rs:85:38
    |
 85 |     html! { <Child with props ref=() ref=() value=1 /> };
    |                                      ^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Using the `with props` syntax in combination with named props is not allowed (note: this does not apply to the `ref` prop).
   --> $DIR/html-component-fail.rs:86:38
    |
 86 |     html! { <Child with props ref=() value=1 ref=() /> };
    |                                      ^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Using the `with props` syntax in combination with named props is not allowed (note: this does not apply to the `ref` prop).
   --> $DIR/html-component-fail.rs:87:31
    |
 87 |     html! { <Child with props value=1 ref=()  ref=() /> };
    |                               ^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Using the `with props` syntax in combination with named props is not allowed (note: this does not apply to the `ref` prop).
   --> $DIR/html-component-fail.rs:88:28
    |
 88 |     html! { <Child value=1 with props  ref=()  ref=() /> };
    |                            ^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Using the `with props` syntax in combination with named props is not allowed (note: this does not apply to the `ref` prop).
   --> $DIR/html-component-fail.rs:89:35
    |
 89 |     html! { <Child value=1 ref=() with props ref=() /> };
    |                                   ^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: too many refs set
   --> $DIR/html-component-fail.rs:90:27
    |
 90 |     html! { <Child ref=() ref=() value=1  with props  /> };
    |                           ^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected token
   --> $DIR/html-component-fail.rs:92:31
    |
 92 |     html! { <Child with props () /> };
    |                               ^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Using the `with props` syntax in combination with named props is not allowed (note: this does not apply to the `ref` prop).
   --> $DIR/html-component-fail.rs:93:28
    |
 93 |     html! { <Child value=1 with props /> };
    |                            ^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Using the `with props` syntax in combination with named props is not allowed (note: this does not apply to the `ref` prop).
   --> $DIR/html-component-fail.rs:94:31
    |
 94 |     html! { <Child with props value=1 /> };
    |                               ^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected identifier
   --> $DIR/html-component-fail.rs:95:20
    |
 95 |     html! { <Child type=0 /> };
    |                    ^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected identifier
   --> $DIR/html-component-fail.rs:96:20
    |
 96 |     html! { <Child invalid-prop-name=0 /> };
    |                    ^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected an expression following this equals sign
   --> $DIR/html-component-fail.rs:98:26
    |
 98 |     html! { <Child string= /> };
    |                          ^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: too many refs set
    --> $DIR/html-component-fail.rs:103:33
     |
 103 |     html! { <Child int=1 ref=() ref=() /> };
     |                                 ^^^
-    |
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing tag has no corresponding opening tag
    --> $DIR/html-component-fail.rs:106:13
     |
 106 |     html! { </Child> };
     |             ^^^^^^^^
-    |
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this opening tag has no corresponding closing tag
    --> $DIR/html-component-fail.rs:107:13
     |
 107 |     html! { <Child><Child></Child> };
     |             ^^^^^^^
-    |
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
    --> $DIR/html-component-fail.rs:108:28
     |
 108 |     html! { <Child></Child><Child></Child> };
     |                            ^^^^^^^^^^^^^^^
-    |
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing tag has no corresponding opening tag
    --> $DIR/html-component-fail.rs:117:30
     |
 117 |     html! { <Generic<String>></Generic> };
     |                              ^^^^^^^^^^
-    |
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing tag has no corresponding opening tag
    --> $DIR/html-component-fail.rs:118:30
     |
 118 |     html! { <Generic<String>></Generic<Vec<String>>> };
     |                              ^^^^^^^^^^^^^^^^^^^^^^^
-    |
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
    --> $DIR/html-component-fail.rs:122:9
     |
 122 |         <span>{ 2 }</span>
     |         ^^^^^^^^^^^^^^^^^^
-    |
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `blah` in this scope
   --> $DIR/html-component-fail.rs:91:25
    |
 91 |     html! { <Child with blah /> };
    |                         ^^^^ not found in this scope
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `unknown` on type `ChildProperties`
   --> $DIR/html-component-fail.rs:97:20
@@ -213,7 +161,6 @@ error[E0609]: no field `unknown` on type `ChildProperties`
    |                    ^^^^^^^ unknown field
    |
    = note: available fields are: `string`, `int`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
   --> $DIR/html-component-fail.rs:97:20
@@ -223,8 +170,6 @@ error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder
 ...
 97 |     html! { <Child unknown="unknown" /> };
    |                    ^^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<(), std::string::String>` is not satisfied
   --> $DIR/html-component-fail.rs:99:33
@@ -239,7 +184,6 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom:
              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
            and 3 others
    = note: required by `yew::virtual_dom::Transformer::transform`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<{integer}, std::string::String>` is not satisfied
    --> $DIR/html-component-fail.rs:100:33
@@ -254,7 +198,6 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom:
               <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
             and 3 others
     = note: required by `yew::virtual_dom::Transformer::transform`
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<{integer}, std::string::String>` is not satisfied
    --> $DIR/html-component-fail.rs:101:33
@@ -269,15 +212,12 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom:
               <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
             and 3 others
     = note: required by `yew::virtual_dom::Transformer::transform`
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
    --> $DIR/html-component-fail.rs:102:30
     |
 102 |     html! { <Child int=1 ref=() /> };
     |                              ^^ expected struct `yew::html::NodeRef`, found `()`
-    |
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<u32, i32>` is not satisfied
    --> $DIR/html-component-fail.rs:104:24
@@ -292,7 +232,6 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom:
               <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
             and 3 others
     = note: required by `yew::virtual_dom::Transformer::transform`
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `string` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
    --> $DIR/html-component-fail.rs:105:20
@@ -306,7 +245,6 @@ error[E0599]: no method named `string` found for struct `ChildPropertiesBuilder<
     = help: items from traits can only be used if the trait is implemented and in scope
     = note: the following trait defines an item `string`, perhaps you need to implement it:
             candidate #1: `proc_macro::bridge::server::Literal`
-    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
    --> $DIR/html-component-fail.rs:109:5

--- a/yew-macro/tests/macro/html-iterable-fail.stderr
+++ b/yew-macro/tests/macro/html-iterable-fail.stderr
@@ -3,8 +3,6 @@ error: expected an expression after the keyword `for`
   |
 4 |     html! { for };
   |             ^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` is not an iterator
  --> $DIR/html-iterable-fail.rs:5:17
@@ -14,7 +12,6 @@ error[E0277]: `()` is not an iterator
   |
   = help: the trait `std::iter::Iterator` is not implemented for `()`
   = note: required by `std::iter::IntoIterator::into_iter`
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` is not an iterator
  --> $DIR/html-iterable-fail.rs:6:17
@@ -24,7 +21,6 @@ error[E0277]: `()` is not an iterator
   |
   = help: the trait `std::iter::Iterator` is not implemented for `()`
   = note: required by `std::iter::IntoIterator::into_iter`
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
  --> $DIR/html-iterable-fail.rs:7:17
@@ -39,7 +35,6 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
   = note: required because of the requirements on the impl of `std::iter::FromIterator<()>` for `yew::virtual_dom::vnode::VNode`
   = note: required by `std::iter::Iterator::collect`
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/html-iterable-fail.rs:10:17
@@ -54,7 +49,6 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
    = note: required because of the requirements on the impl of `std::iter::FromIterator<()>` for `yew::virtual_dom::vnode::VNode`
    = note: required by `std::iter::Iterator::collect`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/html-iterable-fail.rs:13:17
@@ -70,7 +64,6 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `&()`
    = note: required because of the requirements on the impl of `std::iter::FromIterator<&()>` for `yew::virtual_dom::vnode::VNode`
    = note: required by `std::iter::Iterator::collect`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` is not an iterator
   --> $DIR/html-iterable-fail.rs:18:19
@@ -78,6 +71,10 @@ error[E0277]: `()` is not an iterator
 18 |             { for () }
    |                   ^^ `()` is not an iterator
    |
+  ::: $WORKSPACE/yew/src/utils.rs:76:8
+   |
+76 |     T: IntoIterator<Item = U>,
+   |        ---------------------- required by this bound in `yew::utils::into_node_iter`
+   |
    = help: the trait `std::iter::Iterator` is not implemented for `()`
-   = note: required by `std::iter::IntoIterator::into_iter`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: required because of the requirements on the impl of `std::iter::IntoIterator` for `()`

--- a/yew-macro/tests/macro/html-list-fail.stderr
+++ b/yew-macro/tests/macro/html-list-fail.stderr
@@ -3,85 +3,63 @@ error: this opening fragment has no corresponding closing fragment
   |
 4 |     html! { <> };
   |             ^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing fragment has no corresponding opening fragment
  --> $DIR/html-list-fail.rs:5:13
   |
 5 |     html! { </> };
   |             ^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this opening fragment has no corresponding closing fragment
  --> $DIR/html-list-fail.rs:6:15
   |
 6 |     html! { <><> };
   |               ^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing fragment has no corresponding opening fragment
  --> $DIR/html-list-fail.rs:7:13
   |
 7 |     html! { </></> };
   |             ^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this opening fragment has no corresponding closing fragment
  --> $DIR/html-list-fail.rs:8:13
   |
 8 |     html! { <><></> };
   |             ^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
  --> $DIR/html-list-fail.rs:9:18
   |
 9 |     html! { <></><></> };
   |                  ^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected a valid html element
   --> $DIR/html-list-fail.rs:10:15
    |
 10 |     html! { <>invalid</> };
    |               ^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected an expression following this equals sign
   --> $DIR/html-list-fail.rs:11:17
    |
 11 |     html! { <key=></> };
    |                 ^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing tag has no corresponding opening tag
   --> $DIR/html-list-fail.rs:12:36
    |
 12 |     html! { <key="key".to_string()></key> };
    |                                    ^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: only a single `key` prop is allowed on a fragment
   --> $DIR/html-list-fail.rs:14:30
    |
 14 |     html! { <key="first key" key="second key" /> };
    |                              ^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: fragments only accept the `key` prop
   --> $DIR/html-list-fail.rs:15:14
    |
 15 |     html! { <some_attr="test"></> };
    |              ^^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/yew-macro/tests/macro/html-node-fail.stderr
+++ b/yew-macro/tests/macro/html-node-fail.stderr
@@ -3,72 +3,54 @@ error: only one root html element is allowed (hint: you can wrap multiple html e
   |
 4 |     html! { "valid" "invalid" };
   |                     ^^^^^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected token
  --> $DIR/html-node-fail.rs:5:29
   |
 5 |     html! { <span>{ "valid" "invalid" }</span> };
   |                             ^^^^^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsupported type
   --> $DIR/html-node-fail.rs:10:14
    |
 10 |     html! {  b'a' };
    |              ^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsupported type
   --> $DIR/html-node-fail.rs:11:14
    |
 11 |     html! {  b"str" };
    |              ^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: integer literal is too large
   --> $DIR/html-node-fail.rs:12:14
    |
 12 |     html! {  1111111111111111111111111111111111111111111111111111111111111111111111111111 };
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsupported type
   --> $DIR/html-node-fail.rs:13:22
    |
 13 |     html! {  <span>{ b'a' }</span> };
    |                      ^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unsupported type
   --> $DIR/html-node-fail.rs:14:22
    |
 14 |     html! {  <span>{ b"str" }</span> };
    |                      ^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: integer literal is too large
   --> $DIR/html-node-fail.rs:15:22
    |
 15 |     html! {  <span>{ 1111111111111111111111111111111111111111111111111111111111111111111111111111 }</span> };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `invalid` in this scope
  --> $DIR/html-node-fail.rs:7:13
   |
 7 |     html! { invalid };
   |             ^^^^^^^ not found in this scope
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
  --> $DIR/html-node-fail.rs:6:13
@@ -81,17 +63,15 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
   = note: required by `std::convert::From::from`
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/html-node-fail.rs:19:9
    |
 19 |         not_node()
-   |         ^^^^^^^^ `()` cannot be formatted with the default formatter
+   |         ^^^^^^^^^^ `()` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required because of the requirements on the impl of `std::string::ToString` for `()`
    = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
    = note: required by `std::convert::From::from`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/yew-macro/tests/macro/html-tag-fail.stderr
+++ b/yew-macro/tests/macro/html-tag-fail.stderr
@@ -3,208 +3,156 @@ error: this opening tag has no corresponding closing tag
   |
 6 |     html! { <div> };
   |             ^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this opening tag has no corresponding closing tag
  --> $DIR/html-tag-fail.rs:7:18
   |
 7 |     html! { <div><div> };
   |                  ^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing tag has no corresponding opening tag
  --> $DIR/html-tag-fail.rs:8:13
   |
 8 |     html! { </div> };
   |             ^^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this opening tag has no corresponding closing tag
  --> $DIR/html-tag-fail.rs:9:13
   |
 9 |     html! { <div><div></div> };
   |             ^^^^^
-  |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
   --> $DIR/html-tag-fail.rs:10:24
    |
 10 |     html! { <div></div><div></div> };
    |                        ^^^^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing tag has no corresponding opening tag
   --> $DIR/html-tag-fail.rs:11:18
    |
 11 |     html! { <div></span> };
    |                  ^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing tag has no corresponding opening tag
   --> $DIR/html-tag-fail.rs:12:20
    |
 12 |     html! { <tag-a></tag-b> };
    |                    ^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this closing tag has no corresponding opening tag
   --> $DIR/html-tag-fail.rs:13:18
    |
 13 |     html! { <div></span></div> };
    |                  ^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
   --> $DIR/html-tag-fail.rs:14:20
    |
 14 |     html! { <img /></img> };
    |                    ^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected a valid html element
   --> $DIR/html-tag-fail.rs:15:18
    |
 15 |     html! { <div>Invalid</div> };
    |                  ^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the attribute `attr` can only be specified once
   --> $DIR/html-tag-fail.rs:17:27
    |
 17 |     html! { <input attr=1 attr=2 /> };
    |                           ^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the attribute `value` can only be specified once
   --> $DIR/html-tag-fail.rs:18:32
    |
 18 |     html! { <input value="123" value="456" /> };
    |                                ^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the attribute `kind` can only be specified once
   --> $DIR/html-tag-fail.rs:19:36
    |
 19 |     html! { <input kind="checkbox" kind="submit" /> };
    |                                    ^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the attribute `checked` can only be specified once
   --> $DIR/html-tag-fail.rs:20:33
    |
 20 |     html! { <input checked=true checked=false /> };
    |                                 ^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the attribute `disabled` can only be specified once
   --> $DIR/html-tag-fail.rs:21:34
    |
 21 |     html! { <input disabled=true disabled=false /> };
    |                                  ^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the attribute `selected` can only be specified once
   --> $DIR/html-tag-fail.rs:22:35
    |
 22 |     html! { <option selected=true selected=false /> };
    |                                   ^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the attribute `class` can only be specified once
   --> $DIR/html-tag-fail.rs:23:32
    |
 23 |     html! { <div class="first" class="second" /> };
    |                                ^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the attribute `ref` can only be specified once
   --> $DIR/html-tag-fail.rs:38:27
    |
 38 |     html! { <input ref=() ref=() /> };
    |                           ^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the tag `<input>` is a void element and cannot have children (hint: rewrite this as `<input/>`)
   --> $DIR/html-tag-fail.rs:40:13
    |
 40 |     html! { <input type="text"></input> };
    |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the tag `<iNpUt>` is a void element and cannot have children (hint: rewrite this as `<iNpUt/>`)
   --> $DIR/html-tag-fail.rs:41:13
    |
 41 |     html! { <iNpUt type="text"></iNpUt> };
    |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this dynamic tag is missing an expression block defining its value
   --> $DIR/html-tag-fail.rs:43:14
    |
 43 |     html! { <@></@> };
    |              ^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: dynamic closing tags must not have a body (hint: replace it with just `</@>`)
   --> $DIR/html-tag-fail.rs:44:27
    |
 44 |     html! { <@{"test"}></@{"test"}> };
    |                           ^^^^^^^^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this dynamic tag is missing an expression block defining its value
   --> $DIR/html-tag-fail.rs:46:14
    |
 46 |     html! { <@/> };
    |              ^
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/html-tag-fail.rs:25:28
    |
 25 |     html! { <input checked=1 /> };
    |                            ^ expected `bool`, found integer
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/html-tag-fail.rs:26:29
    |
 26 |     html! { <input disabled=1 /> };
    |                             ^ expected `bool`, found integer
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/html-tag-fail.rs:27:30
    |
 27 |     html! { <option selected=1 /> };
    |                              ^ expected `bool`, found integer
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/html-tag-fail.rs:28:25
@@ -215,7 +163,6 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/html-tag-fail.rs:29:26
@@ -226,7 +173,6 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::html::Href: std::convert::From<()>` is not satisfied
   --> $DIR/html-tag-fail.rs:30:21
@@ -238,7 +184,6 @@ error[E0277]: the trait bound `yew::html::Href: std::convert::From<()>` is not s
              <yew::html::Href as std::convert::From<&'a str>>
              <yew::html::Href as std::convert::From<std::string::String>>
    = note: required because of the requirements on the impl of `std::convert::Into<yew::html::Href>` for `()`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/html-tag-fail.rs:32:20
@@ -248,7 +193,6 @@ error[E0308]: mismatched types
    |
    = note: expected enum `yew::callback::Callback<web_sys::features::gen_MouseEvent::MouseEvent>`
               found type `{integer}`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/html-tag-fail.rs:33:20
@@ -258,7 +202,6 @@ error[E0308]: mismatched types
    |
    = note: expected enum `yew::callback::Callback<web_sys::features::gen_MouseEvent::MouseEvent>`
               found enum `yew::callback::Callback<std::string::String>`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `to_string` found for struct `NotToString` in the current scope
   --> $DIR/html-tag-fail.rs:35:27
@@ -276,15 +219,12 @@ error[E0599]: no method named `to_string` found for struct `NotToString` in the 
    = note: the method `to_string` exists but the following trait bounds were not satisfied:
            `NotToString: std::fmt::Display`
            which is required by `NotToString: std::string::ToString`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/html-tag-fail.rs:37:24
    |
 37 |     html! { <input ref=() /> };
    |                        ^^ expected struct `yew::html::NodeRef`, found `()`
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::borrow::Cow<'static, str>: std::convert::From<{integer}>` is not satisfied
   --> $DIR/html-tag-fail.rs:45:15
@@ -299,4 +239,3 @@ error[E0277]: the trait bound `std::borrow::Cow<'static, str>: std::convert::Fro
              <std::borrow::Cow<'a, std::ffi::CStr> as std::convert::From<&'a std::ffi::CStr>>
            and 11 others
    = note: required by `std::convert::From::from`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/yew-router-macro/src/lib.rs
+++ b/yew-router-macro/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate proc_macro;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 

--- a/yew-router/examples/router_component/src/b_component.rs
+++ b/yew-router/examples/router_component/src/b_component.rs
@@ -171,7 +171,7 @@ impl BModel {
         html! {
             <input
                 placeholder="subpath",
-                value=sub_path.unwrap_or("".into()),
+                value=sub_path.unwrap_or_else(|| "".into()),
                 oninput=&self.update_subpath
                 />
         }

--- a/yew-router/src/alias.rs
+++ b/yew-router/src/alias.rs
@@ -10,7 +10,6 @@
 ///
 /// # Example
 /// ```
-/// # #[macro_use] extern crate yew_router;
 /// define_router_state!(Option<String>);
 /// use router_state::Route; // alias to Route<Option<String>>
 /// # fn main() {}

--- a/yew-router/src/alias.rs
+++ b/yew-router/src/alias.rs
@@ -10,6 +10,7 @@
 ///
 /// # Example
 /// ```
+/// # use yew_router::define_router_state;
 /// define_router_state!(Option<String>);
 /// use router_state::Route; // alias to Route<Option<String>>
 /// # fn main() {}

--- a/yew-stdweb/Cargo.toml
+++ b/yew-stdweb/Cargo.toml
@@ -29,8 +29,6 @@ http = "0.2"
 indexmap = "1.0.2"
 js-sys = { version = "0.3", optional = true }
 log = "0.4"
-proc-macro-hack = "0.5"
-proc-macro-nested = "0.1"
 rmp-serde = { version = "0.14.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = { version = "0.11.1", optional = true }

--- a/yew/Cargo.toml
+++ b/yew/Cargo.toml
@@ -28,8 +28,6 @@ http = "0.2"
 indexmap = "1.0.2"
 js-sys = { version = "0.3", optional = true }
 log = "0.4"
-proc-macro-hack = "0.5"
-proc-macro-nested = "0.1"
 rmp-serde = { version = "0.14.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = { version = "0.11.1", optional = true }

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -510,6 +510,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    extern crate self as yew;
+
+    use crate::html;
     use crate::html::*;
     use crate::Properties;
     use std::ops::Deref;
@@ -636,7 +639,7 @@ mod tests {
     }
 
     #[test]
-    fn lifecyle_tests() {
+    fn lifecycle_tests() {
         let lifecycle: Rc<RefCell<Vec<String>>> = Rc::default();
 
         test_lifecycle(

--- a/yew/src/lib.rs
+++ b/yew/src/lib.rs
@@ -96,13 +96,10 @@
 #![recursion_limit = "512"]
 extern crate self as yew;
 
-use proc_macro_hack::proc_macro_hack;
 /// This macro implements JSX-like templates.
-#[proc_macro_hack(support_nested)]
 pub use yew_macro::html;
 
 #[doc(hidden)]
-#[proc_macro_hack(support_nested)]
 pub use yew_macro::html_nested;
 
 /// This module contains macros which implements html! macro and JSX-like templates

--- a/yew/src/utils.rs
+++ b/yew/src/utils.rs
@@ -5,6 +5,7 @@ use cfg_if::cfg_if;
 use cfg_match::cfg_match;
 use std::marker::PhantomData;
 use yew::html::ChildrenRenderer;
+use yew::virtual_dom::VNode;
 cfg_if! {
     if #[cfg(feature = "std_web")] {
         use stdweb::web::{Document, Window};
@@ -67,6 +68,15 @@ pub fn origin() -> Result<String, Error> {
     })?;
 
     Ok(origin)
+}
+
+/// Map IntoIterator<Item=Into<VNode>> to Iterator<Item=VNode>
+pub fn into_node_iter<T, U>(into_node_iter: T) -> impl Iterator<Item = VNode>
+where
+    T: IntoIterator<Item = U>,
+    U: Into<VNode>,
+{
+    into_node_iter.into_iter().map(|n| n.into())
 }
 
 /// A special type necessary for flattening components returned from nested html macros.

--- a/yew/src/virtual_dom/vcomp.rs
+++ b/yew/src/virtual_dom/vcomp.rs
@@ -498,7 +498,7 @@ mod tests {
 
         let children_renderer_method = html! {
             <List>
-                { children_renderer.clone() }
+                { children_renderer }
             </List>
         };
         assert_eq!(

--- a/yew/src/virtual_dom/vcomp.rs
+++ b/yew/src/virtual_dom/vcomp.rs
@@ -524,6 +524,9 @@ mod tests {
 
 #[cfg(all(test, feature = "web_sys"))]
 mod layout_tests {
+    extern crate self as yew;
+
+    use crate::html;
     use crate::virtual_dom::layout_tests::{diff_layouts, TestLayout};
     use crate::{Children, Component, ComponentLink, Html, Properties, ShouldRender};
     use std::marker::PhantomData;

--- a/yew/src/virtual_dom/vlist.rs
+++ b/yew/src/virtual_dom/vlist.rs
@@ -237,6 +237,9 @@ impl VDiff for VList {
 
 #[cfg(all(test, feature = "web_sys"))]
 mod layout_tests {
+    extern crate self as yew;
+
+    use crate::html;
     use crate::virtual_dom::layout_tests::{diff_layouts, TestLayout};
 
     #[cfg(feature = "wasm_test")]
@@ -312,6 +315,9 @@ mod layout_tests {
 
 #[cfg(all(test, feature = "web_sys"))]
 mod layout_tests_keys {
+    extern crate self as yew;
+
+    use crate::html;
     use crate::virtual_dom::layout_tests::{diff_layouts, TestLayout};
     use crate::virtual_dom::VNode;
     use crate::{Children, Component, ComponentLink, Html, Properties, ShouldRender};

--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -177,6 +177,18 @@ impl VTag {
         self.attributes.insert(name.to_owned(), value.to_string());
     }
 
+    /// Set boolean attribute if value is true. Unset if value is false. The name
+    /// of the attribute will be used as the value.
+    ///
+    /// Example: `<button disabled="disabled">`
+    pub fn set_boolean_attribute(&mut self, name: &str, value: bool) {
+        if value {
+            self.attributes.insert(name.to_owned(), name.to_owned());
+        } else {
+            self.attributes.remove(name);
+        }
+    }
+
     /// Adds attributes to a virtual node. Not every attribute works when
     /// it set as attribute. We use workarounds for:
     /// `type/kind`, `value` and `checked`.

--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -816,6 +816,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(unused_parens)]
     fn filter_empty_string_classes() {
         let a = html! { <div class=vec![""]></div> };
         let b = html! { <div class=("")></div> };
@@ -1390,6 +1391,9 @@ mod tests {
 
 #[cfg(all(test, feature = "web_sys"))]
 mod layout_tests {
+    extern crate self as yew;
+
+    use crate::html;
     use crate::virtual_dom::layout_tests::{diff_layouts, TestLayout};
 
     #[cfg(feature = "wasm_test")]

--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -828,10 +828,9 @@ mod tests {
     }
 
     #[test]
-    #[allow(unused_parens)]
     fn filter_empty_string_classes() {
         let a = html! { <div class=vec![""]></div> };
-        let b = html! { <div class=("")></div> };
+        let b = html! { <div class=("", "")></div> };
         let c = html! { <div class=""></div> };
         let d_arr = [""];
         let d = html! { <div class=&d_arr[..]></div> };

--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -681,7 +681,7 @@ mod tests {
         };
 
         let d = html! {
-            <div class=format!("fail")></div>
+            <div class=format!("fail{}", "")></div>
         };
 
         assert_eq!(a, b);

--- a/yew/src/virtual_dom/vtag.rs
+++ b/yew/src/virtual_dom/vtag.rs
@@ -177,7 +177,7 @@ impl VTag {
         self.attributes.insert(name.to_owned(), value.to_string());
     }
 
-    /// Set boolean attribute if value is true. Unset if value is false. The name
+    /// Sets a boolean attribute if `value` is true. Removes if `value` is false. The name
     /// of the attribute will be used as the value.
     ///
     /// Example: `<button disabled="disabled">`

--- a/yew/src/virtual_dom/vtext.rs
+++ b/yew/src/virtual_dom/vtext.rs
@@ -87,6 +87,8 @@ impl PartialEq for VText {
 
 #[cfg(test)]
 mod test {
+    extern crate self as yew;
+
     use crate::html;
 
     #[cfg(feature = "wasm_test")]
@@ -109,6 +111,9 @@ mod test {
 
 #[cfg(all(test, feature = "web_sys"))]
 mod layout_tests {
+    extern crate self as yew;
+
+    use crate::html;
     use crate::virtual_dom::layout_tests::{diff_layouts, TestLayout};
 
     #[cfg(feature = "wasm_test")]

--- a/yewtil-macro/src/lib.rs
+++ b/yewtil-macro/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate proc_macro;
 use proc_macro::TokenStream;
 
 use crate::function_component::function_component_handler;


### PR DESCRIPTION
#### Description
Proc macros are allowed in the expression position as of rust 1.45. As a result of removing the hack, clippy can now properly check expressions inside the `html!` macro!

#### Changes
- removes the use of `proc-macro-hack`
- fix clippy warnings
- Add `set_boolean_attribute` method to `VTag`

Fixes https://github.com/yewstack/yew/issues/1420

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
