### PR TITLE
fix broken import on function_component.rs

### DIFF
--- a/yewtil-macro/src/function_component.rs
+++ b/yewtil-macro/src/function_component.rs
@@ -1,7 +1,6 @@
 use proc_macro::TokenStream as TokenStream1;
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::quote;
-use syn::export::ToTokens;
+use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseBuffer};
 use syn::parse_macro_input;
 use syn::punctuated::Punctuated;


### PR DESCRIPTION
#### Description

Fixes a broken import. `syn` no longer re-exports `ToToken` from `quote`. This changes it to pull `ToToken` from `quote` directly.

Fixes #1681

#### Checklist

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests

This was a build error due to dependency issues, so these tests should be irrelevant?
