### PR TITLE
Appease Clippy

### DIFF
--- a/examples/keyed_list/src/person.rs
+++ b/examples/keyed_list/src/person.rs
@@ -6,20 +6,20 @@ use yewtil::NeqAssign;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PersonInfo {
     pub id: usize,
-    pub name: Rc<String>,
-    pub address: Rc<String>,
+    pub name: Rc<str>,
+    pub address: Rc<str>,
     pub age: usize,
 }
 impl PersonInfo {
     pub fn new_random(id: usize) -> Self {
         let address = {
             let count = random::range_exclusive(3, 6);
-            Rc::new(random::words(count, 5, 12).join(" "))
+            Rc::from(random::words(count, 5, 12).join(" ").as_str())
         };
 
         Self {
             id,
-            name: Rc::new(random::words(2, 4, 15).join(" ")),
+            name: Rc::from(random::words(2, 4, 15).join(" ").as_str()),
             age: random::range_exclusive(7, 77),
             address,
         }

--- a/yew-router/src/switch.rs
+++ b/yew-router/src/switch.rs
@@ -82,9 +82,8 @@ pub trait Switch: Sized {
 pub struct LeadingSlash<T>(pub T);
 impl<U: Switch> Switch for LeadingSlash<U> {
     fn from_route_part<STATE>(part: String, state: Option<STATE>) -> (Option<Self>, Option<STATE>) {
-        if part.starts_with('/') {
-            let part = part[1..].to_string();
-            let (inner, state) = U::from_route_part(part, state);
+        if let Some(part) = part.strip_prefix('/') {
+            let (inner, state) = U::from_route_part(part.to_owned(), state);
             (inner.map(LeadingSlash), state)
         } else {
             (None, None)

--- a/yew/src/virtual_dom/key.rs
+++ b/yew/src/virtual_dom/key.rs
@@ -1,41 +1,41 @@
 //! This module contains the implementation yew's virtual nodes' keys.
 
+use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::rc::Rc;
 
 /// Represents the (optional) key of Yew's virtual nodes.
 ///
 /// Keys are cheap to clone.
-// TODO (#1263): Explain when keys are useful and add an example.
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Key {
-    key: Rc<String>,
+    key: Rc<str>,
 }
 
-impl core::fmt::Display for Key {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", &self.key)
-    }
-}
-
-impl core::fmt::Debug for Key {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", &self.key)
-    }
-}
-
-impl From<Rc<String>> for Key {
-    fn from(key: Rc<String>) -> Self {
-        Key { key }
+impl Display for Key {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.key.fmt(f)
     }
 }
 
 impl Deref for Key {
     type Target = str;
 
-    #[inline]
     fn deref(&self) -> &str {
         self.key.as_ref()
+    }
+}
+
+impl From<Rc<str>> for Key {
+    fn from(key: Rc<str>) -> Self {
+        Self { key }
+    }
+}
+
+impl From<&'_ str> for Key {
+    fn from(key: &'_ str) -> Self {
+        let key: Rc<str> = Rc::from(key);
+        Self::from(key)
     }
 }
 
@@ -43,27 +43,27 @@ macro_rules! key_impl_from_to_string {
     ($type:ty) => {
         impl From<$type> for Key {
             fn from(key: $type) -> Self {
-                Key {
-                    key: Rc::new(key.to_string()),
-                }
+                Self::from(key.to_string().as_str())
             }
         }
     };
 }
-key_impl_from_to_string!(&'static str);
+
 key_impl_from_to_string!(String);
+key_impl_from_to_string!(Rc<String>);
 key_impl_from_to_string!(char);
-key_impl_from_to_string!(usize);
 key_impl_from_to_string!(u8);
 key_impl_from_to_string!(u16);
 key_impl_from_to_string!(u32);
 key_impl_from_to_string!(u64);
 key_impl_from_to_string!(u128);
+key_impl_from_to_string!(usize);
 key_impl_from_to_string!(i8);
 key_impl_from_to_string!(i16);
 key_impl_from_to_string!(i32);
 key_impl_from_to_string!(i64);
 key_impl_from_to_string!(i128);
+key_impl_from_to_string!(isize);
 
 #[cfg(test)]
 mod test {
@@ -78,11 +78,11 @@ mod test {
 
     #[test]
     fn all_key_conversions() {
-        let rc_key = Rc::new("rc".to_string());
         html! {
             <key="string literal">
-                <img key="String".to_string() />
-                <p key=rc_key></p>
+                <img key="String".to_owned() />
+                <p key=Rc::new("rc".to_owned())></p>
+                <p key=Rc::<str>::from("rc")></p>
                 <key='a'>
                     <p key=11_usize></p>
                     <p key=12_u8></p>


### PR DESCRIPTION
#### Description

It's that time of year again, new lints have left the nursery and now wreak havoc upon codebases all around.
This PR is just a small patch that fixes the new issues, mostly related to using `Rc<String>` instead of `Rc<str>` when it isn't needed.

There aren't any major changes in this PR. `Key` gains a few `From` implementations for `Rc<str>`, `&str` (not just static), and `isize` (was missing before for some reason).

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code