### PR TITLE
extend batch_callback for options

### DIFF
--- a/docs/concepts/components/callbacks.md
+++ b/docs/concepts/components/callbacks.md
@@ -10,7 +10,7 @@ The component "link" is the mechanism through which components are able to creat
 ### send_message
 
 Sends a message to the component.
-Messages are handled by the `update` method which decides whether the component should re-render.
+Messages are handled by the `update` method which determines whether the component should re-render.
 
 ### send_message_batch
 
@@ -23,7 +23,7 @@ If the given vector is empty, this function doesn't do anything.
 ### callback
 
 Create a callback that will send a message to the component when it is executed.
-Under the hood, it will call `send_message` with the message that is returned by the provided closure.
+Under the hood, it will call `send_message` with the message returned by the provided closure.
 
 This method has a version that accepts an `FnOnce` instead, `callback_once`.
 You should use this with care though, as the resulting callback will panic if executed more than once.
@@ -65,7 +65,7 @@ Callbacks are used to communicate with services, agents, and parent components w
 
 They have an `emit` function that takes their `<IN>` type as an argument and converts that to a message expected by its destination. If a callback from a parent is provided in props to a child component, the child can call `emit` on the callback in its `update` lifecycle hook to send a message back to its parent. Closures or Functions provided as props inside the `html!` macro are automatically converted to Callbacks.
 
-Simple usage of callbacks can look something like this:
+A simple use of a callback might look something like this:
 
 ```rust
 let onclick = self.link.callback(|_| Msg::Clicked);

--- a/docs/concepts/components/callbacks.md
+++ b/docs/concepts/components/callbacks.md
@@ -8,7 +8,9 @@ The component "link" is the mechanism through which components are able to regis
 
 ### callback
 
-Registers a callback that will send a message to the component's update mechanism when it is executed. Under the hood, it will call `send_self` with the message that is returned by the provided closure. A `Fn(IN) -> COMP::Message` is provided and a `Callback<IN>` is returned.
+Registers a callback that will send a message to the component's update mechanism when it is executed. Under the hood, it will call `send_message` with the message that is returned by the provided closure. `ComponentLink::callback` takes a `Fn(IN) -> COMP::Message` and returns a `Callback<IN>`.
+
+This method has a version that accepts an `FnOnce` instead, `ComponentLink::callback_once`. You should avoid using this unless necessary, as making sure the callback is only called once has a small overhead.
 
 ### send\_message
 
@@ -16,13 +18,44 @@ Sends a message to the component immediately after the current loop finishes, ca
 
 ### batch\_callback
 
-Registers a callback that sends a batch of many messages at once when it is executed. If any of the messages cause the component to re-render, the component will re-render after all messages in the batch have been processed. A `Fn(IN) -> Vec<COMP::Message>` is provided and a `Callback<IN>` is returned.
+Registers a callback that sends a batch of messages at once when it is executed. If any of the messages cause the component to re-render, the component will re-render after all messages in the batch have been processed. The function can take either `Fn(IN) -> Vec<COMP::Message>` or `Fn(IN) -> Option<COMP::Message>`. Returns a `Callback<IN>`.
+
+If the function returns an empty `Vec` or `None`, update *will not* be scheduled. Use this when the callback might not need to do anything.
+
+This method has a version that accepts an `FnOnce` instead, `ComponentLink::batch_callback_once`. You should avoid using this unless necessary, as making sure the callback is only called once has a small overhead.
 
 ## Callbacks
 
 _\(This might need its own short page.\)_
 
-Callbacks are used to communicate with services, agents, and parent components within Yew. They are just a `Fn` wrapped by an `Rc` to allow them to be cloned.
+Callbacks are used to communicate with services, agents, and parent components within Yew. They are just an `Fn` wrapped by an `Rc` to allow them to be cloned.
 
 They have an `emit` function that takes their `<IN>` type as an argument and converts that to a message expected by its destination. If a callback from a parent is provided in props to a child component, the child can call `emit` on the callback in its `update` lifecycle hook to send a message back to its parent. Closures or Functions provided as props inside the `html!` macro are automatically converted to Callbacks.
+
+Simple usage of callbacks can look something like this:
+
+```rust
+let onclick = self.link.callback(|_| Msg::Clicked);
+html! {
+    <button onclick=onclick>{"Click"}</button>
+}
+```
+
+The callback is always given some value. For example, the `onclick` handler will pass a `MouseEvent`. The handler can then decide what kind of message the event should resolve to. This message is scheduled for the next update loop unconditionally.
+
+If you need a callback that might not need to cause an update, use `batch_callback`.
+
+```rust
+let onkeypress = self.link.batch_callback(|event| {
+    if event.key() == "Enter" {
+        Some(Msg::Submit)
+    } else {
+        None
+    }
+});
+
+html! {
+    <input type="text" onkeypress=onkeypress />
+}
+```
 

--- a/docs/concepts/components/callbacks.md
+++ b/docs/concepts/components/callbacks.md
@@ -25,7 +25,7 @@ If the given vector is empty, this function doesn't do anything.
 Create a callback that will send a message to the component when it is executed.
 Under the hood, it will call `send_message` with the message returned by the provided closure.
 
-This method has a version that accepts an `FnOnce` instead, `callback_once`.
+There is a different method called `callback_once` which accepts a `FnOnce` instead of a `Fn`.
 You should use this with care though, as the resulting callback will panic if executed more than once.
 
 ```rust
@@ -61,7 +61,8 @@ The same restrictions apply as for `callback_once`.
 
 _\(This might need its own short page.\)_
 
-Callbacks are used to communicate with services, agents, and parent components within Yew. They are just an `Fn` wrapped by an `Rc` to allow them to be cloned.
+Callbacks are used to communicate with services, agents, and parent components within Yew.
+Internally their type is just `Fn` wrapped in `Rc` to allow them to be cloned.
 
 They have an `emit` function that takes their `<IN>` type as an argument and converts that to a message expected by its destination. If a callback from a parent is provided in props to a child component, the child can call `emit` on the callback in its `update` lifecycle hook to send a message back to its parent. Closures or Functions provided as props inside the `html!` macro are automatically converted to Callbacks.
 
@@ -74,7 +75,7 @@ html! {
 }
 ```
 
-The callback is always given some value. For example, the `onclick` handler will pass a `MouseEvent`. The handler can then decide what kind of message the event should resolve to. This message is scheduled for the next update loop unconditionally.
+The function passed to `callback` must always take a parameter. For example, the `onclick` handler requires a function which takes a parameter of type `MouseEvent`. The handler can then decide what kind of message should be sent to the component. This message is scheduled for the next update loop unconditionally.
 
 If you need a callback that might not need to cause an update, use `batch_callback`.
 

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -47,7 +47,6 @@ pub enum Msg {
     Toggle(usize),
     ClearCompleted,
     Focus,
-    Nope,
 }
 
 impl Component for Model {
@@ -131,7 +130,6 @@ impl Component for Model {
                     input.focus().unwrap();
                 }
             }
-            Msg::Nope => {}
         }
         self.storage.store(KEY, Json(&self.state.entries));
         true
@@ -216,8 +214,8 @@ impl Model {
                    placeholder="What needs to be done?"
                    value=&self.state.value
                    oninput=self.link.callback(|e: InputData| Msg::Update(e.value))
-                   onkeypress=self.link.callback(|e: KeyboardEvent| {
-                       if e.key() == "Enter" { Msg::Add } else { Msg::Nope }
+                   onkeypress=self.link.batch_callback(|e: KeyboardEvent| {
+                       if e.key() == "Enter" { Some(Msg::Add) } else { None }
                    }) />
             /* Or multiline:
             <ul>
@@ -261,8 +259,8 @@ impl Model {
                        onmouseover=self.link.callback(|_| Msg::Focus)
                        oninput=self.link.callback(|e: InputData| Msg::UpdateEdit(e.value))
                        onblur=self.link.callback(move |_| Msg::Edit(idx))
-                       onkeypress=self.link.callback(move |e: KeyboardEvent| {
-                          if e.key() == "Enter" { Msg::Edit(idx) } else { Msg::Nope }
+                       onkeypress=self.link.batch_callback(move |e: KeyboardEvent| {
+                          if e.key() == "Enter" { Some(Msg::Edit(idx)) } else { None }
                        }) />
             }
         } else {

--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -7,7 +7,7 @@ mod listener;
 mod scope;
 
 pub use listener::*;
-pub use scope::{AnyScope, Scope};
+pub use scope::{AnyScope, Scope, SendAsMessage};
 pub(crate) use scope::{ComponentUpdate, Scoped};
 
 use crate::callback::Callback;

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -260,8 +260,8 @@ impl<COMP: Component> Scope<COMP> {
     /// to the linked component's update method when invoked.
     ///
     /// The callback function's return type is generic to allow for dealing with both
-    /// Options and Vecs nicely. Option can be used when dealing with a callback that
-    /// might not need to cause an update.
+    /// `Option` and `Vec` nicely. `Option` can be used when dealing with a callback that
+    /// might not need to send an update.
     ///
     /// ```ignore
     /// link.batch_callback(|_| vec![Msg::A, Msg::B]);
@@ -288,12 +288,12 @@ impl<COMP: Component> Scope<COMP> {
     /// to the linked component's update method when invoked.
     ///
     /// The callback function's return type is generic to allow for dealing with both
-    /// Options and Vecs nicely. Option can be used when dealing with a callback that
-    /// might not need to cause an update.
+    /// `Option` and `Vec` nicely. `Option` can be used when dealing with a callback that
+    /// might not need to send an update.
     ///
     /// ```ignore
-    /// link.batch_callback(|_| vec![Msg::A, Msg::B]);
-    /// link.batch_callback(|_| Some(Msg::A));
+    /// link.batch_callback_once(|_| vec![Msg::A, Msg::B]);
+    /// link.batch_callback_once(|_| Some(Msg::A));
     /// ```
     ///
     /// Please be aware that currently the results of these callbacks

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -209,6 +209,12 @@ impl<COMP: Component> Scope<COMP> {
     /// Please be aware that currently this method synchronously
     /// schedules calls to the [Component](Component) interface.
     pub fn send_message_batch(&self, messages: Vec<COMP::Message>) {
+        // There is no reason to schedule empty batches.
+        // This check is especially handy for the batch_callback method.
+        if messages.is_empty() {
+            return;
+        }
+
         self.update(ComponentUpdate::MessageBatch(messages));
     }
 
@@ -253,17 +259,27 @@ impl<COMP: Component> Scope<COMP> {
     /// Creates a `Callback` which will send a batch of messages back
     /// to the linked component's update method when invoked.
     ///
+    /// The callback function's return type is generic to allow for dealing with both
+    /// Options and Vecs nicely. Option can be used when dealing with a callback that
+    /// might not need to cause an update.
+    ///
+    /// ```ignore
+    /// link.batch_callback(|_| vec![Msg::A, Msg::B]);
+    /// link.batch_callback(|_| Some(Msg::A));
+    /// ```
+    ///
     /// Please be aware that currently the results of these callbacks
     /// will synchronously schedule calls to the
     /// [Component](Component) interface.
-    pub fn batch_callback<F, IN>(&self, function: F) -> Callback<IN>
+    pub fn batch_callback<F, IN, OUT>(&self, function: F) -> Callback<IN>
     where
-        F: Fn(IN) -> Vec<COMP::Message> + 'static,
+        F: Fn(IN) -> OUT + 'static,
+        OUT: SendAsMessage<COMP>,
     {
         let scope = self.clone();
         let closure = move |input| {
             let messages = function(input);
-            scope.send_message_batch(messages);
+            messages.send(&scope);
         };
         closure.into()
     }
@@ -271,19 +287,57 @@ impl<COMP: Component> Scope<COMP> {
     /// Creates a `Callback` from an `FnOnce` which will send a batch of messages back
     /// to the linked component's update method when invoked.
     ///
+    /// The callback function's return type is generic to allow for dealing with both
+    /// Options and Vecs nicely. Option can be used when dealing with a callback that
+    /// might not need to cause an update.
+    ///
+    /// ```ignore
+    /// link.batch_callback(|_| vec![Msg::A, Msg::B]);
+    /// link.batch_callback(|_| Some(Msg::A));
+    /// ```
+    ///
     /// Please be aware that currently the results of these callbacks
     /// will synchronously schedule calls to the
     /// [Component](Component) interface.
-    pub fn batch_callback_once<F, IN>(&self, function: F) -> Callback<IN>
+    pub fn batch_callback_once<F, IN, OUT>(&self, function: F) -> Callback<IN>
     where
-        F: FnOnce(IN) -> Vec<COMP::Message> + 'static,
+        F: FnOnce(IN) -> OUT + 'static,
+        OUT: SendAsMessage<COMP>,
     {
         let scope = self.clone();
         let closure = move |input| {
             let messages = function(input);
-            scope.send_message_batch(messages);
+            messages.send(&scope);
         };
         Callback::once(closure)
+    }
+}
+
+/// Defines a message type that can be sent to a component.
+/// Used for the return value of closure given to [Scope::batch_callback](struct.Scope.html#method.batch_callback).
+pub trait SendAsMessage<COMP: Component> {
+    /// Sends the message to the given component's scope.
+    /// See [Scope::batch_callback](struct.Scope.html#method.batch_callback).
+    fn send(self, scope: &Scope<COMP>);
+}
+
+impl<COMP> SendAsMessage<COMP> for Option<COMP::Message>
+where
+    COMP: Component,
+{
+    fn send(self, scope: &Scope<COMP>) {
+        if let Some(msg) = self {
+            scope.send_message(msg);
+        }
+    }
+}
+
+impl<COMP> SendAsMessage<COMP> for Vec<COMP::Message>
+where
+    COMP: Component,
+{
+    fn send(self, scope: &Scope<COMP>) {
+        scope.send_message_batch(self);
     }
 }
 


### PR DESCRIPTION
Extends Scope::batch_callback to work with Options. Allows for reasonable way to implement callbacks that might not need to do anything.

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [ ] I have added tests - not sure of a good way to test this
