### PR TITLE
Fix issues in `WebSocketTask` during connection

### DIFF
--- a/packages/yew-services/src/websocket.rs
+++ b/packages/yew-services/src/websocket.rs
@@ -245,7 +245,10 @@ impl WebSocketTask {
 
 impl Task for WebSocketTask {
     fn is_active(&self) -> bool {
-        self.ws.ready_state() == WebSocket::OPEN
+        matches!(
+            self.ws.ready_state(),
+            WebSocket::CONNECTING | WebSocket::OPEN
+        )
     }
 }
 
@@ -400,5 +403,52 @@ mod tests {
                 FormatError::ReceivedTextForBinary.to_string()
             ),
         }
+    }
+
+    #[test]
+    async fn is_active_while_connecting() {
+        let url = echo_server_url();
+        let cb_future = CallbackFuture::<Json<Result<Message, anyhow::Error>>>::default();
+        let callback: Callback<_> = cb_future.clone().into();
+        let status_future = CallbackFuture::<WebSocketStatus>::default();
+        let notification: Callback<_> = status_future.clone().into();
+
+        let task = WebSocketService::connect_text(url, callback, notification).unwrap();
+
+        // NOTE: There's a bit of a race here between checking `is_active`
+        // and the WebSocket completing the connection handshake.
+        // The handshake *should* take sufficient time to complete that we
+        // can see it still in the `WebSocket::CONNECTING` state, but it's
+        // not guaranteed.  If someone has a way to guarantee we capture
+        // the WebSocket in the connecting state, please update this test.
+        assert!(task.is_active());
+
+        assert_eq!(status_future.await, WebSocketStatus::Opened);
+    }
+
+    #[test]
+    async fn drop_while_still_connecting() {
+        let url = echo_server_url();
+        let cb_future = CallbackFuture::<Json<Result<Message, anyhow::Error>>>::default();
+        let callback: Callback<_> = cb_future.clone().into();
+        let status_future = CallbackFuture::<WebSocketStatus>::default();
+        let notification: Callback<_> = status_future.clone().into();
+
+        let task = WebSocketService::connect_text(url, callback, notification).unwrap();
+        let ws = task.ws.clone();
+
+        // NOTE: There's a bit of a race here between dropping the
+        // `WebSocketTask` and the WebSocket completing the connection
+        // handshake.  The handshake *should* take sufficient time to complete
+        // that we can see it still in the `WebSocket::CONNECTING` state, but
+        // it's not guaranteed.  If someone has a way to guarantee we capture
+        // the WebSocket in the connecting state, please update this test.
+        drop(task);
+
+        let ws_ready_state = ws.ready_state();
+        assert!(matches!(
+            ws_ready_state,
+            WebSocket::CLOSING | WebSocket::CLOSED
+        ));
     }
 }


### PR DESCRIPTION
#### Description

During the connection handshake:

* `WebSocketTask::is_active` erronously returns `false`.
* Dropping `WebSocketTask` drops the `WebSocket` without
  calling `WebSocket::close` on it, resulting in the WebSocket
  "leaking"; it will typically continue the connection
  handshake and remain connected to the server, despite the
  client having dropped the object representing it.

Fix these by considering the task to be active if the
WebSocket `ready_state` is *either* `WebSocket::OPEN` or
`WebSocket::CONNECTING`.

Add two tests to check that a `WebSocketTask` returns `true`
for `is_active` while it's connecting, and that dropping
the `WebSocketTask` while it's connecting results in
the underlying WebSocket being closed properly.

Fixes #1783

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [X] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
- [X] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
