### PR TITLE
Impl IntoOptPropValue for Option<V> -> Option<T>

### DIFF
--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -64,6 +64,12 @@ macro_rules! impl_into_prop {
                 Some({ $conversion })
             }
         }
+        // implement Option<V> -> Option<T>
+        impl IntoOptPropValue<$to_ty> for Option<$from_ty> {
+            fn into_opt_prop_value(self) -> Option<$to_ty> {
+                self.map(|$value| $value.into_prop_value())
+            }
+        }
     };
 }
 

--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -67,7 +67,7 @@ macro_rules! impl_into_prop {
         // implement Option<V> -> Option<T>
         impl IntoOptPropValue<$to_ty> for Option<$from_ty> {
             fn into_opt_prop_value(self) -> Option<$to_ty> {
-                self.map(|$value| $value.into_prop_value())
+                self.map(IntoPropValue::into_prop_value)
             }
         }
     };


### PR DESCRIPTION
The only implemented types are those passed to impl_into_prop! macro

#### Description

I need this so I can pass `Option<String>` to some html attributes such as `style` and `id`.

Here is an simplified example of what I have:
```rust
impl Compoent for Input {
    fn view(&self) -> Html {
        // this is Option<String>
        let input_style = self.design_system.get_style::<Input>(self);
        <input style=input_style ...etc />
    }
}
```

without this PR I get error saying:
```shell
error[E0277]: the trait bound `Option<std::string::String>: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
   --> src/input.rs:258:30
    |
258 |                        style=input_style
    |                              ^^^^^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `Option<std::string::String>`
    | 
   ::: .../yew/packages/yew/src/virtual_dom/mod.rs:69:47
    |
69  |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
    |                                               --------------------------- required by this bound in `PositionalAttr::new`
    |
    = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `Option<std::string::String>`
```

#### Checklist

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
