### PR TITLE
Cargo make pr-flow should use stable toolchain

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -22,6 +22,7 @@ private = true
 namespace = "core"
 
 [tasks.pr-flow]
+toolchain = "stable"
 category = "Checks"
 description = "Lint and test"
 run_task = { name = ["lint", "tests"], fork = true }


### PR DESCRIPTION
#### Description

I noticed some CI build errors I couldn't reproduce. Then I realized that some tests don't run unless you are using the stable toolchain, so it seems like a good idea to use stable by default in `cargo make pr-flow`.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
