### PR TITLE
Added callback_future_once in yewtil (#1696)

### DIFF
--- a/packages/yew-functional/src/hooks/use_reducer.rs
+++ b/packages/yew-functional/src/hooks/use_reducer.rs
@@ -116,7 +116,7 @@ where
     struct UseReducerState<State> {
         current_state: Rc<State>,
     }
-    impl<T> Hook for UseReducerState<T> {};
+    impl<T> Hook for UseReducerState<T> {}
     let init = Box::new(init);
     let reducer = Rc::new(reducer);
     use_hook(


### PR DESCRIPTION
#### Description

The reasoning is pretty much explained in the issue.

Fixes #1696

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests

P.S. `cargo make pr-flow` has errors, which are totally unrelated to this work.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1696: Adding callback_future_once on LinkFuture trait (yewtil crate)](https://issuehunt.io/repos/114466145/issues/1696)
---
</details>
<!-- /Issuehunt content-->