### PR TITLE
Fix messed up closure types in the docs

### DIFF
--- a/docs/concepts/components/callbacks.md
+++ b/docs/concepts/components/callbacks.md
@@ -8,15 +8,15 @@ The component "link" is the mechanism through which components are able to regis
 
 ### callback
 
-Registers a callback that will send a message to the component's update mechanism when it is executed. Under the hood, it will call `send_self` with the message that is returned by the provided closure. A `Fn(IN) -> Vec<COMP::Message>` is provided and a `Callback<IN>` is returned.
+Registers a callback that will send a message to the component's update mechanism when it is executed. Under the hood, it will call `send_self` with the message that is returned by the provided closure. A `Fn(IN) -> COMP::Message` is provided and a `Callback<IN>` is returned.
 
 ### send\_message
 
 Sends a message to the component immediately after the current loop finishes, causing another update loop to initiate.
 
-### send\_message\_batch
+### batch\_callback
 
-Registers a callback that sends a batch of many messages at once when it is executed. If any of the messages cause the component to re-render, the component will re-render after all messages in the batch have been processed. A `Fn(IN) -> COMP::Message` is provided and a `Callback<IN>` is returned.
+Registers a callback that sends a batch of many messages at once when it is executed. If any of the messages cause the component to re-render, the component will re-render after all messages in the batch have been processed. A `Fn(IN) -> Vec<COMP::Message>` is provided and a `Callback<IN>` is returned.
 
 ## Callbacks
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and which issue is fixed. -->

Closure types in the [description of ComponentLink API](https://yew.rs/docs/en/concepts/components/callbacks/) were
slightly incorrect.

#### Checklist:

- [ ] I have run `./ci/run_stable_checks.sh`
- [ ] I have reviewed my own code
- [ ] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
