### PR TITLE
Make how to write dependencies acurate

### DIFF
--- a/docs/getting-started/choose-web-library.md
+++ b/docs/getting-started/choose-web-library.md
@@ -5,14 +5,16 @@ title: Choosing a web library
 
 Yew apps can be built using either [`web-sys`](https://docs.rs/web-sys) or [`stdweb`](https://docs.rs/stdweb). 
 These two crates provide the bindings between Rust and Web APIs. You'll need to choose one or the other when adding 
-`yew` to your cargo dependencies:
+`yew` to your `[dependencies]` in `Cargo.toml`:
 
 ```toml
 # Choose `web-sys`
 yew = "0.17"
+web-sys = "0.3"
 
 # Choose `stdweb`
 yew = { version = "0.17", package = "yew-stdweb" }
+stdweb = "0.4.20"
 ```
 
 We recommend using `web-sys` due to its support from the [Rust / Wasm Working Group](https://rustwasm.github.io/).


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Prevent beginners from seeing build errors::

```rust
error[E0433]: failed to resolve: use of undeclared type or module `web_sys`
  --> src/lib.rs:24:21
   |
24 |         let window: web_sys::Window = web_sys::window().expect("window not available");
   |                     ^^^^^^^ use of undeclared type or module `web_sys`
```

or

```rust
error[E0433]: failed to resolve: use of undeclared type or module `stdweb`
  --> src/lib.rs:27:21
   |
27 |         let window: stdweb::web::Window = stdweb::web::window();
   |                     ^^^^^^ use of undeclared type or module `stdweb`
```

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
