### PR TITLE
Add detail to NodeRef docs

### DIFF
--- a/docs/concepts/components/refs.md
+++ b/docs/concepts/components/refs.md
@@ -3,9 +3,13 @@ title: Refs
 description: Out-of-band DOM access
 ---
 
-The `ref` keyword can be used inside of any HTML element or component to get the DOM `Element` that the item is attached to. This can be used to make changes to the DOM outside of the `view` lifecycle method.
+The `ref` keyword can be used inside of any HTML element or component to get the DOM `Element` that 
+the item is attached to. This can be used to make changes to the DOM outside of the `view` lifecycle
+method. 
 
-This is useful for getting ahold of canvas elements, or scrolling to different sections of a page.
+This is useful for getting ahold of canvas elements, or scrolling to different sections of a page. 
+For example, using a `NodeRef` in a component's `rendered` method allows you to make draw calls to 
+a canvas element after it has been rendered from `view`.
 
 The syntax is:
 
@@ -18,6 +22,6 @@ html! {
     <div ref=self.node_ref.clone()></div>
 }
 
-// In update
+// In rendered
 let has_attributes = self.node_ref.cast::<Element>().unwrap().has_attributes();
 ```


### PR DESCRIPTION
#### Description

This switches the suggestion from using `NodeRef` in `update`
to using it in `rendered` within the example of a canvas
element.

I believe this is where most people would want to use it,
especially for canvas. I did not know about the `rendered`
method until I asked on Discord but I did see this page
when searching the docs site for "canvas".

Also, thank you for working on this awesome project :)

Fixes https://github.com/yewstack/yew/issues/1502

#### Checklist:

- [ no] I have run `./ci/run_stable_checks.sh` -> Outputs many errors but this is a doc change so I don't think this is needed.
- [ yes] I have reviewed my own code
- [ N/A] I have added tests