### PR TITLE
Use Into instead of From in the macro

### DIFF
--- a/yew-macro/src/html_tree/html_list.rs
+++ b/yew-macro/src/html_tree/html_list.rs
@@ -65,7 +65,7 @@ impl ToTokens for HtmlList {
         } = &self;
 
         let key = if let Some(key) = &open.props.key {
-            quote_spanned! {key.span()=> Some(::yew::virtual_dom::Key::from(#key))}
+            quote_spanned! {key.span()=> Some(::std::convert::Into::<::yew::virtual_dom::Key>::into(#key))}
         } else {
             quote! {None}
         };

--- a/yew-macro/src/html_tree/html_node.rs
+++ b/yew-macro/src/html_tree/html_node.rs
@@ -59,7 +59,9 @@ impl ToNodeIterator for HtmlNode {
             HtmlNode::Literal(_) => None,
             HtmlNode::Expression(expr) => {
                 // NodeSeq turns both Into<T> and Vec<Into<T>> into IntoIterator<Item = T>
-                Some(quote_spanned! {expr.span()=> ::yew::utils::NodeSeq::from(#expr)})
+                Some(
+                    quote_spanned! {expr.span()=> ::std::convert::Into::<::yew::utils::NodeSeq<_, _>>::into(#expr)},
+                )
             }
         }
     }

--- a/yew-macro/src/html_tree/html_tag/mod.rs
+++ b/yew-macro/src/html_tree/html_tag/mod.rs
@@ -205,7 +205,7 @@ impl ToTokens for HtmlTag {
         });
         let set_key = key.iter().map(|key| {
             quote! {
-                #vtag.key = Some(::yew::virtual_dom::Key::from(#key));
+                #vtag.key = Some(::std::convert::Into::<::yew::virtual_dom::Key>::into(#key));
             }
         });
         let listeners: Vec<_> = listeners

--- a/yew-macro/tests/macro/html-block-fail.stderr
+++ b/yew-macro/tests/macro/html-block-fail.stderr
@@ -10,7 +10,8 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>`
-  = note: required by `std::convert::From::from`
+  = note: required because of the requirements on the impl of `std::convert::Into<yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>>` for `()`
+  = note: required by `std::convert::Into::into`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/html-block-fail.rs:12:16
@@ -24,7 +25,8 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
    = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>`
-   = note: required by `std::convert::From::from`
+   = note: required because of the requirements on the impl of `std::convert::Into<yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>>` for `()`
+   = note: required by `std::convert::Into::into`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/html-block-fail.rs:15:17


### PR DESCRIPTION
#### Description

This PR makes it so the code generated by the macro uses the `Into` trait instead of `From` where user input is involved.
The primary reason for this is that it allows users to implement `Into<T>` for their own types.
It's also how Rust APIs should operate in general (using `fn foo(s: impl Into<String>)` instead of the more verbose `fn foo<T>(s: T) where String: From<T>`).

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code