### PR TITLE
Make yewtil stdweb compatible. Fixes #1371

### DIFF
--- a/yewtil/Cargo.toml
+++ b/yewtil/Cargo.toml
@@ -37,7 +37,6 @@ mrc_irc = []
 
 std_web = [
   "yew/std_web",
-  "stdweb"
 ]
 web_sys = [
   "yew/web_sys",
@@ -57,14 +56,6 @@ path = "../yew"
 version = "0.17.0"
 default-features = false
 features = ["agent"]
-
-[dependencies.stdweb]
-version = "0.4.20"
-optional = true
-features = [
-  "futures-support",
-  "experimental_features_which_may_break_on_minor_version_bumps",
-]
 
 [dependencies.web-sys]
 version = "0.3.31"

--- a/yewtil/Cargo.toml
+++ b/yewtil/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/yewstack/yew"
 readme = "README.md"
 
 [features]
-default = ["stable"] # Only stable is included by default.
-all = ["stable", "experimental"]
+default = ["web_sys", "stable"] # Only stable is included by default.
+all = ["web_sys", "stable", "experimental"]
 
 # Broad features
 ## All features MUST be stable or experimental or soft_depricated
@@ -35,14 +35,28 @@ store = []
 lrc = []
 mrc_irc = []
 
+std_web = [
+  "yew/std_web",
+  "stdweb"
+]
+web_sys = [
+  "yew/web_sys",
+  "web-sys"
+]
+
 [dependencies]
 log = "0.4.8"
 serde = {version= "1.0.102", optional = true}
 serde_json = { version = "1.0.41", optional = true }
 wasm-bindgen = {version = "0.2.51", features=["serde-serialize"], optional = true}
 wasm-bindgen-futures = {version = "0.4.3", optional = true}
-yew = { version = "0.17.0", path = "../yew" }
 yewtil-macro = { version = "0.2.0", path = "../yewtil-macro", optional = true }
+
+[dependencies.yew]
+path = "../yew"
+version = "0.17.0"
+default-features = false
+features = ["agent"]
 
 [dependencies.stdweb]
 version = "0.4.20"


### PR DESCRIPTION
#### Description

Added `web_sys` and `std_web` features to yewtil. `web_sys` is enabled by default.

Fixes #1371 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->
- [x] Build passes with both stdweb and web-sys
- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1371: Yewtil is not stdweb compatible](https://issuehunt.io/repos/114466145/issues/1371)
---
</details>
<!-- /Issuehunt content-->