### PR TITLE
Fix the link to new doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@
   </p>
 
   <h4>
-    <a href="https://yew.rs/docs/">Documentation (stable)</a>
+    <a href="https://yew.rs/docs/index">Documentation (stable)</a>
     <span> | </span>
-    <a href="https://yew.rs/docs/next/">Documentation (latest)</a>
+    <a href="https://yew.rs/docs/next/index">Documentation (latest)</a>
     <span> | </span>
-    <a href="https://github.com/yewstack/yew/tree/v0.17/examples">Examples</a>
+    <a href="https://github.com/yewstack/yew/tree/v0.18/examples">Examples</a>
     <span> | </span>
     <a href="https://github.com/yewstack/yew/blob/master/CHANGELOG.md">Changelog</a>
     <span> | </span>
     <a href="https://yew.rs/docs/more/roadmap">Roadmap</a>
     <span> | </span>
-    <a href="https://yew.rs/docs/zh-CN/">简体中文文档</a>
+    <a href="https://yew.rs/zh-CN/docs/index">简体中文文档</a>
     <span> | </span>
-    <a href="https://yew.rs/docs/zh-TW/">繁體中文文檔</a>
+    <a href="https://yew.rs/zh-TW/docs/index">繁體中文文檔</a>
     <span> | </span>
-    <a href="https://yew.rs/docs/ja/">ドキュメント</a>
+    <a href="https://yew.rs/ja/docs/index">ドキュメント</a>
   </h4>
 </div>
 


### PR DESCRIPTION
the Documentation (latest) link is still broken.

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests

