### PR TITLE
Update documentation to use NodeRef::cast

### DIFF
--- a/docs/concepts/components/README.md
+++ b/docs/concepts/components/README.md
@@ -82,7 +82,7 @@ impl Component for MyComponent {
 
     fn rendered(&mut self, first_render: bool) {
         if first_render {
-            if let Some(input) = self.node_ref.try_into::<InputElement>() {
+            if let Some(input) = self.node_ref.cast::<InputElement>() {
                 input.focus();
             }
         }

--- a/docs/concepts/components/refs.md
+++ b/docs/concepts/components/refs.md
@@ -20,6 +20,5 @@ html! {
 }
 
 // In update
-let has_attributes = self.node_ref.try_into::<Element>().has_attributes();
+let has_attributes = self.node_ref.cast::<Element>().has_attributes();
 ```
-

--- a/docs/concepts/components/refs.md
+++ b/docs/concepts/components/refs.md
@@ -20,5 +20,5 @@ html! {
 }
 
 // In update
-let has_attributes = self.node_ref.cast::<Element>().has_attributes();
+let has_attributes = self.node_ref.cast::<Element>().unwrap().has_attributes();
 ```

--- a/website/translated_docs/zh-CN/concepts/components/README.md
+++ b/website/translated_docs/zh-CN/concepts/components/README.md
@@ -84,7 +84,7 @@ impl Component for MyComponent {
     }
 
     fn mounted(&mut self) -> ShouldRender {
-        if let Some(input) = self.node_ref.try_into::<InputElement>() {
+        if let Some(input) = self.node_ref.cast::<InputElement>() {
             input.focus();
         }
         false

--- a/website/translated_docs/zh-CN/concepts/components/refs.md
+++ b/website/translated_docs/zh-CN/concepts/components/refs.md
@@ -22,6 +22,6 @@ html! {
 }
 
 // 在 update 中
-let has_attributes = self.node_ref.try_into::<Element>().has_attributes();
+let has_attributes = self.node_ref.cast::<Element>().has_attributes();
 ```
 

--- a/website/translated_docs/zh-CN/concepts/components/refs.md
+++ b/website/translated_docs/zh-CN/concepts/components/refs.md
@@ -22,6 +22,5 @@ html! {
 }
 
 // 在 update 中
-let has_attributes = self.node_ref.cast::<Element>().has_attributes();
+let has_attributes = self.node_ref.cast::<Element>().unwrap().has_attributes();
 ```
-

--- a/website/translated_docs/zh-TW/concepts/components/README.md
+++ b/website/translated_docs/zh-TW/concepts/components/README.md
@@ -85,7 +85,7 @@ impl Component for MyComponent {
 
     fn rendered(&mut self, first_render: bool) {
         if first_render {
-            if let Some(input) = self.node_ref.try_into::<InputElement>() {
+            if let Some(input) = self.node_ref.cast::<InputElement>() {
                 input.focus();
             }
         }

--- a/website/translated_docs/zh-TW/concepts/components/refs.md
+++ b/website/translated_docs/zh-TW/concepts/components/refs.md
@@ -22,6 +22,6 @@ html! {
 }
 
 // 更新
-let has_attributes = self.node_ref.try_into::<Element>().has_attributes();
+let has_attributes = self.node_ref.cast::<Element>().has_attributes();
 ```
 

--- a/website/translated_docs/zh-TW/concepts/components/refs.md
+++ b/website/translated_docs/zh-TW/concepts/components/refs.md
@@ -22,6 +22,5 @@ html! {
 }
 
 // 更新
-let has_attributes = self.node_ref.cast::<Element>().has_attributes();
+let has_attributes = self.node_ref.cast::<Element>().unwrap().has_attributes();
 ```
-


### PR DESCRIPTION
#### Description

A while ago (v0.12) the `NodeRef::try_into` method was renamed to `cast` but the documentation was never updated. This PR updates all instances where "try_into" was used in the code snippets.
It also adds a missing `unwrap()` call in the `NodeRef` documentation.