### PR TITLE
Add support for the unit struct in Properties derive

### DIFF
--- a/examples/router/src/switch.rs
+++ b/examples/router/src/switch.rs
@@ -36,7 +36,7 @@ impl AppRoute {
 /// This type allows us have the best of both worlds.
 ///
 /// IMPORTANT: You *must* specify a `<base>` tag on your webpage in order for this to work!
-/// For more information, see the 
+/// For more information, see the
 /// [Mozilla Developer Network docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)
 #[derive(Clone, Debug)]
 pub struct PublicUrlSwitch(AppRoute);

--- a/packages/yew-macro/tests/derive_props/pass.rs
+++ b/packages/yew-macro/tests/derive_props/pass.rs
@@ -185,4 +185,13 @@ mod t10 {
     }
 }
 
+mod t11 {
+    use super::*;
+
+    // this test makes sure that deriving the Properties trait works for unit structs
+
+    #[derive(Clone, Properties)]
+    pub struct Foo;
+}
+
 fn main() {}


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->
Added support for unit structs for deriving the `Properties` trait. Now, the following works:
```
#[derive(Properties, Clone, Default)]
struct MyUnitStruct;
```

Fixes #1677  <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [X] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
- [X] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1677: Properties derive macro fails on empty struct](https://issuehunt.io/repos/114466145/issues/1677)
---
</details>
<!-- /Issuehunt content-->