### PR TITLE
Fix "pure_component" yewtil example

### DIFF
--- a/yewtil/examples/pure_component/Cargo.toml
+++ b/yewtil/examples/pure_component/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT/Apache-2.0"
 log = "0.4.8"
 wasm-logger = "0.2.0"
 yew = { path = "../../../yew" }
-yewtil = { path = "../.." }
+yewtil = { path = "../..", features = ["pure"] }


### PR DESCRIPTION
#### Description

#1504 uncovered an issue with the "pure_component" example for Yewtil: It doesn't activate the "pure" feature for yewtil.
