### PR TITLE
Remove the Renderable trait

### DIFF
--- a/docs/concepts/html/components.md
+++ b/docs/concepts/html/components.md
@@ -50,7 +50,7 @@ impl Component for Container {
     fn view(&self) -> Html {
        html! {
            <div id="container">
-               { self.0.children.render() }
+               { self.0.children.clone() }
            </div>
        }
     }

--- a/examples/crm/src/lib.rs
+++ b/examples/crm/src/lib.rs
@@ -7,7 +7,7 @@ use common::markdown;
 use yew::format::Json;
 use yew::services::storage::Area;
 use yew::services::{DialogService, StorageService};
-use yew::{html, Component, ComponentLink, Html, InputData, Renderable, ShouldRender};
+use yew::{html, Component, ComponentLink, Html, InputData, ShouldRender};
 
 const KEY: &str = "yew.crm.database";
 
@@ -153,7 +153,7 @@ impl Component for Model {
                 <div class="crm">
                     <h1>{"List of clients"}</h1>
                     <div class="clients">
-                        { for self.database.clients.iter().map(Renderable::render) }
+                        { for self.database.clients.iter().map(Client::render) }
                     </div>
                     <button onclick=self.link.callback(|_| Msg::SwitchTo(Scene::NewClientForm(Client::empty())))>{ "Add New" }</button>
                     <button onclick=self.link.callback(|_| Msg::SwitchTo(Scene::Settings))>{ "Settings" }</button>
@@ -189,7 +189,7 @@ impl Component for Model {
     }
 }
 
-impl Renderable for Client {
+impl Client {
     fn render(&self) -> Html {
         html! {
             <div class="client" style="margin-bottom: 50px">
@@ -200,9 +200,7 @@ impl Renderable for Client {
             </div>
         }
     }
-}
 
-impl Client {
     fn view_first_name_input(&self, link: &ComponentLink<Model>) -> Html {
         html! {
             <input class="new-client firstname"

--- a/website/translated_docs/ja/concepts/html/components.md
+++ b/website/translated_docs/ja/concepts/html/components.md
@@ -50,7 +50,7 @@ impl Component for Container {
     fn view(&self) -> Html {
        html! {
            <div id="container">
-               { self.0.children.render() }
+               { self.0.children.clone() }
            </div>
        }
     }

--- a/website/translated_docs/ja/version-0.17.3/concepts/html/components.md
+++ b/website/translated_docs/ja/version-0.17.3/concepts/html/components.md
@@ -50,7 +50,7 @@ impl Component for Container {
     fn view(&self) -> Html {
        html! {
            <div id="container">
-               { self.0.children.render() }
+               { self.0.children.clone() }
            </div>
        }
     }

--- a/website/translated_docs/zh-CN/concepts/html/components.md
+++ b/website/translated_docs/zh-CN/concepts/html/components.md
@@ -55,7 +55,7 @@ impl Component for Container {
     fn view(&self) -> Html {
        html! {
            <div id="container">
-               { self.0.children.render() }
+               { self.0.children.clone() }
            </div>
        }
     }

--- a/website/translated_docs/zh-CN/version-0.17.3/concepts/html/components.md
+++ b/website/translated_docs/zh-CN/version-0.17.3/concepts/html/components.md
@@ -55,7 +55,7 @@ impl Component for Container {
     fn view(&self) -> Html {
        html! {
            <div id="container">
-               { self.0.children.render() }
+               { self.0.children.clone() }
            </div>
        }
     }

--- a/website/translated_docs/zh-TW/concepts/html/components.md
+++ b/website/translated_docs/zh-TW/concepts/html/components.md
@@ -55,7 +55,7 @@ impl Component for Container {
     fn view(&self) -> Html {
        html! {
            <div id="container">
-               { self.0.children.render() }
+               { self.0.children.clone() }
            </div>
        }
     }

--- a/website/translated_docs/zh-TW/version-0.17.3/concepts/html/components.md
+++ b/website/translated_docs/zh-TW/version-0.17.3/concepts/html/components.md
@@ -55,7 +55,7 @@ impl Component for Container {
     fn view(&self) -> Html {
        html! {
            <div id="container">
-               { self.0.children.render() }
+               { self.0.children.clone() }
            </div>
        }
     }

--- a/website/versioned_docs/version-0.17.3/concepts/html/components.md
+++ b/website/versioned_docs/version-0.17.3/concepts/html/components.md
@@ -52,7 +52,7 @@ impl Component for Container {
     fn view(&self) -> Html {
        html! {
            <div id="container">
-               { self.0.children.render() }
+               { self.0.children.clone() }
            </div>
        }
     }

--- a/yew-router/src/router.rs
+++ b/yew-router/src/router.rs
@@ -71,7 +71,6 @@ where
     STATE: RouterState,
     SW: Switch + Clone + 'static,
 {
-    // TODO render fn name is overloaded now with that of the trait: Renderable<_> this should be changed. Maybe: display, show, switch, inner...
     /// Wrap a render closure so that it can be used by the Router.
     /// # Example
     /// ```

--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -199,7 +199,7 @@ pub type Children = ChildrenRenderer<Html>;
 ///
 /// In this example, the `List` component can wrap `ListItem` components.
 /// ```
-///# use yew::{html, Component, Renderable, Html, ComponentLink, ChildrenWithProps, Properties};
+///# use yew::{html, Component, Html, ComponentLink, ChildrenWithProps, Properties};
 ///#
 ///# #[derive(Clone, Properties)]
 ///# struct ListProps {
@@ -455,18 +455,6 @@ impl NodeRef {
         let mut this = self.0.borrow_mut();
         this.node = None;
         this.link = Some(node_ref);
-    }
-}
-
-/// Trait for rendering virtual DOM elements
-pub trait Renderable {
-    /// Called by rendering loop.
-    fn render(&self) -> Html;
-}
-
-impl<COMP: Component> Renderable for COMP {
-    fn render(&self) -> Html {
-        self.view()
     }
 }
 

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -1,4 +1,4 @@
-use super::{Callback, Component, NodeRef, Renderable};
+use super::{Callback, Component, NodeRef};
 use crate::scheduler::{scheduler, ComponentRunnableType, Runnable, Shared};
 use crate::virtual_dom::{VDiff, VNode};
 use cfg_if::cfg_if;
@@ -399,7 +399,7 @@ where
             };
 
             if should_update {
-                state.new_root = Some(state.component.render());
+                state.new_root = Some(state.component.view());
                 scheduler().push_comp(
                     ComponentRunnableType::Render,
                     Box::new(RenderComponent {

--- a/yew/src/lib.rs
+++ b/yew/src/lib.rs
@@ -207,7 +207,7 @@ pub mod prelude {
     pub use crate::events::*;
     pub use crate::html::{
         Children, ChildrenWithProps, Component, ComponentLink, Html, NodeRef, Properties,
-        Renderable, ShouldRender,
+        ShouldRender,
     };
     pub use crate::macros::*;
     pub use crate::virtual_dom::Classes;

--- a/yew/src/services/fetch/std_web.rs
+++ b/yew/src/services/fetch/std_web.rs
@@ -185,7 +185,7 @@ impl FetchService {
     /// response body and metadata.
     ///
     /// ```
-    ///# use yew::{Component, ComponentLink, Html, Renderable};
+    ///# use yew::{Component, ComponentLink, Html};
     ///# use yew::services::FetchService;
     ///# use yew::services::fetch::{Response, Request};
     ///# struct Comp;
@@ -225,7 +225,7 @@ impl FetchService {
     ///# use yew::services::FetchService;
     ///# use http::Request;
     ///# use yew::services::fetch::Response;
-    ///# use yew::{Component, ComponentLink, Renderable, Html};
+    ///# use yew::{Component, ComponentLink, Html};
     ///# use serde_derive::Deserialize;
     ///# struct Comp;
     ///# impl Component for Comp {
@@ -276,7 +276,7 @@ impl FetchService {
     /// ```
     ///# use yew::format::Nothing;
     ///# use yew::services::fetch::{self, FetchOptions, Credentials};
-    ///# use yew::{Renderable, Html, Component, ComponentLink};
+    ///# use yew::{Html, Component, ComponentLink};
     ///# use yew::services::FetchService;
     ///# use http::Response;
     ///# struct Comp;

--- a/yew/src/services/fetch/web_sys.rs
+++ b/yew/src/services/fetch/web_sys.rs
@@ -187,7 +187,7 @@ impl FetchService {
     /// response body and metadata.
     ///
     /// ```
-    ///# use yew::{Component, ComponentLink, Html, Renderable};
+    ///# use yew::{Component, ComponentLink, Html};
     ///# use yew::services::FetchService;
     ///# use yew::services::fetch::{Response, Request};
     ///# use anyhow::Error;
@@ -228,7 +228,7 @@ impl FetchService {
     ///# use yew::services::FetchService;
     ///# use http::Request;
     ///# use yew::services::fetch::Response;
-    ///# use yew::{Component, ComponentLink, Renderable, Html};
+    ///# use yew::{Component, ComponentLink, Html};
     ///# use serde_derive::Deserialize;
     ///# use anyhow::Error;
     ///# struct Comp;
@@ -280,7 +280,7 @@ impl FetchService {
     /// ```
     ///# use yew::format::Nothing;
     ///# use yew::services::fetch::{self, FetchOptions, Credentials};
-    ///# use yew::{Renderable, Html, Component, ComponentLink};
+    ///# use yew::{Html, Component, ComponentLink};
     ///# use yew::services::FetchService;
     ///# use http::Response;
     ///# use anyhow::Error;

--- a/yew/src/virtual_dom/vnode.rs
+++ b/yew/src/virtual_dom/vnode.rs
@@ -1,7 +1,7 @@
 //! This module contains the implementation of abstract virtual node.
 
 use super::{Key, VChild, VComp, VDiff, VList, VTag, VText};
-use crate::html::{AnyScope, Component, NodeRef, Renderable};
+use crate::html::{AnyScope, Component, NodeRef};
 use cfg_if::cfg_if;
 use cfg_match::cfg_match;
 use log::warn;
@@ -179,12 +179,6 @@ where
 impl<T: ToString> From<T> for VNode {
     fn from(value: T) -> Self {
         VNode::VText(VText::new(value.to_string()))
-    }
-}
-
-impl<'a> From<&'a dyn Renderable> for VNode {
-    fn from(value: &'a dyn Renderable) -> Self {
-        value.render()
     }
 }
 


### PR DESCRIPTION
#### Description

As briefly discussed in #1512.

This PR also updates the documentation to no longer use the `Renderable` trait for rendering children. Since version 0.17 that's no longer possible anyway but the documentation hasn't been updated until now.

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
