### PR TITLE
Remove Drop bound from Task trait

### DIFF
--- a/yew/src/services/mod.rs
+++ b/yew/src/services/mod.rs
@@ -39,9 +39,9 @@ use std::time::Duration;
 
 /// A task is an ongoing process which is part of a Yew application.
 ///
-/// All tasks must be handled when they are cancelled, which is why the `Drop` trait is required.
-/// Tasks should cancel themselves in their implementation of the `Drop` trait.
-pub trait Task: Drop {
+/// Tasks should cancel themselves when they are dropped.
+#[must_use = "tasks are cancelled when dropped"]
+pub trait Task {
     /// Returns `true` if task is active.
     fn is_active(&self) -> bool;
 }

--- a/yew/src/services/mod.rs
+++ b/yew/src/services/mod.rs
@@ -35,8 +35,6 @@ pub use self::timeout::TimeoutService;
 #[doc(inline)]
 pub use self::websocket::WebSocketService;
 
-use std::time::Duration;
-
 /// A task is an ongoing process which is part of a Yew application.
 ///
 /// Tasks should cancel themselves when they are dropped.
@@ -44,11 +42,4 @@ use std::time::Duration;
 pub trait Task {
     /// Returns `true` if task is active.
     fn is_active(&self) -> bool;
-}
-
-#[doc(hidden)]
-/// Converts a `Duration` into milliseconds.
-fn to_ms(duration: Duration) -> u32 {
-    let ms = duration.subsec_millis();
-    ms + duration.as_secs() as u32 * 1000
 }

--- a/yew/src/services/timeout.rs
+++ b/yew/src/services/timeout.rs
@@ -1,10 +1,11 @@
 //! This module contains Yew's implementation of a service to
 //! send messages when a timeout has elapsed.
 
-use super::{to_ms, Task};
+use super::Task;
 use crate::callback::Callback;
 use cfg_if::cfg_if;
 use cfg_match::cfg_match;
+use std::convert::TryInto;
 use std::fmt;
 use std::time::Duration;
 cfg_if! {
@@ -36,11 +37,18 @@ pub struct TimeoutService {}
 
 impl TimeoutService {
     /// Sets timeout which sends messages from a `converter` after `duration`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `duration` in milliseconds exceeds `u32::MAX` (more than 50 days).
     pub fn spawn(duration: Duration, callback: Callback<()>) -> TimeoutTask {
         let callback = move || {
             callback.emit(());
         };
-        let ms = to_ms(duration);
+        let ms: u32 = duration
+            .as_millis()
+            .try_into()
+            .expect("duration doesn't fit in u32");
         let handle = cfg_match! {
             feature = "std_web" => js! {
                 var callback = @{callback};


### PR DESCRIPTION
#### Description

Rust now emits a warning for `Drop` bounds. This PR simply removes it from the `Task` trait and updates the documentation. A type implementing `Task` doesn't necessarily need to implement `Drop` itself to fulfil the invariant. Especially with `web-sys` / `glee` types that already clean up when dropped there's no need for the task itself to implement `Drop` as well. 

I also removed the long redundant `to_ms` function and made it so the methods panic instead of truncating when `duration` is too big. This technically makes this a breaking change but I'm 99% sure that no one is currently relying on this behaviour :D

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
