### PR TITLE
Bring back &str assignment to optional properties

### DIFF
--- a/packages/yew-functional-macro/tests/function_attr/generic-props-fail.stderr
+++ b/packages/yew-functional-macro/tests/function_attr/generic-props-fail.stderr
@@ -22,9 +22,9 @@ error[E0599]: the function or associated item `new` exists for struct `VChild<Fu
 28 |     html! { <Comp<MissingTypeBounds> /> };
    |              ^^^^ function or associated item cannot be called on `VChild<FunctionComponent<comp<MissingTypeBounds>>>` due to unsatisfied trait bounds
    |
-  ::: $WORKSPACE/packages/yew-functional/src/lib.rs
+  ::: $WORKSPACE/packages/yew-functional/src/lib.rs:73:1
    |
-   | pub struct FunctionComponent<T: FunctionProvider + 'static> {
+73 | pub struct FunctionComponent<T: FunctionProvider + 'static> {
    | ----------------------------------------------------------- doesn't satisfy `_: yew::Component`
    |
    = note: the following trait bounds were not satisfied:

--- a/packages/yew-macro/tests/html_macro/block-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/block-fail.stderr
@@ -34,9 +34,9 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
 15 |         <>{ for (0..3).map(|_| not_tree()) }</>
    |                 ^^^^^^ `()` cannot be formatted with the default formatter
    |
-  ::: $WORKSPACE/packages/yew/src/utils.rs
+  ::: $WORKSPACE/packages/yew/src/utils.rs:51:8
    |
-   |     T: Into<R>,
+51 |     T: Into<R>,
    |        ------- required by this bound in `into_node_iter`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -213,10 +213,10 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
    |
    = help: the following implementations were found:
              <&'static str as IntoPropValue<Cow<'static, str>>>
+             <&'static str as IntoPropValue<Option<Cow<'static, str>>>>
+             <&'static str as IntoPropValue<Option<String>>>
              <&'static str as IntoPropValue<String>>
-             <&T as IntoPropValue<Option<T>>>
-             <&T as IntoPropValue<T>>
-           and 4 others
+           and 11 others
 
 error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfied
   --> $DIR/component-fail.rs:79:26
@@ -226,10 +226,10 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
    |
    = help: the following implementations were found:
              <&'static str as IntoPropValue<Cow<'static, str>>>
+             <&'static str as IntoPropValue<Option<Cow<'static, str>>>>
+             <&'static str as IntoPropValue<Option<String>>>
              <&'static str as IntoPropValue<String>>
-             <&T as IntoPropValue<Option<T>>>
-             <&T as IntoPropValue<T>>
-           and 4 others
+           and 11 others
 
 error[E0308]: mismatched types
   --> $DIR/component-fail.rs:80:30

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -185,16 +185,12 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<Cow<'static, str>>>` is 
    |
 43 |     html! { <input type=() /> };
    |                         ^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `()`
-   |
-   = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `()`
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
   --> $DIR/element-fail.rs:44:26
    |
 44 |     html! { <input value=() /> };
    |                          ^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `()`
-   |
-   = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `()`
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
   --> $DIR/element-fail.rs:45:21
@@ -202,12 +198,10 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<Cow<'static, str>>>` is 
 45 |     html! { <a href=() /> };
    |                     ^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `()`
    |
-  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs
+  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs:61:47
    |
-   |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
-   |                                               --------------------------- required by this bound in `PositionalAttr::new`
-   |
-   = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `()`
+61 |     pub fn new(key: &'static str, value: impl IntoPropValue<Option<AttrValue>>) -> Self {
+   |                                               -------------------------------- required by this bound in `PositionalAttr::new`
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
   --> $DIR/element-fail.rs:46:27
@@ -215,12 +209,10 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<Cow<'static, st
 46 |     html! { <input string=NotToString /> };
    |                           ^^^^^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `NotToString`
    |
-  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs
+  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs:61:47
    |
-   |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
-   |                                               --------------------------- required by this bound in `PositionalAttr::new`
-   |
-   = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `NotToString`
+61 |     pub fn new(key: &'static str, value: impl IntoPropValue<Option<AttrValue>>) -> Self {
+   |                                               -------------------------------- required by this bound in `PositionalAttr::new`
 
 error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
   --> $DIR/element-fail.rs:47:22
@@ -228,12 +220,15 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<Cow<'st
 47 |     html! { <a media=Some(NotToString) /> };
    |                      ^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `Option<NotToString>`
    |
-  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs
+  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs:61:47
    |
-   |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
-   |                                               --------------------------- required by this bound in `PositionalAttr::new`
+61 |     pub fn new(key: &'static str, value: impl IntoPropValue<Option<AttrValue>>) -> Self {
+   |                                               -------------------------------- required by this bound in `PositionalAttr::new`
    |
-   = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `Option<NotToString>`
+   = help: the following implementations were found:
+             <Option<&'static str> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
   --> $DIR/element-fail.rs:48:21
@@ -241,12 +236,15 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<Cow<'stat
 48 |     html! { <a href=Some(5) /> };
    |                     ^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `Option<{integer}>`
    |
-  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs
+  ::: $WORKSPACE/packages/yew/src/virtual_dom/mod.rs:61:47
    |
-   |     pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
-   |                                               --------------------------- required by this bound in `PositionalAttr::new`
+61 |     pub fn new(key: &'static str, value: impl IntoPropValue<Option<AttrValue>>) -> Self {
+   |                                               -------------------------------- required by this bound in `PositionalAttr::new`
    |
-   = note: required because of the requirements on the impl of `IntoOptPropValue<Cow<'static, str>>` for `Option<{integer}>`
+   = help: the following implementations were found:
+             <Option<&'static str> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
 
 error[E0277]: the trait bound `{integer}: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
    --> $DIR/element-fail.rs:51:28
@@ -254,9 +252,9 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<Option<yew::Callback<Mou
 51  |       html! { <input onclick=1 /> };
     |                              ^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `{integer}`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
+   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs:2:1
     |
-    | / impl_action! {
+2   | / impl_action! {
 3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
@@ -267,11 +265,10 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<Option<yew::Callback<Mou
     |
     = help: the following implementations were found:
               <&'static str as IntoPropValue<Cow<'static, str>>>
+              <&'static str as IntoPropValue<Option<Cow<'static, str>>>>
+              <&'static str as IntoPropValue<Option<String>>>
               <&'static str as IntoPropValue<String>>
-              <&T as IntoPropValue<Option<T>>>
-              <&T as IntoPropValue<T>>
-            and 4 others
-    = note: required because of the requirements on the impl of `IntoOptPropValue<yew::Callback<MouseEvent>>` for `{integer}`
+            and 11 others
 
 error[E0277]: the trait bound `yew::Callback<String>: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
    --> $DIR/element-fail.rs:52:28
@@ -279,9 +276,9 @@ error[E0277]: the trait bound `yew::Callback<String>: IntoPropValue<Option<yew::
 52  |       html! { <input onclick=Callback::from(|a: String| ()) /> };
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `yew::Callback<String>`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
+   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs:2:1
     |
-    | / impl_action! {
+2   | / impl_action! {
 3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
@@ -289,8 +286,6 @@ error[E0277]: the trait bound `yew::Callback<String>: IntoPropValue<Option<yew::
 99  | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
 100 | | }
     | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
-    |
-    = note: required because of the requirements on the impl of `IntoOptPropValue<yew::Callback<MouseEvent>>` for `yew::Callback<String>`
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<yew::Callback<FocusEvent>>>` is not satisfied
    --> $DIR/element-fail.rs:53:28
@@ -298,9 +293,9 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<yew::Call
 53  |       html! { <input onfocus=Some(5) /> };
     |                              ^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<FocusEvent>>>` is not implemented for `Option<{integer}>`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
+   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs:2:1
     |
-    | / impl_action! {
+2   | / impl_action! {
 3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
@@ -309,7 +304,10 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<yew::Call
 100 | | }
     | |_- required by this bound in `yew::html::onfocus::Wrapper::__macro_new`
     |
-    = note: required because of the requirements on the impl of `IntoOptPropValue<yew::Callback<FocusEvent>>` for `Option<{integer}>`
+    = help: the following implementations were found:
+              <Option<&'static str> as IntoPropValue<Option<Cow<'static, str>>>>
+              <Option<&'static str> as IntoPropValue<Option<String>>>
+              <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
 
 error[E0308]: mismatched types
   --> $DIR/element-fail.rs:56:24

--- a/packages/yew-macro/tests/html_macro/iterable-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/iterable-fail.stderr
@@ -70,9 +70,9 @@ error[E0277]: `()` is not an iterator
 18 |             { for () }
    |                   ^^ `()` is not an iterator
    |
-  ::: $WORKSPACE/packages/yew/src/utils.rs
+  ::: $WORKSPACE/packages/yew/src/utils.rs:50:9
    |
-   |     IT: IntoIterator<Item = T>,
+50 |     IT: IntoIterator<Item = T>,
    |         ---------------------- required by this bound in `into_node_iter`
    |
    = help: the trait `Iterator` is not implemented for `()`

--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -1,4 +1,4 @@
-use super::{IntoOptPropValue, IntoPropValue};
+use super::IntoPropValue;
 use crate::virtual_dom::AttrValue;
 use indexmap::IndexSet;
 use std::{
@@ -74,8 +74,8 @@ impl IntoPropValue<AttrValue> for Classes {
     }
 }
 
-impl IntoOptPropValue<AttrValue> for Classes {
-    fn into_opt_prop_value(self) -> Option<AttrValue> {
+impl IntoPropValue<Option<AttrValue>> for Classes {
+    fn into_prop_value(self) -> Option<AttrValue> {
         if self.is_empty() {
             None
         } else {

--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -58,15 +58,15 @@ macro_rules! impl_into_prop {
             }
         }
         // implement V -> Option<T>
-        impl IntoOptPropValue<$to_ty> for $from_ty {
-            fn into_opt_prop_value(self) -> Option<$to_ty> {
+        impl IntoPropValue<Option<$to_ty>> for $from_ty {
+            fn into_prop_value(self) -> Option<$to_ty> {
                 let $value = self;
                 Some({ $conversion })
             }
         }
         // implement Option<V> -> Option<T>
-        impl IntoOptPropValue<$to_ty> for Option<$from_ty> {
-            fn into_opt_prop_value(self) -> Option<$to_ty> {
+        impl IntoPropValue<Option<$to_ty>> for Option<$from_ty> {
+            fn into_prop_value(self) -> Option<$to_ty> {
                 self.map(IntoPropValue::into_prop_value)
             }
         }
@@ -79,17 +79,15 @@ impl_into_prop!(|value: &'static str| -> String { value.to_owned() });
 impl_into_prop!(|value: &'static str| -> Cow<'static, str> { Cow::Borrowed(value) });
 impl_into_prop!(|value: String| -> Cow<'static, str> { Cow::Owned(value) });
 
-/// A trait similar to `Into<Option<T>>` which allows conversion to an optional value of a
-/// `Properties` struct.
-pub trait IntoOptPropValue<T> {
-    /// Convert `self` to an optional value of a `Properties` struct.
-    fn into_opt_prop_value(self) -> Option<T>;
-}
-impl<T, V> IntoOptPropValue<V> for T
-where
-    T: IntoPropValue<Option<V>>,
-{
-    fn into_opt_prop_value(self) -> Option<V> {
-        self.into_prop_value()
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_str() {
+        let _: String = "foo".into_prop_value();
+        let _: Option<String> = "foo".into_prop_value();
+        let _: Cow<'static, str> = "foo".into_prop_value();
+        let _: Option<Cow<'static, str>> = "foo".into_prop_value();
     }
 }

--- a/packages/yew/src/html/listener/macros.rs
+++ b/packages/yew/src/html/listener/macros.rs
@@ -6,7 +6,7 @@ macro_rules! impl_action {
         pub mod $action {
             use crate::callback::Callback;
             #[allow(unused_imports)]
-            use crate::html::{listener::*, IntoOptPropValue};
+            use crate::html::{listener::*, IntoPropValue};
             use crate::virtual_dom::Listener;
             use gloo::events::{EventListener, EventListenerOptions};
             use wasm_bindgen::JsValue;
@@ -26,8 +26,8 @@ macro_rules! impl_action {
                 }
 
                 #[doc(hidden)]
-                pub fn __macro_new(callback: impl IntoOptPropValue<Callback<Event>>) -> Option<Rc<dyn Listener>> {
-                    let callback = callback.into_opt_prop_value()?;
+                pub fn __macro_new(callback: impl IntoPropValue<Option<Callback<Event>>>) -> Option<Rc<dyn Listener>> {
+                    let callback = callback.into_prop_value()?;
                     Some(Rc::new(Self::new(callback)))
                 }
             }

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -13,7 +13,7 @@ pub mod vtag;
 #[doc(hidden)]
 pub mod vtext;
 
-use crate::html::{AnyScope, IntoOptPropValue, NodeRef};
+use crate::html::{AnyScope, IntoPropValue, NodeRef};
 use gloo::events::EventListener;
 use indexmap::IndexMap;
 use std::{borrow::Cow, collections::HashMap, fmt, hint::unreachable_unchecked, iter, mem, rc::Rc};
@@ -58,8 +58,8 @@ pub type AttrValue = Cow<'static, str>;
 pub struct PositionalAttr(pub &'static str, pub Option<AttrValue>);
 impl PositionalAttr {
     /// Create a positional attribute
-    pub fn new(key: &'static str, value: impl IntoOptPropValue<AttrValue>) -> Self {
-        Self(key, value.into_opt_prop_value())
+    pub fn new(key: &'static str, value: impl IntoPropValue<Option<AttrValue>>) -> Self {
+        Self(key, value.into_prop_value())
     }
 
     /// Create a boolean attribute.

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -3,7 +3,7 @@
 use super::{
     AttrValue, Attributes, Key, Listener, Listeners, Patch, PositionalAttr, VDiff, VList, VNode,
 };
-use crate::html::{AnyScope, IntoOptPropValue, IntoPropValue, NodeRef};
+use crate::html::{AnyScope, IntoPropValue, NodeRef};
 use crate::utils::document;
 use gloo::events::EventListener;
 use log::warn;
@@ -140,15 +140,15 @@ impl VTag {
 
     /// Sets `value` for an
     /// [InputElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
-    pub fn set_value(&mut self, value: impl IntoOptPropValue<AttrValue>) {
-        self.value = value.into_opt_prop_value();
+    pub fn set_value(&mut self, value: impl IntoPropValue<Option<AttrValue>>) {
+        self.value = value.into_prop_value();
     }
 
     /// Sets `kind` property of an
     /// [InputElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
     /// Same as set `type` attribute.
-    pub fn set_kind(&mut self, value: impl IntoOptPropValue<AttrValue>) {
-        self.kind = value.into_opt_prop_value();
+    pub fn set_kind(&mut self, value: impl IntoPropValue<Option<AttrValue>>) {
+        self.kind = value.into_prop_value();
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
This drops the "optional" conversion concept in favor of directly converting to `Option<T>`.

#### Description

This drops the `IntoOptPropValue` trait, and uses a conversion to `Option<T>` instead. This brings back the ability to assign `&str` to an `Option<String>` or `Option<Cow<'static, str>>` property.

Fixes #1888 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
- [X] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
