### PR TITLE
Add transformer String to VNode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "examples/file_upload",
   "examples/futures",
   "examples/game_of_life",
+  "examples/hello",
   "examples/inner_html",
   "examples/js_callback",
   "examples/keyed_list",

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hello"
+version = "0.1.0"
+authors = ["Yozhgoor <yozhgoor@outlook.com>"]
+edition = "2018"
+
+[dependencies]
+js-sys = "0.3"
+yew = { path = "../../yew" }

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -1,0 +1,13 @@
+# Counter Example
+
+[![Demo](https://img.shields.io/website?label=demo&url=https%3A%2F%2Fexamples.yew.rs%2Fcounter)](https://examples.yew.rs/counter)
+
+A counter which can be increased or decreased with the press of a button.
+
+## Concepts
+
+Demonstrates the use of messages to update state.
+
+## Improvements
+
+- Improve the presentation of the example with CSS.

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -1,13 +1,9 @@
-# Counter Example
+# Hello Example
 
-[![Demo](https://img.shields.io/website?label=demo&url=https%3A%2F%2Fexamples.yew.rs%2Fcounter)](https://examples.yew.rs/counter)
+[![Demo](https://img.shields.io/website?label=demo&url=https%3A%2F%2Fexamples.yew.rs%2Fhello)](https://examples.yew.rs/hello)
 
-A counter which can be increased or decreased with the press of a button.
+A "Hello world!" example.
 
 ## Concepts
 
-Demonstrates the use of messages to update state.
-
-## Improvements
-
-- Improve the presentation of the example with CSS.
+Pass component as property.

--- a/examples/hello/index.html
+++ b/examples/hello/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Yew • Counter</title>
+  </head>
+
+  <body></body>
+</html>

--- a/examples/hello/index.html
+++ b/examples/hello/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Yew • Counter</title>
+    <title>Yew • Hello</title>
   </head>
 
   <body></body>

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -34,6 +34,7 @@ impl Component for Model {
                 <input onchange=self.link.callback(|x| x) />
                 <Hello name=self.value.clone() />
                 <Hello name="world!" />
+                <Hello name=html!(<strong>{"WORLD"}</strong>) />
             </div>
         }
     }

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -1,0 +1,84 @@
+use yew::prelude::*;
+
+pub struct Model {
+    link: ComponentLink<Self>,
+    value: String,
+}
+
+impl Component for Model {
+    type Message = ChangeData;
+    type Properties = ();
+
+    fn create(_props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        Self {
+            link,
+            value: String::from(""),
+        }
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            ChangeData::Value(value) => self.value = value,
+            _ => unreachable!(),
+        }
+        true
+    }
+
+    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
+        false
+    }
+
+    fn view(&self) -> Html {
+        html! {
+            <div>
+                <input onchange=self.link.callback(|x| x) />
+                <Hello name=self.value.clone() />
+                <Hello name="world!" />
+            </div>
+        }
+    }
+}
+
+struct Hello {
+    props: HelloProps,
+}
+
+#[derive(Clone, PartialEq, Properties)]
+struct HelloProps {
+    name: yew::virtual_dom::VNode,
+}
+
+impl Component for Hello {
+    type Message = ();
+    type Properties = HelloProps;
+
+    fn create(props: Self::Properties, _link: ComponentLink<Self>) -> Self {
+        Self { props }
+    }
+
+    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
+        true
+    }
+
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        if props != self.props {
+            self.props = props;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn view(&self) -> Html {
+        return html! {
+            <div>
+                {"Hello "}
+                {self.props.name.clone()}
+            </div>
+        };
+    }
+}
+
+fn main() {
+    yew::start_app::<Model>();
+}

--- a/yew/src/virtual_dom/vnode.rs
+++ b/yew/src/virtual_dom/vnode.rs
@@ -1,6 +1,6 @@
 //! This module contains the implementation of abstract virtual node.
 
-use super::{Key, VChild, VComp, VDiff, VList, VTag, VText};
+use super::{Key, Transformer, VChild, VComp, VDiff, VList, VTag, VText};
 use crate::html::{AnyScope, Component, NodeRef};
 use cfg_if::cfg_if;
 use cfg_match::cfg_match;
@@ -215,6 +215,18 @@ impl PartialEq for VNode {
             (VNode::VComp(_), VNode::VComp(_)) => false,
             _ => false,
         }
+    }
+}
+
+impl Transformer<&str, VNode> for VComp {
+    fn transform(from: &str) -> VNode {
+        VNode::VText(VText::new(from.to_string()))
+    }
+}
+
+impl Transformer<String, VNode> for VComp {
+    fn transform(from: String) -> VNode {
+        VNode::VText(VText::new(from))
     }
 }
 


### PR DESCRIPTION
#### Description

I contribute to [yewprint](https://github.com/cecton/yewprint). I use VNode as a type of some props and I want to allow the user to pass a component instead of just a String. 

Example: https://github.com/cecton/yewprint/pull/55/commits/d2f5ee8442a01863adc78ee714f2dc41af2eb731

```
error[E0277]: the trait bound `yew::virtual_dom::VComp: yew::virtual_dom::Transformer<&str, yew::virtual_dom::VNode>` is not satisfied
  --> yewprint-doc/src/progressbar/mod.rs:84:35
   |
84 | ...                   label="Animate"
   |                             ^^^^^^^^^ the trait `yew::virtual_dom::Transformer<&str, yew::virtual_dom::VNode>` is not implemented for `yew::virtual_dom::VComp`
   |
```

In this example, I have try to use a VNode as a label and now I need to replace all the labels in my code with `label=html!("Animate")` and that in 31 places.



#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
