### PR TITLE
[Doc] Change yew version (0.17->0.18) in build-a-sample-app.md

### DIFF
--- a/website/versioned_docs/version-0.18.0/getting-started/build-a-sample-app.md
+++ b/website/versioned_docs/version-0.18.0/getting-started/build-a-sample-app.md
@@ -20,7 +20,7 @@ edition = "2018"
 
 [dependencies]
 # you can check the latest version here: https://crates.io/crates/yew
-yew = "0.17"
+yew = "0.18"
 ```
 
 Copy the following template into your `src/main.rs` file:


### PR DESCRIPTION
#### Description

On version 0.18 documentation, Build a sample app in Getting Started section is on the yew version 0.17.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
