### PR TITLE
Optimize vtag construction

### DIFF
--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -200,6 +200,7 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required because of the requirements on the impl of `ToString` for `()`
+   = note: required by `to_string`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/element-fail.rs:30:21

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slab = "0.4"
 thiserror = "1"
-wasm-bindgen = "0.2.60"
+wasm-bindgen = "0.2.74"
 wasm-bindgen-futures = "0.4"
 yew-macro = { version = "0.17.0", path = "../yew-macro" }
 
@@ -107,7 +107,7 @@ rustversion = "1.0"
 serde_derive = "1"
 ssri = "6.0.0"
 trybuild = "1.0"
-wasm-bindgen-test = "0.3.4"
+wasm-bindgen-test = "0.3.24"
 
 [features]
 default = ["agent"]

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -55,12 +55,10 @@ type Listeners = Vec<Rc<dyn Listener>>;
 pub struct PositionalAttr(pub &'static str, pub Option<Cow<'static, str>>);
 impl PositionalAttr {
     /// Create a positional attribute
-    #[inline]
     pub fn new(key: &'static str, value: impl Into<Cow<'static, str>>) -> Self {
         Self(key, Some(value.into()))
     }
     /// Create a placeholder for removed attributes
-    #[inline]
     pub fn new_placeholder(key: &'static str) -> Self {
         Self(key, None)
     }

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -55,10 +55,12 @@ type Listeners = Vec<Rc<dyn Listener>>;
 pub struct PositionalAttr(pub &'static str, pub Option<Cow<'static, str>>);
 impl PositionalAttr {
     /// Create a positional attribute
+    #[inline]
     pub fn new(key: &'static str, value: impl Into<Cow<'static, str>>) -> Self {
         Self(key, Some(value.into()))
     }
     /// Create a placeholder for removed attributes
+    #[inline]
     pub fn new_placeholder(key: &'static str) -> Self {
         Self(key, None)
     }

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -33,7 +33,6 @@ enum ElementType {
 }
 
 impl ElementType {
-    #[inline]
     fn from_tag(tag: &str) -> Self {
         match tag.to_ascii_lowercase().as_str() {
             "input" => Self::Input,
@@ -124,7 +123,6 @@ impl VTag {
     // Allows the compiler to inline property and child list construction in the html! macro.
     // This enables higher instruction parallelism by reducing data dependency and avoids `memcpy`
     // of child `VTag`s.
-    #[inline]
     #[allow(clippy::too_many_arguments)]
     pub fn __new_complete(
         tag: impl Into<Cow<'static, str>>,

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -118,11 +118,11 @@ impl VTag {
 
     /// Creates a new `VTag` instance with `tag` name (cannot be changed later in DOM).
     ///
-    /// Unlike `new()`, this sets all the public fields of `VTag` in one call.
+    /// Unlike `new()`, this sets all the public fields of `VTag` in one call. This allows the
+    /// compiler to inline property and child list construction in the html! macro. This enables
+    /// higher instruction parallelism by reducing data dependency and avoids `memcpy` of Vtag
+    /// fields amd child `VTag`s.
     #[doc(hidden)]
-    // Allows the compiler to inline property and child list construction in the html! macro.
-    // This enables higher instruction parallelism by reducing data dependency and avoids `memcpy`
-    // of child `VTag`s.
     #[allow(clippy::too_many_arguments)]
     pub fn __new_complete(
         tag: impl Into<Cow<'static, str>>,


### PR DESCRIPTION
#### Description

Reduced needless copying and reallocations in `VTag` construction from the `html!` macro. 

Benchmark results using https://github.com/bakape/js-framework-benchmark
![Screenshot_20210523_195218](https://user-images.githubusercontent.com/7851952/119269445-6d9d9d80-bc00-11eb-8eff-37b47e3f5423.png)


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
