### PR TITLE
Fix the use_context example

### DIFF
--- a/docs/concepts/function-components/pre-defined-hooks.md
+++ b/docs/concepts/function-components/pre-defined-hooks.md
@@ -229,13 +229,14 @@ struct Theme {
 /// Main component 
 #[function_component(App)]
 pub fn app() -> Html {
-    let (ctx, _set_ctx) = use_state(|| Theme {
+    let ctx = use_state(|| Theme {
         foreground: "#000000".to_owned(),
         background: "#eeeeee".to_owned(),
     });
 
     html! {
-        // `ctx` is type `Rc<Theme>` while we need `Theme` so we deref it
+        // `ctx` is type `Rc<UseStateHandle<Theme>>` while we need `Theme` so we deref it
+        // It derefs to `&Theme`, hence the clone
         <ContextProvider<Theme> context=(*ctx).clone()>
             // Every child here and their children will have access to this context.
             <Toolbar />


### PR DESCRIPTION
#### Description

I overlooked this example when the docs for the new `use_state`, this PR fixes that.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
