### PR TITLE
Bring the context method more inline with other Yew APIs by separating

### DIFF
--- a/packages/yew-functional/src/lib.rs
+++ b/packages/yew-functional/src/lib.rs
@@ -149,7 +149,7 @@ where
     }
 }
 
-pub(crate) fn get_current_scope() -> Option<AnyScope> {
+pub fn get_current_scope() -> Option<AnyScope> {
     if CURRENT_HOOK.is_set() {
         Some(CURRENT_HOOK.with(|state| state.scope.clone()))
     } else {

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -7,7 +7,7 @@ use super::{
     Component,
 };
 use crate::callback::Callback;
-use crate::context::{ContextHandle, ContextProvider};
+use crate::context::{Context, ContextProvider};
 use crate::html::NodeRef;
 use crate::scheduler::{self, Shared};
 use crate::utils::document;
@@ -79,13 +79,10 @@ impl AnyScope {
 
     /// Accesses a value provided by a parent `ContextProvider` component of the
     /// same type.
-    pub fn context<T: Clone + PartialEq + 'static>(
-        &self,
-        callback: Callback<T>,
-    ) -> Option<(T, ContextHandle<T>)> {
+    pub fn context<T: Clone + PartialEq + 'static>(&self) -> Option<Context<T>> {
         let scope = self.find_parent_scope::<ContextProvider<T>>()?;
         let component = scope.get_component()?;
-        Some(component.subscribe_consumer(callback))
+        Some(component.context.clone())
     }
 }
 
@@ -336,11 +333,8 @@ impl<COMP: Component> Scope<COMP> {
 
     /// Accesses a value provided by a parent `ContextProvider` component of the
     /// same type.
-    pub fn context<T: Clone + PartialEq + 'static>(
-        &self,
-        callback: Callback<T>,
-    ) -> Option<(T, ContextHandle<T>)> {
-        self.to_any().context(callback)
+    pub fn context<T: Clone + PartialEq + 'static>(&self) -> Option<Context<T>> {
+        self.to_any().context()
     }
 }
 


### PR DESCRIPTION
registration from getting the current context value.

#### Description

The `context()` method on scopes now returns a `Context<T>` object. This object has separate methods to access the current context vs listen for when the context changes. The `use_context` hook continues to automatically do both.

The need for this split became apparant during the work on #1860 but makes sense to merge separately.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
