### PR TITLE
Added missing KeyboardService re-export

### DIFF
--- a/packages/yew/src/services/mod.rs
+++ b/packages/yew/src/services/mod.rs
@@ -23,6 +23,8 @@ pub use self::fetch::FetchService;
 #[doc(inline)]
 pub use self::interval::IntervalService;
 #[doc(inline)]
+pub use self::keyboard::KeyboardService;
+#[doc(inline)]
 pub use self::reader::ReaderService;
 #[doc(inline)]
 pub use self::render::RenderService;


### PR DESCRIPTION
#### Description

Added missing KeyboardService re-export in yew::services

Consistency with other services. This is the only one not re-exported.

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
