### PR TITLE
Add documentation for boolean attributes

### DIFF
--- a/website/docs/concepts/html/elements.md
+++ b/website/docs/concepts/html/elements.md
@@ -22,7 +22,7 @@ html! {
 ## Boolean Attributes 
 
 Some content attributes (e.g checked, hidden, required) are called boolean attributes. In Yew, 
-boolean attributes need to be explicitly set to 'true':
+boolean attributes need to be set to a bool value:
 
 ```rust
     html! {
@@ -32,7 +32,7 @@ boolean attributes need to be explicitly set to 'true':
     }
 ```
 
-This will result in the following **HTML**: 
+This will result in **HTML** that's functionally equivalent to this:
 ```html
     <div hidden>This div is hidden.</div>
 ```

--- a/website/docs/concepts/html/elements.md
+++ b/website/docs/concepts/html/elements.md
@@ -19,6 +19,43 @@ html! {
 }
 ```
 
+## Boolean Attributes 
+
+Some content attributes (e.g checked, hidden, required) are called boolean attributes. In Yew, 
+boolean attributes need to be explicitly set to 'true':
+
+```rust
+    html! {
+        <div hidden=true>
+            { "This div is hidden." }
+        </div>
+    }
+```
+
+This will result in the following **HTML**: 
+```html
+    <div hidden>This div is hidden.</div>
+```
+
+Setting a boolean attribute to false is equivalent to not using the attribute at all; values from 
+boolean expressions can be used:
+
+```rust
+    let no = 1 + 1 != 2;
+
+    html! {
+        <div hidden=no>
+            { "This div is NOT hidden." }
+        </div>
+    }
+```
+
+This will result in the following **HTML**:
+
+```html
+    <div>This div is NOT hidden.</div>
+```
+
 ## Optional attributes for HTML elements
 
 Most HTML attributes can be marked as optional by placing a `?` in front of

--- a/website/versioned_docs/version-0.18.0/concepts/html/elements.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/elements.md
@@ -22,7 +22,7 @@ html! {
 ## Boolean Attributes 
 
 Some content attributes (e.g checked, hidden, required) are called boolean attributes. In Yew, 
-boolean attributes need to be explicitly set to 'true':
+boolean attributes need to be set to a bool value:
 
 ```rust
     html! {
@@ -32,7 +32,7 @@ boolean attributes need to be explicitly set to 'true':
     }
 ```
 
-This will result in the following **HTML**: 
+This will result in **HTML** that's functionally equivalent to this:
 ```html
     <div hidden>This div is hidden.</div>
 ```

--- a/website/versioned_docs/version-0.18.0/concepts/html/elements.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/elements.md
@@ -19,6 +19,43 @@ html! {
 }
 ```
 
+## Boolean Attributes 
+
+Some content attributes (e.g checked, hidden, required) are called boolean attributes. In Yew, 
+boolean attributes need to be explicitly set to 'true':
+
+```rust
+    html! {
+        <div hidden=true>
+            { "This div is hidden." }
+        </div>
+    }
+```
+
+This will result in the following **HTML**: 
+```html
+    <div hidden>This div is hidden.</div>
+```
+
+Setting a boolean attribute to false is equivalent to not using the attribute at all; values from 
+boolean expressions can be used:
+
+```rust
+    let no = 1 + 1 != 2;
+
+    html! {
+        <div hidden=no>
+            { "This div is NOT hidden." }
+        </div>
+    }
+```
+
+This will result in the following **HTML**:
+
+```html
+    <div>This div is NOT hidden.</div>
+```
+
 ## Optional attributes for HTML elements
 
 Most HTML attributes can use optional values (`Some(x)` or `None`). This allows us


### PR DESCRIPTION
#### Description
Adds documentation for explicit key=value syntax of boolean attributes. 
I made the same update to both 'next' and version 0.18.0 docs. 

<!-- Please include a summary of the change. -->

Fixes #1548<!-- replace with issue number or remove if not applicable -->

Checklist
- [ ] I have run cargo make pr-flow
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
