### PR TITLE
Fix warning about callbacks

### DIFF
--- a/yew-router/src/agent/mod.rs
+++ b/yew-router/src/agent/mod.rs
@@ -113,7 +113,9 @@ where
     }
 
     fn connected(&mut self, id: HandlerId) {
-        self.subscribers.insert(id);
+        if id.is_respondable() {
+            self.subscribers.insert(id);
+        }
     }
 
     fn handle_input(&mut self, msg: Self::Input, who: HandlerId) {


### PR DESCRIPTION
The following warning is shown in the log:

~~~
/usr/src/.cargo-container-home/registry/src/github.com-1ecc6299db9ec823/yew-0.17.4/src/agent/pool.rs:30 The Id of the handler: 12, while present in the slab, is not associated with a callback.
~~~

This change fixes this by not adding handlers what are not "respondable".

#### Description

<!-- Please include a summary of the change. -->

Fixes #870

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
