### PR TITLE
Update Game of Life example

### DIFF
--- a/examples/game_of_life/static/styles.css
+++ b/examples/game_of_life/static/styles.css
@@ -1,98 +1,104 @@
 html,
 body {
-    margin: 0;
-    padding: 0;
-    text-align: center;
+  margin: 0;
+  padding: 0;
+  text-align: center;
 }
 
 body {
-    font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    line-height: 1.4em;
-    color: #4d4d4d;
-    min-width: 230px;
-	max-width: 1000px;
-    margin: 0 auto;
-    -webkit-font-smoothing: antialiased;
-    -moz-font-smoothing: antialiased;
-    font-smoothing: antialiased;
-    font-weight: 300;
-    background-color: #000000;
+  font: 14px "Helvetica Neue", Helvetica, Arial, sans-serif;
+  line-height: 1.4em;
+  color: #4d4d4d;
+  min-width: 230px;
+  max-width: 1000px;
+  margin: 0 auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-font-smoothing: antialiased;
+  font-smoothing: antialiased;
+  font-weight: 300;
+  background-color: #000000;
 }
 
 .app-logo {
-    animation: app-logo-scale infinite 4s linear;
-    height: 80px;
-    width: 80px;
+  animation: app-logo-scale infinite 4s linear;
+  height: 80px;
+  width: 80px;
 }
 
 .app-header {
-    background-color: #000;
-    height: 130px;
-    color: aliceblue;
+  background-color: #000;
+  height: 130px;
+  color: aliceblue;
 }
 
 .app-title {
-    font-size: 24px;
-    width: 100%;
-    font-weight: 100;
-    text-align: center;
-    -webkit-text-rendering: optimizeLegibility;
-    -moz-text-rendering: optimizeLegibility;
-    text-rendering: optimizeLegibility;
+  font-size: 24px;
+  width: 100%;
+  font-weight: 100;
+  text-align: center;
+  -webkit-text-rendering: optimizeLegibility;
+  -moz-text-rendering: optimizeLegibility;
+  text-rendering: optimizeLegibility;
 }
 
 .app-footer {
-    background-color: #000000;
-    height: 30px;
-    padding: 10px;
+  background-color: #000000;
+  height: 30px;
+  padding: 10px;
 }
 
 .footer-text {
-    color: aliceblue;
-    padding-left: 20px;
-    font-size: 14px;
+  color: aliceblue;
+  padding-left: 20px;
+  font-size: 14px;
 }
 
 .game-area {
-    width: 94%;
-    height: 510px;
-    max-width: 500px;
-    margin: 20px auto;
+  width: 94%;
+  margin: 20px auto;
 }
 
 .game-container {
-    background: #000000;
-    margin: 20px 0 0px 0;
+  background: #000000;
+  margin: 20px 0 0px 0;
 }
 
 .game-of-life {
-    background-color: aliceblue;
-    height: 400px;
-    width: 100%;
-    overflow: hidden;
+  display: inline-block;
+  background-color: aliceblue;
+  width: max-content;
+  overflow: hidden;
+}
+
+.game-row {
+  line-height: 0;
 }
 
 .game-cellule {
-    float: left;
-    width: 8px;
-    height: 8px;
-    border: 1px solid #ccc;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border: 1px solid #ccc;
 }
 
 .cellule-dead {
-    background-color: white;
+  background-color: white;
 }
 
 .cellule-live {
-    background-color: black ;
+  background-color: black;
 }
 
 .game-buttons {
-    width: 100%;
-    margin-top: 20px;
+  width: 100%;
+  margin-top: 20px;
 }
 
 @keyframes app-logo-scale {
-    from { transform: scale(0.8); }
-    to { transform: scale(1.2); }
+  from {
+    transform: scale(0.8);
+  }
+  to {
+    transform: scale(1.2);
+  }
 }


### PR DESCRIPTION
#### Description

The Game of Life example currently renders all cells in a single line and has the browser break it into multiple rows. This is problematic because the layout is very important to the core concept of the game.
If the amount of columns in the browser doesn't match with the internal one the entire game breaks.
This PR fixes this by making it so that the cells are rendered in separate rows which makes it easier to style them properly.

Fixes #1461 
