### PR TITLE
Update Rust version for macro tests to 1.51 & enable const generics tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.51.0 # min version with const generics
+          - 1.45.0 # MSRV
           - stable
 
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.45.0 # MSRV
+          - 1.51.0 # min version with const generics
           - stable
 
     steps:
@@ -178,7 +178,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.45.0 # MSRV
+          - 1.51.0 # min version with const generics
           - stable
           - nightly
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,10 @@ Alternatively, you can set the `ECHO_SERVER_URL` environment variable to the URL
 
 When adding or updating tests, please make sure to update the appropriate `stderr` file, which you can find [here](https://github.com/yewstack/yew/tree/master/packages/yew-macro/tests/macro) for the `html!` macro.
 These files ensure that macro compilation errors are correct and easy to understand.
-These errors can change with each release of the compiler so they should be generated with the MSRV (currently 1.45).
+These errors can change with each release of the compiler so they should be generated with the Rust version 1.51 
+(because some tests make use of const generics which were stabilized in that version).
 
-To update or generate a new `stderr` file you can run `TRYBUILD=overwrite cargo +1.45.2 test` in the `yew-macro` directory.
+To update or generate a new `stderr` file you can run `TRYBUILD=overwrite cargo +1.51 test` in the `yew-macro` directory.
 
 ## Linting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ These files ensure that macro compilation errors are correct and easy to underst
 These errors can change with each release of the compiler so they should be generated with the Rust version 1.51 
 (because some tests make use of const generics which were stabilized in that version).
 
-To update or generate a new `stderr` file you can run `TRYBUILD=overwrite cargo +1.51 test` in the `yew-macro` directory.
+To update or generate a new `stderr` file you can run `cargo make test-overwrite` in the `yew-macro` directory.
 
 ## Linting
 

--- a/examples/nested_list/src/list.rs
+++ b/examples/nested_list/src/list.rs
@@ -40,9 +40,9 @@ where
     }
 }
 
-impl Into<Html> for ListVariant {
-    fn into(self) -> Html {
-        match self.props {
+impl From<ListVariant> for Html {
+    fn from(variant: ListVariant) -> Html {
+        match variant.props {
             Variants::Header(props) => {
                 VComp::new::<ListHeader>(props, NodeRef::default(), None).into()
             }

--- a/packages/yew-dsl/src/lib.rs
+++ b/packages/yew-dsl/src/lib.rs
@@ -37,9 +37,9 @@ impl<COMP: Component> BoxedVNodeProducer<COMP> {
     }
 }
 
-impl<COMP: Component> Into<VNode> for BoxedVNodeProducer<COMP> {
-    fn into(self) -> VNode {
-        self.build()
+impl<COMP: Component> From<BoxedVNodeProducer<COMP>> for VNode {
+    fn from(value: BoxedVNodeProducer<COMP>) -> VNode {
+        value.build()
     }
 }
 

--- a/packages/yew-functional-macro/Makefile.toml
+++ b/packages/yew-functional-macro/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.test]
 clear = true
-toolchain = "1.45.2"
+toolchain = "1.51"
 command = "cargo"
 args = ["test"]
 

--- a/packages/yew-functional-macro/tests/function_attr/bad-return-type-fail.stderr
+++ b/packages/yew-functional-macro/tests/function_attr/bad-return-type-fail.stderr
@@ -8,6 +8,6 @@ error[E0308]: mismatched types
   --> $DIR/bad-return-type-fail.rs:14:5
    |
 13 | fn comp(_props: &Props) -> u32 {
-   |                            --- expected `yew::virtual_dom::vnode::VNode` because of return type
+   |                            --- expected `VNode` because of return type
 14 |     1
-   |     ^ expected enum `yew::virtual_dom::vnode::VNode`, found integer
+   |     ^ expected enum `VNode`, found integer

--- a/packages/yew-functional-macro/tests/function_attr/generic-pass.rs
+++ b/packages/yew-functional-macro/tests/function_attr/generic-pass.rs
@@ -20,20 +20,20 @@ fn comp1<T1, T2>(_props: &()) -> ::yew::Html {
     }
 }
 
-// #[::yew_functional::function_component(ConstGenerics)]
-// fn const_generics<const N: i32>() -> ::yew::Html {
-//     ::yew::html! {
-//         <div>
-//             { N }
-//         </div>
-//     }
-// }
+#[::yew_functional::function_component(ConstGenerics)]
+fn const_generics<const N: i32>() -> ::yew::Html {
+    ::yew::html! {
+        <div>
+            { N }
+        </div>
+    }
+}
 
 fn compile_pass() {
     ::yew::html! { <Comp<Props> a=10 /> };
     ::yew::html! { <Comp1<usize, usize> /> };
 
-    // ::yew::html! { <ConstGenerics<10> };
+    ::yew::html! { <ConstGenerics<10> };
 }
 
 fn main() {}

--- a/packages/yew-functional-macro/tests/function_attr/generic-pass.rs
+++ b/packages/yew-functional-macro/tests/function_attr/generic-pass.rs
@@ -33,7 +33,7 @@ fn compile_pass() {
     ::yew::html! { <Comp<Props> a=10 /> };
     ::yew::html! { <Comp1<usize, usize> /> };
 
-    ::yew::html! { <ConstGenerics<10> };
+    ::yew::html! { <ConstGenerics<10> /> };
 }
 
 fn main() {}

--- a/packages/yew-functional-macro/tests/function_attr/generic-pass.rs
+++ b/packages/yew-functional-macro/tests/function_attr/generic-pass.rs
@@ -20,7 +20,6 @@ fn comp1<T1, T2>(_props: &()) -> ::yew::Html {
     }
 }
 
-// TODO: uncomment when min_const_generics are in stable and Rust version in CI is bumped
 // #[::yew_functional::function_component(ConstGenerics)]
 // fn const_generics<const N: i32>() -> ::yew::Html {
 //     ::yew::html! {

--- a/packages/yew-functional-macro/tests/function_attr/generic-props-fail.stderr
+++ b/packages/yew-functional-macro/tests/function_attr/generic-props-fail.stderr
@@ -15,32 +15,28 @@ error[E0599]: no method named `build` found for struct `PropsBuilder<PropsBuilde
 ...
 23 |     html! { <Comp<Props> /> };
    |              ^^^^ method not found in `PropsBuilder<PropsBuilderStep_missing_required_prop_a>`
-   |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `build`, perhaps you need to implement it:
-           candidate #1: `proc_macro::bridge::server::TokenStreamBuilder`
 
-error[E0599]: no function or associated item named `new` found for struct `yew::virtual_dom::vcomp::VChild<yew_functional::FunctionComponent<comp<MissingTypeBounds>>>` in the current scope
+error[E0599]: the function or associated item `new` exists for struct `VChild<FunctionComponent<comp<MissingTypeBounds>>>`, but its trait bounds were not satisfied
   --> $DIR/generic-props-fail.rs:28:14
    |
 28 |     html! { <Comp<MissingTypeBounds> /> };
-   |              ^^^^ function or associated item not found in `yew::virtual_dom::vcomp::VChild<yew_functional::FunctionComponent<comp<MissingTypeBounds>>>`
+   |              ^^^^ function or associated item cannot be called on `VChild<FunctionComponent<comp<MissingTypeBounds>>>` due to unsatisfied trait bounds
    |
   ::: $WORKSPACE/packages/yew-functional/src/lib.rs
    |
    | pub struct FunctionComponent<T: FunctionProvider + 'static> {
-   | ----------------------------------------------------------- doesn't satisfy `_: yew::html::component::Component`
+   | ----------------------------------------------------------- doesn't satisfy `_: yew::Component`
    |
-   = note: the method `new` exists but the following trait bounds were not satisfied:
-           `yew_functional::FunctionComponent<comp<MissingTypeBounds>>: yew::html::component::Component`
+   = note: the following trait bounds were not satisfied:
+           `FunctionComponent<comp<MissingTypeBounds>>: yew::Component`
 
-error[E0277]: the trait bound `MissingTypeBounds: yew::html::component::properties::Properties` is not satisfied
+error[E0277]: the trait bound `MissingTypeBounds: yew::Properties` is not satisfied
   --> $DIR/generic-props-fail.rs:28:14
    |
 28 |     html! { <Comp<MissingTypeBounds> /> };
-   |              ^^^^ the trait `yew::html::component::properties::Properties` is not implemented for `MissingTypeBounds`
+   |              ^^^^ the trait `yew::Properties` is not implemented for `MissingTypeBounds`
    |
-   = note: required because of the requirements on the impl of `yew_functional::FunctionProvider` for `comp<MissingTypeBounds>`
+   = note: required because of the requirements on the impl of `FunctionProvider` for `comp<MissingTypeBounds>`
 
 error[E0277]: can't compare `MissingTypeBounds` with `MissingTypeBounds`
   --> $DIR/generic-props-fail.rs:28:14
@@ -48,11 +44,23 @@ error[E0277]: can't compare `MissingTypeBounds` with `MissingTypeBounds`
 28 |     html! { <Comp<MissingTypeBounds> /> };
    |              ^^^^ no implementation for `MissingTypeBounds == MissingTypeBounds`
    |
-   = help: the trait `std::cmp::PartialEq` is not implemented for `MissingTypeBounds`
-   = note: required because of the requirements on the impl of `yew_functional::FunctionProvider` for `comp<MissingTypeBounds>`
+   = help: the trait `PartialEq` is not implemented for `MissingTypeBounds`
+   = note: required because of the requirements on the impl of `FunctionProvider` for `comp<MissingTypeBounds>`
 
-error[E0107]: wrong number of type arguments: expected 1, found 0
+error[E0107]: missing generics for type alias `Comp`
   --> $DIR/generic-props-fail.rs:31:14
    |
 31 |     html! { <Comp /> };
    |              ^^^^ expected 1 type argument
+   |
+note: type alias defined here, with 1 type parameter: `P`
+  --> $DIR/generic-props-fail.rs:9:22
+   |
+9  | #[function_component(Comp)]
+   |                      ^^^^
+10 | fn comp<P>(_props: &P) -> Html
+   |         -
+help: use angle brackets to add missing type argument
+   |
+31 |     html! { <Comp<P> /> };
+   |                  ^^^

--- a/packages/yew-functional-macro/tests/function_attr_test.rs
+++ b/packages/yew-functional-macro/tests/function_attr_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.45), test)]
+#[rustversion::attr(stable(1.51), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/function_attr/*-pass.rs");

--- a/packages/yew-macro/Makefile.toml
+++ b/packages/yew-macro/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.test]
 clear = true
-toolchain = "1.45.2"
+toolchain = "1.51"
 command = "cargo"
 args = ["test"]
 

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -64,13 +64,13 @@ impl Parse for PropValue {
     }
 }
 
-impl Into<Prop> for PropValue {
-    fn into(self) -> Prop {
-        let Self {
+impl From<PropValue> for Prop {
+    fn from(prop_value: PropValue) -> Prop {
+        let PropValue {
             label,
             colon_token,
             value,
-        } = self;
+        } = prop_value;
         Prop {
             label,
             question_mark: None,

--- a/packages/yew-macro/tests/classes_macro/classes-fail.stderr
+++ b/packages/yew-macro/tests/classes_macro/classes-fail.stderr
@@ -10,92 +10,95 @@ error: string literals must not contain more than one class (hint: use `"two", "
 18 |     classes!("one", "two three", "four");
    |                     ^^^^^^^^^^^
 
-error[E0277]: the trait bound `yew::html::classes::Classes: std::convert::From<{integer}>` is not satisfied
+error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
  --> $DIR/classes-fail.rs:4:14
   |
 4 |     classes!(42);
-  |              ^^ the trait `std::convert::From<{integer}>` is not implemented for `yew::html::classes::Classes`
+  |              ^^ the trait `From<{integer}>` is not implemented for `Classes`
   |
   = help: the following implementations were found:
-            <yew::html::classes::Classes as std::convert::From<&'static str>>
-            <yew::html::classes::Classes as std::convert::From<&[T]>>
-            <yew::html::classes::Classes as std::convert::From<&std::option::Option<T>>>
-            <yew::html::classes::Classes as std::convert::From<&std::string::String>>
+            <Classes as From<&'static str>>
+            <Classes as From<&Option<T>>>
+            <Classes as From<&String>>
+            <Classes as From<&[T]>>
           and 4 others
-  = note: required because of the requirements on the impl of `std::convert::Into<yew::html::classes::Classes>` for `{integer}`
+  = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
 
-error[E0277]: the trait bound `yew::html::classes::Classes: std::convert::From<{float}>` is not satisfied
+error[E0277]: the trait bound `Classes: From<{float}>` is not satisfied
  --> $DIR/classes-fail.rs:5:14
   |
 5 |     classes!(42.0);
-  |              ^^^^ the trait `std::convert::From<{float}>` is not implemented for `yew::html::classes::Classes`
+  |              ^^^^ the trait `From<{float}>` is not implemented for `Classes`
   |
   = help: the following implementations were found:
-            <yew::html::classes::Classes as std::convert::From<&'static str>>
-            <yew::html::classes::Classes as std::convert::From<&[T]>>
-            <yew::html::classes::Classes as std::convert::From<&std::option::Option<T>>>
-            <yew::html::classes::Classes as std::convert::From<&std::string::String>>
+            <Classes as From<&'static str>>
+            <Classes as From<&Option<T>>>
+            <Classes as From<&String>>
+            <Classes as From<&[T]>>
           and 4 others
-  = note: required because of the requirements on the impl of `std::convert::Into<yew::html::classes::Classes>` for `{float}`
+  = note: required because of the requirements on the impl of `Into<Classes>` for `{float}`
 
-error[E0277]: the trait bound `yew::html::classes::Classes: std::convert::From<{integer}>` is not satisfied
+error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
  --> $DIR/classes-fail.rs:9:14
   |
 9 |     classes!(vec![42]);
-  |              ^^^ the trait `std::convert::From<{integer}>` is not implemented for `yew::html::classes::Classes`
+  |              ^^^ the trait `From<{integer}>` is not implemented for `Classes`
   |
   = help: the following implementations were found:
-            <yew::html::classes::Classes as std::convert::From<&'static str>>
-            <yew::html::classes::Classes as std::convert::From<&[T]>>
-            <yew::html::classes::Classes as std::convert::From<&std::option::Option<T>>>
-            <yew::html::classes::Classes as std::convert::From<&std::string::String>>
+            <Classes as From<&'static str>>
+            <Classes as From<&Option<T>>>
+            <Classes as From<&String>>
+            <Classes as From<&[T]>>
           and 4 others
-  = note: required because of the requirements on the impl of `std::convert::Into<yew::html::classes::Classes>` for `{integer}`
-  = note: required because of the requirements on the impl of `std::convert::From<std::vec::Vec<{integer}>>` for `yew::html::classes::Classes`
-  = note: required because of the requirements on the impl of `std::convert::Into<yew::html::classes::Classes>` for `std::vec::Vec<{integer}>`
+  = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
+  = note: required because of the requirements on the impl of `From<std::vec::Vec<{integer}>>` for `Classes`
+  = note: 1 redundant requirements hidden
+  = note: required because of the requirements on the impl of `Into<Classes>` for `std::vec::Vec<{integer}>`
 
-error[E0277]: the trait bound `yew::html::classes::Classes: std::convert::From<{integer}>` is not satisfied
+error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
   --> $DIR/classes-fail.rs:13:14
    |
 13 |     classes!(some);
-   |              ^^^^ the trait `std::convert::From<{integer}>` is not implemented for `yew::html::classes::Classes`
+   |              ^^^^ the trait `From<{integer}>` is not implemented for `Classes`
    |
    = help: the following implementations were found:
-             <yew::html::classes::Classes as std::convert::From<&'static str>>
-             <yew::html::classes::Classes as std::convert::From<&[T]>>
-             <yew::html::classes::Classes as std::convert::From<&std::option::Option<T>>>
-             <yew::html::classes::Classes as std::convert::From<&std::string::String>>
+             <Classes as From<&'static str>>
+             <Classes as From<&Option<T>>>
+             <Classes as From<&String>>
+             <Classes as From<&[T]>>
            and 4 others
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::html::classes::Classes>` for `{integer}`
-   = note: required because of the requirements on the impl of `std::convert::From<std::option::Option<{integer}>>` for `yew::html::classes::Classes`
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::html::classes::Classes>` for `std::option::Option<{integer}>`
+   = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
+   = note: required because of the requirements on the impl of `From<Option<{integer}>>` for `Classes`
+   = note: 1 redundant requirements hidden
+   = note: required because of the requirements on the impl of `Into<Classes>` for `Option<{integer}>`
 
-error[E0277]: the trait bound `yew::html::classes::Classes: std::convert::From<u32>` is not satisfied
+error[E0277]: the trait bound `Classes: From<u32>` is not satisfied
   --> $DIR/classes-fail.rs:14:14
    |
 14 |     classes!(none);
-   |              ^^^^ the trait `std::convert::From<u32>` is not implemented for `yew::html::classes::Classes`
+   |              ^^^^ the trait `From<u32>` is not implemented for `Classes`
    |
    = help: the following implementations were found:
-             <yew::html::classes::Classes as std::convert::From<&'static str>>
-             <yew::html::classes::Classes as std::convert::From<&[T]>>
-             <yew::html::classes::Classes as std::convert::From<&std::option::Option<T>>>
-             <yew::html::classes::Classes as std::convert::From<&std::string::String>>
+             <Classes as From<&'static str>>
+             <Classes as From<&Option<T>>>
+             <Classes as From<&String>>
+             <Classes as From<&[T]>>
            and 4 others
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::html::classes::Classes>` for `u32`
-   = note: required because of the requirements on the impl of `std::convert::From<std::option::Option<u32>>` for `yew::html::classes::Classes`
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::html::classes::Classes>` for `std::option::Option<u32>`
+   = note: required because of the requirements on the impl of `Into<Classes>` for `u32`
+   = note: required because of the requirements on the impl of `From<Option<u32>>` for `Classes`
+   = note: 1 redundant requirements hidden
+   = note: required because of the requirements on the impl of `Into<Classes>` for `Option<u32>`
 
-error[E0277]: the trait bound `yew::html::classes::Classes: std::convert::From<{integer}>` is not satisfied
+error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
   --> $DIR/classes-fail.rs:16:21
    |
 16 |     classes!("one", 42);
-   |                     ^^ the trait `std::convert::From<{integer}>` is not implemented for `yew::html::classes::Classes`
+   |                     ^^ the trait `From<{integer}>` is not implemented for `Classes`
    |
    = help: the following implementations were found:
-             <yew::html::classes::Classes as std::convert::From<&'static str>>
-             <yew::html::classes::Classes as std::convert::From<&[T]>>
-             <yew::html::classes::Classes as std::convert::From<&std::option::Option<T>>>
-             <yew::html::classes::Classes as std::convert::From<&std::string::String>>
+             <Classes as From<&'static str>>
+             <Classes as From<&Option<T>>>
+             <Classes as From<&String>>
+             <Classes as From<&[T]>>
            and 4 others
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::html::classes::Classes>` for `{integer}`
+   = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`

--- a/packages/yew-macro/tests/classes_macro_test.rs
+++ b/packages/yew-macro/tests/classes_macro_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.45), test)]
+#[rustversion::attr(stable(1.51), test)]
 fn classes_macro() {
     let t = trybuild::TestCases::new();
     t.pass("tests/classes_macro/*-pass.rs");

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -9,6 +9,10 @@ error: cannot find attribute `props` in this scope
    |
 22 |         #[props(default)]
    |           ^^^^^
+   |
+   = note: consider importing one of these items:
+           yew::props
+           yew_macro::props
 
 error[E0425]: cannot find value `foo` in this scope
   --> $DIR/fail.rs:87:24
@@ -40,12 +44,8 @@ error[E0599]: no method named `build` found for struct `t3::PropsBuilder<t3::Pro
 ...
 35 |         Props::builder().build();
    |                          ^^^^^ method not found in `t3::PropsBuilder<t3::PropsBuilderStep_missing_required_prop_value>`
-   |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `build`, perhaps you need to implement it:
-           candidate #1: `proc_macro::bridge::server::TokenStreamBuilder`
 
-error[E0599]: no method named `b` found for struct `t4::PropsBuilder<t4::PropsBuilderStep_missing_required_prop_a>` in the current scope
+error[E0599]: no method named `b` found for struct `t4::PropsBuilder<PropsBuilderStep_missing_required_prop_a>` in the current scope
   --> $DIR/fail.rs:48:26
    |
 41 |     #[derive(Clone, Properties)]
@@ -58,10 +58,14 @@ error[E0308]: mismatched types
   --> $DIR/fail.rs:67:19
    |
 67 |         #[prop_or(123)]
-   |                   ^^^
-   |                   |
-   |                   expected struct `std::string::String`, found integer
-   |                   help: try using a conversion method: `123.to_string()`
+   |                   ^^^ expected struct `String`, found integer
+   |
+help: try using a conversion method
+   |
+67 |         #[prop_or(123.to_string())]
+   |                   ^^^^^^^^^^^^^^^
+67 |         #[prop_or(123.to_string())]
+   |                   ^^^^^^^^^^^^^^^
 
 error[E0618]: expected function, found `{integer}`
   --> $DIR/fail.rs:77:24
@@ -76,15 +80,22 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
     |                        ^^^- supplied 0 arguments
     |                        |
     |                        expected 1 argument
-...
+    |
+note: function defined here
+   --> $DIR/fail.rs:101:8
+    |
 101 |     fn foo(bar: i32) -> String {
-    |     -------------------------- defined here
+    |        ^^^ --------
 
 error[E0308]: mismatched types
    --> $DIR/fail.rs:111:24
     |
 111 |         #[prop_or_else(foo)]
-    |                        ^^^
-    |                        |
-    |                        expected struct `std::string::String`, found `i32`
-    |                        help: try using a conversion method: `foo.to_string()`
+    |                        ^^^ expected struct `String`, found `i32`
+    |
+help: try using a conversion method
+    |
+111 |         #[prop_or_else(foo.to_string())]
+    |                        ^^^^^^^^^^^^^^^
+111 |         #[prop_or_else(foo.to_string())]
+    |                        ^^^^^^^^^^^^^^^

--- a/packages/yew-macro/tests/derive_props_test.rs
+++ b/packages/yew-macro/tests/derive_props_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.45), test)]
+#[rustversion::attr(stable(1.51), test)]
 fn derive_props() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_props/pass.rs");

--- a/packages/yew-macro/tests/html_macro/block-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/block-fail.stderr
@@ -6,12 +6,12 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   |
   = help: the trait `std::fmt::Display` is not implemented for `()`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-  = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
-  = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
-  = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>`
-  = note: required because of the requirements on the impl of `std::convert::Into<yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>>` for `()`
-  = note: required by `std::convert::Into::into`
+  = note: required because of the requirements on the impl of `ToString` for `()`
+  = note: required because of the requirements on the impl of `From<()>` for `VNode`
+  = note: required because of the requirements on the impl of `Into<VNode>` for `()`
+  = note: 2 redundant requirements hidden
+  = note: required because of the requirements on the impl of `Into<NodeSeq<(), VNode>>` for `()`
+  = note: required by `into`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/block-fail.rs:12:16
@@ -21,12 +21,12 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
-   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>`
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::utils::NodeSeq<(), yew::virtual_dom::vnode::VNode>>` for `()`
-   = note: required by `std::convert::Into::into`
+   = note: required because of the requirements on the impl of `ToString` for `()`
+   = note: required because of the requirements on the impl of `From<()>` for `VNode`
+   = note: required because of the requirements on the impl of `Into<VNode>` for `()`
+   = note: 2 redundant requirements hidden
+   = note: required because of the requirements on the impl of `Into<NodeSeq<(), VNode>>` for `()`
+   = note: required by `into`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/block-fail.rs:15:17
@@ -37,10 +37,10 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   ::: $WORKSPACE/packages/yew/src/utils.rs
    |
    |     T: Into<R>,
-   |        ------- required by this bound in `yew::utils::into_node_iter`
+   |        ------- required by this bound in `into_node_iter`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
+   = note: required because of the requirements on the impl of `ToString` for `()`
+   = note: required because of the requirements on the impl of `From<()>` for `VNode`
+   = note: required because of the requirements on the impl of `Into<VNode>` for `()`

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -205,67 +205,67 @@ error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder
 74 |     html! { <Child unknown="unknown" /> };
    |                    ^^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
 
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<(), std::string::String>` is not satisfied
+error[E0277]: the trait bound `yew::virtual_dom::VComp: Transformer<(), String>` is not satisfied
   --> $DIR/component-fail.rs:77:33
    |
 77 |     html! { <Child int=1 string={} /> };
-   |                                 ^^ the trait `yew::virtual_dom::Transformer<(), std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
+   |                                 ^^ the trait `Transformer<(), String>` is not implemented for `yew::virtual_dom::VComp`
    |
    = help: the following implementations were found:
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
+             <yew::virtual_dom::VComp as Transformer<&'a T, Option<T>>>
+             <yew::virtual_dom::VComp as Transformer<&'a T, T>>
+             <yew::virtual_dom::VComp as Transformer<&'a str, Option<String>>>
+             <yew::virtual_dom::VComp as Transformer<&'a str, String>>
            and 3 others
-   = note: required by `yew::virtual_dom::Transformer::transform`
+   = note: required by `transform`
 
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<{integer}, std::string::String>` is not satisfied
+error[E0277]: the trait bound `yew::virtual_dom::VComp: Transformer<{integer}, String>` is not satisfied
   --> $DIR/component-fail.rs:78:33
    |
 78 |     html! { <Child int=1 string=3 /> };
-   |                                 ^ the trait `yew::virtual_dom::Transformer<{integer}, std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
+   |                                 ^ the trait `Transformer<{integer}, String>` is not implemented for `yew::virtual_dom::VComp`
    |
    = help: the following implementations were found:
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
+             <yew::virtual_dom::VComp as Transformer<&'a T, Option<T>>>
+             <yew::virtual_dom::VComp as Transformer<&'a T, T>>
+             <yew::virtual_dom::VComp as Transformer<&'a str, Option<String>>>
+             <yew::virtual_dom::VComp as Transformer<&'a str, String>>
            and 3 others
-   = note: required by `yew::virtual_dom::Transformer::transform`
+   = note: required by `transform`
 
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<{integer}, std::string::String>` is not satisfied
+error[E0277]: the trait bound `yew::virtual_dom::VComp: Transformer<{integer}, String>` is not satisfied
   --> $DIR/component-fail.rs:79:33
    |
 79 |     html! { <Child int=1 string={3} /> };
-   |                                 ^^^ the trait `yew::virtual_dom::Transformer<{integer}, std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
+   |                                 ^^^ the trait `Transformer<{integer}, String>` is not implemented for `yew::virtual_dom::VComp`
    |
    = help: the following implementations were found:
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
+             <yew::virtual_dom::VComp as Transformer<&'a T, Option<T>>>
+             <yew::virtual_dom::VComp as Transformer<&'a T, T>>
+             <yew::virtual_dom::VComp as Transformer<&'a str, Option<String>>>
+             <yew::virtual_dom::VComp as Transformer<&'a str, String>>
            and 3 others
-   = note: required by `yew::virtual_dom::Transformer::transform`
+   = note: required by `transform`
 
 error[E0308]: mismatched types
   --> $DIR/component-fail.rs:80:30
    |
 80 |     html! { <Child int=1 ref=() /> };
-   |                              ^^ expected struct `yew::html::NodeRef`, found `()`
+   |                              ^^ expected struct `NodeRef`, found `()`
 
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<u32, i32>` is not satisfied
+error[E0277]: the trait bound `yew::virtual_dom::VComp: Transformer<u32, i32>` is not satisfied
   --> $DIR/component-fail.rs:82:24
    |
 82 |     html! { <Child int=0u32 /> };
-   |                        ^^^^ the trait `yew::virtual_dom::Transformer<u32, i32>` is not implemented for `yew::virtual_dom::vcomp::VComp`
+   |                        ^^^^ the trait `Transformer<u32, i32>` is not implemented for `yew::virtual_dom::VComp`
    |
    = help: the following implementations were found:
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
+             <yew::virtual_dom::VComp as Transformer<&'a T, Option<T>>>
+             <yew::virtual_dom::VComp as Transformer<&'a T, T>>
+             <yew::virtual_dom::VComp as Transformer<&'a str, Option<String>>>
+             <yew::virtual_dom::VComp as Transformer<&'a str, String>>
            and 3 others
-   = note: required by `yew::virtual_dom::Transformer::transform`
+   = note: required by `transform`
 
 error[E0599]: no method named `string` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
   --> $DIR/component-fail.rs:83:20
@@ -275,10 +275,6 @@ error[E0599]: no method named `string` found for struct `ChildPropertiesBuilder<
 ...
 83 |     html! { <Child string="abc" /> };
    |                    ^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
-   |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `string`, perhaps you need to implement it:
-           candidate #1: `proc_macro::bridge::server::Literal`
 
 error[E0609]: no field `children` on type `ChildProperties`
   --> $DIR/component-fail.rs:87:14
@@ -313,10 +309,6 @@ error[E0599]: no method named `build` found for struct `ChildContainerProperties
 ...
 96 |     html! { <ChildContainer /> };
    |              ^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
-   |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `build`, perhaps you need to implement it:
-           candidate #1: `proc_macro::bridge::server::TokenStreamBuilder`
 
 error[E0599]: no method named `build` found for struct `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
   --> $DIR/component-fail.rs:97:14
@@ -326,34 +318,30 @@ error[E0599]: no method named `build` found for struct `ChildContainerProperties
 ...
 97 |     html! { <ChildContainer></ChildContainer> };
    |              ^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
-   |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `build`, perhaps you need to implement it:
-           candidate #1: `proc_macro::bridge::server::TokenStreamBuilder`
 
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vtext::VText>` is not satisfied
+error[E0277]: the trait bound `VChild<Child>: From<yew::virtual_dom::VText>` is not satisfied
   --> $DIR/component-fail.rs:98:31
    |
 98 |     html! { <ChildContainer>{ "Not allowed" }</ChildContainer> };
-   |                               ^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vtext::VText>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
+   |                               ^^^^^^^^^^^^^ the trait `From<yew::virtual_dom::VText>` is not implemented for `VChild<Child>`
    |
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vtext::VText`
-   = note: required by `std::convert::Into::into`
+   = note: required because of the requirements on the impl of `Into<VChild<Child>>` for `yew::virtual_dom::VText`
+   = note: required by `into`
 
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied
+error[E0277]: the trait bound `VChild<Child>: From<VNode>` is not satisfied
   --> $DIR/component-fail.rs:99:29
    |
 99 |     html! { <ChildContainer><></></ChildContainer> };
-   |                             ^ the trait `std::convert::From<yew::virtual_dom::vnode::VNode>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
+   |                             ^ the trait `From<VNode>` is not implemented for `VChild<Child>`
    |
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vnode::VNode`
-   = note: required by `std::convert::Into::into`
+   = note: required because of the requirements on the impl of `Into<VChild<Child>>` for `VNode`
+   = note: required by `into`
 
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied
+error[E0277]: the trait bound `VChild<Child>: From<VNode>` is not satisfied
    --> $DIR/component-fail.rs:100:30
     |
 100 |     html! { <ChildContainer><other /></ChildContainer> };
-    |                              ^^^^^ the trait `std::convert::From<yew::virtual_dom::vnode::VNode>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
+    |                              ^^^^^ the trait `From<VNode>` is not implemented for `VChild<Child>`
     |
-    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vnode::VNode`
-    = note: required by `std::convert::Into::into`
+    = note: required because of the requirements on the impl of `Into<VChild<Child>>` for `VNode`
+    = note: required by `into`

--- a/packages/yew-macro/tests/html_macro/component-unimplemented-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-unimplemented-fail.stderr
@@ -1,17 +1,17 @@
-error[E0599]: no function or associated item named `new` found for struct `yew::virtual_dom::vcomp::VChild<Unimplemented>` in the current scope
+error[E0599]: the function or associated item `new` exists for struct `VChild<Unimplemented>`, but its trait bounds were not satisfied
  --> $DIR/component-unimplemented-fail.rs:6:14
   |
 3 | struct Unimplemented;
-  | --------------------- doesn't satisfy `Unimplemented: yew::html::component::Component`
+  | --------------------- doesn't satisfy `Unimplemented: yew::Component`
 ...
 6 |     html! { <Unimplemented /> };
-  |              ^^^^^^^^^^^^^ function or associated item not found in `yew::virtual_dom::vcomp::VChild<Unimplemented>`
+  |              ^^^^^^^^^^^^^ function or associated item cannot be called on `VChild<Unimplemented>` due to unsatisfied trait bounds
   |
-  = note: the method `new` exists but the following trait bounds were not satisfied:
-          `Unimplemented: yew::html::component::Component`
+  = note: the following trait bounds were not satisfied:
+          `Unimplemented: yew::Component`
 
-error[E0277]: the trait bound `Unimplemented: yew::html::component::Component` is not satisfied
+error[E0277]: the trait bound `Unimplemented: yew::Component` is not satisfied
  --> $DIR/component-unimplemented-fail.rs:6:14
   |
 6 |     html! { <Unimplemented /> };
-  |              ^^^^^^^^^^^^^ the trait `yew::html::component::Component` is not implemented for `Unimplemented`
+  |              ^^^^^^^^^^^^^ the trait `yew::Component` is not implemented for `Unimplemented`

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -154,7 +154,7 @@ error: `ref` does not support being used as an optional attribute
 59 |     html! { <input ref?=() /> };
    |                    ^^^^^
 
-warning: use of deprecated item 'compile_fail::deprecated_use_of_class': the use of `(...)` with the attribute `class` is deprecated and will be removed in version 0.19. Use the `classes!` macro instead.
+warning: use of deprecated function `compile_fail::deprecated_use_of_class`: the use of `(...)` with the attribute `class` is deprecated and will be removed in version 0.19. Use the `classes!` macro instead.
   --> $DIR/element-fail.rs:63:24
    |
 63 |     html! { <div class=("deprecated", "warning") /> };
@@ -188,8 +188,8 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-   = note: required by `std::string::ToString::to_string`
+   = note: required because of the requirements on the impl of `ToString` for `()`
+   = note: required by `to_string`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/element-fail.rs:29:26
@@ -199,7 +199,7 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
+   = note: required because of the requirements on the impl of `ToString` for `()`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/element-fail.rs:30:21
@@ -209,26 +209,26 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-   = note: required by `std::string::ToString::to_string`
+   = note: required because of the requirements on the impl of `ToString` for `()`
+   = note: required by `to_string`
 
 error[E0308]: mismatched types
   --> $DIR/element-fail.rs:32:28
    |
 32 |     html! { <input onclick=1 /> };
-   |                            ^ expected enum `yew::callback::Callback`, found integer
+   |                            ^ expected enum `yew::Callback`, found integer
    |
-   = note: expected enum `yew::callback::Callback<web_sys::features::gen_MouseEvent::MouseEvent>`
+   = note: expected enum `yew::Callback<MouseEvent>`
               found type `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/element-fail.rs:33:28
    |
 33 |     html! { <input onclick=Callback::from(|a: String| ()) /> };
-   |                            ^^^^^^^^ expected struct `web_sys::features::gen_MouseEvent::MouseEvent`, found struct `std::string::String`
+   |                            ^^^^^^^^ expected struct `MouseEvent`, found struct `String`
    |
-   = note: expected enum `yew::callback::Callback<web_sys::features::gen_MouseEvent::MouseEvent>`
-              found enum `yew::callback::Callback<std::string::String>`
+   = note: expected enum `yew::Callback<MouseEvent>`
+              found enum `yew::Callback<String>`
 
 error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
   --> $DIR/element-fail.rs:35:27
@@ -238,29 +238,29 @@ error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `NotToString`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `NotToString`
-   = note: required by `std::string::ToString::to_string`
+   = note: required because of the requirements on the impl of `ToString` for `NotToString`
+   = note: required by `to_string`
 
 error[E0308]: mismatched types
   --> $DIR/element-fail.rs:37:24
    |
 37 |     html! { <input ref=() /> };
-   |                        ^^ expected struct `yew::html::NodeRef`, found `()`
+   |                        ^^ expected struct `NodeRef`, found `()`
 
-error[E0277]: the trait bound `std::borrow::Cow<'static, str>: std::convert::From<{integer}>` is not satisfied
+error[E0277]: the trait bound `Cow<'static, str>: From<{integer}>` is not satisfied
   --> $DIR/element-fail.rs:45:15
    |
 45 |     html! { <@{55}></@> };
-   |               ^^^^ the trait `std::convert::From<{integer}>` is not implemented for `std::borrow::Cow<'static, str>`
+   |               ^^^^ the trait `From<{integer}>` is not implemented for `Cow<'static, str>`
    |
    = help: the following implementations were found:
-             <std::borrow::Cow<'a, [T]> as std::convert::From<&'a [T]>>
-             <std::borrow::Cow<'a, [T]> as std::convert::From<&'a std::vec::Vec<T>>>
-             <std::borrow::Cow<'a, [T]> as std::convert::From<std::vec::Vec<T>>>
-             <std::borrow::Cow<'a, std::ffi::CStr> as std::convert::From<&'a std::ffi::CStr>>
+             <Cow<'a, CStr> as From<&'a CStr>>
+             <Cow<'a, CStr> as From<&'a CString>>
+             <Cow<'a, CStr> as From<CString>>
+             <Cow<'a, OsStr> as From<&'a OsStr>>
            and 11 others
-   = note: required because of the requirements on the impl of `std::convert::Into<std::borrow::Cow<'static, str>>` for `{integer}`
-   = note: required by `std::convert::Into::into`
+   = note: required because of the requirements on the impl of `Into<Cow<'static, str>>` for `{integer}`
+   = note: required by `into`
 
 error[E0308]: mismatched types
   --> $DIR/element-fail.rs:48:23
@@ -268,10 +268,10 @@ error[E0308]: mismatched types
 48 |     html! { <a media?="media" /> };
    |                       ^^^^^^^
    |                       |
-   |                       expected enum `std::option::Option`, found `&str`
+   |                       expected enum `Option`, found `&str`
    |                       help: try using a variant of the expected enum: `Some("media")`
    |
-   = note:   expected enum `std::option::Option<_>`
+   = note:   expected enum `Option<_>`
            found reference `&'static str`
 
 error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
@@ -282,8 +282,8 @@ error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `NotToString`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `NotToString`
-   = note: required by `std::string::ToString::to_string`
+   = note: required because of the requirements on the impl of `ToString` for `NotToString`
+   = note: required by `to_string`
 
 error[E0308]: mismatched types
   --> $DIR/element-fail.rs:51:26
@@ -291,10 +291,10 @@ error[E0308]: mismatched types
 51 |     html! { <input type?="kind" /> };
    |                          ^^^^^^
    |                          |
-   |                          expected enum `std::option::Option`, found `&str`
+   |                          expected enum `Option`, found `&str`
    |                          help: try using a variant of the expected enum: `Some("kind")`
    |
-   = note:   expected enum `std::option::Option<_>`
+   = note:   expected enum `Option<_>`
            found reference `&'static str`
 
 error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
@@ -305,8 +305,8 @@ error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `NotToString`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `NotToString`
-   = note: required by `std::string::ToString::to_string`
+   = note: required because of the requirements on the impl of `ToString` for `NotToString`
+   = note: required by `to_string`
 
 error[E0308]: mismatched types
   --> $DIR/element-fail.rs:53:24
@@ -314,10 +314,10 @@ error[E0308]: mismatched types
 53 |     html! { <li value?="value" /> };
    |                        ^^^^^^^
    |                        |
-   |                        expected enum `std::option::Option`, found `&str`
+   |                        expected enum `Option`, found `&str`
    |                        help: try using a variant of the expected enum: `Some("value")`
    |
-   = note:   expected enum `std::option::Option<_>`
+   = note:   expected enum `Option<_>`
            found reference `&'static str`
 
 error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
@@ -328,8 +328,8 @@ error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `NotToString`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `NotToString`
-   = note: required by `std::string::ToString::to_string`
+   = note: required because of the requirements on the impl of `ToString` for `NotToString`
+   = note: required by `to_string`
 
 error[E0308]: mismatched types
   --> $DIR/element-fail.rs:56:22
@@ -337,10 +337,10 @@ error[E0308]: mismatched types
 56 |     html! { <a href?="href" /> };
    |                      ^^^^^^
    |                      |
-   |                      expected enum `std::option::Option`, found `&str`
+   |                      expected enum `Option`, found `&str`
    |                      help: try using a variant of the expected enum: `Some("href")`
    |
-   = note:   expected enum `std::option::Option<_>`
+   = note:   expected enum `Option<_>`
            found reference `&'static str`
 
 error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
@@ -351,16 +351,16 @@ error[E0277]: `NotToString` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `NotToString`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `NotToString`
-   = note: required by `std::string::ToString::to_string`
+   = note: required because of the requirements on the impl of `ToString` for `NotToString`
+   = note: required by `to_string`
 
 error[E0308]: mismatched types
   --> $DIR/element-fail.rs:60:20
    |
 60 |     html! { <input onfocus?=Some(5) /> };
-   |                    ^^^^^^^ expected enum `yew::callback::Callback`, found integer
+   |                    ^^^^^^^ expected enum `yew::Callback`, found integer
    |
-   = note: expected enum `yew::callback::Callback<web_sys::features::gen_FocusEvent::FocusEvent>`
+   = note: expected enum `yew::Callback<FocusEvent>`
               found type `{integer}`
 
 error[E0308]: mismatched types
@@ -369,8 +369,8 @@ error[E0308]: mismatched types
 61 |     html! { <input onfocus?=Callback::from(|_| ()) /> };
    |                             ^^^^^^^^^^^^^^^^^^^^^^
    |                             |
-   |                             expected enum `std::option::Option`, found enum `yew::callback::Callback`
+   |                             expected enum `Option`, found enum `yew::Callback`
    |                             help: try using a variant of the expected enum: `Some(Callback::from(|_| ()))`
    |
-   = note: expected enum `std::option::Option<_>`
-              found enum `yew::callback::Callback<_>`
+   = note: expected enum `Option<_>`
+              found enum `yew::Callback<_>`

--- a/packages/yew-macro/tests/html_macro/iterable-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/iterable-fail.stderr
@@ -10,8 +10,9 @@ error[E0277]: `()` is not an iterator
 5 |     html! { for () };
   |                 ^^ `()` is not an iterator
   |
-  = help: the trait `std::iter::Iterator` is not implemented for `()`
-  = note: required by `std::iter::IntoIterator::into_iter`
+  = help: the trait `Iterator` is not implemented for `()`
+  = note: required because of the requirements on the impl of `IntoIterator` for `()`
+  = note: required by `into_iter`
 
 error[E0277]: `()` is not an iterator
  --> $DIR/iterable-fail.rs:6:17
@@ -19,51 +20,49 @@ error[E0277]: `()` is not an iterator
 6 |     html! { for {()} };
   |                 ^^^^ `()` is not an iterator
   |
-  = help: the trait `std::iter::Iterator` is not implemented for `()`
-  = note: required by `std::iter::IntoIterator::into_iter`
+  = help: the trait `Iterator` is not implemented for `()`
+  = note: required because of the requirements on the impl of `IntoIterator` for `()`
+  = note: required by `into_iter`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
- --> $DIR/iterable-fail.rs:7:17
-  |
-7 |     html! { for Vec::<()>::new().into_iter() };
-  |                 ^^^ `()` cannot be formatted with the default formatter
-  |
-  = help: the trait `std::fmt::Display` is not implemented for `()`
-  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-  = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
-  = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
-  = note: required because of the requirements on the impl of `std::iter::FromIterator<()>` for `yew::virtual_dom::vnode::VNode`
-  = note: required by `std::iter::Iterator::collect`
+    --> $DIR/iterable-fail.rs:7:17
+     |
+7    |     html! { for Vec::<()>::new().into_iter() };
+     |                 ^^^ `()` cannot be formatted with the default formatter
+     |
+     = help: the trait `std::fmt::Display` is not implemented for `()`
+     = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+     = note: required because of the requirements on the impl of `ToString` for `()`
+     = note: required because of the requirements on the impl of `From<()>` for `VNode`
+     = note: required because of the requirements on the impl of `Into<VNode>` for `()`
+     = note: required because of the requirements on the impl of `FromIterator<()>` for `VNode`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> $DIR/iterable-fail.rs:10:17
-   |
-10 |     html! { for empty };
-   |                 ^^^^^ `()` cannot be formatted with the default formatter
-   |
-   = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `()`
-   = note: required because of the requirements on the impl of `std::iter::FromIterator<()>` for `yew::virtual_dom::vnode::VNode`
-   = note: required by `std::iter::Iterator::collect`
+    --> $DIR/iterable-fail.rs:10:17
+     |
+10   |     html! { for empty };
+     |                 ^^^^^ `()` cannot be formatted with the default formatter
+     |
+     = help: the trait `std::fmt::Display` is not implemented for `()`
+     = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+     = note: required because of the requirements on the impl of `ToString` for `()`
+     = note: required because of the requirements on the impl of `From<()>` for `VNode`
+     = note: required because of the requirements on the impl of `Into<VNode>` for `()`
+     = note: required because of the requirements on the impl of `FromIterator<()>` for `VNode`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> $DIR/iterable-fail.rs:13:17
-   |
-13 |     html! { for empty.iter() };
-   |                 ^^^^^ `()` cannot be formatted with the default formatter
-   |
-   = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::fmt::Display` for `&()`
-   = note: required because of the requirements on the impl of `std::string::ToString` for `&()`
-   = note: required because of the requirements on the impl of `std::convert::From<&()>` for `yew::virtual_dom::vnode::VNode`
-   = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vnode::VNode>` for `&()`
-   = note: required because of the requirements on the impl of `std::iter::FromIterator<&()>` for `yew::virtual_dom::vnode::VNode`
-   = note: required by `std::iter::Iterator::collect`
+    --> $DIR/iterable-fail.rs:13:17
+     |
+13   |     html! { for empty.iter() };
+     |                 ^^^^^ `()` cannot be formatted with the default formatter
+     |
+     = help: the trait `std::fmt::Display` is not implemented for `()`
+     = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+     = note: required because of the requirements on the impl of `std::fmt::Display` for `&()`
+     = note: required because of the requirements on the impl of `ToString` for `&()`
+     = note: required because of the requirements on the impl of `From<&()>` for `VNode`
+     = note: required because of the requirements on the impl of `Into<VNode>` for `&()`
+     = note: required because of the requirements on the impl of `FromIterator<&()>` for `VNode`
 
 error[E0277]: `()` is not an iterator
   --> $DIR/iterable-fail.rs:18:19
@@ -74,7 +73,7 @@ error[E0277]: `()` is not an iterator
   ::: $WORKSPACE/packages/yew/src/utils.rs
    |
    |     IT: IntoIterator<Item = T>,
-   |         ---------------------- required by this bound in `yew::utils::into_node_iter`
+   |         ---------------------- required by this bound in `into_node_iter`
    |
-   = help: the trait `std::iter::Iterator` is not implemented for `()`
-   = note: required because of the requirements on the impl of `std::iter::IntoIterator` for `()`
+   = help: the trait `Iterator` is not implemented for `()`
+   = note: required because of the requirements on the impl of `IntoIterator` for `()`

--- a/packages/yew-macro/tests/html_macro/node-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/node-fail.stderr
@@ -48,9 +48,9 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   |
   = help: the trait `std::fmt::Display` is not implemented for `()`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-  = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
-  = note: required by `std::convert::From::from`
+  = note: required because of the requirements on the impl of `ToString` for `()`
+  = note: required because of the requirements on the impl of `From<()>` for `VNode`
+  = note: required by `from`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/node-fail.rs:17:9
@@ -60,6 +60,6 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
-   = note: required because of the requirements on the impl of `std::convert::From<()>` for `yew::virtual_dom::vnode::VNode`
-   = note: required by `std::convert::From::from`
+   = note: required because of the requirements on the impl of `ToString` for `()`
+   = note: required because of the requirements on the impl of `From<()>` for `VNode`
+   = note: required by `from`

--- a/packages/yew-macro/tests/html_macro_test.rs
+++ b/packages/yew-macro/tests/html_macro_test.rs
@@ -1,7 +1,7 @@
 use yew::html;
 
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.45), test)]
+#[rustversion::attr(stable(1.51), test)]
 fn html_macro() {
     let t = trybuild::TestCases::new();
 

--- a/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
@@ -1,17 +1,21 @@
-error[E0277]: the trait bound `std::vec::Vec<_>: yew::html::component::properties::Properties` is not satisfied
+error[E0277]: the trait bound `std::vec::Vec<_>: yew::Properties` is not satisfied
   --> $DIR/resolve-prop-fail.rs:38:17
    |
 38 |     yew::props!(Vec<_> {});
-   |                 ^^^ the trait `yew::html::component::properties::Properties` is not implemented for `std::vec::Vec<_>`
+   |                 ^^^ the trait `yew::Properties` is not implemented for `std::vec::Vec<_>`
+   |
+   = note: required by `builder`
 
-error[E0277]: the trait bound `MyComp: yew::html::component::properties::Properties` is not satisfied
+error[E0277]: the trait bound `MyComp: yew::Properties` is not satisfied
   --> $DIR/resolve-prop-fail.rs:39:17
    |
 39 |     yew::props!(MyComp {});
-   |                 ^^^^^^ the trait `yew::html::component::properties::Properties` is not implemented for `MyComp`
+   |                 ^^^^^^ the trait `yew::Properties` is not implemented for `MyComp`
+   |
+   = note: required by `builder`
 
-error[E0277]: the trait bound `MyNotAComponent: yew::html::component::Component` is not satisfied
+error[E0277]: the trait bound `MyNotAComponent: yew::Component` is not satisfied
   --> $DIR/resolve-prop-fail.rs:40:17
    |
 40 |     yew::props!(MyNotAComponent::Properties {});
-   |                 ^^^^^^^^^^^^^^^ the trait `yew::html::component::Component` is not implemented for `MyNotAComponent`
+   |                 ^^^^^^^^^^^^^^^ the trait `yew::Component` is not implemented for `MyNotAComponent`

--- a/packages/yew-macro/tests/props_macro_test.rs
+++ b/packages/yew-macro/tests/props_macro_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.45), test)]
+#[rustversion::attr(stable(1.51), test)]
 fn props_macro() {
     let t = trybuild::TestCases::new();
     t.pass("tests/props_macro/*-pass.rs");

--- a/packages/yew-router/src/alias.rs
+++ b/packages/yew-router/src/alias.rs
@@ -37,52 +37,49 @@ macro_rules! define_router_state {
             #[doc = ">](route_service/struct.RouteService.html)."]
             pub type RouteService = $crate::service::RouteService<$StateT>;
 
-            #[cfg(feature="agent")]
+            #[cfg(feature = "agent")]
             #[doc = "Alias to [RouteAgent<"]
             #[doc = $StateName]
             #[doc = ">](agent/struct.RouteAgent.html)."]
             pub type RouteAgent = $crate::agent::RouteAgent<$StateT>;
 
-            #[cfg(feature="agent")]
+            #[cfg(feature = "agent")]
             #[doc = "Alias to [RouteAgentBridge<"]
             #[doc = $StateName]
             #[doc = ">](agent/bridge/struct.RouteAgentBridge.html)`."]
             pub type RouteAgentBridge = $crate::agent::RouteAgentBridge<$StateT>;
 
-            #[cfg(feature="agent")]
+            #[cfg(feature = "agent")]
             #[doc = "Alias to [RouteAgentDispatcher<"]
             #[doc = $StateName]
             #[doc = ">](agent/struct.RouteAgentDispatcher.html)`."]
             pub type RouteAgentDispatcher = $crate::agent::RouteAgentDispatcher<$StateT>;
 
-
             #[allow(deprecated)]
             #[deprecated(note = "Has been renamed to RouterAnchor")]
-            #[cfg(feature="components")]
+            #[cfg(feature = "components")]
             #[doc = "Alias to [RouterLink<"]
             #[doc = $StateName]
             #[doc = ">](components/struct.RouterLink.html)`."]
             pub type RouterLink = $crate::components::RouterLink<$StateT>;
 
-
-            #[cfg(feature="components")]
+            #[cfg(feature = "components")]
             #[doc = "Alias to [RouterAnchor<"]
             #[doc = $StateName]
             #[doc = ">](components/struct.RouterAnchor.html)`."]
             pub type RouterAnchor = $crate::components::RouterAnchor<$StateT>;
 
-            #[cfg(feature="components")]
+            #[cfg(feature = "components")]
             #[doc = "Alias to [RouterButton<"]
             #[doc = $StateName]
             #[doc = ">](components/struct.RouterButton.html)`."]
             pub type RouterButton = $crate::components::RouterButton<$StateT>;
 
-            #[cfg(feature="router")]
+            #[cfg(feature = "router")]
             #[doc = "Alias to [Router<"]
             #[doc = $StateName]
             #[doc = ">](router/router/struct.Router.html)."]
             pub type Router<SW> = $crate::router::Router<$StateT, SW>;
-
         }
-    }
+    };
 }

--- a/packages/yew-services/src/callback_test_util.rs
+++ b/packages/yew-services/src/callback_test_util.rs
@@ -35,9 +35,9 @@ impl<T> Default for CallbackFuture<T> {
     }
 }
 
-impl<T: 'static> Into<Callback<T>> for CallbackFuture<T> {
-    fn into(self) -> Callback<T> {
-        Callback::from(move |r| self.finish(r))
+impl<T: 'static> From<CallbackFuture<T>> for Callback<T> {
+    fn from(f: CallbackFuture<T>) -> Self {
+        Callback::from(move |r| f.finish(r))
     }
 }
 

--- a/packages/yew-services/src/fetch.rs
+++ b/packages/yew-services/src/fetch.rs
@@ -74,27 +74,27 @@ pub struct FetchOptions {
     pub integrity: Option<String>,
 }
 
-impl Into<RequestInit> for FetchOptions {
-    fn into(self) -> RequestInit {
+impl From<FetchOptions> for RequestInit {
+    fn from(fetch_options: FetchOptions) -> RequestInit {
         let mut init = RequestInit::new();
 
-        if let Some(cache) = self.cache {
+        if let Some(cache) = fetch_options.cache {
             init.cache(cache);
         }
 
-        if let Some(credentials) = self.credentials {
+        if let Some(credentials) = fetch_options.credentials {
             init.credentials(credentials);
         }
 
-        if let Some(redirect) = self.redirect {
+        if let Some(redirect) = fetch_options.redirect {
             init.redirect(redirect);
         }
 
-        if let Some(mode) = self.mode {
+        if let Some(mode) = fetch_options.mode {
             init.mode(mode);
         }
 
-        if let Some(referrer) = self.referrer {
+        if let Some(referrer) = fetch_options.referrer {
             match referrer {
                 Referrer::SameOriginUrl(referrer) => init.referrer(&referrer),
                 Referrer::AboutClient => init.referrer("about:client"),
@@ -102,11 +102,11 @@ impl Into<RequestInit> for FetchOptions {
             };
         }
 
-        if let Some(referrer_policy) = self.referrer_policy {
+        if let Some(referrer_policy) = fetch_options.referrer_policy {
             init.referrer_policy(referrer_policy);
         }
 
-        if let Some(integrity) = self.integrity {
+        if let Some(integrity) = fetch_options.integrity {
             init.integrity(&integrity);
         }
 

--- a/packages/yew/src/format/macros.rs
+++ b/packages/yew/src/format/macros.rs
@@ -20,12 +20,12 @@
 #[macro_export]
 macro_rules! text_format {
     ($type:ident based on $format:ident) => {
-        impl<'a, T> Into<$crate::format::Text> for $type<&'a T>
+        impl<'a, T> From<$type<&'a T>> for $crate::format::Text
         where
             T: ::serde::Serialize,
         {
-            fn into(self) -> $crate::format::Text {
-                $format::to_string(&self.0).map_err(::anyhow::Error::from)
+            fn from(value: $type<&'a T>) -> $crate::format::Text {
+                $format::to_string(&value.0).map_err(::anyhow::Error::from)
             }
         }
 
@@ -108,12 +108,12 @@ macro_rules! binary_format {
         binary_format!($type, $format::to_vec, $format::from_slice);
     };
     ($type:ident, $into:path, $from:path) => {
-        impl<'a, T> Into<$crate::format::Binary> for $type<&'a T>
+        impl<'a, T> From<$type<&'a T>> for $crate::format::Binary
         where
             T: ::serde::Serialize,
         {
-            fn into(self) -> $crate::format::Binary {
-                $into(&self.0).map_err(::anyhow::Error::from)
+            fn from(value: $type<&'a T>) -> $crate::format::Binary {
+                $into(&value.0).map_err(::anyhow::Error::from)
             }
         }
 

--- a/packages/yew/src/format/nothing.rs
+++ b/packages/yew/src/format/nothing.rs
@@ -7,6 +7,7 @@ use anyhow::bail;
 #[derive(Debug)]
 pub struct Nothing;
 
+#[allow(clippy::from_over_into)]
 impl Into<Text> for Nothing {
     fn into(self) -> Text {
         bail!("nothing")
@@ -19,6 +20,7 @@ impl From<Text> for Nothing {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<Binary> for Nothing {
     fn into(self) -> Binary {
         bail!("nothing")


### PR DESCRIPTION
#### Description

This PR:
* Updates Rust version for macro tests to 1.51
* Enables const generics component tests for yew-functional-macro
* Applies Clippy and Rustfmt fixes

Fixes #1766

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  (Non applicable)

