### PR TITLE
DO NOT MERGE -- experiment investigating test issue

### DIFF
--- a/packages/yew-services/src/fetch.rs
+++ b/packages/yew-services/src/fetch.rs
@@ -642,10 +642,13 @@ mod tests {
         };
         let cb_future = CallbackFuture::<Response<Json<Result<HttpBin, anyhow::Error>>>>::default();
         let callback: Callback<_> = cb_future.clone().into();
+        let request_debug = format!("{:?}", request);
         let _task = FetchService::fetch_with_options(request, options, callback);
         let resp = cb_future.await;
         assert_eq!(resp.status(), StatusCode::OK);
+        let response_debug = format!("{:?}", resp);
         if let Json(Ok(http_bin)) = resp.body() {
+            panic!("request: {}, response: {}", request_debug, response_debug);
             let referrer = http_bin.headers.get("Referer").expect("no referer set");
             assert!(referrer.ends_with("/same-origin"));
         } else {


### PR DESCRIPTION
DO NOT MERGE --

Dump entire request, response, and parsed headers
in `yew_services::fetch::tests::fetch_referrer_same_origin_url`
to investigate why this test fails sometimes in github CI.

DO NOT MERGE --

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
