### PR TITLE
fix nested_list example

### DIFF
--- a/examples/nested_list/src/app.rs
+++ b/examples/nested_list/src/app.rs
@@ -7,8 +7,8 @@ use yew::prelude::*;
 pub struct App {
     link: ComponentLink<Self>,
     hovered: Hovered,
-    list_link: WeakComponentLink::<List>,
-    sub_list_link: WeakComponentLink::<List>,
+    list_link: WeakComponentLink<List>,
+    sub_list_link: WeakComponentLink<List>,
 }
 
 pub enum Msg {

--- a/examples/nested_list/src/app.rs
+++ b/examples/nested_list/src/app.rs
@@ -7,6 +7,8 @@ use yew::prelude::*;
 pub struct App {
     link: ComponentLink<Self>,
     hovered: Hovered,
+    list_link: WeakComponentLink::<List>,
+    sub_list_link: WeakComponentLink::<List>,
 }
 
 pub enum Msg {
@@ -21,6 +23,8 @@ impl Component for App {
         App {
             link,
             hovered: Hovered::None,
+            list_link: WeakComponentLink::<List>::default(),
+            sub_list_link: WeakComponentLink::<List>::default(),
         }
     }
 
@@ -38,8 +42,8 @@ impl Component for App {
     fn view(&self) -> Html {
         let on_hover = &self.link.callback(Msg::Hover);
         let onmouseenter = &self.link.callback(|_| Msg::Hover(Hovered::None));
-        let list_link = &WeakComponentLink::<List>::default();
-        let sub_list_link = &WeakComponentLink::<List>::default();
+        let list_link = &self.list_link;
+        let sub_list_link = &self.sub_list_link;
         html! {
             <div class="main" onmouseenter=onmouseenter>
                 <h1>{ "Nested List Demo" }</h1>

--- a/examples/nested_list/src/header.rs
+++ b/examples/nested_list/src/header.rs
@@ -37,7 +37,10 @@ impl Component for ListHeader {
     fn view(&self) -> Html {
         let list_link = self.props.list_link.borrow().clone().unwrap();
         let onclick = list_link.callback(|_| ListMsg::HeaderClick);
-        let onmouseover = self.props.on_hover.reform(|_| Hovered::Header);
+        let onmouseover = self.props.on_hover.reform(|e: MouseEvent| {
+            e.stop_propagation();
+            Hovered::Header
+        });
         html! {
             <div class="list-header" onmouseover=onmouseover onclick=onclick>
                 { &self.props.text }

--- a/examples/nested_list/src/item.rs
+++ b/examples/nested_list/src/item.rs
@@ -39,13 +39,10 @@ impl Component for ListItem {
 
     fn view(&self) -> Html {
         let name = self.props.name.clone();
-        let onmouseover = self
-            .props
-            .on_hover
-            .reform(move |e: MouseEvent| {
-                e.stop_propagation();
-                Hovered::Item(name.clone())
-            });
+        let onmouseover = self.props.on_hover.reform(move |e: MouseEvent| {
+            e.stop_propagation();
+            Hovered::Item(name.clone())
+        });
         html! {
             <div class="list-item" onmouseover=onmouseover>
                 { &self.props.name }

--- a/examples/nested_list/src/item.rs
+++ b/examples/nested_list/src/item.rs
@@ -42,7 +42,10 @@ impl Component for ListItem {
         let onmouseover = self
             .props
             .on_hover
-            .reform(move |_| Hovered::Item(name.clone()));
+            .reform(move |e: MouseEvent| {
+                e.stop_propagation();
+                Hovered::Item(name.clone())
+            });
         html! {
             <div class="list-item" onmouseover=onmouseover>
                 { &self.props.name }


### PR DESCRIPTION
1, each time at the mouseover, the app view creates the default WeakComponentLink, resulting in headers and item to get to the parent link is None. 
2, last-hovered is always List container.