### PR TITLE
Docs: add --locked flag for trunk installation

### DIFF
--- a/docs/getting-started/build-a-sample-app.md
+++ b/docs/getting-started/build-a-sample-app.md
@@ -104,7 +104,8 @@ Finally, add an `index.html` file in the root directory of your app:
 If you haven't already, install [Trunk](https://github.com/thedodd/trunk):
 
 ```bash
-cargo install trunk wasm-bindgen-cli
+cargo install --locked trunk
+cargo install wasm-bindgen-cli
 ```
 
 Now all you have to do is run the following:

--- a/docs/getting-started/project-setup/using-trunk.md
+++ b/docs/getting-started/project-setup/using-trunk.md
@@ -5,7 +5,8 @@ title: Using trunk
 ## Install
 
 ```bash
-cargo install trunk wasm-bindgen-cli
+cargo install --locked trunk
+cargo install wasm-bindgen-cli
 ```
 
 ## Usage


### PR DESCRIPTION
#### Description

`cargo install trunk` fails on windows for some reason, but `cargo install --locked trunk` not. In [trunk docs](https://github.com/thedodd/trunk/#install) they use `--locked` flag.

