### PR TITLE
Revert "Update rand requirement from 0.7 to 0.8"

### DIFF
--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -8,7 +8,7 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 lipsum = "0.7"
 log = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
-rand = { version = "0.8", features = ["small_rng"] }
+rand = { version = "0.7", features = ["small_rng"] }
 wasm-logger = "0.2"
 yew = { path = "../../yew" }
 yew-router = { path = "../../yew-router" }


### PR DESCRIPTION
Reverts yewstack/yew#1682

Thanks for nothing, dependabot.
The lipsum crate depends on `^0.7` so it doesn't accept our 0.8 and as such doesn't care for the small rng feature.