### PR TITLE
More ergonomic use state 1505

### DIFF
--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -213,7 +213,7 @@ where
     )
 }
 
-pub fn use_state<T, F>(initial_state_fn: F) -> (Rc<T>, Box<impl Fn(T)>)
+pub fn use_state<T, F>(initial_state_fn: F) -> (Rc<T>, Rc<impl Fn(T)>)
 where
     F: FnOnce() -> T,
     T: 'static,
@@ -227,7 +227,7 @@ where
             let current = prev.current.clone();
             (
                 current,
-                Box::new(move |o: T| {
+                Rc::new(move |o: T| {
                     hook_callback(
                         |state: &mut UseStateState<T>| {
                             state.current = Rc::new(o);

--- a/yew-functional/tests/lib.rs
+++ b/yew-functional/tests/lib.rs
@@ -42,6 +42,49 @@ fn use_state_works() {
 }
 
 #[wasm_bindgen_test]
+fn multiple_use_state_setters() {
+    struct UseStateFunction {}
+    impl FunctionProvider for UseStateFunction {
+        type TProps = ();
+
+        fn run(_: &Self::TProps) -> Html {
+            let (counter, set_counter_in_use_effect) = use_state(|| 0);
+            let counter = *counter;
+            // clone without manually wrapping with Rc
+            let set_counter_in_another_scope = set_counter_in_use_effect.clone();
+            use_effect_with_deps(
+                move |_| {
+                    // 1st location
+                    set_counter_in_use_effect(counter + 1);
+                    || {}
+                },
+                (),
+            );
+            let another_scope = move || {
+                if counter < 11 {
+                    // 2nd location
+                    set_counter_in_another_scope(counter + 10)
+                }
+            };
+            another_scope();
+            return html! {
+                <div>
+                    {"Test Output: "}
+                    // expected output
+                    <div id="result">{counter}</div>
+                    {"\n"}
+                </div>
+            };
+        }
+    }
+    type UseComponent = FunctionComponent<UseStateFunction>;
+    let app: App<UseComponent> = yew::App::new();
+    app.mount(yew::utils::document().get_element_by_id("output").unwrap());
+    let result = obtain_result();
+    assert_eq!(result.as_str(), "11");
+}
+
+#[wasm_bindgen_test]
 fn props_are_passed() {
     struct PropsPassedFunction {}
     #[derive(Properties, Clone, PartialEq)]


### PR DESCRIPTION
Makes calling use_state setter from multiple locations more ergonomic

#### Description

For `use_state`, I replaced `Box` with `Rc` on the returned setter. This allows the user to avoid manually wrapping with `Rc` when calling the setter from more than one location. Arguably, this is unnecessary when the setter is only called from a single location, but the change does seem more user friendly.

Fixes #1505

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
