### PR TITLE
Added relevant examples section to the docs

### DIFF
--- a/docs/concepts/components/callbacks.md
+++ b/docs/concepts/components/callbacks.md
@@ -92,3 +92,7 @@ html! {
     <input type="text" onkeypress=onkeypress />
 }
 ```
+
+## Relevant Examples
+- [Counter](https://github.com/yewstack/yew/tree/master/examples/counter)
+- [Timer](https://github.com/yewstack/yew/tree/master/examples/timer)

--- a/docs/concepts/components/callbacks.md
+++ b/docs/concepts/components/callbacks.md
@@ -93,6 +93,6 @@ html! {
 }
 ```
 
-## Relevant Examples
+## Relevant examples
 - [Counter](https://github.com/yewstack/yew/tree/master/examples/counter)
 - [Timer](https://github.com/yewstack/yew/tree/master/examples/timer)

--- a/docs/concepts/components/refs.md
+++ b/docs/concepts/components/refs.md
@@ -26,5 +26,5 @@ html! {
 let has_attributes = self.node_ref.cast::<Element>().unwrap().has_attributes();
 ```
 
-## Relevant Example
+## Relevant examples
 - [Node Refs](https://github.com/yewstack/yew/tree/master/examples/node_refs)

--- a/docs/concepts/components/refs.md
+++ b/docs/concepts/components/refs.md
@@ -25,3 +25,6 @@ html! {
 // In rendered
 let has_attributes = self.node_ref.cast::<Element>().unwrap().has_attributes();
 ```
+
+## Relevant Example
+- [Node Refs](https://github.com/yewstack/yew/tree/master/examples/node_refs)

--- a/docs/concepts/html/components.md
+++ b/docs/concepts/html/components.md
@@ -151,7 +151,7 @@ html! { <Model unique_id=5 text="literals are fun" /> };
 html! { <Model unique_id=Some(5) text="literals are fun".to_owned() /> };
 ```
 
-## Relevant Examples
+## Relevant examples
 - [Boids](https://github.com/yewstack/yew/tree/master/examples/boids)
 - [Router](https://github.com/yewstack/yew/tree/master/examples/router)
 - [Store](https://github.com/yewstack/yew/tree/master/examples/store)

--- a/docs/concepts/html/components.md
+++ b/docs/concepts/html/components.md
@@ -150,3 +150,8 @@ html! { <Model unique_id=5 text="literals are fun" /> };
 // instead of:
 html! { <Model unique_id=Some(5) text="literals are fun".to_owned() /> };
 ```
+
+## Relevant Examples
+- [Boids](https://github.com/yewstack/yew/tree/master/examples/boids)
+- [Router](https://github.com/yewstack/yew/tree/master/examples/router)
+- [Store](https://github.com/yewstack/yew/tree/master/examples/store)

--- a/docs/concepts/html/lists.md
+++ b/docs/concepts/html/lists.md
@@ -53,7 +53,7 @@ html! {
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-## Relevant Examples
+## Relevant examples
 - [TodoMVC](https://github.com/yewstack/yew/tree/master/examples/todomvc)
 - [Keyed List](https://github.com/yewstack/yew/tree/master/examples/keyed_list)
 - [Router](https://github.com/yewstack/yew/tree/master/examples/router)

--- a/docs/concepts/html/lists.md
+++ b/docs/concepts/html/lists.md
@@ -52,3 +52,8 @@ html! {
 }
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
+
+## Relevant Examples
+- [TodoMVC](https://github.com/yewstack/yew/tree/master/examples/todomvc)
+- [Keyed List](https://github.com/yewstack/yew/tree/master/examples/keyed_list)
+- [Router](https://github.com/yewstack/yew/tree/master/examples/router)

--- a/docs/concepts/router.md
+++ b/docs/concepts/router.md
@@ -85,3 +85,5 @@ For structs and enums with named fields, you must specify the field's name withi
 
 The Switch trait works with capture groups that are more structured than just Strings. You can specify any type that implements `Switch`. So you can specify that the capture group is a `usize`, and if the captured section of the URL can't be converted to it, then the variant won't match.
 
+## Relevant Example
+- [Router](https://github.com/yewstack/yew/tree/master/examples/router)

--- a/docs/concepts/router.md
+++ b/docs/concepts/router.md
@@ -85,5 +85,5 @@ For structs and enums with named fields, you must specify the field's name withi
 
 The Switch trait works with capture groups that are more structured than just Strings. You can specify any type that implements `Switch`. So you can specify that the capture group is a `usize`, and if the captured section of the URL can't be converted to it, then the variant won't match.
 
-## Relevant Example
+## Relevant examples
 - [Router](https://github.com/yewstack/yew/tree/master/examples/router)

--- a/packages/yew/src/callback.rs
+++ b/packages/yew/src/callback.rs
@@ -1,6 +1,6 @@
 //! This module contains data types for interacting with `Scope`s.
 //!
-//! ## Relevant Examples
+//! ## Relevant examples
 //! - [Counter](https://github.com/yewstack/yew/tree/master/examples/counter)
 //! - [Timer](https://github.com/yewstack/yew/tree/master/examples/timer)
 

--- a/packages/yew/src/callback.rs
+++ b/packages/yew/src/callback.rs
@@ -1,4 +1,8 @@
 //! This module contains data types for interacting with `Scope`s.
+//!
+//! ## Relevant Examples
+//! - [Counter](https://github.com/yewstack/yew/tree/master/examples/counter)
+//! - [Timer](https://github.com/yewstack/yew/tree/master/examples/timer)
 
 use std::cell::RefCell;
 use std::fmt;

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -73,6 +73,9 @@ pub type Html = VNode;
 ///         }
 ///     }
 /// }
+/// ```
+/// ## Relevant examples
+/// - [Node Refs](https://github.com/yewstack/yew/tree/master/examples/node_refs)
 #[derive(Debug, Default, Clone)]
 pub struct NodeRef(Rc<RefCell<NodeRefInner>>);
 


### PR DESCRIPTION
This draft is for tracking and eventually close #1381 

#### Description

I'm adding links to relevant examples in the docs to help users understand the Yew docs more easily.

Note: I'm making this draft first before finishing it because I would like to hear some feedback on the current link style before I start using it everywhere.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] link to examples from yew.rs pages
- [x] link to examples from docs.rs pages
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1381: Link to examples from relevant sections of Yew docs](https://issuehunt.io/repos/114466145/issues/1381)
---
</details>
<!-- /Issuehunt content-->