### PR TITLE
Fix broken references to yew_services

### DIFF
--- a/docs/concepts/services/fetch.md
+++ b/docs/concepts/services/fetch.md
@@ -26,7 +26,7 @@ pub type Binary = Result<Vec<u8>, Error>;
 Here is what a typical GET request will look like:
 ```rust
 use yew::format::Nothing;
-use yew_services::fetch::Request;
+use yew::services::fetch::Request;
 let get_request = Request::get("https://example.com/api/v1/get/something")
     .body(Nothing)
     .expect("Could not build that request");
@@ -36,7 +36,7 @@ Here is what a typical POST request will look like:
 ```rust
 use serde_json::json;
 use yew::format::Json;
-use yew_services::fetch::Request;
+use yew::services::fetch::Request;
 let post_request = Request::post("https://example.com/api/v1/post/something")
     .header("Content-Type", "application/json")
     .body(Json(&json!({"key": "value"})))
@@ -95,7 +95,7 @@ An illustrated example of how to fetch data from an API giving information about
 
 use serde::Deserialize;
 use yew::{format::{Json, Nothing}, prelude::*};
-use yew_services::fetch::{FetchService, FetchTask, Request, Response};
+use yew::services::fetch::{FetchService, FetchTask, Request, Response};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ISSPosition {
@@ -238,6 +238,6 @@ The Rust Wasm Book also contains [useful debugging tips](https://rustwasm.github
 for Wasm applications.
 
 ## Further reading
-* [The API documentation](https://docs.rs/yew-services/latest/yew_services/fetch/index.html)
+* [The API documentation](https://docs.rs/yew/latest/yew/services/fetch/index.html)
 * The [dashboard](https://github.com/yewstack/yew/tree/master/examples/dashboard) example.
 * [The Rust Wasm Book on debugging Wasm applications](https://rustwasm.github.io/book/reference/debugging.html)

--- a/docs/more/debugging.md
+++ b/docs/more/debugging.md
@@ -5,12 +5,12 @@ title: Debugging
 ## Panics
 
 The [`console_error_panic`](https://github.com/rustwasm/console_error_panic_hook) crate catches
-`panic!`s and outputs them to the console. Yew will automatically catch `panic!`s and log them to
-your browser's console.
+`panic!`s and outputs them to the console. Yew automatically catches `panic!`s and logs them to
+the browser console.
 
 ## Console Logging
 
-In general, Wasm web apps are able to interact with Browser APIs, and the `console.log` API is no 
+In general, Wasm web apps are able to interact with Browser APIs. The `console.log` API is no 
 exception. There are a few options available:
 
 ### [`wasm-logger`](https://crates.io/crates/wasm-logger)
@@ -27,9 +27,9 @@ fn main() {
 log::info!("Update: {:?}", msg);
 ```
 
-### [`ConsoleService`](https://docs.rs/yew-services/latest/yew_services/struct.ConsoleService.html)
+### [`ConsoleService`](https://docs.rs/yew/latest/yew/services/console/struct.ConsoleService.html)
 
-This service is included within the [`yew-services`](https://crates.io/crates/yew-services) crate:
+This service is included with Yew.
 
 ```rust
 // usage
@@ -38,7 +38,7 @@ ConsoleService::info(format!("Update: {:?}", msg));
 
 ## Source Maps
 
-There is currently no first-class support for source maps for Rust / Wasm web apps. This, of course, is subject to change. If this is no longer true or if progress is made, please suggest a change!
+There is currently no first-class support for source maps for Rust/Wasm web apps. This could change in the future.
 
 ### Latest Info
 

--- a/docs/more/debugging.md
+++ b/docs/more/debugging.md
@@ -6,7 +6,7 @@ title: Debugging
 
 The [`console_error_panic`](https://github.com/rustwasm/console_error_panic_hook) crate catches
 `panic!`s and outputs them to the console. Yew automatically catches `panic!`s and logs them to
-the browser console.
+the browser's console.
 
 ## Console Logging
 

--- a/docs/more/debugging.md
+++ b/docs/more/debugging.md
@@ -10,7 +10,7 @@ the browser's console.
 
 ## Console Logging
 
-In general, Wasm web apps are able to interact with Browser APIs. The `console.log` API is no 
+Wasm web apps can call Browser APIs. The `console.log` API is no 
 exception. There are a few options available:
 
 ### [`wasm-logger`](https://crates.io/crates/wasm-logger)


### PR DESCRIPTION
Update the `use` statement in the Fetch example.
Fix the broken links to Rust docs.

Improve wording.