### PR TITLE
Contributing md update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,12 +38,10 @@ To run all tests, use the following command:
 cargo make tests
 ```
 
-<small>
 Note: On Arch Linux (and presumably a few other Linux Distros), the package for
 Firefox Developer Edition does _not_ create a `firefox` alias, which causes the
 tests to fail unless you also have Firefox installed. To fix this, run
 `sudo ln -s /usr/bin/firefox-developer-edition /usr/bin/firefox`.
-</small>
 
 ### Browser tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Because Geckodriver looks for `firefox` in the path, if you use
 FireFox Developer Edition, you may get an error, because Developer Editions
 binary is called `firefox-developer-edition` on some Linux distributions.
 To fix this, either install the standard version of Firefox or symlink
-`/usr/bin/firefox` to `/usr/bin/firefox-developer-edition`
+`/usr/bin/firefox` to `/usr/bin/firefox-developer-edition`.
 
 ### Fetch service tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Because Geckodriver looks for `firefox` in the path, if you use
 FireFox Developer Edition, you may get an error, because Developer Editions
 binary is called `firefox-developer-edition` on some Linux distributions.
 To fix this, either install the standard version of Firefox or symlink
-`/usr/bin/firefox` to `/usr/bin/firefox-developer-edition`.
+`firefox` to `firefox-developer-edition`.
 
 ### Fetch service tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,14 +38,15 @@ To run all tests, use the following command:
 cargo make tests
 ```
 
-Note: On Arch Linux (and presumably a few other Linux Distros), the package for
-Firefox Developer Edition does _not_ create a `firefox` alias, which causes the
-tests to fail unless you also have Firefox installed. To fix this, run
-`sudo ln -s /usr/bin/firefox-developer-edition /usr/bin/firefox`.
-
 ### Browser tests
 
 `cargo make tests` will automatically download Geckodriver to a temporary location if it isn't in the PATH.
+
+Because Geckodriver looks for `firefox` in the path, if you use
+FireFox Developer Edition, you may get an error, because Developer Editions
+binary is called `firefox-developer-edition` on some Linux distributions.
+To fix this, either install the standard version of Firefox or symlink
+`/usr/bin/firefox` to `/usr/bin/firefox-developer-edition`
 
 ### Fetch service tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,13 @@ To run all tests, use the following command:
 cargo make tests
 ```
 
+<small>
+Note: On Arch Linux (and presumably a few other Linux Distros), the package for
+Firefox Developer Edition does _not_ create a `firefox` alias, which causes the
+tests to fail unless you also have Firefox installed. To fix this, run
+`sudo ln -s /usr/bin/firefox-developer-edition /usr/bin/firefox`.
+</small>
+
 ### Browser tests
 
 `cargo make tests` will automatically download Geckodriver to a temporary location if it isn't in the PATH.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ cargo make tests
 
 Because Geckodriver looks for `firefox` in the path, if you use
 FireFox Developer Edition, you may get an error, because Developer Editions
-binary is called `firefox-developer-edition` on some Linux distributions.
+binary is called `firefox-developer-edition`.
 To fix this, either install the standard version of Firefox or symlink
 `firefox` to `firefox-developer-edition`.
 


### PR DESCRIPTION
#### Description

On some Linux distributions, `firefox-developer-edition` does not create a `firefox` symlink, so the test suite will fail if you only have `firefox-developer-edition` and not `firefox` installed. To fix this, you can make the symlink manually with `sudo ln -sf /usr/bin/firefox-developer-edition /usr/bin/firefox`. This PR just adds a note that explains that to `CONTRIBUTING.md`.
