### PR TITLE
Simplify unit tests and test the yew-validation crate

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -218,8 +218,7 @@ jobs:
             cargo-${{ runner.os }}-
 
       - name: Run tests
-        run: |
-          packages=("yew-components" "yew-functional" "yew-macro" "yew-router" "yew-router-macro" "yew-router-route-parser" "yewtil")
-          for package in "${packages[@]}"; do
-            (cd "$package" && cargo test)
-          done
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --exclude yew --exclude yew-stdweb

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -221,4 +221,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --exclude yew --exclude yew-stdweb
+          args: --all-targets --workspace --exclude yew


### PR DESCRIPTION
This PR makes it so the unit tests *excludes* `yew` instead of explicitly *including* all other crates.
The inclusion list was missing "yew-dsl" and "yew-validation".