### PR TITLE
Fix crash in link to destroyed agents

### DIFF
--- a/packages/yew/src/agent/link.rs
+++ b/packages/yew/src/agent/link.rs
@@ -207,6 +207,7 @@ where
                     .take()
                     .expect("trying to destroy not existent agent");
                 agent.destroy();
+                state.destroyed = true;
             }
         }
     }


### PR DESCRIPTION
#### Description

The destroyed field on the agent state was never set, so the early return in `run` didn't prevent crashes when agents receive messages after they are destroyed.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [X] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
