### PR TITLE
Clean up asserts in WebSocket services test

### DIFF
--- a/packages/yew-services/src/websocket.rs
+++ b/packages/yew-services/src/websocket.rs
@@ -327,15 +327,11 @@ mod tests {
         let status_future = CallbackFuture::<WebSocketStatus>::default();
         let notification: Callback<_> = status_future.clone().into();
         let task = WebSocketService::connect_text(url, callback, notification);
-        assert!(task.is_err());
-        if let Err(err) = task {
-            #[allow(irrefutable_let_patterns)]
-            if let WebSocketError::CreationError(creation_err) = err {
-                assert!(creation_err.starts_with("SyntaxError:"));
-            } else {
-                assert!(false);
-            }
-        }
+        assert!(matches!(
+            task,
+            Err(WebSocketError::CreationError(creation_err))
+                if creation_err.starts_with("SyntaxError:")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
#### Description

In `test_invalid_url_error`:

* First `assert` followed by `if let` is redundant.
* Second `if let` requires suppression of
  `irrefutable_let_patterns` since there is only one variant.
* Second `if let` necessitates a third "catch-all else" assert.

Replacing all of this with a single `assert!(matches!(...))`
makes it easier to read and removes the need for the
lint suppression without changing what's being tested.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [X] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
