### PR TITLE
Document html_nested! macro and add regression doc-tests for #1527

### DIFF
--- a/yew/src/lib.rs
+++ b/yew/src/lib.rs
@@ -98,27 +98,26 @@ extern crate self as yew;
 
 /// This macro implements JSX-like templates.
 ///
-/// This macro erases the component type and always returns [`Html`].
-/// If you want non-erased type, look at [`html_nested!`] macro.
+/// This macro always returns [`Html`].
+/// If you need to preserve the type of a component, use the [`html_nested!`] macro instead.
 ///
-/// More information about using the `html!` macro can be found in yew's [manual].
+/// More information about using the `html!` macro can be found in the [Yew Docs]
 ///
 /// [`Html`]: ./html/type.Html.html
 /// [`html_nested!`]: ./macro.html_nested.html
-/// [manual]: https://yew.rs/docs/en/concepts/html/
+/// [Yew Docs]: https://yew.rs/docs/en/concepts/html/
 pub use yew_macro::html;
 
-/// This macro is similar to [`html!`], but returns actual component type instead
-/// of a generic [`Html`].
+/// This macro is similar to [`html!`], but preserves the component type instead
+/// of wrapping it in [`Html`].
 ///
 /// That macro is useful when, for example, in a typical implementation of a list
-/// component (let's assume it's called `List`). In a typical implementation you
-/// would have two connected components -- `List` and `ListItem`, and `List`'s
-/// children would be a number of `ListItem`s.
+/// component (let's assume it's called `List`).
+/// In a typical implementation you might find two component types -- `List` and `ListItem`.
+/// Only `ListItem` components are allowed to be children of List`.
 ///
 /// You can find an example implementation of this in the [`nested_list`] example.
-/// That example shows, how to create static lists with their children, but in
-/// most use cases the contents of a list is dynamic and thus known only at runtime.
+/// That example shows, how to create static lists with their children.
 ///
 /// ```
 /// # use yew::prelude::*;
@@ -160,7 +159,8 @@ pub use yew_macro::html;
 ///   fn into(self) -> Html { self.view() }
 /// }
 ///
-/// // Manually you create list by just nesting `ListItem`'s into `List`:
+/// // You can use `List` with nested `ListItem` components.
+/// // Using any other kind of element would result in a compile error.
 /// # fn test() -> Html {
 /// html! {
 ///   <List>

--- a/yew/src/lib.rs
+++ b/yew/src/lib.rs
@@ -97,15 +97,28 @@
 extern crate self as yew;
 
 /// This macro implements JSX-like templates.
+///
+/// This macro erases the component type and always returns [`Html`].
+/// If you want non-erased type, look at [`html_nested!`] macro.
+///
+/// More information about using the `html!` macro can be found in yew's [manual].
+///
+/// [`Html`]: ./html/type.Html.html
+/// [`html_nested!`]: ./macro.html_nested.html
+/// [manual]: https://yew.rs/docs/en/concepts/html/
 pub use yew_macro::html;
 
 /// This macro is similar to [`html!`], but returns actual component type instead
-/// of generic [`Html`].
+/// of a generic [`Html`].
 ///
-/// That macro is useful when, for example, in typical implementation of `List`
-/// component. In the typical implementation you have two connected components --
-/// `List` and `ListItem`, and `List` allowing only `ListItem`s inside them.
-/// Example of such component you can find in the [`nested_list`] example.
+/// That macro is useful when, for example, in a typical implementation of a list
+/// component (let's assume it's called `List`). In a typical implementation you
+/// would have two connected components -- `List` and `ListItem`, and `List`'s
+/// children would be a number of `ListItem`s.
+///
+/// You can find an example implementation of this in the [`nested_list`] example.
+/// That example shows, how to create static lists with their children, but in
+/// most use cases the contents of a list is dynamic and thus known only at runtime.
 ///
 /// ```
 /// # use yew::prelude::*;
@@ -143,8 +156,8 @@ pub use yew_macro::html;
 ///   fn from(child: VChild<ListItem>) -> Self { Self }
 /// }
 ///
-/// impl From<ListItem> for Html {
-///   fn from(item: ListItem) -> Html { item.view() }
+/// impl Into<Html> for ListItem {
+///   fn into(self) -> Html { self.view() }
 /// }
 ///
 /// // Manually you create list by just nesting `ListItem`'s into `List`:
@@ -157,7 +170,7 @@ pub use yew_macro::html;
 ///   </List>
 /// }
 /// # }
-/// /// # fn test_iter() -> Html {
+/// # fn test_iter() -> Html {
 /// # let some_iter = (0..10);
 /// // In many cases you might want to create the content dynamically.
 /// // To do this, you can use the following code:
@@ -170,9 +183,9 @@ pub use yew_macro::html;
 /// ```
 ///
 /// If you used the [`html!`] macro instead of `html_nested!`, the code would
-/// not be compiled because we explicitly indicated to the compiler that `List`
+/// not compile because we explicitly indicated to the compiler that `List`
 /// can only contain elements of type `ListItem` using [`ChildrenRenderer<ListItem>`],
-/// while [`html!`] wraps their contents into [`Html`].
+/// while [`html!`] creates items of type [`Html`].
 ///
 ///
 /// [`html!`]: ./macro.html.html

--- a/yew/src/lib.rs
+++ b/yew/src/lib.rs
@@ -99,7 +99,119 @@ extern crate self as yew;
 /// This macro implements JSX-like templates.
 pub use yew_macro::html;
 
-#[doc(hidden)]
+/// This macro is similar to [`html!`], but returns actual component type instead
+/// of generic [`Html`].
+///
+/// That macro is useful when, for example, in typical implementation of `List`
+/// component. In the typical implementation you have two connected components --
+/// `List` and `ListItem`, and `List` allowing only `ListItem`s inside them.
+/// Example of such component you can find in the [`nested_list`] example.
+///
+/// Manually you create list by just nesting `ListItem`'s into `List`:
+///
+/// ```
+/// # use yew::prelude::*;
+/// use yew::html::ChildrenRenderer;
+/// use yew::virtual_dom::VChild;
+///
+/// #[derive(Clone, Properties)]
+/// struct List {
+///   children: ChildrenRenderer<ListItem>,
+/// }
+/// impl Component for List {
+///   // ...
+/// #   type Message = ();
+/// #   type Properties = Self;
+/// #   fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self { props }
+/// #   fn update(&mut self, _: Self::Message) -> ShouldRender { false }
+/// #   fn change(&mut self, _: Self::Properties) -> ShouldRender { false }
+/// #   fn view(&self) -> Html { unimplemented!() }
+/// }
+///
+/// #[derive(Clone)]
+/// struct ListItem;
+/// impl Component for ListItem {
+/// #   type Message = ();
+///   type Properties = ();
+///   // ...
+/// #   fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { Self }
+/// #   fn update(&mut self, _: Self::Message) -> ShouldRender { false }
+/// #   fn change(&mut self, _: Self::Properties) -> ShouldRender { false }
+/// #   fn view(&self) -> Html { unimplemented!() }
+/// }
+///
+/// // Required for ChildrenRenderer
+/// impl From<VChild<ListItem>> for ListItem {
+///   fn from(child: VChild<ListItem>) -> Self { Self }
+/// }
+///
+/// impl From<ListItem> for Html {
+///   fn from(item: ListItem) -> Html { item.view() }
+/// }
+///
+/// # fn test() -> Html {
+/// html! {
+///   <List>
+///     <ListItem/>
+///     <ListItem/>
+///     <ListItem/>
+///   </List>
+/// }
+/// # }
+/// ```
+///
+/// But in most real cases you need to forming content of you list programmatically.
+/// That's mean, that you would write code like this:
+/// ```
+/// # use yew::prelude::*;
+/// # use yew::html::ChildrenRenderer;
+/// # use yew::virtual_dom::VChild;
+/// # #[derive(Clone, Properties)]
+/// # struct List { children: ChildrenRenderer<ListItem> }
+/// # impl Component for List {
+/// #   type Message = ();
+/// #   type Properties = Self;
+/// #   fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self { props }
+/// #   fn update(&mut self, _: Self::Message) -> ShouldRender { false }
+/// #   fn change(&mut self, _: Self::Properties) -> ShouldRender { false }
+/// #   fn view(&self) -> Html { unimplemented!() }
+/// # }
+/// # #[derive(Clone)]
+/// # struct ListItem;
+/// # impl Component for ListItem {
+/// #   type Message = ();
+/// #   type Properties = ();
+/// #   fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { Self }
+/// #   fn update(&mut self, _: Self::Message) -> ShouldRender { false }
+/// #   fn change(&mut self, _: Self::Properties) -> ShouldRender { false }
+/// #   fn view(&self) -> Html { unimplemented!() }
+/// # }
+/// # impl From<VChild<ListItem>> for ListItem {
+/// #   fn from(child: VChild<ListItem>) -> Self { Self }
+/// # }
+/// # impl From<ListItem> for Html {
+/// #   fn from(item: ListItem) -> Html { item.view() }
+/// # }
+/// # fn test() -> Html {
+/// # let some_iter = (0..10);
+/// html! {
+///   <List>
+///     { for some_iter.map(|_| html_nested!{ <ListItem/> }) }
+///   </List>
+/// }
+/// # }
+/// ```
+///
+/// If you used the [`html!`] macro instead of `html_nested!`, the code would
+/// not be compiled because we explicitly indicated to the compiler that `List`
+/// can only contain elements of type `ListItem` using [`ChildrenRenderer<ListItem>`],
+/// while [`html!`] wraps their contents into [`Html`].
+///
+///
+/// [`html!`]: ./macro.html.html
+/// [`Html`]: ./html/type.Html.html
+/// [`nested_list`]: https://github.com/yewstack/yew/tree/master/examples/nested_list
+/// [`ChildrenRenderer<ListItem>`]: ./html/struct.ChildrenRenderer.html
 pub use yew_macro::html_nested;
 
 /// This module contains macros which implements html! macro and JSX-like templates

--- a/yew/src/lib.rs
+++ b/yew/src/lib.rs
@@ -107,8 +107,6 @@ pub use yew_macro::html;
 /// `List` and `ListItem`, and `List` allowing only `ListItem`s inside them.
 /// Example of such component you can find in the [`nested_list`] example.
 ///
-/// Manually you create list by just nesting `ListItem`'s into `List`:
-///
 /// ```
 /// # use yew::prelude::*;
 /// use yew::html::ChildrenRenderer;
@@ -119,9 +117,9 @@ pub use yew_macro::html;
 ///   children: ChildrenRenderer<ListItem>,
 /// }
 /// impl Component for List {
-///   // ...
 /// #   type Message = ();
-/// #   type Properties = Self;
+///   type Properties = Self;
+///   // ...
 /// #   fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self { props }
 /// #   fn update(&mut self, _: Self::Message) -> ShouldRender { false }
 /// #   fn change(&mut self, _: Self::Properties) -> ShouldRender { false }
@@ -132,7 +130,7 @@ pub use yew_macro::html;
 /// struct ListItem;
 /// impl Component for ListItem {
 /// #   type Message = ();
-///   type Properties = ();
+/// #   type Properties = ();
 ///   // ...
 /// #   fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { Self }
 /// #   fn update(&mut self, _: Self::Message) -> ShouldRender { false }
@@ -149,6 +147,7 @@ pub use yew_macro::html;
 ///   fn from(item: ListItem) -> Html { item.view() }
 /// }
 ///
+/// // Manually you create list by just nesting `ListItem`'s into `List`:
 /// # fn test() -> Html {
 /// html! {
 ///   <List>
@@ -158,42 +157,10 @@ pub use yew_macro::html;
 ///   </List>
 /// }
 /// # }
-/// ```
-///
-/// But in most real cases you need to forming content of you list programmatically.
-/// That's mean, that you would write code like this:
-/// ```
-/// # use yew::prelude::*;
-/// # use yew::html::ChildrenRenderer;
-/// # use yew::virtual_dom::VChild;
-/// # #[derive(Clone, Properties)]
-/// # struct List { children: ChildrenRenderer<ListItem> }
-/// # impl Component for List {
-/// #   type Message = ();
-/// #   type Properties = Self;
-/// #   fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self { props }
-/// #   fn update(&mut self, _: Self::Message) -> ShouldRender { false }
-/// #   fn change(&mut self, _: Self::Properties) -> ShouldRender { false }
-/// #   fn view(&self) -> Html { unimplemented!() }
-/// # }
-/// # #[derive(Clone)]
-/// # struct ListItem;
-/// # impl Component for ListItem {
-/// #   type Message = ();
-/// #   type Properties = ();
-/// #   fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self { Self }
-/// #   fn update(&mut self, _: Self::Message) -> ShouldRender { false }
-/// #   fn change(&mut self, _: Self::Properties) -> ShouldRender { false }
-/// #   fn view(&self) -> Html { unimplemented!() }
-/// # }
-/// # impl From<VChild<ListItem>> for ListItem {
-/// #   fn from(child: VChild<ListItem>) -> Self { Self }
-/// # }
-/// # impl From<ListItem> for Html {
-/// #   fn from(item: ListItem) -> Html { item.view() }
-/// # }
-/// # fn test() -> Html {
+/// /// # fn test_iter() -> Html {
 /// # let some_iter = (0..10);
+/// // In many cases you might want to create the content dynamically.
+/// // To do this, you can use the following code:
 /// html! {
 ///   <List>
 ///     { for some_iter.map(|_| html_nested!{ <ListItem/> }) }


### PR DESCRIPTION
#### Description

Documentation for `html_nested!`, typical usage and regression tests for #1527 in documentation

#### Checklist:

- [x] I have run `./ci/run_stable_checks.sh`
- [x] I have reviewed my own code
- [x] I have added tests
<!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
<!-- If this is a feature, my tests prove that the feature works -->

<!-- Testing instructions -->
<!-- Check out the link below on how to setup and run tests -->
<!-- https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md#test -->
<!-- If you're not sure how to test, let us know and we can provide guidance :) -->

<!-- Benchmark instructions -->
<!-- 1. Fork and clone https://github.com/yewstack/js-framework-benchmark -->
<!-- 2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for this PR -->
<!-- 3. Open a new PR with your `Cargo.toml` changes -->
<!-- 4. Paste a link to the benchmark results: -->
<!-- - [ ] I have opened a PR against https://github.com/yewstack/js-framework-benchmark -->
