### PR TITLE
Remove blank lines within list items

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -14,24 +14,21 @@ In order for agents to run concurrently, Yew uses [web-workers](https://develope
 
 ## Types of Agents
 
-#### Reaches
+### Reaches
 
-* Context - There will exist at most one instance of a Context Agent at any given time. Bridges will 
+* Context - There will exist at most one instance of a Context Agent at any given time. Bridges will
+  spawn or connect to an already spawned agent on the UI thread. This can be used to coordinate
+  state between components or other agents. When no bridges are connected to this agent, the agent
+  will disappear.
 
-  spawn or connect to an already spawned agent on the UI thread. This can be used to coordinate state 
-
-  between components or other agents. When no bridges are connected to this agent, the agent will 
-
-  disappear.
-
-* Job - Spawn a new agent on the UI thread for every new bridge. This is good for moving shared but 
-
-  independent behavior that communicates with the browser out of components. \(TODO verify\) When the 
-
-  task is done, the agent will disappear.
+* Job - Spawn a new agent on the UI thread for every new bridge. This is good for moving shared but
+  independent behavior that communicates with the browser out of components. \(TODO verify\) When
+  the task is done, the agent will disappear.
 
 * Public - Same as Context, but runs on its own web worker.
+
 * Private - Same as Job, but runs on its own web worker.
+
 * Global \(WIP\)
 
 ## Communication between Agents and Components
@@ -51,4 +48,3 @@ Agents that live in their own separate web worker \(Private and Public\) incur s
 ## Further reading
 
 * The [pub\_sub](https://github.com/yewstack/yew/tree/master/examples/pub_sub) example shows how components can use agents to communicate with each other.
-


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and which issue is fixed. -->

Blank lines within the list items in "Agents" made the lines render as separate paragraphs. This PR removes the blank lines and trailing whitespace, and wraps at 100 columns. Also changed a h4 to a h3.

Blank lines between list items make them render with extra spacing, so they were left in and made consistent between all the list items.

This is a minor change without a corresponding issue.

#### Checklist:

- [ ] I have run `./ci/run_stable_checks.sh`
- [ ] I have reviewed my own code
- [ ] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
