### PR TITLE
[docs] wasm-bindgen exact version

### DIFF
--- a/docs/getting-started/build-a-sample-app.md
+++ b/docs/getting-started/build-a-sample-app.md
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 yew = "0.17"
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.67"
 ```
 
 Copy the following template into your `src/lib.rs` file:


### PR DESCRIPTION


#### Description

I just tried the sample app.
I had to specify the exact wasm-bindgen otherwise, wasm-pack is hanging

same as: rustwasm/wasm-pack-template#44

Fixes just docs

#### Checklist:

- [ ] I have run `./ci/run_stable_checks.sh`
- [ ] I have reviewed my own code
- [ ] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
