### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,10 @@ install:
   - rustup target add wasm32-unknown-unknown
   - cargo +stable install wasm-pack
   - curl --retry 5 -LO https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
-  - tar -xzf geckodriver-v0.27.0-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzf geckodriver-v0.27.0-linux64.tar.gz -C geckodriver
   - export PATH="$PATH:$PWD/geckodriver"
+  - geckodriver --version
   - ./ci/install_cargo_web.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ install:
   - rustup install stable
   - rustup target add wasm32-unknown-unknown
   - cargo +stable install wasm-pack
-  - curl --retry 5 -LO https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
+  - curl --retry 5 -LO https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
   - mkdir geckodriver
-  - tar -xzf geckodriver-v0.27.0-linux64.tar.gz -C geckodriver
+  - tar -xzf geckodriver-v0.26.0-linux64.tar.gz -C geckodriver
   - export PATH="$PATH:$PWD/geckodriver"
   - geckodriver --version
   - ./ci/install_cargo_web.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ install:
   - rustup install stable
   - rustup target add wasm32-unknown-unknown
   - cargo +stable install wasm-pack
+  - curl --retry 5 -LO https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
+  - tar -xzf geckodriver-v0.27.0-linux64.tar.gz
+  - export PATH="$PATH:$PWD/geckodriver"
   - ./ci/install_cargo_web.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ install:
   - rustup install stable
   - rustup target add wasm32-unknown-unknown
   - cargo +stable install wasm-pack
-  - curl --retry 5 -LO https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
-  - tar -xzf geckodriver-v0.26.0-linux64.tar.gz
   - ./ci/install_cargo_web.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ install:
 
 script:
   - ./ci/run_stable_checks.sh
-  - GECKODRIVER="$(pwd)/geckodriver" HTTPBIN_URL="http://localhost:8000" ./ci/run_tests.sh
+  - HTTPBIN_URL="http://localhost:8000" ./ci/run_tests.sh


### PR DESCRIPTION
#### Description

wasm-pack can automatically download the latest Geckodriver so we don't need to do it manually. I forgot to include this in #1415 but now is a good time to do it because it should fix the builds.

See Also: rustwasm/wasm-bindgen#2261.