### PR TITLE
Install trunk in 1s to speed-up CI/CD

### DIFF
--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -29,9 +29,15 @@ jobs:
           restore-keys: |
             cargo-${{ runner.os }}-
 
-      - name: Install trunk
-        run: |
-          cargo install trunk wasm-bindgen-cli
+      - uses: jetli/trunk-action@v0.1.0
+        with:
+          # Optional version of trunk to install(eg. 'v0.8.1', 'latest')
+          version: 'latest'
+          
+      - uses: jetli/wasm-bindgen-action@v0.1.0
+        with:
+          # Optional version of wasm-bindgen to install(eg. '0.2.68', 'latest')
+          version: 'latest'
 
       - name: Build examples
         run: |


### PR DESCRIPTION
#### Description

Use trunk-action and wasm-bindgen-action, speed up publish-examples from 11m to 1s, e.g.  in this build: https://github.com/yewstack/yew/runs/2289071966?check_suite_focus=true, Install trunk step takes up to 12m, but in this build:  https://github.com/AlephAlpha/muicss-yew/runs/2258767096, Install wasm-bindgen and Install trunk only take 1s each.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
