### PR TITLE
Correctly use yew::services

### DIFF
--- a/docs/concepts/services/fetch.md
+++ b/docs/concepts/services/fetch.md
@@ -238,6 +238,6 @@ The Rust Wasm Book also contains [useful debugging tips](https://rustwasm.github
 for Wasm applications.
 
 ## Further reading
-* [The API documentation](https://docs.rs/yew-services/latest/yew::services/fetch/index.html)
+* [The API documentation](https://docs.rs/yew/latest/yew/services/fetch/index.html)
 * The [dashboard](https://github.com/yewstack/yew/tree/master/examples/dashboard) example.
 * [The Rust Wasm Book on debugging Wasm applications](https://rustwasm.github.io/book/reference/debugging.html)

--- a/docs/concepts/services/fetch.md
+++ b/docs/concepts/services/fetch.md
@@ -26,7 +26,7 @@ pub type Binary = Result<Vec<u8>, Error>;
 Here is what a typical GET request will look like:
 ```rust
 use yew::format::Nothing;
-use yew_services::fetch::Request;
+use yew::services::fetch::Request;
 let get_request = Request::get("https://example.com/api/v1/get/something")
     .body(Nothing)
     .expect("Could not build that request");
@@ -36,7 +36,7 @@ Here is what a typical POST request will look like:
 ```rust
 use serde_json::json;
 use yew::format::Json;
-use yew_services::fetch::Request;
+use yew::services::fetch::Request;
 let post_request = Request::post("https://example.com/api/v1/post/something")
     .header("Content-Type", "application/json")
     .body(Json(&json!({"key": "value"})))
@@ -95,7 +95,7 @@ An illustrated example of how to fetch data from an API giving information about
 
 use serde::Deserialize;
 use yew::{format::{Json, Nothing}, prelude::*};
-use yew_services::fetch::{FetchService, FetchTask, Request, Response};
+use yew::services::fetch::{FetchService, FetchTask, Request, Response};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ISSPosition {
@@ -238,6 +238,6 @@ The Rust Wasm Book also contains [useful debugging tips](https://rustwasm.github
 for Wasm applications.
 
 ## Further reading
-* [The API documentation](https://docs.rs/yew-services/latest/yew_services/fetch/index.html)
+* [The API documentation](https://docs.rs/yew-services/latest/yew::services/fetch/index.html)
 * The [dashboard](https://github.com/yewstack/yew/tree/master/examples/dashboard) example.
 * [The Rust Wasm Book on debugging Wasm applications](https://rustwasm.github.io/book/reference/debugging.html)

--- a/docs/more/debugging.md
+++ b/docs/more/debugging.md
@@ -27,7 +27,7 @@ fn main() {
 log::info!("Update: {:?}", msg);
 ```
 
-### [`ConsoleService`](https://docs.rs/yew-services/latest/yew_services/struct.ConsoleService.html)
+### [`ConsoleService`](https://docs.rs/yew-services/latest/yew::services/struct.ConsoleService.html)
 
 This service is included within the [`yew-services`](https://crates.io/crates/yew-services) crate:
 

--- a/docs/more/debugging.md
+++ b/docs/more/debugging.md
@@ -27,7 +27,7 @@ fn main() {
 log::info!("Update: {:?}", msg);
 ```
 
-### [`ConsoleService`](https://docs.rs/yew/0.2.0/yew/services/console/struct.ConsoleService.html)
+### [`ConsoleService`](https://docs.rs/yew/latest/yew/services/console/struct.ConsoleService.html)
 
 This service is included within the [`yew-services`](https://crates.io/crates/yew-services) crate:
 

--- a/docs/more/debugging.md
+++ b/docs/more/debugging.md
@@ -27,7 +27,7 @@ fn main() {
 log::info!("Update: {:?}", msg);
 ```
 
-### [`ConsoleService`](https://docs.rs/yew-services/latest/yew::services/struct.ConsoleService.html)
+### [`ConsoleService`](https://docs.rs/yew/0.2.0/yew/services/console/struct.ConsoleService.html)
 
 This service is included within the [`yew-services`](https://crates.io/crates/yew-services) crate:
 

--- a/examples/boids/src/settings.rs
+++ b/examples/boids/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use yew::format::Json;
-use yew_services::storage::{Area, StorageService};
+use yew::services::storage::{Area, StorageService};
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Settings {

--- a/examples/boids/src/simulation.rs
+++ b/examples/boids/src/simulation.rs
@@ -3,7 +3,7 @@ use crate::math::Vector2D;
 use crate::settings::Settings;
 use std::time::Duration;
 use yew::{html, Component, ComponentLink, Html, Properties, ShouldRender};
-use yew_services::interval::{IntervalService, IntervalTask};
+use yew::services::interval::{IntervalService, IntervalTask};
 
 pub const SIZE: Vector2D = Vector2D::new(1600.0, 1000.0);
 

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,6 +1,6 @@
 use js_sys::Date;
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
-use yew_services::ConsoleService;
+use yew::services::ConsoleService;
 
 pub enum Msg {
     Increment,

--- a/examples/crm/README.md
+++ b/examples/crm/README.md
@@ -14,7 +14,7 @@ For a much more sophisticated approach check out [`yew-router`](https://yew.rs/d
 One major flaw with the implementation used by this example is that the scenes aren't tied to the URL.
 Reloading the page always brings the user back to the initial scene.
 
-The example also uses the [`StorageService`](https://docs.rs/yew-services/latest/yew_services/struct.StorageService.html)
+The example also uses the [`StorageService`](https://docs.rs/yew-services/latest/yew::services/struct.StorageService.html)
 to persist the clients across sessions.
 
 ## Improvements

--- a/examples/crm/README.md
+++ b/examples/crm/README.md
@@ -14,7 +14,7 @@ For a much more sophisticated approach check out [`yew-router`](https://yew.rs/d
 One major flaw with the implementation used by this example is that the scenes aren't tied to the URL.
 Reloading the page always brings the user back to the initial scene.
 
-The example also uses the [`StorageService`](https://docs.rs/yew-services/latest/yew::services/struct.StorageService.html)
+The example also uses the [`StorageService`](https://docs.rs/yew/latest/yew/services/storage/struct.StorageService.html)
 to persist the clients across sessions.
 
 ## Improvements

--- a/examples/crm/src/main.rs
+++ b/examples/crm/src/main.rs
@@ -2,8 +2,8 @@ use add_client::AddClientForm;
 use serde::{Deserialize, Serialize};
 use yew::format::Json;
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
-use yew_services::storage::Area;
-use yew_services::{DialogService, StorageService};
+use yew::services::storage::Area;
+use yew::services::{DialogService, StorageService};
 
 mod add_client;
 

--- a/examples/dashboard/src/main.rs
+++ b/examples/dashboard/src/main.rs
@@ -2,8 +2,8 @@ use anyhow::Error;
 use serde_derive::{Deserialize, Serialize};
 use yew::format::{Json, Nothing, Toml};
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
-use yew_services::fetch::{FetchService, FetchTask, Request, Response};
-use yew_services::websocket::{WebSocketService, WebSocketStatus, WebSocketTask};
+use yew::services::fetch::{FetchService, FetchTask, Request, Response};
+use yew::services::websocket::{WebSocketService, WebSocketStatus, WebSocketTask};
 
 type AsBinary = bool;
 
@@ -72,7 +72,7 @@ impl Model {
         }
     }
 
-    fn fetch_json(&mut self, binary: AsBinary) -> yew_services::fetch::FetchTask {
+    fn fetch_json(&mut self, binary: AsBinary) -> yew::services::fetch::FetchTask {
         let callback = self.link.batch_callback(
             move |response: Response<Json<Result<DataFromFile, Error>>>| {
                 let (meta, Json(data)) = response.into_parts();
@@ -92,7 +92,7 @@ impl Model {
         }
     }
 
-    pub fn fetch_toml(&mut self, binary: AsBinary) -> yew_services::fetch::FetchTask {
+    pub fn fetch_toml(&mut self, binary: AsBinary) -> yew::services::fetch::FetchTask {
         let callback = self.link.batch_callback(
             move |response: Response<Toml<Result<DataFromFile, Error>>>| {
                 let (meta, Toml(data)) = response.into_parts();

--- a/examples/file_upload/src/main.rs
+++ b/examples/file_upload/src/main.rs
@@ -1,5 +1,5 @@
 use yew::{html, ChangeData, Component, ComponentLink, Html, ShouldRender};
-use yew_services::reader::{File, FileChunk, FileData, ReaderService, ReaderTask};
+use yew::services::reader::{File, FileChunk, FileData, ReaderService, ReaderTask};
 
 type Chunks = bool;
 

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -2,7 +2,7 @@ use cell::Cellule;
 use rand::Rng;
 use std::time::Duration;
 use yew::{classes, html, Component, ComponentLink, Html, ShouldRender};
-use yew_services::interval::{IntervalService, IntervalTask};
+use yew::services::interval::{IntervalService, IntervalTask};
 
 mod cell;
 

--- a/examples/multi_thread/src/context.rs
+++ b/examples/multi_thread/src/context.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use yew::worker::{Agent, AgentLink, Context, HandlerId};
-use yew_services::interval::{IntervalService, IntervalTask};
+use yew::services::interval::{IntervalService, IntervalTask};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Request {

--- a/examples/multi_thread/src/job.rs
+++ b/examples/multi_thread/src/job.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use yew::worker::{Agent, AgentLink, HandlerId, Job};
-use yew_services::interval::{IntervalService, IntervalTask};
+use yew::services::interval::{IntervalService, IntervalTask};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Request {

--- a/examples/multi_thread/src/native_worker.rs
+++ b/examples/multi_thread/src/native_worker.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use yew::worker::{Agent, AgentLink, HandlerId, Public};
-use yew_services::interval::{IntervalService, IntervalTask};
+use yew::services::interval::{IntervalService, IntervalTask};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Request {

--- a/examples/router/src/components/progress_delay.rs
+++ b/examples/router/src/components/progress_delay.rs
@@ -1,7 +1,7 @@
 use instant::Instant;
 use std::time::Duration;
 use yew::prelude::*;
-use yew_services::interval::{IntervalService, IntervalTask};
+use yew::services::interval::{IntervalService, IntervalTask};
 use yewtil::NeqAssign;
 
 const RESOLUTION: u64 = 500;

--- a/examples/store/src/main.rs
+++ b/examples/store/src/main.rs
@@ -6,7 +6,7 @@ use agents::posts::{PostId, PostStore, Request};
 use post::Post;
 use text_input::TextInput;
 use yew::prelude::*;
-use yew_services::ConsoleService;
+use yew::services::ConsoleService;
 use yewtil::store::{Bridgeable, ReadOnly, StoreWrapper};
 
 pub enum Msg {

--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -13,6 +13,6 @@ but also makes use of some more advanced [`ConsoleService`] features.
 
 - Apply the concept to something more fun than just a dry technical demonstration
 
-[`timeoutservice`]: https://docs.rs/yew-services/latest/yew_services/struct.TimeoutService.html
-[`intervalservice`]: https://docs.rs/yew-services/latest/yew_services/struct.IntervalService.html
-[`consoleservice`]: https://docs.rs/yew-services/latest/yew_services/struct.ConsoleService.html
+[`timeoutservice`]: https://docs.rs/yew-services/latest/yew::services/struct.TimeoutService.html
+[`intervalservice`]: https://docs.rs/yew-services/latest/yew::services/struct.IntervalService.html
+[`consoleservice`]: https://docs.rs/yew-services/latest/yew::services/struct.ConsoleService.html

--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -13,6 +13,6 @@ but also makes use of some more advanced [`ConsoleService`] features.
 
 - Apply the concept to something more fun than just a dry technical demonstration
 
-[`timeoutservice`]: https://docs.rs/yew-services/latest/yew::services/struct.TimeoutService.html
-[`intervalservice`]: https://docs.rs/yew-services/latest/yew::services/struct.IntervalService.html
-[`consoleservice`]: https://docs.rs/yew-services/latest/yew::services/struct.ConsoleService.html
+[`timeoutservice`]: https://docs.rs/yew/latest/yew/services/timeout/struct.TimeoutService.html
+[`intervalservice`]: https://docs.rs/yew/latest/yew/services/interval/struct.IntervalService.html
+[`consoleservice`]: https://docs.rs/yew/latest/yew/services/console/struct.ConsoleService.html

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use yew::{html, Callback, Component, ComponentLink, Html, ShouldRender};
-use yew_services::interval::{IntervalService, IntervalTask};
-use yew_services::{ConsoleService, Task, TimeoutService};
+use yew::services::interval::{IntervalService, IntervalTask};
+use yew::services::{ConsoleService, Task, TimeoutService};
 
 pub enum Msg {
     StartTimeout,

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -4,7 +4,7 @@ use yew::format::Json;
 use yew::web_sys::HtmlInputElement as InputElement;
 use yew::{classes, html, Component, ComponentLink, Html, InputData, NodeRef, ShouldRender};
 use yew::{events::KeyboardEvent, Classes};
-use yew_services::storage::{Area, StorageService};
+use yew::services::storage::{Area, StorageService};
 
 mod state;
 

--- a/examples/webgl/src/main.rs
+++ b/examples/webgl/src/main.rs
@@ -1,8 +1,8 @@
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlCanvasElement, WebGlRenderingContext as GL};
 use yew::{html, Component, ComponentLink, Html, NodeRef, ShouldRender};
-use yew_services::render::RenderTask;
-use yew_services::RenderService;
+use yew::services::render::RenderTask;
+use yew::services::RenderService;
 
 pub enum Msg {
     Render(f64),

--- a/packages/yew-functional/tests/use_context.rs
+++ b/packages/yew-functional/tests/use_context.rs
@@ -26,7 +26,7 @@ fn use_context_scoping_works() {
 
         fn run(_props: &Self::TProps) -> Html {
             if use_context::<ExampleContext>().is_some() {
-                yew_services::ConsoleService::log(&format!(
+                yew::services::ConsoleService::log(&format!(
                     "Context should be None here, but was {:?}!",
                     use_context::<ExampleContext>().unwrap()
                 ));

--- a/packages/yew-services/src/fetch.rs
+++ b/packages/yew-services/src/fetch.rs
@@ -171,7 +171,7 @@ impl FetchService {
     /// ```
     ///# use serde_json::json;
     ///# use yew::format::{Nothing, Json};
-    ///# use yew_services::fetch::Request;
+    ///# use yew::services::fetch::Request;
     /// let post_request = Request::post("https://my.api/v1/resource")
     ///     .header("Content-Type", "application/json")
     ///     .body(Json(&json!({"foo": "bar"})))
@@ -188,8 +188,8 @@ impl FetchService {
     /// ```
     ///# use anyhow::Error;
     ///# use yew::{Component, ComponentLink, Html};
-    ///# use yew_services::FetchService;
-    ///# use yew_services::fetch::{Response, Request};
+    ///# use yew::services::FetchService;
+    ///# use yew::services::fetch::{Response, Request};
     ///# struct Comp;
     ///# impl Component for Comp {
     ///#     type Message = Msg;type Properties = ();
@@ -228,8 +228,8 @@ impl FetchService {
     ///# use serde::Deserialize;
     ///# use yew::{Component, ComponentLink, Html};
     ///# use yew::format::{Json, Nothing, Format};
-    ///# use yew_services::fetch::Response;
-    ///# use yew_services::FetchService;
+    ///# use yew::services::fetch::Response;
+    ///# use yew::services::FetchService;
     ///# struct Comp;
     ///# impl Component for Comp {
     ///#     type Message = Msg;type Properties = ();
@@ -281,7 +281,7 @@ impl FetchService {
     ///# use http::Response;
     ///# use yew::format::Nothing;
     ///# use yew::{Html, Component, ComponentLink};
-    ///# use yew_services::fetch::{self, FetchOptions, FetchService, Credentials};
+    ///# use yew::services::fetch::{self, FetchOptions, FetchService, Credentials};
     ///# struct Comp;
     ///# impl Component for Comp {
     ///#     type Message = Msg;


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

When i was checking out examples i found out that they won't compile because of wrongly used yew::services. Also some link weren't working, like that:
![Zrzut ekranu 2021-02-13 o 13 00 39](https://user-images.githubusercontent.com/22203423/107849443-7b6ea600-6dfb-11eb-9116-39b83ade926a.png)


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
