### PR TITLE
Show correct usage of ConsoleService in debugging docs

### DIFF
--- a/docs/more/debugging.md
+++ b/docs/more/debugging.md
@@ -39,7 +39,7 @@ This service is included within Yew and is available when the "services" feature
 
 ```rust
 // usage
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg));
 ```
 
 ## Source Maps

--- a/website/versioned_docs/version-0.17.3/more/debugging.md
+++ b/website/versioned_docs/version-0.17.3/more/debugging.md
@@ -32,7 +32,7 @@ This service is included within yew and is available when the `"services"` featu
 
 ```rust
 // usage
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg));
 ```
 
 ## Source Maps


### PR DESCRIPTION
#### Description

Quick docs change for the Debugging section to show the correct usage of yew's ConsoleService.
