### PR TITLE
[Docs] Add prerequisite target to "build a sample app"

### DIFF
--- a/website/versioned_docs/version-0.18.0/getting-started/build-a-sample-app.md
+++ b/website/versioned_docs/version-0.18.0/getting-started/build-a-sample-app.md
@@ -107,7 +107,8 @@ If you haven't already, install [Trunk](https://github.com/thedodd/trunk):
 cargo install trunk wasm-bindgen-cli
 ```
 
-Also, if not already done, you need to install the wasm32-unknown-unknown target to compile Rust to Wasm. If you're using rustup, you just need to run :
+If you haven't already installed it, you need to add the `wasm32-unknown-unknown` target. 
+To install this with Rustup:
 
 ```bash
 rustup target add wasm32-unknown-unknown

--- a/website/versioned_docs/version-0.18.0/getting-started/build-a-sample-app.md
+++ b/website/versioned_docs/version-0.18.0/getting-started/build-a-sample-app.md
@@ -107,6 +107,12 @@ If you haven't already, install [Trunk](https://github.com/thedodd/trunk):
 cargo install trunk wasm-bindgen-cli
 ```
 
+Also, if not already done, you need to install the wasm32-unknown-unknown target to compile Rust to Wasm. If you're using rustup, you just need to run :
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
 Now all you have to do is run the following:
 
 ```bash


### PR DESCRIPTION
#### Description

While trying to get a simple app running on Yew, I had the target "wasm32-unknown-unknown" missing so my project couldn't work.

I managed to find the missing target (by searching from the error message I was getting) on the same "Getting started" documentation, but later than the "build a sample app" page I was on.

It is my opinion that this can be needed during the "build a sample app" step, earlier than the "Project setup" step (where it is indicated that we need to use this target.

Another option could be to reference the "Project setup" from "build a sample app", in order to troubleshoot why the sample app is not working.

This is but a proposal and if you think this is not needed, please close this PR.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
