### PR TITLE
Specify target to make example work

### DIFF
--- a/docs/getting-started/build-a-sample-app.md
+++ b/docs/getting-started/build-a-sample-app.md
@@ -108,7 +108,7 @@ cargo install --locked trunk
 cargo install wasm-bindgen-cli
 ```
 
-Also specify the rust target.
+Also specify the WASM target.
 ```
 rustup target add wasm32-unknown-unknown
 ```

--- a/docs/getting-started/build-a-sample-app.md
+++ b/docs/getting-started/build-a-sample-app.md
@@ -108,6 +108,11 @@ cargo install --locked trunk
 cargo install wasm-bindgen-cli
 ```
 
+Also specify the rust target.
+```
+rustup target add wasm32-unknown-unknown
+```
+
 Now all you have to do is run the following:
 
 ```bash


### PR DESCRIPTION
The target needs to specified. Added it to the example docs.

The example at https://yew.rs/docs/en/next/ won't work without it.