### PR TITLE
Implement `#[bind(...)]` for Routable macro

### DIFF
--- a/examples/router/src/main.rs
+++ b/examples/router/src/main.rs
@@ -15,14 +15,17 @@ pub enum Route {
     #[at("/posts/:id")]
     Post { id: u64 },
     #[at("/posts")]
-    Posts,
+    Posts {
+        #[bind(query)]
+        page: u64,
+    },
     #[at("/authors/:id")]
     Author { id: u64 },
     #[at("/authors")]
     Authors,
     #[at("/")]
     Home,
-    #[not_found]
+    #[bind(not_found)]
     #[at("/404")]
     NotFound,
 }
@@ -111,7 +114,7 @@ impl Model {
                         <Link<Route> classes=classes!("navbar-item") route=Route::Home>
                             { "Home" }
                         </Link<Route>>
-                        <Link<Route> classes=classes!("navbar-item") route=Route::Posts>
+                        <Link<Route> classes=classes!("navbar-item") route=Route::Posts { page: 1 }>
                             { "Posts" }
                         </Link<Route>>
 
@@ -139,8 +142,8 @@ fn switch(routes: &Route) -> Html {
         Route::Post { id } => {
             html! { <Post seed=*id /> }
         }
-        Route::Posts => {
-            html! { <PostList /> }
+        Route::Posts { page } => {
+            html! { <PostList page=page /> }
         }
         Route::Author { id } => {
             html! { <Author seed=*id /> }

--- a/packages/yew-router-macro/Cargo.toml
+++ b/packages/yew-router-macro/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 heck = "0.3.2"
 proc-macro2 = "1.0.24"
 quote = "1.0.9"
-syn = { version = "1.0.64", features = ["full","extra-traits"] }
+syn = { version = "1.0", features = ["full","extra-traits"] }
 
 [dev-dependencies]
 rustversion = "1.0"

--- a/packages/yew-router-macro/src/lib.rs
+++ b/packages/yew-router-macro/src/lib.rs
@@ -1,6 +1,6 @@
 mod routable_derive;
-use routable_derive::{routable_derive_impl, Routable};
-use syn::parse_macro_input;
+use routable_derive::routable_derive_impl;
+use syn::{parse_macro_input, DeriveInput};
 
 /// Derive macro used to mark an enum as Routable.
 ///
@@ -23,8 +23,10 @@ use syn::parse_macro_input;
 ///     NotFound,
 /// }
 /// ```
-#[proc_macro_derive(Routable, attributes(at, not_found))]
+#[proc_macro_derive(Routable, attributes(at, bind))]
 pub fn routable_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = parse_macro_input!(input as Routable);
-    routable_derive_impl(input).into()
+    let input = parse_macro_input!(input as DeriveInput);
+    routable_derive_impl(input)
+        .unwrap_or_else(|it| it.to_compile_error())
+        .into()
 }

--- a/packages/yew-router-macro/src/routable_derive.rs
+++ b/packages/yew-router-macro/src/routable_derive.rs
@@ -53,7 +53,16 @@ pub fn routable_derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                     let attrs = field
                         .attrs
                         .iter()
-                        .filter(|attr| attr.path.is_ident(BIND_ATTR_PATH));
+                        .filter(|attr| attr.path.is_ident(BIND_ATTR_PATH))
+                        .collect::<Vec<_>>();
+
+                    if attrs.len() > 1 {
+                        return Err(syn::Error::new_spanned(
+                            quote! { #(#attrs)* },
+                            "a field can have only one `#[bind(...)]`"
+                        ))
+                    }
+
                     for attr in attrs {
                         // todo maybe don't clone?
                         let ident = field.ident.clone().unwrap(); // named fields have idents

--- a/packages/yew-router-macro/src/routable_derive.rs
+++ b/packages/yew-router-macro/src/routable_derive.rs
@@ -119,6 +119,7 @@ impl Routable {
                         //named fields have idents
                         it.ident.as_ref().unwrap()
                     });
+
                     quote! { Self::#ident { #(#fields: params.get(stringify!(#fields))?.parse().ok()?)*, } }
                 }
                 Fields::Unnamed(_) => unreachable!(), // already checked
@@ -131,7 +132,11 @@ impl Routable {
         });
 
         quote! {
-            fn from_path(path: &str, params: &::std::collections::HashMap<&str, &str>) -> ::std::option::Option<Self> {
+            fn from_path(
+                path: &str,
+                params: &::std::collections::HashMap<&str, &str>,
+                queries: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
+            ) -> ::std::option::Option<Self> {
                 match path {
                     #(#from_path_matches),*,
                     _ => ::std::option::Option::None,
@@ -223,11 +228,11 @@ pub fn routable_derive_impl(input: Routable) -> TokenStream {
                 #cache_thread_local_ident.with(|val| ::std::clone::Clone::clone(&*val.borrow()))
             }
 
-            fn recognize(pathname: &str) -> ::std::option::Option<Self> {
+            fn recognize(location: ::yew_router::__macro::Location) -> ::std::option::Option<Self> {
                 ::std::thread_local! {
                     static ROUTER: ::yew_router::__macro::Router = ::yew_router::__macro::build_router::<#ident>();
                 }
-                let route = ROUTER.with(|router| ::yew_router::__macro::recognize_with_router(router, pathname));
+                let route = ROUTER.with(|router| ::yew_router::__macro::recognize_with_router(router, location));
                 {
                     let route = ::std::clone::Clone::clone(&route);
                     #cache_thread_local_ident.with(move |val| {

--- a/packages/yew-router-macro/src/routable_derive.rs
+++ b/packages/yew-router-macro/src/routable_derive.rs
@@ -1,228 +1,196 @@
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::parse::{Parse, ParseStream};
-use syn::punctuated::Punctuated;
+use quote::{quote, quote_spanned};
+use std::collections::HashMap;
 use syn::spanned::Spanned;
-use syn::{Data, DeriveInput, Fields, Ident, LitStr, Variant};
+use syn::{Data, DeriveInput, Fields, Ident, LitStr};
 
-const AT_ATTR_IDENT: &str = "at";
-const NOT_FOUND_ATTR_IDENT: &str = "not_found";
+const AT_ATTR_PATH: &str = "at";
+const BIND_ATTR_PATH: &str = "bind";
 
-pub struct Routable {
-    ident: Ident,
-    ats: Vec<LitStr>,
-    variants: Punctuated<Variant, syn::token::Comma>,
-    not_found_route: Option<Ident>,
-}
-
-impl Parse for Routable {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let DeriveInput { ident, data, .. } = input.parse()?;
-
-        let data = match data {
-            Data::Enum(data) => data,
-            Data::Struct(s) => {
-                return Err(syn::Error::new(
-                    s.struct_token.span(),
-                    "expected enum, found struct",
-                ))
-            }
-            Data::Union(u) => {
-                return Err(syn::Error::new(
-                    u.union_token.span(),
-                    "expected enum, found union",
-                ))
-            }
-        };
-
-        let (not_found_route, ats) = parse_variants_attributes(&data.variants)?;
-
-        Ok(Self {
-            ident,
-            variants: data.variants,
-            ats,
-            not_found_route,
-        })
-    }
-}
-
-fn parse_variants_attributes(
-    variants: &Punctuated<Variant, syn::token::Comma>,
-) -> syn::Result<(Option<Ident>, Vec<LitStr>)> {
-    let mut not_founds = vec![];
-    let mut ats: Vec<LitStr> = vec![];
-
-    let mut not_found_attrs = vec![];
-
-    for variant in variants.iter() {
-        if let Fields::Unnamed(ref field) = variant.fields {
+pub fn routable_derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
+    let DeriveInput { ident, data, .. } = input;
+    let data = match data {
+        Data::Enum(e) => e,
+        Data::Struct(s) => {
             return Err(syn::Error::new(
-                field.span(),
-                "only named fields are supported",
-            ));
+                s.struct_token.span(),
+                "expected enum, found struct",
+            ))
         }
+        Data::Union(u) => {
+            return Err(syn::Error::new(
+                u.union_token.span(),
+                "expected enum, found union",
+            ))
+        }
+    };
 
-        let attrs = &variant.attrs;
-        let at_attrs = attrs
-            .iter()
-            .filter(|attr| attr.path.is_ident(AT_ATTR_IDENT))
-            .collect::<Vec<_>>();
+    let mut variants = Vec::new();
+    for variant in data.variants {
+        let mut binds = HashMap::new();
 
-        let attr = match at_attrs.len() {
-            1 => *at_attrs.first().unwrap(),
-            0 => {
-                return Err(syn::Error::new(
-                    variant.span(),
-                    format!(
-                        "{} attribute must be present on every variant",
-                        AT_ATTR_IDENT
-                    ),
+        let at = {
+            let mut at = None;
+            for attr in variant.attrs.iter() {
+                if attr.path.is_ident(AT_ATTR_PATH) {
+                    at = Some(attr.parse_args::<LitStr>()?);
+                }
+            }
+
+            at.ok_or_else(|| {
+                let attrs = &variant.attrs;
+                syn::Error::new_spanned(
+                    quote! { #(#attrs)* },
+                    &format!("{} attribute not found", AT_ATTR_PATH),
+                )
+            })?
+        };
+
+        match &variant.fields {
+            Fields::Unit => {}
+            Fields::Named(fields) => {
+                for field in &fields.named {
+                    let attrs = field
+                        .attrs
+                        .iter()
+                        .filter(|attr| attr.path.is_ident(BIND_ATTR_PATH));
+                    for attr in attrs {
+                        // todo maybe don't clone?
+                        let ident = field.ident.clone().unwrap(); // named fields have idents
+                        let attr = attr.parse_args::<Ident>()?;
+                        binds.insert(ident, attr);
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                return Err(syn::Error::new_spanned(
+                    quote! { #fields },
+                    "only named fields are allowed",
                 ))
             }
-            _ => {
+        }
+
+        // special casing because it's the only field level bind
+        let not_found = {
+            let not_founds = variant
+                .attrs
+                .iter()
+                .filter(|attr| attr.path.is_ident(BIND_ATTR_PATH))
+                .filter(|attr| {
+                    attr.parse_args::<Ident>()
+                        .map(|it| it == "not_found")
+                        .unwrap_or(false)
+                })
+                .collect::<Vec<_>>();
+
+            let len = not_founds.len();
+
+            if len == 0 {
+                false
+            } else if len == 1 {
+                true
+            } else {
                 return Err(syn::Error::new_spanned(
-                    quote! { #(#at_attrs)* },
-                    format!("only one {} attribute must be present", AT_ATTR_IDENT),
-                ))
+                    quote! { #(#not_founds)* },
+                    "only one `#[bind(not_found)]` can be present",
+                ));
             }
         };
 
-        let lit = attr.parse_args::<LitStr>()?;
-        ats.push(lit);
-
-        for attr in attrs.iter() {
-            if attr.path.is_ident(NOT_FOUND_ATTR_IDENT) {
-                not_found_attrs.push(attr);
-                not_founds.push(variant.ident.clone())
-            }
-        }
-    }
-
-    if not_founds.len() > 1 {
-        return Err(syn::Error::new_spanned(
-            quote! { #(#not_found_attrs)* },
-            format!("there can only be one {}", NOT_FOUND_ATTR_IDENT),
-        ));
-    }
-
-    Ok((not_founds.into_iter().next(), ats))
-}
-
-impl Routable {
-    fn build_from_path(&self) -> TokenStream {
-        let from_path_matches = self.variants.iter().enumerate().map(|(i, variant)| {
-            let ident = &variant.ident;
-            let right = match &variant.fields {
-                Fields::Unit => quote! { Self::#ident },
-                Fields::Named(field) => {
-                    let fields = field.named.iter().map(|it| {
-                        //named fields have idents
-                        it.ident.as_ref().unwrap()
-                    });
-
-                    quote! { Self::#ident { #(#fields: params.get(stringify!(#fields))?.parse().ok()?)*, } }
-                }
-                Fields::Unnamed(_) => unreachable!(), // already checked
-            };
-
-            let left = self.ats.get(i).unwrap();
-            quote! {
-                #left => ::std::option::Option::Some(#right)
-            }
+        variants.push(RoutableVariant {
+            at,
+            binds,
+            not_found,
+            ident: variant.ident,
+            fields: variant.fields,
         });
-
-        quote! {
-            fn from_path(
-                path: &str,
-                params: &::std::collections::HashMap<&str, &str>,
-                queries: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
-            ) -> ::std::option::Option<Self> {
-                match path {
-                    #(#from_path_matches),*,
-                    _ => ::std::option::Option::None,
-                }
-            }
-        }
     }
-
-    fn build_to_path(&self) -> TokenStream {
-        let to_path_matches = self.variants.iter().enumerate().map(|(i, variant)| {
-            let ident = &variant.ident;
-            let mut right = self.ats.get(i).unwrap().value();
-
-            match &variant.fields {
-                Fields::Unit => quote! { Self::#ident => ::std::string::ToString::to_string(#right) },
-                Fields::Named(field) => {
-                    let fields = field
-                        .named
-                        .iter()
-                        .map(|it| it.ident.as_ref().unwrap())
-                        .collect::<Vec<_>>();
-
-                    for field in fields.iter() {
-                        // :param -> {param}
-                        // so we can pass it to `format!("...", param)`
-                        right = right.replace(&format!(":{}", field), &format!("{{{}}}", field))
-                    }
-
-                    quote! {
-                        Self::#ident { #(#fields),* } => ::std::format!(#right, #(#fields = #fields),*)
-                    }
-                }
-                Fields::Unnamed(_) => unreachable!(), // already checked
-            }
-        });
-
-        quote! {
-            fn to_path(&self) -> ::std::string::String {
-                match self {
-                    #(#to_path_matches),*,
-                }
-            }
-        }
-    }
-}
-
-pub fn routable_derive_impl(input: Routable) -> TokenStream {
-    let Routable {
-        ats,
-        not_found_route,
-        ident,
-        ..
-    } = &input;
-
-    let from_path = input.build_from_path();
-    let to_path = input.build_to_path();
-
-    let not_found_route = match not_found_route {
-        Some(route) => quote! { ::std::option::Option::Some(Self::#route) },
-        None => quote! { ::std::option::Option::None },
-    };
 
     let cache_thread_local_ident = Ident::new(
         &format!("__{}_ROUTER_CURRENT_ROUTE_CACHE", ident),
         ident.span(),
     );
 
-    quote! {
+    let routes = variants.iter().map(|it| &it.at);
+    let not_found_route = variants
+        .iter()
+        .find(|it| it.not_found)
+        .map(|it| {
+            let ident = &it.ident;
+            quote! {
+                ::std::option::Option::Some(Self::#ident)
+            }
+        })
+        .unwrap_or_else(|| {
+            quote! {
+                ::std::option::Option::None
+            }
+        });
+
+    let to_paths = variants
+        .iter()
+        .map(|it| it.build_to_path())
+        .collect::<Vec<_>>();
+    let from_path = variants
+        .iter()
+        .map(|it| it.build_from_path())
+        .collect::<Vec<_>>();
+
+    let bindings = {
+        let items = variants
+            .iter()
+            .map(|it| {
+                let at = it.at.value();
+                let bindings = it.build_bindings();
+                quote! { map.insert(#at, #bindings); }
+            })
+            .collect::<Vec<_>>();
+
+        let len = items.len();
+
+        quote! {
+            {
+                let mut map = ::std::collections::HashMap::with_capacity(#len);
+                #(#items)*
+                map
+            }
+        }
+    };
+
+    let output = quote! {
         ::std::thread_local! {
             #[doc(hidden)]
             #[allow(non_upper_case_globals)]
             static #cache_thread_local_ident: ::std::cell::RefCell<::std::option::Option<#ident>> = ::std::cell::RefCell::new(::std::option::Option::None);
         }
 
-        #[automatically_derived]
+
         impl ::yew_router::Routable for #ident {
-            #from_path
-            #to_path
+            fn from_path(
+                path: &str,
+                params: &::std::collections::HashMap<&str, &str>,
+                queries: ::std::collections::HashMap<::std::string::String, ::std::string::String>
+            ) -> ::std::option::Option<Self> {
+                match path {
+                    #(#from_path),*,
+                    _ => ::std::option::Option::None,
+                }
+            }
+
+            fn to_path(&self) -> ::std::string::String {
+                match self {
+                    #(#to_paths),*
+                }
+            }
 
             fn routes() -> ::std::vec::Vec<&'static str> {
-                ::std::vec![#(#ats),*]
+                ::std::vec![#(#routes),*]
             }
 
             fn not_found_route() -> ::std::option::Option<Self> {
                 #not_found_route
             }
+
 
             fn current_route() -> ::std::option::Option<Self> {
                 #cache_thread_local_ident.with(|val| ::std::clone::Clone::clone(&*val.borrow()))
@@ -232,7 +200,10 @@ pub fn routable_derive_impl(input: Routable) -> TokenStream {
                 ::std::thread_local! {
                     static ROUTER: ::yew_router::__macro::Router = ::yew_router::__macro::build_router::<#ident>();
                 }
-                let route = ROUTER.with(|router| ::yew_router::__macro::recognize_with_router(router, location));
+
+                let bindings = #bindings;
+
+                let route = ROUTER.with(|router| ::yew_router::__macro::recognize_with_router(router, location, bindings));
                 {
                     let route = ::std::clone::Clone::clone(&route);
                     #cache_thread_local_ident.with(move |val| {
@@ -246,6 +217,122 @@ pub fn routable_derive_impl(input: Routable) -> TokenStream {
                 #cache_thread_local_ident.with(move |val| {
                     *val.borrow_mut() = ::std::option::Option::None;
                 });
+            }
+        }
+    };
+    Ok(output)
+}
+
+#[derive(Debug)]
+struct RoutableVariant {
+    /// The path literal
+    ///
+    /// `#[at("/")]`
+    at: LitStr,
+    /// The `#[bind(Ident)]` found on the named fields values.
+    /// Map of [`Ident`] of field to [`Ident`] of the binding type (query, etc)
+    binds: HashMap<Ident, Ident>,
+    /// Is this 404 redirect route
+    not_found: bool,
+    /// Variant's ident
+    ident: Ident,
+    fields: Fields,
+}
+
+impl RoutableVariant {
+    fn build_to_path(&self) -> TokenStream {
+        let mut at = self.at.value();
+        let ident = &self.ident;
+        match &self.fields {
+            Fields::Unit => quote! { Self::#ident => ::std::string::ToString::to_string(#at) },
+            Fields::Named(field) => {
+                let fields = field
+                    .named
+                    .iter()
+                    .map(|it| it.ident.as_ref().unwrap())
+                    .collect::<Vec<_>>();
+
+                for field in fields.iter() {
+                    // :param -> {param}
+                    // so we can pass it to `format!("...", param)`
+                    at = at.replace(&format!(":{}", field), &format!("{{{}}}", field))
+                }
+
+                let query_params = self
+                    .binds
+                    .iter()
+                    .filter(|(_, attr)| *attr == "query")
+                    .collect::<Vec<_>>();
+                if !query_params.is_empty() {
+                    at.push('?')
+                }
+
+                for (ident, _) in query_params {
+                    at.push_str(&format!("{}={{{}}}", ident, ident))
+                }
+
+                quote! {
+                    Self::#ident { #(#fields),* } => ::std::format!(#at, #(#fields = #fields),*)
+                }
+            }
+            Fields::Unnamed(_) => unreachable!(), // already checked
+        }
+    }
+
+    fn build_from_path(&self) -> TokenStream {
+        let Self {
+            at,
+            binds,
+            ident,
+            fields,
+            ..
+        } = &self;
+        let binds = binds
+            .iter()
+            .map(|(ident, attr)| (ident.to_string(), attr.to_string()))
+            .collect::<HashMap<_, _>>();
+        let right = match fields {
+            Fields::Unit => quote! { Self::#ident },
+            Fields::Named(fields) => {
+                let fields = fields
+                    .named
+                    .iter()
+                    .map(|it| it.ident.as_ref().expect("named fields have idents"))
+                    .map(|field| {
+                        let map_ident = if binds.contains_key(&field.to_string()) {
+                            quote! { queries }
+                        } else {
+                            quote! { params }
+                        };
+                        quote! { #field: #map_ident.get(stringify!(#field)).map(|it| it.parse().ok()).flatten()? }
+                    });
+
+                quote! { Self::#ident { #(#fields),* } }
+            }
+            Fields::Unnamed(_) => unreachable!(),
+        };
+        quote! {
+            #at => ::std::option::Option::Some(#right)
+        }
+    }
+
+    fn build_bindings(&self) -> TokenStream {
+        let mut binds = vec![];
+        for (ident, attr) in self.binds.iter() {
+            if attr == "query" {
+                let bind = quote_spanned!(attr.span()=> Query);
+                let ident = quote_spanned!(ident.span()=> stringify!(#ident));
+                binds.push(quote! {
+                    map.insert(#ident, ::yew_router::__macro::Binding::#bind);
+                });
+            }
+        }
+
+        quote! {
+            {
+                let mut map = ::std::collections::HashMap::with_capacity(1);
+                #(#binds)*
+                map
             }
         }
     }

--- a/packages/yew-router-macro/tests/routable_derive/bad-ats-fail.rs
+++ b/packages/yew-router-macro/tests/routable_derive/bad-ats-fail.rs
@@ -1,9 +1,9 @@
-#[derive(yew_router::Routable)]
+#[derive(Clone, yew_router::Routable)]
 enum Routes {
     One,
 }
 
-#[derive(yew_router::Routable)]
+#[derive(Clone, yew_router::Routable)]
 enum RoutesTwo {
     #[at("/one")]
     #[at("/two")]

--- a/packages/yew-router-macro/tests/routable_derive/bad-ats-fail.stderr
+++ b/packages/yew-router-macro/tests/routable_derive/bad-ats-fail.stderr
@@ -1,12 +1,20 @@
-error: at attribute must be present on every variant
- --> $DIR/bad-ats-fail.rs:3:5
+error: at attribute not found
+ --> $DIR/bad-ats-fail.rs:1:10
   |
-3 |     One,
-  |     ^^^
+1 | #[derive(yew_router::Routable)]
+  |          ^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: only one at attribute must be present
- --> $DIR/bad-ats-fail.rs:8:5
-  |
-8 | /     #[at("/one")]
-9 | |     #[at("/two")]
-  | |_________________^
+error[E0277]: the trait bound `RoutesTwo: Clone` is not satisfied
+  --> $DIR/bad-ats-fail.rs:6:10
+   |
+6  | #[derive(yew_router::Routable)]
+   |          ^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `RoutesTwo`
+   |
+  ::: $WORKSPACE/packages/yew-router/src/routable.rs
+   |
+   | pub trait Routable: Sized + Clone {
+   |                             ----- required by this bound in `Routable`
+   |
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-router-macro/tests/routable_derive/invalid-bind-fail.rs
+++ b/packages/yew-router-macro/tests/routable_derive/invalid-bind-fail.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, Clone, PartialEq, yew_router::Routable)]
+enum Routes {
+    #[at("/")]
+    Home {
+        #[bind(query)]
+        #[bind(query)]
+        id: u32
+    },
+}
+
+fn main() {}

--- a/packages/yew-router-macro/tests/routable_derive/invalid-bind-fail.stderr
+++ b/packages/yew-router-macro/tests/routable_derive/invalid-bind-fail.stderr
@@ -1,0 +1,6 @@
+error: a field can have only one `#[bind(...)]`
+ --> $DIR/invalid-bind-fail.rs:5:9
+  |
+5 | /         #[bind(query)]
+6 | |         #[bind(query)]
+  | |______________________^

--- a/packages/yew-router-macro/tests/routable_derive/invalid-not-found-fail.rs
+++ b/packages/yew-router-macro/tests/routable_derive/invalid-not-found-fail.rs
@@ -1,18 +1,18 @@
-#[derive(Debug, PartialEq, yew_router::Routable)]
+#[derive(Clone, Debug, PartialEq, yew_router::Routable)]
 enum RoutesOne {
     #[at("/")]
-    #[not_found]
+    #[bind(not_found)]
     Home,
     #[at("/404")]
-    #[not_found]
+    #[bind(not_found)]
     NotFound,
 }
 
-#[derive(Debug, PartialEq, yew_router::Routable)]
+#[derive(Clone, Debug, PartialEq, yew_router::Routable)]
 enum RoutesTwo {
     #[at("/404")]
-    #[not_found]
-    #[not_found]
+    #[bind(not_found)]
+    #[bind(not_found)]
     NotFound,
 }
 fn main() {}

--- a/packages/yew-router-macro/tests/routable_derive/invalid-not-found-fail.stderr
+++ b/packages/yew-router-macro/tests/routable_derive/invalid-not-found-fail.stderr
@@ -1,15 +1,19 @@
-error: there can only be one not_found
- --> $DIR/invalid-not-found-fail.rs:4:5
-  |
-4 | /     #[not_found]
-5 | |     Home,
-6 | |     #[at("/404")]
-7 | |     #[not_found]
-  | |________________^
-
-error: there can only be one not_found
+error: only one `#[bind(not_found)]` can be present
   --> $DIR/invalid-not-found-fail.rs:14:5
    |
-14 | /     #[not_found]
-15 | |     #[not_found]
-   | |________________^
+14 | /     #[bind(not_found)]
+15 | |     #[bind(not_found)]
+   | |______________________^
+
+error[E0277]: the trait bound `RoutesOne: Clone` is not satisfied
+  --> $DIR/invalid-not-found-fail.rs:1:28
+   |
+1  | #[derive(Debug, PartialEq, yew_router::Routable)]
+   |                            ^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `RoutesOne`
+   |
+  ::: $WORKSPACE/packages/yew-router/src/routable.rs
+   |
+   | pub trait Routable: Sized + Clone {
+   |                             ----- required by this bound in `Routable`
+   |
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-router-macro/tests/routable_derive/no-clone-fail.rs
+++ b/packages/yew-router-macro/tests/routable_derive/no-clone-fail.rs
@@ -1,6 +1,6 @@
 #![no_implicit_prelude]
 
-#[derive(Debug, PartialEq, Clone, ::yew_router::Routable)]
+#[derive(::yew_router::Routable)]
 enum Routes {
     #[at("/")]
     One,

--- a/packages/yew-router-macro/tests/routable_derive/no-clone-fail.stderr
+++ b/packages/yew-router-macro/tests/routable_derive/no-clone-fail.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `Routes: Clone` is not satisfied
+  --> $DIR/no-clone-fail.rs:3:10
+   |
+3  | #[derive(::yew_router::Routable)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `Routes`
+   |
+  ::: $WORKSPACE/packages/yew-router/src/routable.rs
+   |
+   | pub trait Routable: Sized + Clone {
+   |                             ----- required by this bound in `Routable`
+   |
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-router-macro/tests/routable_derive/unnamed-fields-fail.rs
+++ b/packages/yew-router-macro/tests/routable_derive/unnamed-fields-fail.rs
@@ -1,4 +1,4 @@
-#[derive(yew_router::Routable)]
+#[derive(Clone, yew_router::Routable)]
 enum Routes {
     #[at("/one/:two")]
     One(u32),

--- a/packages/yew-router-macro/tests/routable_derive/unnamed-fields-fail.stderr
+++ b/packages/yew-router-macro/tests/routable_derive/unnamed-fields-fail.stderr
@@ -1,4 +1,4 @@
-error: only named fields are supported
+error: only named fields are allowed
  --> $DIR/unnamed-fields-fail.rs:4:8
   |
 4 |     One(u32),

--- a/packages/yew-router/Cargo.toml
+++ b/packages/yew-router/Cargo.toml
@@ -37,7 +37,6 @@ features = [
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 yew-functional = { path = "../yew-functional" }
-serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies.web-sys]
 version = "0.3"

--- a/packages/yew-router/Cargo.toml
+++ b/packages/yew-router/Cargo.toml
@@ -19,8 +19,6 @@ js-sys = "0.3"
 weblog = "0.3.0"
 gloo = "0.2.1"
 route-recognizer = "0.3.0"
-serde = "1.0"
-serde_urlencoded = "0.7"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/packages/yew-router/README.md
+++ b/packages/yew-router/README.md
@@ -15,7 +15,7 @@ enum Route {
     Home,
     #[at("/secure")]
     Secure,
-    #[not_found]
+    #[bind(not_found)]
     #[at("/404")]
     NotFound,
 }

--- a/packages/yew-router/src/lib.rs
+++ b/packages/yew-router/src/lib.rs
@@ -14,7 +14,7 @@
 //!     Home,
 //!     #[at("/secure")]
 //!     Secure,
-//!     #[not_found]
+//!     #[bind(not_found)]
 //!     #[at("/404")]
 //!     NotFound,
 //! }

--- a/packages/yew-router/src/macro_helpers.rs
+++ b/packages/yew-router/src/macro_helpers.rs
@@ -1,5 +1,7 @@
 use crate::utils::{base_url, strip_slash_suffix};
 use crate::Routable;
+pub use web_sys::Location;
+use std::collections::HashMap;
 
 // re-export Router because the macro needs to access it
 pub type Router = route_recognizer::Router<String>;
@@ -24,13 +26,69 @@ pub fn build_router<R: Routable>() -> Router {
     router
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum Binding {
+    Query,
+    QueryCollection,
+}
+
+#[derive(Debug, Clone)]
+pub enum Query {
+    Single(HashMap<String, String>),
+    Collection(HashMap<String, Vec<String>>),
+}
+
 /// Use a `route_recognizer::Router` to build the route of a `Routable`
-pub fn recognize_with_router<R: Routable>(router: &Router, pathname: &str) -> Option<R> {
-    let pathname = strip_slash_suffix(pathname);
+pub fn recognize_with_router<R: Routable>(router: &Router, location: web_sys::Location) -> Option<R> {
+    let bindings = {
+        let mut map = HashMap::with_capacity(1);
+        map.insert("collection_key", Binding::QueryCollection);
+        map.insert("key", Binding::Query);
+        map
+    };
+
+    let pathname = location.pathname().unwrap();
+    let pathname = strip_slash_suffix(&pathname);
+
+    let search = location.search();
+    let query = search.as_deref().map(|query| query.strip_prefix("?").unwrap_or(""));
+    let mut queries = HashMap::new();
+    let mut query_collections = HashMap::new();
+    if let Ok(_query) = query {
+        let query_iter = fuck(); // TODO parse query ...
+        for (k, v) in query_iter {
+            let binding = bindings[k.as_str()];
+            match binding {
+                Binding::Query => {
+                    queries.insert(k, v);
+                }
+                Binding::QueryCollection => {
+                    match query_collections.get_mut(&k) {
+                        Some(map) => {
+                            map.push(v);
+                        },
+                        None => {
+                            query_collections.insert(k, vec![v]);
+                        }
+                    }
+                }
+            };
+        }
+    }
+
+
     let matched = router.recognize(pathname);
 
     match matched {
-        Ok(matched) => R::from_path(matched.handler(), &matched.params().into_iter().collect()),
+        Ok(matched) => R::from_path(
+            matched.handler(),
+            &matched.params().into_iter().collect(),
+            queries,
+        ),
         Err(_) => R::not_found_route(),
     }
+}
+
+fn fuck() -> impl Iterator<Item = (String, String)> {
+    std::iter::once((String::new(), String::new()))
 }

--- a/packages/yew-router/src/macro_helpers.rs
+++ b/packages/yew-router/src/macro_helpers.rs
@@ -1,7 +1,8 @@
 use crate::utils::{base_url, strip_slash_suffix};
 use crate::Routable;
-pub use web_sys::Location;
 use std::collections::HashMap;
+use wasm_bindgen::{JsCast, JsValue};
+pub use web_sys::Location;
 
 // re-export Router because the macro needs to access it
 pub type Router = route_recognizer::Router<String>;
@@ -32,63 +33,67 @@ pub enum Binding {
     QueryCollection,
 }
 
-#[derive(Debug, Clone)]
-pub enum Query {
-    Single(HashMap<String, String>),
-    Collection(HashMap<String, Vec<String>>),
-}
-
 /// Use a `route_recognizer::Router` to build the route of a `Routable`
-pub fn recognize_with_router<R: Routable>(router: &Router, location: web_sys::Location) -> Option<R> {
-    let bindings = {
-        let mut map = HashMap::with_capacity(1);
-        map.insert("collection_key", Binding::QueryCollection);
-        map.insert("key", Binding::Query);
-        map
-    };
-
+pub fn recognize_with_router<R: Routable>(
+    router: &Router,
+    location: web_sys::Location,
+    bindings: HashMap<&str, HashMap<&str, Binding>>,
+) -> Option<R> {
     let pathname = location.pathname().unwrap();
     let pathname = strip_slash_suffix(&pathname);
-
-    let search = location.search();
-    let query = search.as_deref().map(|query| query.strip_prefix("?").unwrap_or(""));
-    let mut queries = HashMap::new();
-    let mut query_collections = HashMap::new();
-    if let Ok(_query) = query {
-        let query_iter = fuck(); // TODO parse query ...
-        for (k, v) in query_iter {
-            let binding = bindings[k.as_str()];
-            match binding {
-                Binding::Query => {
-                    queries.insert(k, v);
-                }
-                Binding::QueryCollection => {
-                    match query_collections.get_mut(&k) {
-                        Some(map) => {
-                            map.push(v);
-                        },
-                        None => {
-                            query_collections.insert(k, vec![v]);
-                        }
-                    }
-                }
-            };
-        }
-    }
-
-
     let matched = router.recognize(pathname);
 
     match matched {
-        Ok(matched) => R::from_path(
-            matched.handler(),
-            &matched.params().into_iter().collect(),
-            queries,
-        ),
+        Ok(matched) => {
+            let path = matched.handler();
+            let bindings = &bindings[path.as_str()];
+            let search = location.search();
+            let query = search
+                .as_deref()
+                .map(|query| query.strip_prefix("?").unwrap_or(""));
+            let mut queries = HashMap::new();
+            let mut query_collections: HashMap<String, Vec<String>> = HashMap::new();
+            if let Ok(_query) = query {
+                let query_iter = parse_query();
+                for (k, v) in query_iter {
+                    let binding = bindings[k.as_str()];
+                    match binding {
+                        Binding::Query => {
+                            queries.insert(k, v);
+                        }
+                        Binding::QueryCollection => match query_collections.get_mut(&k) {
+                            Some(map) => {
+                                map.push(v);
+                            }
+                            None => {
+                                query_collections.insert(k, vec![v]);
+                            }
+                        },
+                    };
+                }
+            }
+            R::from_path(path, &matched.params().into_iter().collect(), queries)
+        }
         Err(_) => R::not_found_route(),
     }
 }
 
-fn fuck() -> impl Iterator<Item = (String, String)> {
-    std::iter::once((String::new(), String::new()))
+fn parse_query() -> impl Iterator<Item = (String, String)> {
+    let url = web_sys::Url::new(&yew::utils::document().url().unwrap()).unwrap();
+
+    js_sys::try_iter(&JsValue::from(&url.search_params()))
+        .expect("try_iter failed")
+        .expect("try_iter failed")
+        .into_iter()
+        .map(|it| it.unwrap().unchecked_into::<js_sys::Array>().to_vec())
+        .map(|it| {
+            let mut iter = it.into_iter();
+            // unwraps are unreachable
+            // there will be at least 2 values here
+            // both of them will be strings
+            (
+                iter.next().unwrap().as_string().unwrap(),
+                iter.next().unwrap().as_string().unwrap(),
+            )
+        })
 }

--- a/packages/yew-router/src/routable.rs
+++ b/packages/yew-router/src/routable.rs
@@ -15,7 +15,11 @@ pub use yew_router_macro::Routable;
 /// the functions exposed at the [crate's root][crate] to perform operations with the router.
 pub trait Routable: Sized + Clone {
     /// Converts path to an instance of the routes enum.
-    fn from_path(path: &str, params: &HashMap<&str, &str>, queries: HashMap<String, String>) -> Option<Self>;
+    fn from_path(
+        path: &str,
+        params: &HashMap<&str, &str>,
+        queries: HashMap<String, String>,
+    ) -> Option<Self>;
 
     /// Converts the route to a string that can passed to the history API.
     fn to_path(&self) -> String;

--- a/packages/yew-router/src/routable.rs
+++ b/packages/yew-router/src/routable.rs
@@ -15,7 +15,7 @@ pub use yew_router_macro::Routable;
 /// the functions exposed at the [crate's root][crate] to perform operations with the router.
 pub trait Routable: Sized + Clone {
     /// Converts path to an instance of the routes enum.
-    fn from_path(path: &str, params: &HashMap<&str, &str>) -> Option<Self>;
+    fn from_path(path: &str, params: &HashMap<&str, &str>, queries: HashMap<String, String>) -> Option<Self>;
 
     /// Converts the route to a string that can passed to the history API.
     fn to_path(&self) -> String;
@@ -32,7 +32,7 @@ pub trait Routable: Sized + Clone {
     fn current_route() -> Option<Self>;
 
     /// Match a route based on the path
-    fn recognize(pathname: &str) -> Option<Self>;
+    fn recognize(location: web_sys::Location) -> Option<Self>;
 
     /// Called when [`Router`](crate::Router) is destroyed.
     fn cleanup() {}

--- a/packages/yew-router/src/router.rs
+++ b/packages/yew-router/src/router.rs
@@ -100,8 +100,7 @@ where
     }
 
     fn view(&self) -> Html {
-        let pathname = yew::utils::window().location().pathname().unwrap();
-        let route = R::recognize(&pathname);
+        let route = R::recognize(yew::utils::window().location());
 
         match route {
             Some(route) => (self.props.render.0)(&route),

--- a/packages/yew-router/src/service.rs
+++ b/packages/yew-router/src/service.rs
@@ -1,38 +1,13 @@
 use crate::utils::base_url;
 use crate::Routable;
 use gloo::events::EventListener;
-use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
 use web_sys::Event;
 use yew::Callback;
 
 /// Navigate to a specific route.
 pub fn push_route(route: impl Routable) {
-    push_impl(route.to_path())
-}
-
-/// Navigate to a specific route with query parameters.
-///
-/// This should be used in cases where [`Link`](crate::prelude::Link) is insufficient.
-pub fn push_route_with_query<S>(
-    route: impl Routable,
-    query: S,
-) -> Result<(), serde_urlencoded::ser::Error>
-where
-    S: Serialize,
-{
-    let mut url = route.to_path();
-    let query = serde_urlencoded::to_string(query)?;
-    if !query.is_empty() {
-        url.push_str(&format!("?{}", query));
-    }
-
-    push_impl(url);
-
-    Ok(())
-}
-
-fn push_impl(url: String) {
+    let url = route.to_path();
     let history = yew::utils::window().history().expect("no history");
     let base = base_url();
     let path = match base {
@@ -54,14 +29,6 @@ fn push_impl(url: String) {
     yew::utils::window()
         .dispatch_event(&event)
         .expect("dispatch");
-}
-
-pub fn parse_query<T>() -> Result<T, serde_urlencoded::de::Error>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let query = yew::utils::document().location().unwrap().search().unwrap();
-    serde_urlencoded::from_str(query.strip_prefix("?").unwrap_or(""))
 }
 
 pub fn current_route<R: Routable>() -> Option<R> {

--- a/packages/yew-router/src/utils.rs
+++ b/packages/yew-router/src/utils.rs
@@ -43,11 +43,8 @@ pub fn fetch_base_url() -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use serde::Serialize;
-    use std::collections::HashMap;
     use wasm_bindgen_test::wasm_bindgen_test as test;
     use yew::utils::*;
-    use yew_router::parse_query;
     use yew_router::prelude::*;
     use yew_router::utils::*;
 
@@ -80,35 +77,5 @@ mod tests {
             .unwrap()
             .set_inner_html(r#"<base href="/base">"#);
         assert_eq!(fetch_base_url(), Some("/base".to_string()));
-    }
-
-    #[derive(Serialize, Clone)]
-    struct QueryParams {
-        foo: String,
-        bar: u32,
-    }
-
-    #[test]
-    fn test_get_query_params() {
-        assert_eq!(
-            parse_query::<HashMap<String, String>>().unwrap(),
-            HashMap::new()
-        );
-
-        let query = QueryParams {
-            foo: "test".to_string(),
-            bar: 69,
-        };
-
-        yew_router::push_route_with_query(Routes::Home, query).unwrap();
-
-        let params: HashMap<String, String> = parse_query().unwrap();
-
-        assert_eq!(params, {
-            let mut map = HashMap::new();
-            map.insert("foo".to_string(), "test".to_string());
-            map.insert("bar".to_string(), "69".to_string());
-            map
-        });
     }
 }

--- a/packages/yew-router/tests/router.rs
+++ b/packages/yew-router/tests/router.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::prelude::*;
 use yew_functional::function_component;

--- a/packages/yew-router/tests/router.rs
+++ b/packages/yew-router/tests/router.rs
@@ -9,17 +9,16 @@ use utils::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-#[derive(Serialize, Deserialize)]
-struct Query {
-    foo: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Routable)]
+#[derive(Debug, Clone, PartialEq, Routable)]
 enum Routes {
     #[at("/")]
     Home,
     #[at("/no/:id")]
-    No { id: u32 },
+    No {
+        id: u32,
+        #[bind(query)]
+        query_param: String,
+    },
     #[at("/404")]
     NotFound,
 }
@@ -27,6 +26,7 @@ enum Routes {
 #[derive(Properties, PartialEq, Clone)]
 struct NoProps {
     id: u32,
+    query_param: String,
 }
 
 #[function_component(No)]
@@ -36,7 +36,7 @@ fn no(props: &NoProps) -> Html {
     html! {
         <>
             <div id="result-params">{ route }</div>
-            <div id="result-query">{ yew_router::parse_query::<Query>().unwrap().foo }</div>
+            <div id="result-query">{ props.query_param.clone() }</div>
         </>
     }
 }
@@ -45,13 +45,10 @@ fn no(props: &NoProps) -> Html {
 fn component() -> Html {
     let switch = Router::render(|routes| {
         let onclick = Callback::from(|_| {
-            yew_router::push_route_with_query(
-                Routes::No { id: 2 },
-                Query {
-                    foo: "bar".to_string(),
-                },
-            )
-            .unwrap();
+            yew_router::push_route(Routes::No {
+                id: 2,
+                query_param: "bar".to_string(),
+            })
         });
 
         match routes {
@@ -61,7 +58,7 @@ fn component() -> Html {
                     <a onclick=onclick>{"click me"}</a>
                 </>
             },
-            Routes::No { id } => html! { <No id=id /> },
+            Routes::No { id, query_param } => html! { <No id=id query_param=query_param /> },
             Routes::NotFound => html! { <div id="result">{"404"}</div> },
         }
     });

--- a/website/docs/concepts/router.md
+++ b/website/docs/concepts/router.md
@@ -68,7 +68,7 @@ To navigate between pages, use either a `Link` component (which renders a `<a>` 
 
 ### Query Parameters
 
-The fields in the routes enum variant can be marked ``#[bind(query)]` to be perceived 
+The fields in the routes enum variant can be marked `#[bind(query)]` to be perceived 
 as query parameters. 
 
 ## Relevant examples

--- a/website/docs/concepts/router.md
+++ b/website/docs/concepts/router.md
@@ -23,7 +23,7 @@ enum Route {
     Home,
     #[at("/secure")]
     Secure,
-    #[not_found]
+    #[bind(not_found)]
     #[at("/404")]
     NotFound,
 }
@@ -31,7 +31,7 @@ enum Route {
 
 The `Router` component takes the `Routable` enum as its type parameter, finds the first variant whose path matches the 
 browser's current URL and passes it to the `render` callback. The callback then decides what to render. 
-In case no path is matched, the router navigates to the path with `not_found` attribute. If no route is specified, 
+In case no path is matched, the router navigates to the path with `#[bind(not_found)]` attribute. If no route is specified, 
 nothing is rendered, and a message is logged to console stating that no route was matched.
 
 `yew_router::current_route` is used to programmatically obtain the current route.
@@ -68,16 +68,8 @@ To navigate between pages, use either a `Link` component (which renders a `<a>` 
 
 ### Query Parameters
 
-#### Specifying query parameters when navigating
-
-In order to specify query parameters when navigating to a new route, use `yew_router::push_route_with_query` function.
-It uses `serde` to serialize the parameters into query string for the URL so any type that implements `Serialize` can be passed.
-In its simplest form this is just a `HashMap` containing string pairs.
-
-#### Obtaining query parameters for current route
-
-`yew_router::parse_query` is used to obtain the query parameters.
-It uses `serde` to deserialize the parameters from query string in the URL.
+The fields in the routes enum variant can be marked ``#[bind(query)]` to be perceived 
+as query parameters. 
 
 ## Relevant examples
 - [Router](https://github.com/yewstack/yew/tree/master/examples/router)


### PR DESCRIPTION
#### Description

This is a different implementation of changes in #1892.  
CC: @Diggsey 

This PR adds:
- `#[bind(query)]`
- `#[bind(not_found)]`

There's also some ground work done for `query_collection` but that isn't exposed right now.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
