### PR TITLE
Bump minimum serde_yaml version in order to appease deps.rs

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -36,7 +36,7 @@ yew-macro = { version = "0.17.0", path = "../yew-macro" }
 bincode = { version = "1", optional = true }
 rmp-serde = { version = "0.15.0", optional = true }
 serde_cbor = { version = "0.11.1", optional = true }
-serde_yaml = { version = "0.8.3", optional = true }
+serde_yaml = { version = "0.8.4", optional = true }
 toml = { version = "0.5", optional = true }
 
 [dependencies.web-sys]


### PR DESCRIPTION
#### Description

Yew is one of the most starred Rust projects and appears in the [deps.rs](https://deps.rs) homepage. Now that stdweb support has been removed, which made yew's dependencies be marked as insecure because of stdweb having a RustSec advisory for deprecation, `insecure` should have gone away. However the minimum allowed semver version of `serde_yaml` has a security advisory ([see here](https://rustsec.org/advisories/RUSTSEC-2018-0005.html)). This bumps it in order to make deps.rs mark yew's dependencies as secure.

deps.rs status for current master: [![dependency status](https://deps.rs/repo/github/yewstack/yew/status.svg)](https://deps.rs/repo/github/yewstack/yew)
deps.rs status after this change: [![dependency status](https://deps.rs/repo/github/paolobarbolini/yew/status.svg)](https://deps.rs/repo/github/paolobarbolini/yew)

#### Checklist

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
