### PR TITLE
yewtil: function_component: Permit empty params

### DIFF
--- a/packages/yewtil-macro/src/function_component.rs
+++ b/packages/yewtil-macro/src/function_component.rs
@@ -146,8 +146,15 @@ impl ToTokens for FunctionComponentInfo {
             })
             .collect::<Punctuated<_, Token![,]>>();
 
+        // Derive also `Default` for empty properties
+        let derives = if fields.is_empty() {
+            quote! { ::std::clone::Clone, ::std::cmp::PartialEq, ::std::default::Default, ::yew::Properties }
+        } else {
+            quote! { ::std::clone::Clone, ::std::cmp::PartialEq, ::yew::Properties }
+        };
+
         let component_struct = quote! {
-            #[derive(::std::clone::Clone, ::std::cmp::PartialEq, ::yew::Properties)]
+            #[derive(#derives)]
             #vis struct #impl_name {
                 #new_fields
             }


### PR DESCRIPTION
#### Description

Sometimes it might be suitable to have the App top level component be just plain aggregator of other (possibly stateful) components. So it is a good candidate for `PureComponent` from `yewtil`. The `function_component` could reduce the boilerplate even further, e.g:

```rust

#[function_component(Model)]
fn model() -> Html {
    html! {
        <div>
            I am composed of lots of stuff ....
        </div>
    }
}

#[wasm_bindgen(start)]
pub fn run_app() {
    App::<Model>::new().mount_to_body();
}
```
But that fails due to:

```
error[E0599]: the method `mount_to_body` exists for struct `yew::App<Pure<FuncCompModel>>`, but its trait bounds were not satisfied
  --> src/lib.rs:36:25
   |
24 | #[function_component(Model)]
   | ---------------------------- doesn't satisfy `FuncCompModel: std::default::Default`
...
36 |     App::<Model>::new().mount_to_body();
   |                         ^^^^^^^^^^^^^ method cannot be called on `yew::App<Pure<FuncCompModel>>` due to unsatisfied trait bounds
   |
   = note: the following trait bounds were not satisfied:
           `FuncCompModel: std::default::Default`

error: aborting due to previous error; 2 warnings emitted

For more information about this error, try `rustc --explain E0599`.

```

This PR attempts to fix the `function_component` procedural macro. I'm pretty new to Yew and I'm not sure if this won't have any adverse effect on other sorts of usages of the `function_component` macro. Feedback is most welcome :-) 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
