### PR TITLE
Remove unnecessary allocation from `AnyScope`

### DIFF
--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -21,9 +21,9 @@ use web_sys::{Element, Node};
 /// Untyped scope used for accessing parent scope
 #[derive(Debug, Clone)]
 pub struct AnyScope {
-    pub(crate) type_id: TypeId,
-    pub(crate) parent: Option<Rc<AnyScope>>,
-    pub(crate) state: Rc<dyn Any>,
+    type_id: TypeId,
+    parent: Option<Rc<AnyScope>>,
+    state: Rc<dyn Any>,
 }
 
 impl<COMP: Component> From<Scope<COMP>> for AnyScope {
@@ -31,12 +31,21 @@ impl<COMP: Component> From<Scope<COMP>> for AnyScope {
         AnyScope {
             type_id: TypeId::of::<COMP>(),
             parent: scope.parent,
-            state: Rc::new(scope.state),
+            state: scope.state,
         }
     }
 }
 
 impl AnyScope {
+    #[cfg(test)]
+    pub(crate) fn test() -> Self {
+        Self {
+            type_id: TypeId::of::<()>(),
+            parent: None,
+            state: Rc::new(()),
+        }
+    }
+
     /// Returns the parent scope
     pub fn get_parent(&self) -> Option<&AnyScope> {
         self.parent.as_deref()
@@ -53,9 +62,8 @@ impl AnyScope {
             parent: self.parent,
             state: self
                 .state
-                .downcast_ref::<Shared<Option<ComponentState<COMP>>>>()
-                .expect("unexpected component type")
-                .clone(),
+                .downcast::<RefCell<Option<ComponentState<COMP>>>>()
+                .expect("unexpected component type"),
         }
     }
 }

--- a/packages/yew/src/virtual_dom/vcomp.rs
+++ b/packages/yew/src/virtual_dom/vcomp.rs
@@ -459,11 +459,7 @@ mod tests {
     use super::{AnyScope, Element};
 
     fn setup_parent() -> (AnyScope, Element) {
-        let scope = AnyScope {
-            type_id: std::any::TypeId::of::<()>(),
-            parent: None,
-            state: std::rc::Rc::new(()),
-        };
+        let scope = AnyScope::test();
         let parent = document().create_element("div").unwrap();
 
         document().body().unwrap().append_child(&parent).unwrap();
@@ -527,11 +523,7 @@ mod tests {
 
     #[test]
     fn reset_node_ref() {
-        let scope = AnyScope {
-            type_id: std::any::TypeId::of::<()>(),
-            parent: None,
-            state: std::rc::Rc::new(()),
-        };
+        let scope = AnyScope::test();
         let parent = document().create_element("div").unwrap();
 
         document().body().unwrap().append_child(&parent).unwrap();

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -502,7 +502,7 @@ where
 mod tests {
     use super::*;
     use crate::html;
-    use std::any::TypeId;
+
     #[cfg(feature = "wasm_test")]
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
@@ -510,11 +510,7 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     fn test_scope() -> AnyScope {
-        AnyScope {
-            type_id: TypeId::of::<()>(),
-            parent: None,
-            state: Rc::new(()),
-        }
+        AnyScope::test()
     }
 
     #[test]


### PR DESCRIPTION
#### Description

`Rc<dyn Any>` can be directly downcasted into an `Rc<T>` so there is no need to add a new layer of `Rc`.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
