### PR TITLE
Add reasons to "must_use" attributes

### DIFF
--- a/yew/src/services/fetch/std_web.rs
+++ b/yew/src/services/fetch/std_web.rs
@@ -147,7 +147,7 @@ enum FetchError {
 }
 
 /// A handle to control sent requests. Can be canceled with a `Task::cancel` call.
-#[must_use]
+#[must_use = "the request will be cancelled when the task is dropped"]
 pub struct FetchTask(Option<Value>);
 
 impl fmt::Debug for FetchTask {

--- a/yew/src/services/fetch/web_sys.rs
+++ b/yew/src/services/fetch/web_sys.rs
@@ -149,7 +149,7 @@ struct Handle {
 }
 
 /// A handle to control sent requests.
-#[must_use]
+#[must_use = "the request will be cancelled when the task is dropped"]
 pub struct FetchTask(Handle);
 
 impl fmt::Debug for FetchTask {

--- a/yew/src/services/interval.rs
+++ b/yew/src/services/interval.rs
@@ -19,7 +19,7 @@ cfg_if! {
 
 /// A handle which helps to cancel interval. Uses
 /// [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval).
-#[must_use]
+#[must_use = "the interval is only active until the handle is dropped"]
 pub struct IntervalTask(
     #[cfg(feature = "std_web")] Value,
     #[cfg(feature = "web_sys")] Interval,

--- a/yew/src/services/keyboard.rs
+++ b/yew/src/services/keyboard.rs
@@ -30,6 +30,7 @@ pub struct KeyboardService {}
 /// Handle for the key event listener.
 ///
 /// When the handle goes out of scope, the listener will be removed from the element.
+#[must_use = "the listener is only active until the handle is dropped"]
 pub struct KeyListenerHandle(
     #[cfg(feature = "std_web")] Option<EventListenerHandle>,
     #[cfg(feature = "web_sys")] EventListener,

--- a/yew/src/services/reader/std_web.rs
+++ b/yew/src/services/reader/std_web.rs
@@ -110,7 +110,7 @@ impl ReaderService {
 }
 
 /// A handle to control reading.
-#[must_use]
+#[must_use = "the reader will abort when the task is dropped"]
 pub struct ReaderTask {
     pub(super) file_reader: FileReader,
 }

--- a/yew/src/services/reader/web_sys.rs
+++ b/yew/src/services/reader/web_sys.rs
@@ -87,7 +87,7 @@ impl ReaderService {
 }
 
 /// A handle to control reading.
-#[must_use]
+#[must_use = "the reader will abort when the task is dropped"]
 pub struct ReaderTask {
     pub(super) file_reader: FileReader,
     #[allow(dead_code)]

--- a/yew/src/services/render.rs
+++ b/yew/src/services/render.rs
@@ -20,7 +20,7 @@ cfg_if! {
 }
 
 /// A handle to cancel a render task.
-#[must_use]
+#[must_use = "the task will be cancelled when the task is dropped"]
 pub struct RenderTask(
     #[cfg(feature = "std_web")] Value,
     #[cfg(feature = "web_sys")] RenderTaskInner,

--- a/yew/src/services/resize.rs
+++ b/yew/src/services/resize.rs
@@ -19,7 +19,7 @@ cfg_if! {
 pub struct ResizeService {}
 
 /// A handle for the event listener listening for resize events.
-#[must_use]
+#[must_use = "the listener is only active until the task is dropped"]
 pub struct ResizeTask(
     #[cfg(feature = "std_web")] Value,
     #[cfg(feature = "web_sys")] EventListener,

--- a/yew/src/services/timeout.rs
+++ b/yew/src/services/timeout.rs
@@ -18,7 +18,7 @@ cfg_if! {
 }
 
 /// A handle to cancel a timeout task.
-#[must_use]
+#[must_use = "the timeout will be cleared when the task is dropped"]
 pub struct TimeoutTask(
     #[cfg(feature = "std_web")] Option<Value>,
     #[cfg(feature = "web_sys")] Option<Timeout>,

--- a/yew/src/services/websocket.rs
+++ b/yew/src/services/websocket.rs
@@ -32,7 +32,7 @@ pub enum WebSocketStatus {
 }
 
 /// A handle to control current websocket connection. Implements `Task` and could be canceled.
-#[must_use]
+#[must_use = "the connection will be closed when the task is dropped"]
 pub struct WebSocketTask {
     ws: WebSocket,
     notification: Callback<WebSocketStatus>,


### PR DESCRIPTION
#### Description

This PR adds reasons to the `#[must_use]` attributes explaining the consequences of not keeping the value alive.
Hopefully this will help users understand why a service isn't doing anything (assuming that they heed the warning).

It will look something like this:

```rust
warning: unused `yew::services::websocket::WebSocketTask` that must be used
 |
 | / WebSocketService::connect();
 | |____________________________^
 |
 = note: the connection will be closed when the task is dropped
```

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
