### PR TITLE
Fix call stack exceeded bug

### DIFF
--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -459,6 +459,11 @@ impl NodeRef {
 
     /// Reuse an existing `NodeRef`
     pub(crate) fn reuse(&self, node_ref: Self) {
+        // Avoid circular references
+        if self == &node_ref {
+            return;
+        }
+
         let mut this = self.0.borrow_mut();
         let existing = node_ref.0.borrow();
         this.node = existing.node.clone();

--- a/yew/src/html/mod.rs
+++ b/yew/src/html/mod.rs
@@ -456,6 +456,14 @@ impl NodeRef {
         this.node = None;
         this.link = Some(node_ref);
     }
+
+    /// Reuse an existing `NodeRef`
+    pub(crate) fn reuse(&self, node_ref: Self) {
+        let mut this = self.0.borrow_mut();
+        let existing = node_ref.0.borrow();
+        this.node = existing.node.clone();
+        this.link = existing.link.clone();
+    }
 }
 
 /// Trait for building properties for a component

--- a/yew/src/html/scope.rs
+++ b/yew/src/html/scope.rs
@@ -23,8 +23,8 @@ pub(crate) enum ComponentUpdate<COMP: Component> {
     Message(COMP::Message),
     /// Wraps batch of messages for a component.
     MessageBatch(Vec<COMP::Message>),
-    /// Wraps properties and next sibling for a component.
-    Properties(COMP::Properties, NodeRef),
+    /// Wraps properties, node ref, and next sibling for a component.
+    Properties(COMP::Properties, NodeRef, NodeRef),
 }
 
 /// Untyped scope used for accessing parent scope
@@ -445,7 +445,9 @@ where
                 ComponentUpdate::MessageBatch(messages) => messages
                     .into_iter()
                     .fold(false, |acc, msg| state.component.update(msg) || acc),
-                ComponentUpdate::Properties(props, next_sibling) => {
+                ComponentUpdate::Properties(props, node_ref, next_sibling) => {
+                    // When components are updated, a new node ref could have been passed in
+                    state.node_ref = node_ref;
                     // When components are updated, their siblings were likely also updated
                     state.next_sibling = next_sibling;
                     state.component.change(props)


### PR DESCRIPTION
#### Description
Whenever a component re-renders, the new component links to the old component's node ref and if this repeats long enough, the call stack will be exceeded.

Rather than link, the new component should reuse the existing node ref

Fixes https://github.com/yewstack/yew/issues/1449

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
