### PR TITLE
Enable Rust syntax highlighting on docs website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -88,7 +88,7 @@ module.exports = {
       ],
     },
     prism: {
-      // TODO additionalLanguages: ['rust'],
+      additionalLanguages: ['rust'],
     },
     algolia: {
       apiKey: "bbaacf676920f3836ccab85fb87dd37c",


### PR DESCRIPTION
#### Description

Enables syntax highlighting for Rust on the new Docusaurus v2 website.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
