### PR TITLE
Add docs for Hooks 

### DIFF
--- a/docs/concepts/function-components.md
+++ b/docs/concepts/function-components.md
@@ -51,3 +51,4 @@ Yew comes with the following predefined hooks:
 #### Custom Hooks
 
 There are cases where you want to define your own hooks for reasons. Yew allows you to define your own hooks which lets you extract your potentially stateful logic from the component into reusable functions. 
+See [Defining custom hooks](function-components/custom-hooks.md#defining-custom-hooks) section for more information.

--- a/docs/concepts/function-components.md
+++ b/docs/concepts/function-components.md
@@ -51,4 +51,4 @@ Yew comes with the following predefined Hooks:
 #### Custom Hooks
 
 There are cases where you want to define your own Hooks for reasons. Yew allows you to define your own Hooks which lets you extract your potentially stateful logic from the component into reusable functions. 
-See [Defining custom Hooks](function-components/custom-hooks.md#defining-custom-hooks) section for more information.
+See the [Defining custom hooks](function-components/custom-hooks.md#defining-custom-hooks) section for more information.

--- a/docs/concepts/function-components.md
+++ b/docs/concepts/function-components.md
@@ -5,7 +5,7 @@ description: Introduction to function components
 ---
 
 :::warning
-We're still working on function components and hooks. They're not quite ready to be used yet.
+We're still working on function components and Hooks. They're not quite ready to be used yet.
 If you'd like to help out, take a look at the [project board](https://github.com/yewstack/yew/projects/3) for a list of things that still need to be done.
 :::
 
@@ -13,7 +13,7 @@ If you'd like to help out, take a look at the [project board](https://github.com
 Function components are a simplified version of normal components.
 They consist of a single function that receives props and determines what should be rendered by returning `Html`.
 Basically, it's a component that's been reduced to just the `view` method.
-On its own that would be quite limiting because you can only create pure components, but that's where hooks come in.
+On its own that would be quite limiting because you can only create pure components, but that's where Hooks come in.
 Hooks allow function components to use state and other Yew features without implementing the `Component` trait.
 
 ## Creating function components
@@ -36,11 +36,11 @@ The `#[function_component]` attribute essentially just implements `FunctionProvi
 
 ### Hooks
 
-Hooks are simply functions that let you “hook into” components' state and/or lifecycle and perform actions. Yew comes with a few pre-defined hooks. You can also create your own.
+Hooks are simply functions that let you “hook into” components' state and/or lifecycle and perform actions. Yew comes with a few pre-defined Hooks. You can also create your own.
 
 #### Pre-defined Hooks
 
-Yew comes with the following predefined hooks:
+Yew comes with the following predefined Hooks:
 - [`use_state`](function-components/pre-defined-hooks.md#use_state)
 - [`use_ref`](function-components/pre-defined-hooks.md#use_ref)
 - [`use_reducer`](function-components/pre-defined-hooks.md#use_reducer)
@@ -50,5 +50,5 @@ Yew comes with the following predefined hooks:
 
 #### Custom Hooks
 
-There are cases where you want to define your own hooks for reasons. Yew allows you to define your own hooks which lets you extract your potentially stateful logic from the component into reusable functions. 
-See [Defining custom hooks](function-components/custom-hooks.md#defining-custom-hooks) section for more information.
+There are cases where you want to define your own Hooks for reasons. Yew allows you to define your own Hooks which lets you extract your potentially stateful logic from the component into reusable functions. 
+See [Defining custom Hooks](function-components/custom-hooks.md#defining-custom-hooks) section for more information.

--- a/docs/concepts/function-components/custom-hooks.md
+++ b/docs/concepts/function-components/custom-hooks.md
@@ -5,7 +5,7 @@ description: Defining your own Hooks
 
 ## Defining custom Hooks
 
-Component's stateful logic can be extracted into usable function by creating custom Gooks. 
+Component's stateful logic can be extracted into usable function by creating custom Hooks. 
 
 Consider that we have a component which subscribes to an agent and displays the messages sent to it.
 ```rust
@@ -25,15 +25,16 @@ pub fn show_messages() -> Html {
         });
     }
 
-    let output = state.borrow().deref().iter().map(|it| html! { <p>{it} </p>}).collect::<Html>();
-    html! { <div> {output} </div> }
+    let output = state.borrow().deref().iter().map(|it| html! { <p>{ it }</p> });
+    html! { <div>{ for output }</div> }
 }
 ```
 
-There's one problem with this code: if this stateful logic can't be reused. If it is to be used in other component, 
-there will be code duplication. This problem can easily be solved by moving this logic to a new hook.
+There's one problem with this code: the logic can't be reused by another component.
+If we build another component which keeps track of the messages, instead of copying the code we can move the logic into a custom hook.
 
-We'll start by creating a new function called `use_subscribe`. The `use_` prefix conventionally denotes this is a hook.
+We'll start by creating a new function called `use_subscribe`.
+The `use_` prefix conventionally denotes that a function is a hook.
 This function will take no arguments and return `Rc<RefCell<Vec<String>>>`.
 ```rust
 fn use_subscribe() -> Rc<RefCell<Vec<String>>> {
@@ -93,13 +94,13 @@ fn use_subscribe() -> Rc<RefCell<Vec<String>>> {
 }
 ```
 
-We can consume this hook like:
+We can now use our custom hook like this:
 ```rust
 #[function_component(ShowMessages)]
 pub fn show_messages() -> Html {
     let state = use_subscribe();
-    let output = state.borrow().deref().into_iter().map(|it| html! { <p>{it} </p>}).collect::<Html>();
+    let output = state.borrow().deref().into_iter().map(|it| html! { <p>{ it }</p> });
 
-    html! { <div> {output} </div> }
+    html! { <div>{ for output }</div> }
 }
 ```

--- a/docs/concepts/function-components/custom-hooks.md
+++ b/docs/concepts/function-components/custom-hooks.md
@@ -11,14 +11,15 @@ Consider that we have a component which subscribes to an agent and displays the 
 ```rust
 #[function_component(ShowMessages)]
 pub fn show_messages() -> Html {
-    let (state, set_state) = use_state(|| RefCell::new(vec![]));
+    let (state, set_state) = use_state(|| vec![]);
 
     {
         let mut state = Rc::clone(&state);
         use_effect(move || {
             let producer = EventBus::bridge(Callback::from(move |msg| {
-                (*state).borrow_mut().deref_mut().push(msg);
-                set_state((*state).clone())
+                let mut messages = (*state).clone();
+                messages.push(msg);
+                set_state(messages)
             }));
 
             || drop(producer)

--- a/docs/concepts/function-components/custom-hooks.md
+++ b/docs/concepts/function-components/custom-hooks.md
@@ -1,11 +1,11 @@
 ---
-title: Custom hooks
-description: Defining your own hooks 
+title: Custom Hooks
+description: Defining your own Hooks 
 ---
 
-## Defining custom hooks
+## Defining custom Hooks
 
-Component's stateful logic can be extracted into usable function by creating custom hooks. 
+Component's stateful logic can be extracted into usable function by creating custom Gooks. 
 
 Consider that we have a component which subscribes to an agent and displays the messages sent to it.
 ```rust
@@ -42,7 +42,7 @@ fn use_subscribe() -> Rc<RefCell<Vec<String>>> {
 ```
 
 The hook's logic goes inside the `use_hook`'s callback.
-`use_hook` is the handler function for custom hooks. It takes in 2 arguments: `hook_runner` and `initial_state_producer`. 
+`use_hook` is the handler function for custom Hooks. It takes in 2 arguments: `hook_runner` and `initial_state_producer`. 
 
 `hook_runner` is where all the hook's logic goes. `use_hook` returns the value returned by this callback.
 `hook_runner` itself takes 2 arguments: a mutable reference to the internal state of the hook and `hook_callback`.
@@ -69,7 +69,7 @@ fn use_subscribe() -> Rc<RefCell<Vec<String>>> {
     use_hook(
         // hook's handler. all the logic goes in here
         |state: &mut UseSubscribeState, hook_callback| {
-            // calling other hooks inside a hook
+            // calling other Hooks inside a hook
             use_effect(move || {
                 let producer = EventBus::bridge(Callback::from(move |msg| {
                     hook_callback(

--- a/docs/concepts/function-components/custom-hooks.md
+++ b/docs/concepts/function-components/custom-hooks.md
@@ -26,7 +26,7 @@ pub fn show_messages() -> Html {
         });
     }
 
-    let output = state.borrow().deref().iter().map(|it| html! { <p>{ it }</p> });
+    let output = state.iter().map(|it| html! { <p>{ it }</p> });
     html! { <div>{ for output }</div> }
 }
 ```
@@ -105,3 +105,23 @@ pub fn show_messages() -> Html {
     html! { <div>{ for output }</div> }
 }
 ```
+
+It's important to note that `use_hook` isn't necessarily required to create custom hooks 
+as they can just consist of other hooks. `use_hook` should generally be avoided. 
+
+```rust
+fn use_subscribe() -> Rc<Vec<String>> {
+    let (state, set_state) = use_state(Vec::new);
+  
+    use_effect(move || {
+        let producer = EventBus::bridge(Callback::from(move |msg| {
+            let mut messages = (*state).clone();
+            messages.push(msg);
+            set_state(messages)
+        }));
+        || drop(producer)
+    });
+
+    state
+}
+```   

--- a/docs/concepts/function-components/custom-hooks.md
+++ b/docs/concepts/function-components/custom-hooks.md
@@ -5,8 +5,101 @@ description: Defining your own hooks
 
 ## Defining custom hooks
 
-:::important contribute
-Contribute to our docs: Add details about defining custom hooks
+Component's stateful logic can be extracted into usable function by creating custom hooks. 
 
-Take a look at the [project board](https://github.com/yewstack/yew/projects/3) for details and consider helping out.
-::: 
+Consider that we have a component which subscribes to an agent and displays the messages sent to it.
+```rust
+#[function_component(ShowMessages)]
+pub fn show_messages() -> Html {
+    let (state, set_state) = use_state(|| RefCell::new(vec![]));
+
+    {
+        let mut state = Rc::clone(&state);
+        use_effect(move || {
+            let producer = EventBus::bridge(Callback::from(move |msg| {
+                (*state).borrow_mut().deref_mut().push(msg);
+                set_state((*state).clone())
+            }));
+
+            || drop(producer)
+        });
+    }
+
+    let output = state.borrow().deref().iter().map(|it| html! { <p>{it} </p>}).collect::<Html>();
+    html! { <div> {output} </div> }
+}
+```
+
+There's one problem with this code: if this stateful logic can't be reused. If it is to be used in other component, 
+there will be code duplication. This problem can easily be solved by moving this logic to a new hook.
+
+We'll start by creating a new function called `use_subscribe`. The `use_` prefix conventionally denotes this is a hook.
+This function will take no arguments and return `Rc<RefCell<Vec<String>>>`.
+```rust
+fn use_subscribe() -> Rc<RefCell<Vec<String>>> {
+    // ...
+}
+```
+
+The hook's logic goes inside the `use_hook`'s callback.
+`use_hook` is the handler function for custom hooks. It takes in 2 arguments: `hook_runner` and `initial_state_producer`. 
+
+`hook_runner` is where all the hook's logic goes. `use_hook` returns the value returned by this callback.
+`hook_runner` itself takes 2 arguments: a mutable reference to the internal state of the hook and `hook_callback`.
+`hook_callback` also takes in 2 arguments: a callback and, a bool indicating whether it is run post render of the component.
+The callback takes in `internal_state` which is a mutable reference to the instance of the internal state and performs the actual mutations. 
+It returns `ShouldRender` bool.
+`use_hook`'s second argument of `initial_state_producer` takes in a callback for creating an instance of the internal state.
+The internal state is a struct which implements the `Hook` trait.
+
+Now let's create the state struct for our `use_subscribe` hook.
+```rust
+/// `use_subscribe` internal state
+struct UseSubscribeState {
+    /// holds all the messages received
+    pub messages: Rc<RefCell<Vec<String>>>,
+}
+
+impl Hook for UseSubscribeState {}
+```
+
+Now we'll modify `use_subscribe` to contain the actual logic.
+```rust
+fn use_subscribe() -> Rc<RefCell<Vec<String>>> {
+    use_hook(
+        // hook's handler. all the logic goes in here
+        |state: &mut UseSubscribeState, hook_callback| {
+            // calling other hooks inside a hook
+            use_effect(move || {
+                let producer = EventBus::bridge(Callback::from(move |msg| {
+                    hook_callback(
+                        // where the mutations of state are performed
+                        |state| {
+                            (*state.messages).borrow_mut().deref_mut().push(msg);
+                            true // should re-render
+                        }, false // run post-render
+                    )
+                }));
+
+                || drop(producer)
+            });
+
+            // return from hook
+            state.messages.clone()
+        },
+        // initial state producer
+        || UseSubscribeState { messages: Rc::new(RefCell::new(vec![])) },
+    )
+}
+```
+
+We can consume this hook like:
+```rust
+#[function_component(ShowMessages)]
+pub fn show_messages() -> Html {
+    let state = use_subscribe();
+    let output = state.borrow().deref().into_iter().map(|it| html! { <p>{it} </p>}).collect::<Html>();
+
+    html! { <div> {output} </div> }
+}
+```

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -71,28 +71,31 @@ If you need the component to be re-rendered on state change, consider using [`us
 ```rust
 #[function_component(UseRef)]
 fn ref_hook() -> Html {
-    let (outer_html, set_outer_html) = use_state(String::new);
+    let (message, set_message) = use_state(|| "".to_string());
+    let message_count = use_ref(|| 0);
 
-    let node_ref = use_ref(NodeRef::default);
+    let onclick = Callback::from(move |e| {
+        let window = yew::utils::window();
 
-    let onclick = {
-        let node_ref = Rc::clone(&node_ref);
+        if *message_count.borrow_mut() > 3 {
+            window.alert_with_message("Message limit reached");
+        } else {
+            *message_count.borrow_mut() += 1;
+            window.alert_with_message("Message sent");
+        }
+    });
 
-        Callback::from(move |e| {
-            let outer_html = (*node_ref.borrow().deref())
-                .cast::<yew::web_sys::Element>()
-                .unwrap()
-                .outer_html();
-            set_outer_html(outer_html)
-        })
-    };
+    let onchange = Callback::from(move |e| {
+        if let ChangeData::Value(value) = e {
+            set_message(value)
+        }
+    });
+
     html! {
-        <>
-            <div id="result" ref=(*node_ref.borrow_mut().deref_mut()).clone()>{ "Filler" }</div>
-            { outer_html }
-            <br />
-            <button onclick=onclick>{ "Refresh" }</button>
-        </>
+        <div>
+            <input onchange=onchange value=message />
+            <button onclick=onclick>{ "Send" }</button>
+        </div>
     }
 }
 ```

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -267,7 +267,7 @@ In order to use contexts, we need a struct which defines what data is to be pass
 For the above use-case, consider the following struct:
 ```rust
 #[derive(Clone, Debug, PartialEq)]
-struct ThemeContext {
+struct Theme {
     foreground: String,
     background: String,
 }
@@ -289,10 +289,10 @@ pub fn app() -> Html {
     });
 
     html! {
-        <ThemeContextProvider context=ctx>
+        <ContextProvider<Theme> context=ctx>
             // Every child here and their children will have access to this context.
             <Toolbar />
-        </ThemeContextProvider>
+        </ContextProvider<Theme>>
     }
 }
 

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -283,7 +283,7 @@ Let's implement the aforementioned Navbar using contexts and function components
 /// Main component 
 #[function_component(App)]
 pub fn app() -> Html {
-    let (ctx, _set_ctx) = use_state(|| ThemeContext {
+    let (ctx, _set_ctx) = use_state(|| Theme {
         foreground: "#000000".into(),
         background: "#eeeeee".into(),
     });
@@ -311,7 +311,7 @@ pub fn toolbar() -> Html {
 /// As this component is a child of `ThemeContextProvider` in the component tree, it also has access to the context.
 #[function_component(ThemedButton)]
 pub fn themed_button() -> Html {
-    let theme = use_context::<Rc<ThemeContext>>().expect("no ctx found");
+    let theme = use_context::<Rc<Theme>>().expect("no ctx found");
 
     html! {
         <button style=format!("background: {}; color: {};", theme.background, theme.foreground)>

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -9,19 +9,239 @@ Contribute to our docs: Add details about pre-defined hooks
 Take a look at the [project board](https://github.com/yewstack/yew/projects/3) for details and consider helping out.
 :::
 
+:::note Why Hooks return `Rc`?
+
+In most cases, you'll be cloning the values returned from the hooks.
+As it may be expensive to clone such values, they're `Rc`ed, so they can be cloned relatively cheaply.
+
+Following example shows one of the most common cases which requires cloning the values:
+
+```rust
+let (counter, set_counter) = use_state(|| 0);
+let onclick = {
+    let counter = Rc::clone(&counter);
+    // Values must be moved into this closure so in order to be able to use them later on, they must be cloned
+    Callback::from(move |_| set_counter(*counter + 1)) 
+};
+
+html! {
+    // If `counter` wasn't cloned above, it would've been impossible to use it here
+    { counter }
+}
+```
+:::
+
 ## `use_state`
 
+`use_state` is used to mange state in a function component.
+It returns a `Rc` of the stateful value, and a setter function.
+
+Initially, the state is set to the result of the function passed.
+This value remains up-to-date on subsequent renders.
+
+The setter function is used to update the value and trigger a re-render.
+
+### Example
+
+```rust
+#[function_component(UseState)]
+fn state() -> Html {
+    let (
+        counter, // the returned state
+        set_counter // setter to update the state
+    ) = use_state(|| 0);
+    let onclick = {
+        let counter = Rc::clone(&counter);
+        Callback::from(move |_| set_counter(*counter + 1))
+    };
+
+    html! {
+        <div>
+            <button onclick=onclick>{ "Increment value" }</button>
+            <p>
+                <b>{ "Current value: " }</b>
+                { counter }
+            </p>
+        </div>
+    }
+}
+```
 
 ## `use_ref`
+`use_ref` is used for obtaining a mutable reference to a stateful value.
+Its state persists across renders.
+
+It is important to note that you do not get notified of state changes.
+If you need the component to be re-rendered on state change, consider using [`use_state`](#use_state).
+
+### Example
+
+```rust
+#[function_component(UseRef)]
+fn ref_hook() -> Html {
+    let (outer_html, set_outer_html) = use_state(|| "".to_string());
+
+    let node_ref: Rc<RefCell<NodeRef>> = use_ref(|| NodeRef::default());
+
+    let on_click = {
+        let node_ref = Rc::clone(&node_ref);
+
+        Callback::from(move |e| {
+            let to_set = (*node_ref.borrow().deref())
+                .cast::<yew::web_sys::Element>()
+                .unwrap()
+                .outer_html();
+            set_outer_html(to_set)
+        })
+    };
+    html! {
+        <>
+            <div id="result" ref=(*node_ref.borrow_mut().deref_mut()).clone()>{"Filler"}</div>
+            {outer_html}
+            <br />
+            <button onclick=on_click>{"Refresh"}</button>
+        </>
+    }
+}
+```
 
 
 ## `use_reducer`
 
+`use_reducer` is an alternative to [`use_state`](#use_state). It is used to handle component's state and is used
+when complex actions needs to be performed on said state.
+
+It accepts a reducer function and initial state and returns `Rc` of the state, and a dispatch function.
+The dispatch function takes one argument of `Action`. When called, the action and current value
+are passed to the reducer function which computes a new state which is returned,
+and the component is re-rendered.
+
+For lazy initialization, consider using [`use_reducer_with_init`](#use_reducer_with_init) instead.
+
+### Example
+
+```rust
+#[function_component(UseReducer)]
+fn reducer() -> Html {
+    /// reducer's Action
+    enum Action {
+        Double,
+        Square,
+    }
+
+    /// reducer's State
+    struct CounterState {
+        counter: i32,
+    }
+
+    let (
+        counter, // the state
+        // function to update the state 
+        // as the same suggests, it dispatches the values to the reducer function
+        dispatch  
+    ) = use_reducer(
+        // the reducer function
+        |prev: Rc<CounterState>, action: Action| CounterState {
+            counter: match action {
+                Action::Double => prev.counter * 2,
+                Action::Square => prev.counter * prev.counter,
+            }
+        },
+        // initial state
+        CounterState { counter: 1 },
+    );
+
+    let double_onclick = {
+        let dispatch = Rc::clone(&dispatch);
+        Callback::from(move |_| dispatch(Action::Double))
+    };
+    let square_onclick = Callback::from(move |_| dispatch(Action::Square));
+
+    html! {
+        <>
+            <div id="result">{counter.counter}</div>
+
+            <button onclick=double_onclick>{"Double"}</button>
+            <button onclick=square_onclick>{"Square"}</button>
+        </>
+    }
+}
+```
 
 ## `use_reducer_with_init`
+`use_reducer` but with init argument. The Hook is passed the initial state
+which is then passed down to `init` function which initializes the state and returns it.
+The hook then returns this state.
 
+This is useful for lazy initialization where it is beneficial not to perform expensive
+computation up-front
+
+### Example
+
+```rust
+#[function_component(UseReducerWithInit)]
+fn reducer_with_init() -> Html {
+    struct CounterState {
+        counter: i32,
+    }
+    let (counter, dispatch) = use_reducer_with_init(
+        // reducer function
+        |prev: Rc<CounterState>, action: i32| CounterState {
+            counter: prev.counter + action,
+        },
+        0, // initial value
+        |initial: i32| CounterState { // init method
+            counter: initial + 10,
+        },
+    );
+
+    html! {
+        <>
+            <div id="result">{counter.counter}</div>
+
+            <button onclick=Callback::from(move |_| dispatch(10))>{"Increment by 10"}</button>
+        </>
+    }
+}
+```
 
 ## `use_effect`
 
+`use_effect` is used for hooking into the component's lifecycle. 
+Similar to `rendered` method of `Component` trait, 
+`use_effect` takes a function which is called after the render finishes.
+
+The said function returns another function, the destructor function,
+which called when the component is destroyed. It can be used to clean up the effects introduced.
+This is similar to `destroyed` method of `Component` trait.
+
+### Example
+
+```rust
+#[function_component(UseEffect)]
+fn effect() -> Html {
+    let (counter, set_counter) = use_state(|| 0);
+
+    let counter_one = counter.clone();
+    use_effect(move || {
+        // Make a call to DOM API after component is rendered
+        yew::utils::document().set_title(&format!("You clicked {} times", counter_one));
+
+        // Perform the cleanup
+        || yew::utils::document().set_title(&format!("You clicked 0 times"))
+    });
+    
+    let onclick = {
+        let counter = Rc::clone(&counter);
+        Callback::from(move |_| set_counter(*counter + 1))
+    };
+
+    return html! {<>
+        <button onclick=onclick>{ format!("Increment to {}", counter) }</button>
+    </>};
+}
+```
 
 ## `use_effect_with_deps`
+
+<!-- TODO -->

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -234,7 +234,7 @@ use_effect_with_deps(
 
 ## `use_context`
 
-`use_context` used for consuming contexts in function components. See the explanation and example below to learn how to use it. 
+`use_context` is used for consuming contexts in function components. See the explanation and example in the following section to learn how to use it. 
 
 ### Contexts
 
@@ -284,8 +284,8 @@ Let's implement the aforementioned Navbar using contexts and function components
 #[function_component(App)]
 pub fn app() -> Html {
     let (ctx, _set_ctx) = use_state(|| Theme {
-        foreground: "#000000".into(),
-        background: "#eeeeee".into(),
+        foreground: "#000000".to_owned(),
+        background: "#eeeeee".to_owned(),
     });
 
     html! {

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -204,7 +204,7 @@ fn effect() -> Html {
         let counter = counter.clone();
         use_effect(move || {
             // Make a call to DOM API after component is rendered
-            yew::utils::document().set_title(&format!("You clicked {} times", counter_one));
+            yew::utils::document().set_title(&format!("You clicked {} times", counter));
     
             // Perform the cleanup
             || yew::utils::document().set_title("You clicked 0 times")

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -15,7 +15,7 @@ let (text, set_text) = use_state(|| "Hello".to_owned());
 let onclick = {
     let text = Rc::clone(&text);
     // Values must be moved into this closure so in order to use them later on, they must be cloned
-    Callback::from(move |_| format!("{} World", text)) 
+    Callback::from(move |_| set_text(format!("{} World", text))) 
 };
 
 // If `text` wasn't cloned above, it would've been impossible to use it here

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -3,12 +3,6 @@ title: Pre-defined hooks
 description: The pre-defined hooks that Yew comes with 
 ---
 
-:::important contribute
-Contribute to our docs: Add details about pre-defined hooks
-
-Take a look at the [project board](https://github.com/yewstack/yew/projects/3) for details and consider helping out.
-:::
-
 :::note Why do Hooks return `Rc`?
 
 In most cases, you'll be cloning the values returned from the hooks.

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -197,15 +197,16 @@ The destructor can be used to clean up the effects introduced and it can take ow
 fn effect() -> Html {
     let (counter, set_counter) = use_state(|| 0);
 
-    let counter_one = counter.clone();
-    use_effect(move || {
-        // Make a call to DOM API after component is rendered
-        yew::utils::document().set_title(&format!("You clicked {} times", counter_one));
-
-        // Perform the cleanup
-        || yew::utils::document().set_title(&format!("You clicked 0 times"))
-    });
+    {
+        let counter = counter.clone();
+        use_effect(move || {
+            // Make a call to DOM API after component is rendered
+            yew::utils::document().set_title(&format!("You clicked {} times", counter_one));
     
+            // Perform the cleanup
+            || yew::utils::document().set_title("You clicked 0 times")
+        });
+    }    
     let onclick = {
         let counter = Rc::clone(&counter);
         Callback::from(move |_| set_counter(*counter + 1))

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -9,7 +9,7 @@ Contribute to our docs: Add details about pre-defined hooks
 Take a look at the [project board](https://github.com/yewstack/yew/projects/3) for details and consider helping out.
 :::
 
-:::note Why Hooks return `Rc`?
+:::note Why do Hooks return `Rc`?
 
 In most cases, you'll be cloning the values returned from the hooks.
 As it may be expensive to clone such values, they're `Rc`ed, so they can be cloned relatively cheaply.
@@ -243,5 +243,9 @@ fn effect() -> Html {
 ```
 
 ## `use_effect_with_deps`
+
+<!-- TODO -->
+
+## `use_context`
 
 <!-- TODO -->

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -123,7 +123,7 @@ fn reducer() -> Html {
 
     /// reducer's State
     struct CounterState {
-        value: i32,
+        counter: i32,
     }
 
     let (
@@ -135,12 +135,12 @@ fn reducer() -> Html {
         // the reducer function
         |prev: Rc<CounterState>, action: Action| CounterState {
             counter: match action {
-                Action::Double => prev.value * 2,
-                Action::Square => prev.value * prev.value,
+                Action::Double => prev.counter * 2,
+                Action::Square => prev.counter * prev.counter,
             }
         },
         // initial state
-        CounterState { value: 1 },
+        CounterState { counter: 1 },
     );
 
     let double_onclick = {
@@ -151,7 +151,7 @@ fn reducer() -> Html {
 
     html! {
         <>
-            <div id="result">{ counter.value }</div>
+            <div id="result">{ counter.counter }</div>
 
             <button onclick=double_onclick>{ "Double" }</button>
             <button onclick=square_onclick>{ "Square" }</button>

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -6,9 +6,9 @@ description: The pre-defined hooks that Yew comes with
 :::note Why do Hooks return `Rc`?
 
 In most cases, you'll be cloning the values returned from the hooks.
-As it may be expensive to clone such values, they're `Rc`ed, so they can be cloned relatively cheaply.
+As it is generally expensive to clone such values, they're `Rc`ed, so they can be cloned relatively cheaply.
 
-Following example shows one of the most common cases which requires cloning the values:
+The following example shows one of the most common cases which requires cloning the values:
 
 ```rust
 let (counter, set_counter) = use_state(|| 0);
@@ -105,8 +105,8 @@ fn ref_hook() -> Html {
 `use_reducer` is an alternative to [`use_state`](#use_state). It is used to handle component's state and is used
 when complex actions needs to be performed on said state.
 
-It accepts a reducer function and initial state and returns `Rc` of the state, and a dispatch function.
-The dispatch function takes one argument of `Action`. When called, the action and current value
+It accepts a reducer function and initial state and returns `Rc` pointing to the state, and a dispatch function.
+The dispatch function takes one argument of type `Action`. When called, the action and current value
 are passed to the reducer function which computes a new state which is returned,
 and the component is re-rendered.
 

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -168,41 +168,25 @@ fn reducer() -> Html {
 }
 ```
 
-## `use_reducer_with_init`
+### `use_reducer_with_init`
 `use_reducer` but with init argument. The Hook is passed the initial state
 which is then passed down to `init` function which initializes the state and returns it.
 The hook then returns this state.
 
 This is useful for lazy initialization where it is beneficial not to perform expensive
-computation up-front
-
-### Example
+computation up-front.
 
 ```rust
-#[function_component(UseReducerWithInit)]
-fn reducer_with_init() -> Html {
-    struct CounterState {
-        counter: i32,
-    }
-    let (counter, dispatch) = use_reducer_with_init(
-        // reducer function
-        |prev: Rc<CounterState>, action: i32| CounterState {
-            counter: prev.counter + action,
-        },
-        0, // initial value
-        |initial: i32| CounterState { // init method
-            counter: initial + 10,
-        },
-    );
-
-    html! {
-        <>
-            <div id="result">{counter.counter}</div>
-
-            <button onclick=Callback::from(move |_| dispatch(10))>{"Increment by 10"}</button>
-        </>
-    }
-}
+let (counter, dispatch) = use_reducer_with_init(
+    // reducer function
+    |prev: Rc<CounterState>, action: i32| CounterState {
+        counter: prev.counter + action,
+    },
+    0, // initial value
+    |initial: i32| CounterState { // init method
+        counter: initial + 10,
+    },
+);
 ```
 
 ## `use_effect`
@@ -242,9 +226,20 @@ fn effect() -> Html {
 }
 ```
 
-## `use_effect_with_deps`
+### `use_effect_with_deps`
 
-<!-- TODO -->
+Sometimes, it's needed to manually define dependencies for [`use_effect`](#use_effect). In such cases, we use `use_effect_with_deps`.
+```rust
+use_effect_with_deps(
+    move |_| {
+        // ...
+        || {}
+    },
+    (), // dependents
+);
+```
+
+**Note**: `dependents` must implement `PartialEq`.
 
 ## `use_context`
 

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -28,7 +28,7 @@ html! {
 ## `use_state`
 
 `use_state` is used to mange state in a function component.
-It returns a `Rc` of the stateful value, and a setter function.
+It returns a `Rc` pointing to the value of the hook's state, and a setter function.
 
 Initially, the state is set to the result of the function passed.
 This value remains up-to-date on subsequent renders.

--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -1,11 +1,11 @@
 ---
-title: Pre-defined hooks
-description: The pre-defined hooks that Yew comes with 
+title: Pre-defined Hooks
+description: The pre-defined Hooks that Yew comes with 
 ---
 
 :::note Why do Hooks return `Rc`?
 
-In most cases, you'll be cloning the values returned from the hooks.
+In most cases, you'll be cloning the values returned from the Hooks.
 As it is generally expensive to clone such values, they're `Rc`ed, so they can be cloned relatively cheaply.
 
 The following example shows one of the most common cases which requires cloning the values:

--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -205,28 +205,31 @@ where
 /// #
 /// #[function_component(UseRef)]
 /// fn ref_hook() -> Html {
-///     let (outer_html, set_outer_html) = use_state(String::new);
+///     let (message, set_message) = use_state(|| "".to_string());
+///     let message_count = use_ref(|| 0);
 ///
-///     let node_ref = use_ref(NodeRef::default);
+///     let onclick = Callback::from(move |e| {
+///         let window = yew::utils::window();
 ///
-///     let onclick = {
-///         let node_ref = Rc::clone(&node_ref);
+///         if *message_count.borrow_mut() > 3 {
+///             window.alert_with_message("Message limit reached");
+///         } else {
+///             *message_count.borrow_mut() += 1;
+///             window.alert_with_message("Message sent");
+///         }
+///     });
 ///
-///         Callback::from(move |e| {
-///             let outer_html = (*node_ref.borrow().deref())
-///                 .cast::<yew::web_sys::Element>()
-///                 .unwrap()
-///                 .outer_html();
-///             set_outer_html(outer_html)
-///         })
-///     };
+///     let onchange = Callback::from(move |e| {
+///         if let ChangeData::Value(value) = e {
+///             set_message(value)
+///         }
+///     });
+///
 ///     html! {
-///         <>
-///             <div id="result" ref=(*node_ref.borrow_mut().deref_mut()).clone()>{ "Filler" }</div>
-///             { outer_html }
-///             <br />
-///             <button onclick=onclick>{ "Refresh" }</button>
-///         </>
+///         <div>
+///             <input onchange=onchange value=message />
+///             <button onclick=onclick>{ "Send" }</button>
+///         </div>
 ///     }
 /// }
 /// ```

--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -12,7 +12,7 @@
 //! }
 //! ```
 //!
-//! More details about function components and Hooks can be found on [Yew's website](https://yew.rs/docs/en/next/concepts/function-components)
+//! More details about function components and Hooks can be found on [Yew Docs](https://yew.rs/docs/en/next/concepts/function-components)
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
@@ -522,8 +522,11 @@ where
     );
 }
 
-/// Sometimes, it's needed to manually define dependencies for [`use_effect`].
-/// In such cases, we use `use_effect_with_deps`.
+/// This hook is similar to [`use_effect`] but it accepts dependencies.
+///
+/// Whenever the dependencies are changed, the effect callback is called again.
+/// To detect changes, dependencies must implement `PartialEq`.
+/// Note that the destructor also runs when dependencies change.
 pub fn use_effect_with_deps<F, Destructor, Dependents>(callback: F, deps: Dependents)
 where
     F: FnOnce(&Dependents) -> Destructor + 'static,

--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```rust
 //! # use yew_functional::function_component;
 //! # use yew::prelude::*;
-//!
+//! #
 //! #[function_component(HelloWorld)]
 //! fn hello_world() -> Html {
 //!     html! { "Hello world" }
@@ -43,7 +43,7 @@
 //! # use yew_functional::{function_component, use_state};
 //! # use yew::prelude::*;
 //! # use std::rc::Rc;
-//!
+//! #
 //! fn component() -> Html {
 //!     let (data, set_data) = use_state(|| "".to_string());
 //!     let onclick = {
@@ -250,30 +250,30 @@ where
 /// # use std::rc::Rc;
 /// # use std::cell::RefCell;
 /// # use std::ops::{Deref, DerefMut};
-///
+/// #
 /// #[function_component(UseRef)]
 /// fn ref_hook() -> Html {
-///     let (outer_html, set_outer_html) = use_state(|| "".to_string());
+///     let (outer_html, set_outer_html) = use_state(String::new);
 ///
-///     let node_ref: Rc<RefCell<NodeRef>> = use_ref(|| NodeRef::default());
+///     let node_ref = use_ref(NodeRef::default);
 ///
-///     let on_click = {
+///     let onclick = {
 ///         let node_ref = Rc::clone(&node_ref);
 ///
 ///         Callback::from(move |e| {
-///             let to_set = (*node_ref.borrow().deref())
+///             let outer_html = (*node_ref.borrow().deref())
 ///                 .cast::<yew::web_sys::Element>()
 ///                 .unwrap()
 ///                 .outer_html();
-///             set_outer_html(to_set)
+///             set_outer_html(outer_html)
 ///         })
 ///     };
 ///     html! {
 ///         <>
-///             <div id="result" ref=(*node_ref.borrow_mut().deref_mut()).clone()>{"Filler"}</div>
-///             {outer_html}
+///             <div id="result" ref=(*node_ref.borrow_mut().deref_mut()).clone()>{ "Filler" }</div>
+///             { outer_html }
 ///             <br />
-///             <button onclick=on_click>{"Refresh"}</button>
+///             <button onclick=onclick>{ "Refresh" }</button>
 ///         </>
 ///     }
 /// }
@@ -312,16 +312,16 @@ where
 /// # use yew::prelude::*;
 /// # use std::rc::Rc;
 /// # use std::ops::DerefMut;
-///
+/// #
 /// #[function_component(UseReducer)]
 /// fn reducer() -> Html {
-///     //// reducer's Action
+///     /// reducer's Action
 ///     enum Action {
 ///         Double,
 ///         Square,
 ///     }
 ///
-///     //// reducer's State
+///     /// reducer's State
 ///     struct CounterState {
 ///         counter: i32,
 ///     }
@@ -343,7 +343,7 @@ where
 ///         CounterState { counter: 1 },
 ///     );
 ///
-///     let double_onclick = {
+///    let double_onclick = {
 ///         let dispatch = Rc::clone(&dispatch);
 ///         Callback::from(move |_| dispatch(Action::Double))
 ///     };
@@ -351,10 +351,10 @@ where
 ///
 ///     html! {
 ///         <>
-///             <div id="result">{counter.counter}</div>
+///             <div id="result">{ counter.counter }</div>
 ///
-///             <button onclick=double_onclick>{"Double"}</button>
-///             <button onclick=square_onclick>{"Square"}</button>
+///             <button onclick=double_onclick>{ "Double" }</button>
+///             <button onclick=square_onclick>{ "Square" }</button>
 ///         </>
 ///     }
 /// }
@@ -381,7 +381,7 @@ where
 /// # use yew_functional::{function_component, use_reducer_with_init};
 /// # use yew::prelude::*;
 /// # use std::rc::Rc;
-///
+/// #
 /// #[function_component(UseReducerWithInit)]
 /// fn reducer_with_init() -> Html {
 ///     struct CounterState {
@@ -460,7 +460,7 @@ where
 /// # use yew_functional::{function_component, use_state, use_ref};
 /// # use yew::prelude::*;
 /// # use std::rc::Rc;
-///
+/// #
 /// #[function_component(UseState)]
 /// fn state() -> Html {
 ///     let (
@@ -528,7 +528,7 @@ where
 /// # use yew_functional::{function_component, use_effect, use_state};
 /// # use yew::prelude::*;
 /// # use std::rc::Rc;
-///
+/// #
 /// #[function_component(UseEffect)]
 /// fn effect() -> Html {
 ///     let (counter, set_counter) = use_state(|| 0);
@@ -547,9 +547,9 @@ where
 ///         Callback::from(move |_| set_counter(*counter + 1))
 ///     };
 ///
-///     return html! {<>
+///     html! {
 ///         <button onclick=onclick>{ format!("Increment to {}", counter) }</button>
-///     </>};
+///     }
 /// }
 /// ```
 pub fn use_effect<F, Destructor>(callback: F)

--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -178,6 +178,43 @@ where
 ///
 /// It is important to note that you do not get notified of state changes.
 /// If you need the component to be re-rendered on state change, consider using [`use_state`].
+///
+/// # Example
+///
+/// ```rust
+/// # use yew_functional::{function_component, use_state, use_ref};
+/// # use yew::prelude::*;
+/// # use std::rc::Rc;
+/// # use std::cell::RefCell;
+/// # use std::ops::{Deref, DerefMut};
+///
+/// #[function_component(UseRef)]
+/// fn ref_hook() -> Html {
+///     let (outer_html, set_outer_html) = use_state(|| "".to_string());
+///
+///     let node_ref: Rc<RefCell<NodeRef>> = use_ref(|| NodeRef::default());
+///
+///     let on_click = {
+///         let node_ref = Rc::clone(&node_ref);
+///
+///         Callback::from(move |e| {
+///             let to_set = (*node_ref.borrow().deref())
+///                 .cast::<yew::web_sys::Element>()
+///                 .unwrap()
+///                 .outer_html();
+///             set_outer_html(to_set)
+///         })
+///     };
+///     html! {
+///         <>
+///             <div id="result" ref=(*node_ref.borrow_mut().deref_mut()).clone()>{"Filler"}</div>
+///             {outer_html}
+///             <br />
+///             <button onclick=on_click>{"Refresh"}</button>
+///         </>
+///     }
+/// }
+/// ```
 pub fn use_ref<T: 'static, InitialProvider>(initial_value: InitialProvider) -> Rc<RefCell<T>>
 where
     InitialProvider: FnOnce() -> T,
@@ -204,6 +241,61 @@ where
 /// and the component is re-rendered.
 ///
 /// For lazy initialization, consider using [`use_reducer_with_init`] instead.
+///
+/// # Example
+///
+/// ```rust
+/// # use yew_functional::{function_component, use_reducer};
+/// # use yew::prelude::*;
+/// # use std::rc::Rc;
+/// # use std::ops::DerefMut;
+///
+/// #[function_component(UseReducer)]
+/// fn reducer() -> Html {
+///     //// reducer's Action
+///     enum Action {
+///         Double,
+///         Square,
+///     }
+///
+///     //// reducer's State
+///     struct CounterState {
+///         counter: i32,
+///     }
+///
+///     let (
+///         counter, // the state
+///         // function to update the state
+///         // as the same suggests, it dispatches the values to the reducer function
+///         dispatch
+///     ) = use_reducer(
+///         // the reducer function
+///         |prev: Rc<CounterState>, action: Action| CounterState {
+///             counter: match action {
+///                 Action::Double => prev.counter * 2,
+///                 Action::Square => prev.counter * prev.counter,
+///             }
+///         },
+///         // initial state
+///         CounterState { counter: 1 },
+///     );
+///
+///     let double_onclick = {
+///         let dispatch = Rc::clone(&dispatch);
+///         Callback::from(move |_| dispatch(Action::Double))
+///     };
+///     let square_onclick = Callback::from(move |_| dispatch(Action::Square));
+///
+///     html! {
+///         <>
+///             <div id="result">{counter.counter}</div>
+///
+///             <button onclick=double_onclick>{"Double"}</button>
+///             <button onclick=square_onclick>{"Square"}</button>
+///         </>
+///     }
+/// }
+/// ```
 pub fn use_reducer<Action: 'static, Reducer, State: 'static>(
     reducer: Reducer,
     initial_state: State,
@@ -220,6 +312,37 @@ where
 ///
 /// This is useful for lazy initialization where it is beneficial not to perform expensive
 /// computation up-front
+///
+/// # Example
+/// ```rust
+/// # use yew_functional::{function_component, use_reducer_with_init};
+/// # use yew::prelude::*;
+/// # use std::rc::Rc;
+///
+/// #[function_component(UseReducerWithInit)]
+/// fn reducer_with_init() -> Html {
+///     struct CounterState {
+///         counter: i32,
+///     }
+///     let (counter, dispatch) = use_reducer_with_init(
+///         |prev: Rc<CounterState>, action: i32| CounterState {
+///             counter: prev.counter + action,
+///         },
+///         0,
+///         |initial: i32| CounterState {
+///             counter: initial + 10,
+///         },
+///     );
+///
+///     html! {
+///         <>
+///             <div id="result">{counter.counter}</div>
+///
+///             <button onclick=Callback::from(move |_| dispatch(10))>{"Increment by 10"}</button>
+///         </>
+///     }
+/// }
+/// ```
 pub fn use_reducer_with_init<Action: 'static, Reducer, State: 'static, InitialState, InitFn>(
     reducer: Reducer,
     initial_state: InitialState,
@@ -267,6 +390,36 @@ where
 /// This value remains up-to-date on subsequent renders.
 ///
 /// The setter function is used to update the value and trigger a re-render.
+///
+/// # Example
+///
+/// ```rust
+/// # use yew_functional::{function_component, use_state, use_ref};
+/// # use yew::prelude::*;
+/// # use std::rc::Rc;
+///
+/// #[function_component(UseState)]
+/// fn state() -> Html {
+///     let (
+///         counter, // the returned state
+///         set_counter // setter to update the state
+///     ) = use_state(|| 0);
+///     let onclick = {
+///         let counter = Rc::clone(&counter);
+///         Callback::from(move |_| set_counter(*counter + 1))
+///     };
+///
+///     html! {
+///         <div>
+///             <button onclick=onclick>{ "Increment value" }</button>
+///             <p>
+///                 <b>{ "Current value: " }</b>
+///                 { counter }
+///             </p>
+///         </div>
+///     }
+/// }
+/// ```
 pub fn use_state<T, F>(initial_state_fn: F) -> (Rc<T>, Rc<impl Fn(T)>)
 where
     F: FnOnce() -> T,
@@ -305,6 +458,37 @@ where
 /// The said function returns another function, the destructor function,
 /// which called when the component is destroyed. It can be used to clean up the effects introduced.
 /// This is similar to `destroyed` method of [`Component`] trait.
+///
+/// # Example
+///
+/// ```rust
+/// # use yew_functional::{function_component, use_effect, use_state};
+/// # use yew::prelude::*;
+/// # use std::rc::Rc;
+///
+/// #[function_component(UseEffect)]
+/// fn effect() -> Html {
+///     let (counter, set_counter) = use_state(|| 0);
+///
+///     let counter_one = counter.clone();
+///     use_effect(move || {
+///         /// Make a call to DOM API after component is rendered
+///         yew::utils::document().set_title(&format!("You clicked {} times", counter_one));
+///
+///         /// Perform the cleanup
+///         || yew::utils::document().set_title(&format!("You clicked 0 times"))
+///     });
+///
+///     let onclick = {
+///         let counter = Rc::clone(&counter);
+///         Callback::from(move |_| set_counter(*counter + 1))
+///     };
+///
+///     return html! {<>
+///         <button onclick=onclick>{ format!("Increment to {}", counter) }</button>
+///     </>};
+/// }
+/// ```
 pub fn use_effect<F, Destructor>(callback: F)
 where
     F: FnOnce() -> Destructor + 'static,
@@ -341,6 +525,28 @@ where
     );
 }
 
+/// Sometimes, it's needed to manually define dependencies for [`use_effect`].
+/// In such cases, we use `use_effect_with_deps`.
+///
+/// # Example
+///
+/// ```rust
+/// use yew_functional::{function_component, use_effect_with_deps};
+/// use yew::prelude::*;
+///
+/// # #[function_component(UseEffectWithDeps)]
+/// # fn effect_with_deps() -> Html {
+///     use_effect_with_deps(
+///         move |_| {
+///             // ...
+///             || {}
+///         },
+///         (), // dependents
+///     );
+///
+/// #    html! {}
+/// # }
+/// ```
 pub fn use_effect_with_deps<F, Destructor, Dependents>(callback: F, deps: Dependents)
 where
     F: FnOnce(&Dependents) -> Destructor + 'static,

--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -590,26 +590,6 @@ where
 
 /// Sometimes, it's needed to manually define dependencies for [`use_effect`].
 /// In such cases, we use `use_effect_with_deps`.
-///
-/// # Example
-///
-/// ```rust
-/// use yew_functional::{function_component, use_effect_with_deps};
-/// use yew::prelude::*;
-///
-/// # #[function_component(UseEffectWithDeps)]
-/// # fn effect_with_deps() -> Html {
-///     use_effect_with_deps(
-///         move |_| {
-///             // ...
-///             || {}
-///         },
-///         (), // dependents
-///     );
-///
-/// #    html! {}
-/// # }
-/// ```
 pub fn use_effect_with_deps<F, Destructor, Dependents>(callback: F, deps: Dependents)
 where
     F: FnOnce(&Dependents) -> Destructor + 'static,

--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -189,14 +189,13 @@ where
     }
 }
 
-/// `use_ref` is used for obtaining a mutable reference to a stateful value.
+/// This hook is used for obtaining a mutable reference to a stateful value.
 /// Its state persists across renders.
 ///
 /// It is important to note that you do not get notified of state changes.
 /// If you need the component to be re-rendered on state change, consider using [`use_state`].
 ///
 /// # Example
-///
 /// ```rust
 /// # use yew_functional::{function_component, use_state, use_ref};
 /// # use yew::prelude::*;
@@ -248,13 +247,12 @@ where
         move || UseRefState(Rc::new(RefCell::new(initial_value()))),
     )
 }
-/// `use_reducer` is an alternative to [`use_state`]. It is used to handle component's state and is used
+/// This hook is an alternative to [`use_state`]. It is used to handle component's state and is used
 /// when complex actions needs to be performed on said state.
 ///
 /// For lazy initialization, consider using [`use_reducer_with_init`] instead.
 ///
 /// # Example
-///
 /// ```rust
 /// # use yew_functional::{function_component, use_reducer};
 /// # use yew::prelude::*;
@@ -392,10 +390,9 @@ where
     )
 }
 
-/// `use_state` is used to mange state in a function component.
+/// This hook is used to mange state in a function component.
 ///
 /// # Example
-///
 /// ```rust
 /// # use yew_functional::{function_component, use_state, use_ref};
 /// # use yew::prelude::*;
@@ -454,10 +451,9 @@ where
     )
 }
 
-/// `use_effect` is used for hooking into the component's lifecycle.
+/// This hook is used for hooking into the component's lifecycle.
 ///
 /// # Example
-///
 /// ```rust
 /// # use yew_functional::{function_component, use_effect, use_state};
 /// # use yew::prelude::*;

--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -1,8 +1,6 @@
 //! Function components are a simplified version of normal components.
-//! They consist of a single function that receives props and determines what should be rendered by returning [`Html`].
-//! Basically, it's a component that's been reduced to just the [`Component::view`] method.
-//! On its own that would be quite limiting because you can only create pure components, but that's where Hooks come in.
-//! Hooks allow function components to use state and other Yew features without implementing the [`Component`] trait.
+//! They consist of a single function annotated with the attribute `#[function_component(_)]`
+//! that receives props and determines what should be rendered by returning [`Html`].
 //!
 //! ```rust
 //! # use yew_functional::function_component;
@@ -14,52 +12,7 @@
 //! }
 //! ```
 //!
-//! # Defining function components
-//!
-//! The simplest way to define function components is use the [`function_component`] attribute.
-//! It is also possible to define them manually by implementing [`FunctionProvider`] trait and
-//! using [`FunctionComponent`] struct. [`function_component`] provides an abstraction over
-//! implementing [`FunctionProvider`] and exposing [`FunctionComponent`] type.
-//!
-//! # Hooks
-//!
-//! Hooks are simply functions that let you “hook into” components' state and/or lifecycle and perform actions. Yew comes with a few pre-defined Hooks.
-//! You can also create your own by using [`use_hook`] function.
-//!
-//! A full guide for consuming Hooks and define custom ones can be found on [Yew's website](https://yew.rs/)
-//!
-//! ## Why do Hooks return an [`Rc`]?
-//!
-//! In most cases, you'll be cloning the values returned from the Hooks.
-//! As it may be expensive to clone such values, they're `Rc`ed, so they can be cloned relatively cheaply.
-//! An example of such a situation would be when you have to clone a a large HashMap or Vector.
-//! It will be much cheaper to clone an `Rc` than to clone such a type.
-//!
-//! It is worth noting that this problem doesn't occur with premitives and with types that implment [`Copy`]
-//!
-//! Following example shows one of the most common cases which requires cloning the values:
-//!
-//! ```rust
-//! # use yew_functional::{function_component, use_state};
-//! # use yew::prelude::*;
-//! # use std::rc::Rc;
-//! #
-//! fn component() -> Html {
-//!     let (data, set_data) = use_state(|| "".to_string());
-//!     let onclick = {
-//!         let data = Rc::clone(&data);
-//!         // Values must be moved into this closure so in order to be able to use them later on, they must be cloned
-//!         Callback::from(move |_| set_data(format!("{}MoreData", data)))
-//!     };
-//!
-//!     html! { <>
-//!         // If `data` wasn't cloned above, it would've been impossible to use it here
-//!         { &data }
-//!         <button onclick=onclick>{"Show data"}</button>
-//!     </>}
-//! }
-//! ```
-//!
+//! More details about function components and Hooks can be found on [Yew's website](https://yew.rs/docs/en/next/concepts/function-components)
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
@@ -298,11 +251,6 @@ where
 /// `use_reducer` is an alternative to [`use_state`]. It is used to handle component's state and is used
 /// when complex actions needs to be performed on said state.
 ///
-/// It accepts a reducer function and initial state and returns [`Rc`] of the state, and a dispatch function.
-/// The dispatch function takes one argument of `Action`. When called, the action and current value
-/// are passed to the reducer function which computes a new state which is returned,
-/// and the component is re-rendered.
-///
 /// For lazy initialization, consider using [`use_reducer_with_init`] instead.
 ///
 /// # Example
@@ -369,9 +317,7 @@ where
     use_reducer_with_init(reducer, initial_state, |a| a)
 }
 
-/// [`use_reducer`] but with init argument. The Hook is passed the initial state
-/// which is then passed down to `init` function which initializes the state and returns it.
-/// The hook then returns this state.
+/// [`use_reducer`] but with init argument.
 ///
 /// This is useful for lazy initialization where it is beneficial not to perform expensive
 /// computation up-front
@@ -447,12 +393,6 @@ where
 }
 
 /// `use_state` is used to mange state in a function component.
-/// It returns a `Rc` of the stateful value, and a setter function.
-///
-/// Initially, the state is set to the result of the function passed.
-/// This value remains up-to-date on subsequent renders.
-///
-/// The setter function is used to update the value and trigger a re-render.
 ///
 /// # Example
 ///
@@ -515,12 +455,6 @@ where
 }
 
 /// `use_effect` is used for hooking into the component's lifecycle.
-/// Similar to `rendered` method of [`Component`] trait,
-/// `use_effect` takes a function which is called after the render finishes.
-///
-/// The said function returns another function, the destructor function,
-/// which called when the component is destroyed. It can be used to clean up the effects introduced.
-/// This is similar to `destroyed` method of [`Component`] trait.
 ///
 /// # Example
 ///

--- a/yew-functional/src/lib.rs
+++ b/yew-functional/src/lib.rs
@@ -1,7 +1,7 @@
 //! Function components are a simplified version of normal components.
 //! They consist of a single function that receives props and determines what should be rendered by returning [`Html`].
 //! Basically, it's a component that's been reduced to just the [`Component::view`] method.
-//! On its own that would be quite limiting because you can only create pure components, but that's where hooks come in.
+//! On its own that would be quite limiting because you can only create pure components, but that's where Hooks come in.
 //! Hooks allow function components to use state and other Yew features without implementing the [`Component`] trait.
 //!
 //! ```rust
@@ -23,14 +23,14 @@
 //!
 //! # Hooks
 //!
-//! Hooks are simply functions that let you “hook into” components' state and/or lifecycle and perform actions. Yew comes with a few pre-defined hooks.
+//! Hooks are simply functions that let you “hook into” components' state and/or lifecycle and perform actions. Yew comes with a few pre-defined Hooks.
 //! You can also create your own by using [`use_hook`] function.
 //!
-//! A full guide for consuming hooks and define custom ones can be found on [Yew's website](https://yew.rs/)
+//! A full guide for consuming Hooks and define custom ones can be found on [Yew's website](https://yew.rs/)
 //!
-//! ## Why do hooks return an [`Rc`]?
+//! ## Why do Hooks return an [`Rc`]?
 //!
-//! In most cases, you'll be cloning the values returned from the hooks.
+//! In most cases, you'll be cloning the values returned from the Hooks.
 //! As it may be expensive to clone such values, they're `Rc`ed, so they can be cloned relatively cheaply.
 //! An example of such a situation would be when you have to clone a a large HashMap or Vector.
 //! It will be much cheaper to clone an `Rc` than to clone such a type.

--- a/yew-functional/src/use_context_hook.rs
+++ b/yew-functional/src/use_context_hook.rs
@@ -124,7 +124,7 @@ where
 /// The context of the type passed as `T` is returned. If there is no such context in scope, `None` is returned.
 /// A component which calls `use_context` will re-render when the data of the context changes.
 ///
-/// More information about contexts and how to define and consume them can be found on [Yew's website](https://yew.rs).
+/// More information about contexts and how to define and consume them can be found on [Yew Docs](https://yew.rs).
 ///
 /// # Example
 /// ```rust
@@ -143,7 +143,7 @@ where
 ///
 ///     html! {
 ///         <button style=format!("background: {}; color: {}", theme.background, theme.foreground)>
-///             {"Click me"}
+///             { "Click me" }
 ///         </button>
 ///     }
 /// }

--- a/yew-functional/src/use_context_hook.rs
+++ b/yew-functional/src/use_context_hook.rs
@@ -10,12 +10,16 @@ use yew::{Children, Component, ComponentLink, Html, Properties};
 
 type ConsumerCallback<T> = Box<dyn Fn(Rc<T>)>;
 
+/// Props for [`ContextProvider`]
 #[derive(Clone, PartialEq, Properties)]
 pub struct ContextProviderProps<T: Clone + PartialEq> {
     pub context: T,
     pub children: Children,
 }
 
+/// The context provider struct. This is required to consume the context.
+/// This implements the [`Component`] trait.
+/// Every children of it in the component tree will have access to the context passed to it.
 pub struct ContextProvider<T: Clone + PartialEq + 'static> {
     context: Rc<T>,
     children: Children,
@@ -115,6 +119,34 @@ where
         .and_then(|scope| scope.get_component().map(|comp| f(&*comp)))
 }
 
+/// `use_context` used for consuming contexts in function components.
+/// The context of the type passed as `T` is returned. If there is no such context in scope, `None` is returned.
+/// A component which calls `use_context` will re-render when the data of the context changes.
+///
+/// More information about contexts and how to define and consume them can be found on [Yew's website](https://yew.rs).
+///
+/// # Example
+/// ```rust
+/// # use yew_functional::{function_component, use_context};
+/// # use yew::prelude::*;
+/// # use std::rc::Rc;
+///
+/// # #[derive(Clone, Debug, PartialEq)]
+/// # struct ThemeContext {
+/// #    foreground: String,
+/// #    background: String,
+/// # }
+/// #[function_component(ThemedButton)]
+/// pub fn themed_button() -> Html {
+///     let theme = use_context::<Rc<ThemeContext>>().expect("no ctx found");
+///
+///     html! {
+///         <button style=format!("background: {}; color: {}", theme.background, theme.foreground)>
+///             {"Click me"}
+///         </button>
+///     }
+/// }
+/// ```
 pub fn use_context<T: Clone + PartialEq + 'static>() -> Option<Rc<T>> {
     struct UseContextState<T2: Clone + PartialEq + 'static> {
         provider_scope: Option<Scope<ContextProvider<T2>>>,

--- a/yew-functional/src/use_context_hook.rs
+++ b/yew-functional/src/use_context_hook.rs
@@ -17,9 +17,10 @@ pub struct ContextProviderProps<T: Clone + PartialEq> {
     pub children: Children,
 }
 
-/// The context provider struct. This is required to consume the context.
-/// This implements the [`Component`] trait.
-/// Every children of it in the component tree will have access to the context passed to it.
+/// The context provider component.
+///
+/// Every child (direct or indirect) of this component may access the context value.
+/// Currently the only way to consume the context is using the [`use_context`] hook.
 pub struct ContextProvider<T: Clone + PartialEq + 'static> {
     context: Rc<T>,
     children: Children,
@@ -119,7 +120,7 @@ where
         .and_then(|scope| scope.get_component().map(|comp| f(&*comp)))
 }
 
-/// `use_context` used for consuming contexts in function components.
+/// Hook for consuming context values in function components.
 /// The context of the type passed as `T` is returned. If there is no such context in scope, `None` is returned.
 /// A component which calls `use_context` will re-render when the data of the context changes.
 ///


### PR DESCRIPTION
#### Description

This PR adds documentation for Hooks, both on website and in doc strings. Some of these docs are inspired by React's docs for Hooks.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
