### PR TITLE
yew-macro: fix inability to set the autoplay attribute

### DIFF
--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -85,6 +85,7 @@ lazy_static! {
         vec![
             "async",
             "autofocus",
+            "autoplay",
             "controls",
             "default",
             "defer",

--- a/packages/yew-macro/tests/html_macro/html-block-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/html-block-fail.stderr
@@ -34,9 +34,9 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
 15 |         <>{ for (0..3).map(|_| not_tree()) }</>
    |                 ^^^^^^ `()` cannot be formatted with the default formatter
    |
-  ::: $WORKSPACE/packages/yew/src/utils.rs
+  ::: $WORKSPACE/packages/yew/src/utils.rs:76:8
    |
-   |     T: Into<R>,
+76 |     T: Into<R>,
    |        ------- required by this bound in `into_node_iter`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`

--- a/packages/yew-macro/tests/html_macro/html-element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/html-element-fail.stderr
@@ -202,9 +202,9 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<Cow<'static, str>>>` is 
 45 |     html! { <a href=() /> };
    |                     ^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `()`
    |
-  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs
+  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs:69:47
    |
-   |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
+69 |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
    |                                               --------------------------- required by this bound in `PositionalAttr::new`
    |
    = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `()`
@@ -215,9 +215,9 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<Cow<'static, st
 46 |     html! { <input string=NotToString /> };
    |                           ^^^^^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `NotToString`
    |
-  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs
+  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs:69:47
    |
-   |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
+69 |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
    |                                               --------------------------- required by this bound in `PositionalAttr::new`
    |
    = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `NotToString`
@@ -228,9 +228,9 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<Cow<'st
 47 |     html! { <a media=Some(NotToString) /> };
    |                      ^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `Option<NotToString>`
    |
-  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs
+  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs:69:47
    |
-   |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
+69 |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
    |                                               --------------------------- required by this bound in `PositionalAttr::new`
    |
    = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `Option<NotToString>`
@@ -241,9 +241,9 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<Cow<'stat
 48 |     html! { <a href=Some(5) /> };
    |                     ^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `Option<{integer}>`
    |
-  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs
+  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs:69:47
    |
-   |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
+69 |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
    |                                               --------------------------- required by this bound in `PositionalAttr::new`
    |
    = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `Option<{integer}>`
@@ -254,9 +254,9 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<Option<yew::Callback<Mou
 51  |       html! { <input onclick=1 /> };
     |                              ^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `{integer}`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/listener_web_sys.rs
+   ::: $WORKSPACE/packages/yew/src/html/listener/listener_web_sys.rs:2:1
     |
-    | / impl_action! {
+2   | / impl_action! {
 3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
@@ -279,9 +279,9 @@ error[E0277]: the trait bound `yew::Callback<String>: IntoPropValue<Option<yew::
 52  |       html! { <input onclick=Callback::from(|a: String| ()) /> };
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `yew::Callback<String>`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/listener_web_sys.rs
+   ::: $WORKSPACE/packages/yew/src/html/listener/listener_web_sys.rs:2:1
     |
-    | / impl_action! {
+2   | / impl_action! {
 3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
@@ -298,9 +298,9 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<yew::Call
 53  |       html! { <input onfocus=Some(5) /> };
     |                              ^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<FocusEvent>>>` is not implemented for `Option<{integer}>`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/listener_web_sys.rs
+   ::: $WORKSPACE/packages/yew/src/html/listener/listener_web_sys.rs:2:1
     |
-    | / impl_action! {
+2   | / impl_action! {
 3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -23,6 +23,7 @@ fn compile_pass() {
                     <option selected=true disabled=false value="">{"Selected"}</option>
                     <option selected=false disabled=true value="">{"Unselected"}</option>
                 </select>
+                <video autoplay=true controls=true />
             </div>
             <svg width="149" height="147" viewBox="0 0 149 147" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M60.5776 13.8268L51.8673 42.6431L77.7475 37.331L60.5776 13.8268Z" fill="#DEB819"/>

--- a/packages/yew-macro/tests/html_macro/html-iterable-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/html-iterable-fail.stderr
@@ -70,9 +70,9 @@ error[E0277]: `()` is not an iterator
 18 |             { for () }
    |                   ^^ `()` is not an iterator
    |
-  ::: $WORKSPACE/packages/yew/src/utils.rs
+  ::: $WORKSPACE/packages/yew/src/utils.rs:75:9
    |
-   |     IT: IntoIterator<Item = T>,
+75 |     IT: IntoIterator<Item = T>,
    |         ---------------------- required by this bound in `into_node_iter`
    |
    = help: the trait `Iterator` is not implemented for `()`


### PR DESCRIPTION
#### Description

Fixes regression introduced in v0.17.4 -> v0.18.0, whereby you can no longer set the `autoplay` attribute, as it requires a boolean value but expands into a call to `PositionalAttr::new()` instead of `PositionalAttr::new_boolean()`, resulting in the following error:

```
autoplay=true
         ^^^^ the trait `IntoPropValue<std::option::Option<Cow<'static, str>>>` is not implemented for `bool`
```

After this passes, I will check if master is affected and merge + PR, if needed. 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow` (test fail even on unmodified v0.18 for me; lets see what the CI will say) 
- [x] I have reviewed my own code
- [x] I have added tests (extended one)
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
