### PR TITLE
Upgraded Hook API

### DIFF
--- a/packages/yew-functional/Cargo.toml
+++ b/packages/yew-functional/Cargo.toml
@@ -14,6 +14,8 @@ description = "A framework for making client-side single-page apps"
 wasm-bindgen-test = "0.3.9"
 web-sys = "0.3.36"
 yew = { path = "../yew" }
+log = "0.4"
+wasm-logger = "0.2"
 
 [dependencies]
 yew = { path = "../yew" }

--- a/packages/yew-functional/src/hooks/mod.rs
+++ b/packages/yew-functional/src/hooks/mod.rs
@@ -10,29 +10,22 @@ pub use use_reducer::*;
 pub use use_ref::*;
 pub use use_state::*;
 
-use crate::CURRENT_HOOK;
+use crate::{HookUpdater, CURRENT_HOOK};
 use std::cell::RefCell;
 use std::ops::DerefMut;
 use std::rc::Rc;
 
-pub trait Hook {
-    fn tear_down(&mut self) {}
-}
-
-pub fn use_hook<InternalHookState, HookRunner, R, InitialStateProvider, HookUpdate: 'static>(
-    hook_runner: HookRunner,
-    initial_state_producer: InitialStateProvider,
-) -> R
-where
-    HookRunner: FnOnce(&mut InternalHookState, Box<dyn Fn(HookUpdate, bool)>) -> R,
-    InternalHookState: Hook + 'static,
-    InitialStateProvider: FnOnce() -> InternalHookState,
-    HookUpdate: FnOnce(&mut InternalHookState) -> bool,
-{
+pub fn use_hook<InternalHook: 'static, Output, Tear: FnOnce(&mut InternalHook) -> () + 'static>(
+    initializer: impl FnOnce() -> InternalHook,
+    runner: impl FnOnce(&mut InternalHook, HookUpdater) -> Output,
+    tear_down: Tear,
+) -> Output {
     // Extract current hook
-    let (hook, process_message) = CURRENT_HOOK.with(|hook_state_holder| {
-        let hook_state_holder = hook_state_holder.try_borrow_mut();
-        let mut hook_state_holder = hook_state_holder.expect("Nested hooks not supported");
+    let updater = CURRENT_HOOK.with(|hook_state_holder| {
+        let mut hook_state_holder = hook_state_holder
+            .try_borrow_mut()
+            .expect("Nested hooks not supported");
+
         let mut hook_state = hook_state_holder
             .as_mut()
             .expect("No current hook. Hooks can only be called inside function components");
@@ -43,41 +36,33 @@ where
 
         // Initialize hook if this is the first call
         if hook_pos >= hook_state.hooks.len() {
-            let initial_state = Rc::new(RefCell::new(initial_state_producer()));
+            let initial_state = Rc::new(RefCell::new(initializer()));
             hook_state.hooks.push(initial_state.clone());
             hook_state.destroy_listeners.push(Box::new(move || {
-                initial_state.borrow_mut().deref_mut().tear_down();
+                let mut is = initial_state.borrow_mut();
+                let ihook = is.deref_mut();
+                tear_down(ihook);
             }));
         }
 
-        let hook = hook_state.hooks[hook_pos].clone();
+        let hook = hook_state
+            .hooks
+            .get(hook_pos)
+            .expect("Not the same number of hooks. Hooks must not be called conditionally")
+            .clone();
 
-        (hook, hook_state.process_message.clone())
+        HookUpdater {
+            hook,
+            process_message: hook_state.process_message.clone(),
+        }
     });
-
-    let hook_callback = {
-        let hook = hook.clone();
-        Box::new(move |update: HookUpdate, post_render| {
-            let hook = hook.clone();
-            process_message(
-                Box::new(move || {
-                    let mut hook = hook.borrow_mut();
-                    let hook = hook.downcast_mut::<InternalHookState>();
-                    let hook = hook.expect(
-                        "Incompatible hook type. Hooks must always be called in the same order",
-                    );
-                    update(hook)
-                }),
-                post_render,
-            );
-        })
-    };
-    let mut hook = hook.borrow_mut();
-    let hook = hook.downcast_mut::<InternalHookState>();
-    let mut hook =
-        hook.expect("Incompatible hook type. Hooks must always be called in the same order");
 
     // Execute the actual hook closure we were given. Let it mutate the hook state and let
     // it create a callback that takes the mutable hook state.
-    hook_runner(&mut hook, hook_callback)
+    let mut hook = updater.hook.borrow_mut();
+    let hook: &mut InternalHook = hook
+        .downcast_mut()
+        .expect("Incompatible hook type. Hooks must always be called in the same order");
+
+    runner(hook, updater.clone())
 }

--- a/packages/yew-functional/src/hooks/use_context.rs
+++ b/packages/yew-functional/src/hooks/use_context.rs
@@ -1,5 +1,4 @@
-use super::{use_hook, Hook};
-use crate::get_current_scope;
+use crate::{get_current_scope, use_hook};
 use std::any::TypeId;
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
@@ -9,18 +8,66 @@ use yew::html::{AnyScope, Scope};
 use yew::{Children, Component, ComponentLink, Html, Properties};
 
 type ConsumerCallback<T> = Box<dyn Fn(Rc<T>)>;
+type UseContextOutput<T> = Option<Rc<T>>;
 
-/// Props for [`ContextProvider`]
+struct UseContext<T2: Clone + PartialEq + 'static> {
+    provider_scope: Option<Scope<ContextProvider<T2>>>,
+    current_context: Option<Rc<T2>>,
+    callback: Option<Rc<ConsumerCallback<T2>>>,
+}
+
+pub fn use_context<T: Clone + PartialEq + 'static>() -> UseContextOutput<T> {
+    let scope = get_current_scope()
+        .expect("No current Scope. `use_context` can only be called inside function components");
+
+    use_hook(
+        // Initializer
+        move || {
+            let provider_scope = find_context_provider_scope::<T>(&scope);
+            let current_context =
+                with_provider_component(&provider_scope, |comp| Rc::clone(&comp.context));
+
+            UseContext {
+                provider_scope,
+                current_context,
+                callback: None,
+            }
+        },
+        // Runner
+        |hook, updater| {
+            // setup a listener for the context provider to update us
+            let listener = move |ctx: Rc<T>| {
+                updater.callback(move |state: &mut UseContext<T>| {
+                    state.current_context = Some(ctx);
+                    true
+                });
+            };
+            hook.callback = Some(Rc::new(Box::new(listener)));
+
+            // Subscribe to the context provider with our callback
+            let weak_cb = Rc::downgrade(hook.callback.as_ref().unwrap());
+            with_provider_component(&hook.provider_scope, |comp| {
+                comp.subscribe_consumer(weak_cb)
+            });
+
+            // Return the current state
+            hook.current_context.clone()
+        },
+        // Cleanup
+        |hook| {
+            if let Some(cb) = hook.callback.take() {
+                drop(cb);
+            }
+        },
+    )
+}
+
 #[derive(Clone, PartialEq, Properties)]
 pub struct ContextProviderProps<T: Clone + PartialEq> {
     pub context: T,
     pub children: Children,
 }
 
-/// The context provider component.
-///
-/// Every child (direct or indirect) of this component may access the context value.
-/// Currently the only way to consume the context is using the [`use_context`] hook.
 pub struct ContextProvider<T: Clone + PartialEq + 'static> {
     context: Rc<T>,
     children: Children,
@@ -31,8 +78,8 @@ impl<T: Clone + PartialEq> ContextProvider<T> {
     /// Add the callback to the subscriber list to be called whenever the context changes.
     /// The consumer is unsubscribed as soon as the callback is dropped.
     fn subscribe_consumer(&self, mut callback: Weak<ConsumerCallback<T>>) {
-        let mut consumers = self.consumers.borrow_mut();
         // consumers re-subscribe on every render. Try to keep the subscriber list small by reusing dead slots.
+        let mut consumers = self.consumers.borrow_mut();
         for cb in consumers.iter_mut() {
             if cb.strong_count() == 0 {
                 mem::swap(cb, &mut callback);
@@ -118,80 +165,4 @@ where
     provider_scope
         .as_ref()
         .and_then(|scope| scope.get_component().map(|comp| f(&*comp)))
-}
-
-/// Hook for consuming context values in function components.
-/// The context of the type passed as `T` is returned. If there is no such context in scope, `None` is returned.
-/// A component which calls `use_context` will re-render when the data of the context changes.
-///
-/// More information about contexts and how to define and consume them can be found on [Yew Docs](https://yew.rs).
-///
-/// # Example
-/// ```rust
-/// # use yew_functional::{function_component, use_context};
-/// # use yew::prelude::*;
-/// # use std::rc::Rc;
-///
-/// # #[derive(Clone, Debug, PartialEq)]
-/// # struct ThemeContext {
-/// #    foreground: String,
-/// #    background: String,
-/// # }
-/// #[function_component(ThemedButton)]
-/// pub fn themed_button() -> Html {
-///     let theme = use_context::<Rc<ThemeContext>>().expect("no ctx found");
-///
-///     html! {
-///         <button style=format!("background: {}; color: {}", theme.background, theme.foreground)>
-///             { "Click me" }
-///         </button>
-///     }
-/// }
-/// ```
-pub fn use_context<T: Clone + PartialEq + 'static>() -> Option<Rc<T>> {
-    struct UseContextState<T2: Clone + PartialEq + 'static> {
-        provider_scope: Option<Scope<ContextProvider<T2>>>,
-        current_context: Option<Rc<T2>>,
-        callback: Option<Rc<ConsumerCallback<T2>>>,
-    }
-    impl<T: Clone + PartialEq + 'static> Hook for UseContextState<T> {
-        fn tear_down(&mut self) {
-            if let Some(cb) = self.callback.take() {
-                drop(cb);
-            }
-        }
-    }
-
-    let scope = get_current_scope()
-        .expect("No current Scope. `use_context` can only be called inside function components");
-
-    use_hook(
-        |state: &mut UseContextState<T>, hook_callback| {
-            state.callback = Some(Rc::new(Box::new(move |ctx: Rc<T>| {
-                hook_callback(
-                    |state: &mut UseContextState<T>| {
-                        state.current_context = Some(ctx);
-                        true
-                    },
-                    false, // run pre render
-                );
-            })));
-            let weak_cb = Rc::downgrade(state.callback.as_ref().unwrap());
-            with_provider_component(&state.provider_scope, |comp| {
-                comp.subscribe_consumer(weak_cb)
-            });
-
-            state.current_context.clone()
-        },
-        move || {
-            let provider_scope = find_context_provider_scope::<T>(&scope);
-            let current_context =
-                with_provider_component(&provider_scope, |comp| Rc::clone(&comp.context));
-            UseContextState {
-                provider_scope,
-                current_context,
-                callback: None,
-            }
-        },
-    )
 }

--- a/packages/yew-functional/src/hooks/use_ref.rs
+++ b/packages/yew-functional/src/hooks/use_ref.rs
@@ -1,6 +1,5 @@
-use super::{use_hook, Hook};
-use std::cell::RefCell;
-use std::rc::Rc;
+use crate::use_hook;
+use std::{cell::RefCell, rc::Rc};
 
 /// This hook is used for obtaining a mutable reference to a stateful value.
 /// Its state persists across renders.
@@ -46,20 +45,10 @@ use std::rc::Rc;
 ///     }
 /// }
 /// ```
-pub fn use_ref<T: 'static, InitialProvider>(initial_value: InitialProvider) -> Rc<RefCell<T>>
-where
-    InitialProvider: FnOnce() -> T,
-{
-    #[derive(Clone)]
-    struct UseRefState<T>(Rc<RefCell<T>>);
-    impl<T> Hook for UseRefState<T> {}
-
+pub fn use_ref<T: 'static>(initial_value: impl FnOnce() -> T + 'static) -> Rc<RefCell<T>> {
     use_hook(
-        |state: &mut UseRefState<T>, hook_callback| {
-            // we need it to be a specific closure type, even if we never use it
-            let _ignored = || hook_callback(|_| false, false);
-            state.0.clone()
-        },
-        move || UseRefState(Rc::new(RefCell::new(initial_value()))),
+        || Rc::new(RefCell::new(initial_value())),
+        |state, _| state.clone(),
+        |_| {},
     )
 }


### PR DESCRIPTION
#### Description
<!-- Please include a summary of the change. -->

This PR adds a new API for defining hooks which will add more strongly typed interfaces and clearer function + type names. This should make the creation of new fundamental hooks much easier.

I've also moved the existing hooks to the new format and split them up into different files so they're easier to work on.

- [x] use_state
- [x] use_ref
- [x] use_effect
- [x] use_context
- [x] use_reducer
- [x] use_effect_deps

As a n.b. I'm creating custom hooks for a port of [RecoilJS](https://recoiljs.org) to Rust, and perhaps ReduxToolkit while I'm at it, so I'm dog-fooding the new API.

For example, this is what the use_state hook looks like now:

```rust
pub fn use_state<T: 'static, F: FnOnce() -> T + 'static>(
    initial_state_fn: F,
) -> (Rc<T>, Rc<dyn Fn(T)>) {
    use_hook(
        // Initializer
        move || UseState {
            current: Rc::new(initial_state_fn()),
        },
        // Runner
        move |hook, updater| {
            let setter: Rc<(dyn Fn(T))> = Rc::new(move |new_val: T| {
                updater.callback(move |st: &mut UseState<T>| {
                    st.current = Rc::new(new_val);
                    true
                })
            });

            let current = hook.current.clone();
            (current, setter)
        },
        // Teardown
        |_| {},
    )
}
```

Fixes #1644 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
