### PR TITLE
Replace bash with cargo-make

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -13,18 +13,14 @@ namespace = "default"
 description = "Runs all validations for both workspaces on rust stable only."
 workspace = false
 condition = { channels = [ "stable" ] }
-run_task = { name = [ "stable-checks-workspace", "stable-checks-stdweb-workspace" ], fork = true }
+run_task = { name = [ "stable-checks-flow", "stable-checks-stdweb" ], fork = true }
 
-[tasks.stable-checks-workspace]
-private = true
-run_task = "stable-checks-flow"
-
-[tasks.stable-checks-stdweb-workspace]
+[tasks.stable-checks-stdweb]
 private = true
 workspace = false
 cwd = "yew-stdweb"
 command = "cargo"
-args = ["make", "stable-checks-workspace"]
+args = ["make", "stable-checks-flow"]
 
 [tasks.stable-checks-flow]
 private = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,7 +28,7 @@ run_task = { name = [ "stable-checks-flow", "stable-checks-stdweb" ], fork = tru
 [tasks.run-tests]
 dependencies = ["tests-setup"]
 env = { CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["examples/*", "yewtil/examples/*"] }
-run_task = { name = [ "run-tests-flow", "run-tests-stdweb" ], fork = true }
+run_task = { name = [ "run-tests-flow", "run-tests-stdweb", "tests-cleanup" ], fork = true }
 
 [tasks.stable-checks-stdweb]
 private = true
@@ -66,12 +66,57 @@ script = [
 test_flags= array --headless --firefox
 yew_test_features= set wasm_test
 
-if is_defined HTTPBIN_URL
+fn set_httpbin_test_features
+    HTTPBIN_URL = get_env HTTPBIN_URL
     echo INFO: using ${HTTPBIN_URL} for fetch service tests
     yew_test_features = set "${yew_test_features},httpbin_test"
+end
+
+if is_defined HTTPBIN_URL
+    set_httpbin_test_features
 else
-  echo INFO: HTTPBIN_URL isn't set, won't run fetch service tests
-  echo "      please see the CONTRIBUTING.md file for instructions"
+    start_docker = set true
+    args_provided = not is_empty ${CARGO_MAKE_TASK_ARGS}
+    if ${args_provided}
+        args = split ${CARGO_MAKE_TASK_ARGS} ;
+        for arg in ${args}
+            if eq ${arg} --skip-httpbin
+                start_docker = set false
+                release ${args}
+            end
+        end
+    end
+
+    if ${start_docker}
+        echo Starting httpbin docker image...
+        mkdir ./target
+        cidfile = set ./target/httpbin_container.cid
+
+        # if container already running, stop it
+        if is_file ${cidfile}
+            container_id = readfile ${cidfile}
+            rm ${cidfile}
+            set_env HTTPBIN_CONTAINER_ID ${container_id}
+            cm_run_task tests-cleanup
+        end
+
+        exec docker run -d --cidfile ${cidfile} -p 8080:8080 kennethreitz/httpbin
+        container_id = readfile ${cidfile}
+        container_id = trim ${container_id}
+        set_env HTTPBIN_CONTAINER_ID ${container_id}
+        set_env HTTPBIN_URL http://localhost:8080
+        set_httpbin_test_features
+
+        # wait for docker container to boot before running tests
+        if is_defined HTTPBIN_WAIT
+            sleep ${HTTPBIN_WAIT}
+        else
+            sleep 500
+        end
+    else
+        echo INFO: HTTPBIN_URL isn't set, won't run fetch service tests
+        echo "      please see the CONTRIBUTING.md file for instructions"
+    end
 end
 
 yew_test_flags = array_join ${test_flags} " "
@@ -81,6 +126,12 @@ set_env YEW_TEST_FLAGS ${yew_test_flags}
 set_env YEW_TEST_FEATURES ${yew_test_features}
 '''
 ]
+
+[tasks.tests-cleanup]
+condition = { env_set = ["HTTPBIN_CONTAINER_ID"] }
+ignore_errors = true
+command = "docker"
+args = ["stop", "${HTTPBIN_CONTAINER_ID}"]
 
 [tasks.run-tests-flow]
 workspace = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,41 @@
+
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+CARGO_MAKE_CLIPPY_ARGS = "-- --deny=warnings"
+RUST_RECURSION_COUNT = { unset = true } # todo remove as its fixed in 0.32.2
+min_version = "0.32.1" # todo 0.32.2
+
+[config.modify_core_tasks]
+private = true
+namespace = "default"
+
+[tasks.stable-checks]
+description = "Runs all validations for both workspaces on rust stable only."
+workspace = false
+condition = { channels = [ "stable" ] }
+run_task = { name = [ "stable-checks-workspace", "stable-checks-stdweb-workspace" ], fork = true }
+
+[tasks.stable-checks-workspace]
+private = true
+run_task = "stable-checks-flow"
+
+[tasks.stable-checks-stdweb-workspace]
+private = true
+workspace = false
+cwd = "yew-stdweb"
+command = "cargo"
+args = ["make", "stable-checks-workspace"]
+
+[tasks.stable-checks-flow]
+private = true
+dependencies = [
+    "default::check-format-flow",
+    "default::check-flow",
+    "default::clippy-flow",
+    "web-check"
+]
+
+[tasks.web-check]
+condition = { env_true = [ "YEW_WEB_CHECK" ] }
+command = "cargo"
+args = ["web", "check", "--target", "wasm32-unknown-unknown"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -139,7 +139,7 @@ set_env YEW_TEST_FEATURES ${yew_test_features}
 condition = { env_set = ["HTTPBIN_CONTAINER_ID"] }
 ignore_errors = true
 command = "docker"
-args = ["stop", "${HTTPBIN_CONTAINER_ID}"]
+args = ["rm", "--force", "${HTTPBIN_CONTAINER_ID}"]
 
 [tasks.run-tests-flow]
 workspace = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,12 @@
 
+######################
+#
+# public tasks:
+# * stable-checks
+# * run-tests
+#
+######################
+
 [config]
 min_version = "0.32.1" # todo 0.32.2
 default_to_workspace = false
@@ -6,6 +14,7 @@ default_to_workspace = false
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 CARGO_MAKE_CLIPPY_ARGS = "-- --deny=warnings"
+CARGO_MAKE_CARGO_BUILD_TEST_FLAGS = ""
 
 [config.modify_core_tasks]
 private = true
@@ -15,6 +24,10 @@ namespace = "core"
 description = "Runs all validations for both workspaces on rust stable only."
 condition = { channels = [ "stable" ] }
 run_task = { name = [ "stable-checks-flow", "stable-checks-stdweb" ], fork = true }
+
+[tasks.run-tests]
+dependencies = ["tests-setup"]
+run_task = { name = [ "run-tests-flow", "run-tests-stdweb" ], fork = true }
 
 [tasks.stable-checks-stdweb]
 private = true
@@ -44,3 +57,46 @@ dependencies = [
 [tasks.web-check]
 command = "cargo"
 args = ["web", "check", "--target", "wasm32-unknown-unknown"]
+
+[tasks.tests-setup]
+script = [
+'''
+#!@duckscript
+test_flags= array --headless --firefox
+yew_test_features= set wasm_test
+
+if is_defined HTTPBIN_URL
+    echo INFO: using ${HTTPBIN_URL} for fetch service tests
+    yew_test_features = set "${yew_test_features},httpbin_test"
+else
+  echo INFO: HTTPBIN_URL isn't set, won't run fetch service tests
+  echo "      please see the CONTRIBUTING.md file for instructions"
+end
+
+yew_test_flags = array_join ${test_flags} " "
+echo "running tests with flags: ${yew_test_flags} and features: ${yew_test_features}"
+
+set_env YEW_TEST_FLAGS ${yew_test_flags}
+set_env YEW_TEST_FEATURES ${yew_test_features}
+'''
+]
+
+[tasks.run-tests-flow]
+workspace = true
+dependencies = [ "test" ]
+
+[tasks.run-tests-stdweb]
+private = true
+extend = "core::wasm-pack-base"
+cwd = "yew-stdweb"
+args = [
+    "test",
+    "@@split(YEW_TEST_FLAGS, )",
+    "--",
+    "--features",
+    "${YEW_TEST_FEATURES}"
+]
+
+[tasks.test]
+command = "cargo"
+args = ["test"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,7 +8,7 @@
 ######################
 
 [config]
-min_version = "0.32.3"
+min_version = "0.32.4"
 default_to_workspace = false
 
 [env]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,7 +28,7 @@ run_task = { name = [ "stable-checks-flow", "stable-checks-stdweb" ], fork = tru
 [tasks.run-tests]
 dependencies = ["tests-setup"]
 env = { CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["examples/*", "yewtil/examples/*"] }
-run_task = { name = [ "run-tests-flow", "run-tests-stdweb", "tests-cleanup" ], fork = true }
+run_task = { name = [ "run-tests-flow", "run-tests-stdweb" ], fork = true, cleanup_task = "tests-cleanup" }
 
 [tasks.stable-checks-stdweb]
 private = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,37 +1,46 @@
 
+[config]
+min_version = "0.32.1" # todo 0.32.2
+default_to_workspace = false
+
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 CARGO_MAKE_CLIPPY_ARGS = "-- --deny=warnings"
-RUST_RECURSION_COUNT = { unset = true } # todo remove as its fixed in 0.32.2
-min_version = "0.32.1" # todo 0.32.2
 
 [config.modify_core_tasks]
 private = true
-namespace = "default"
+namespace = "core"
 
 [tasks.stable-checks]
 description = "Runs all validations for both workspaces on rust stable only."
-workspace = false
 condition = { channels = [ "stable" ] }
 run_task = { name = [ "stable-checks-flow", "stable-checks-stdweb" ], fork = true }
 
 [tasks.stable-checks-stdweb]
 private = true
-workspace = false
 cwd = "yew-stdweb"
 command = "cargo"
-args = ["make", "stable-checks-flow"]
+args = [
+    "make",
+    "--loglevel",
+    "${CARGO_MAKE_LOG_LEVEL}",
+    "--profile",
+    "${CARGO_MAKE_PROFILE}",
+    "stable-checks-flow"
+]
 
 [tasks.stable-checks-flow]
 private = true
+workspace = true
 dependencies = [
-    "default::check-format-flow",
-    "default::check-flow",
-    "default::clippy-flow",
-    "web-check"
+    "core::check-format-flow",
+    "core::check-flow",
+    "core::clippy-flow",
+    "post-stable-checks"
 ]
 
+[tasks.post-stable-checks]
+
 [tasks.web-check]
-condition = { env_true = [ "YEW_WEB_CHECK" ] }
 command = "cargo"
 args = ["web", "check", "--target", "wasm32-unknown-unknown"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -100,11 +100,19 @@ else
             cm_run_task tests-cleanup
         end
 
-        exec docker run -d --cidfile ${cidfile} -p 8080:8080 kennethreitz/httpbin
+        # bind to a random free port
+        exec docker run -d --cidfile ${cidfile} -p 80 kennethreitz/httpbin
         container_id = readfile ${cidfile}
         container_id = trim ${container_id}
         set_env HTTPBIN_CONTAINER_ID ${container_id}
-        set_env HTTPBIN_URL http://localhost:8080
+
+        docker_port = exec docker port ${container_id}
+        # format is `80/tcp -> 0.0.0.0:<PORT>`
+        docker_port = split ${docker_port.stdout} :
+        docker_port = array_pop ${docker_port}
+        docker_port = trim ${docker_port}
+
+        set_env HTTPBIN_URL http://localhost:${docker_port}
         set_httpbin_test_features
 
         # wait for docker container to boot before running tests

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,7 +8,7 @@
 ######################
 
 [config]
-min_version = "0.32.2"
+min_version = "0.32.3"
 default_to_workspace = false
 
 [env]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -27,6 +27,7 @@ run_task = { name = [ "stable-checks-flow", "stable-checks-stdweb" ], fork = tru
 
 [tasks.run-tests]
 dependencies = ["tests-setup"]
+env = { CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["examples/*", "yewtil/examples/*"] }
 run_task = { name = [ "run-tests-flow", "run-tests-stdweb" ], fork = true }
 
 [tasks.stable-checks-stdweb]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -75,7 +75,10 @@ end
 if is_defined HTTPBIN_URL
     set_httpbin_test_features
 else
-    start_docker = set true
+    # only enable docker is docker executable is available
+    # and --skip-httpbin cli argument not provided to cargo make
+    docker_path = which docker
+    start_docker = is_defined docker_path
     args_provided = not is_empty ${CARGO_MAKE_TASK_ARGS}
     if ${args_provided}
         args = split ${CARGO_MAKE_TASK_ARGS} ;
@@ -100,19 +103,19 @@ else
             cm_run_task tests-cleanup
         end
 
+        # get local port
+        docker_port = get_env YEW_HTTPBIN_PORT
+        if not is_defined docker_port
+            docker_port = set 7117
+        end
+
         # bind to a random free port
-        exec docker run -d --cidfile ${cidfile} -p 80 kennethreitz/httpbin
+        exec docker run -d --cidfile ${cidfile} -p "${docker_port}:80" kennethreitz/httpbin
         container_id = readfile ${cidfile}
         container_id = trim ${container_id}
         set_env HTTPBIN_CONTAINER_ID ${container_id}
 
-        docker_port = exec docker port ${container_id}
-        # format is `80/tcp -> 0.0.0.0:<PORT>`
-        docker_port = split ${docker_port.stdout} :
-        docker_port = array_pop ${docker_port}
-        docker_port = trim ${docker_port}
-
-        set_env HTTPBIN_URL http://localhost:${docker_port}
+        echo Using HTTPBIN_URL: http://localhost:${docker_port}
         set_httpbin_test_features
 
         # wait for docker container to boot before running tests

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,7 +8,7 @@
 ######################
 
 [config]
-min_version = "0.32.1" # todo 0.32.2
+min_version = "0.32.2"
 default_to_workspace = false
 
 [env]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -115,7 +115,7 @@ else
         container_id = trim ${container_id}
         set_env HTTPBIN_CONTAINER_ID ${container_id}
 
-        echo Using HTTPBIN_URL: http://localhost:${docker_port}
+        set_env HTTPBIN_URL http://localhost:${docker_port}
         set_httpbin_test_features
 
         # wait for docker container to boot before running tests

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -75,7 +75,7 @@ end
 if is_defined HTTPBIN_URL
     set_httpbin_test_features
 else
-    # only enable docker is docker executable is available
+    # only enable docker if docker executable is available
     # and --skip-httpbin cli argument not provided to cargo make
     docker_path = which docker
     start_docker = is_defined docker_path

--- a/yew-functional/Makefile.toml
+++ b/yew-functional/Makefile.toml
@@ -1,0 +1,8 @@
+
+[tasks.test]
+clear = true
+extend = "core::wasm-pack-base"
+args = [
+    "test",
+    "@@split(YEW_TEST_FLAGS, )"
+]

--- a/yew-macro/Makefile.toml
+++ b/yew-macro/Makefile.toml
@@ -1,0 +1,16 @@
+
+[tasks.test]
+clear = true
+dependencies = ["test-macro", "test-derive-props", "test-doc"]
+
+[tasks.test-macro]
+command = "cargo"
+args = ["test", "--test", "macro_test"]
+
+[tasks.test-derive-props]
+command = "cargo"
+args = ["test", "--test", "derive_props_test"]
+
+[tasks.test-doc]
+command = "cargo"
+args = ["test", "--doc"]

--- a/yew-stdweb/examples/webgl/Makefile.toml
+++ b/yew-stdweb/examples/webgl/Makefile.toml
@@ -1,3 +1,3 @@
 
-[env]
-YEW_WEB_CHECK = true
+[tasks.post-stable-checks]
+alias = "web-check"

--- a/yew-stdweb/examples/webgl/Makefile.toml
+++ b/yew-stdweb/examples/webgl/Makefile.toml
@@ -1,0 +1,3 @@
+
+[env]
+YEW_WEB_CHECK = true

--- a/yew/Makefile.toml
+++ b/yew/Makefile.toml
@@ -1,0 +1,6 @@
+
+[env]
+CARGO_MAKE_CLIPPY_ARGS = "--features cbor,msgpack,toml,yaml -- --deny=warnings"
+
+[tasks."default::check"]
+args = ["check", "--features", "cbor,msgpack,toml,yaml"]

--- a/yew/Makefile.toml
+++ b/yew/Makefile.toml
@@ -4,3 +4,26 @@ CARGO_MAKE_CLIPPY_ARGS = "--features cbor,msgpack,toml,yaml -- --deny=warnings"
 
 [tasks."core::check"]
 args = ["check", "--features", "cbor,msgpack,toml,yaml"]
+
+[tasks.test]
+clear = true
+dependencies = ["test-wasm", "test-doc-partial-features", "test-doc-all-features"]
+
+[tasks.test-wasm]
+private = true
+extend = "core::wasm-pack-base"
+args = [
+    "test",
+    "@@split(YEW_TEST_FLAGS, )",
+    "--",
+    "--features",
+    "${YEW_TEST_FEATURES}"
+]
+
+[tasks.test-doc-partial-features]
+command = "cargo"
+args = ["test", "--doc", "--features", "doc_test,wasm_test,yaml,msgpack,cbor,toml"]
+
+[tasks.test-doc-all-features]
+command = "cargo"
+args = ["test", "--doc", "--features", "doc_test,wasm_test,yaml,msgpack,cbor,toml,std_web,agent,services", "--no-default-features"]

--- a/yew/Makefile.toml
+++ b/yew/Makefile.toml
@@ -2,5 +2,5 @@
 [env]
 CARGO_MAKE_CLIPPY_ARGS = "--features cbor,msgpack,toml,yaml -- --deny=warnings"
 
-[tasks."default::check"]
+[tasks."core::check"]
 args = ["check", "--features", "cbor,msgpack,toml,yaml"]


### PR DESCRIPTION
#### Description

See #1418 
Basically this first draft only replaces the run_stable_checks script to cargo make.
In addition it also installs rustfmt, clippy and cargo-web if missing.
You can run it from the root as ```cargo make stable-checks```

By the way, one of the member crates is failing on cargo check.

```console
[cargo-make][2] INFO - Execute Command: "cargo" "check"
    Checking pure_component v0.1.0 (/workspace/yew/yewtil/examples/pure_component)
error[E0432]: unresolved imports `yewtil::Pure`, `yewtil::PureComponent`
 --> yewtil/examples/pure_component/src/button.rs:3:14
  |
3 | use yewtil::{Pure, PureComponent};
  |              ^^^^  ^^^^^^^^^^^^^ no `PureComponent` in the root
  |              |
  |              no `Pure` in the root

error: aborting due to previous error
```

Fixes # (issue)

#### Checklist:

- [ x] I have run `./ci/run_stable_checks.sh`. - sort of, i ran `cargo make stable-checks`
- [ x] I have reviewed my own code
- [ ] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
