### PR TITLE
Remove reference to `npm_and_rest` example

### DIFF
--- a/docs/concepts/services/fetch.md
+++ b/docs/concepts/services/fetch.md
@@ -239,6 +239,5 @@ for Wasm applications.
 
 ## Further reading
 * [The API documentation](https://docs.rs/yew-services/latest/yew_services/fetch/index.html)
-* The [dashboard](https://github.com/yewstack/yew/tree/master/examples/dashboard) and 
-[npm_and_rest](https://github.com/yewstack/yew/tree/master/examples/web_sys/npm_and_rest) examples.
+* The [dashboard](https://github.com/yewstack/yew/tree/master/examples/dashboard) example.
 * [The Rust Wasm Book on debugging Wasm applications](https://rustwasm.github.io/book/reference/debugging.html)


### PR DESCRIPTION
It no longer exists.

#### Description

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
