### PR TITLE
yew/scheduler: batch component update scheduling

### DIFF
--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -477,8 +477,13 @@ where
 
             state.has_rendered = true;
             state.component.rendered(self.first_render);
-            for update in state.pending_updates.drain(..) {
-                scheduler().push_comp(ComponentRunnableType::Update, update);
+            if !state.pending_updates.is_empty() {
+                scheduler().push_comp_update_batch(
+                    state
+                        .pending_updates
+                        .drain(..)
+                        .map(|u| u as Box<dyn Runnable>),
+                );
             }
         }
     }

--- a/yew/src/scheduler.rs
+++ b/yew/src/scheduler.rs
@@ -92,6 +92,11 @@ impl Scheduler {
         self.start();
     }
 
+    pub(crate) fn push_comp_update_batch(&self, it: impl IntoIterator<Item = Box<dyn Runnable>>) {
+        self.component.update.borrow_mut().extend(it);
+        self.start();
+    }
+
     pub(crate) fn push(&self, runnable: Box<dyn Runnable>) {
         self.main.borrow_mut().push_back(runnable);
         self.start();


### PR DESCRIPTION
#### Description

Micro optimization that removes the need to obtain refcell locks, clone Rcs and match update enums when scheduling a vector of component updates. 

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [ ] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
[x] I have opened a PR against https://github.com/yewstack/js-framework-benchmark: https://github.com/yewstack/js-framework-benchmark/pull/11/checks?check_run_id=955329393
