### PR TITLE
[Doc] Fix broken docs links

### DIFF
--- a/packages/yew-functional/src/hooks/mod.rs
+++ b/packages/yew-functional/src/hooks/mod.rs
@@ -27,7 +27,7 @@ use std::rc::Rc;
 ///
 /// See the pre-defined hooks for examples of how to use this function.
 ///
-/// [Yew Docs]: https://yew.rs/docs/en/next/concepts/function-components/custom-hooks
+/// [Yew Docs]: https://yew.rs/docs/next/concepts/function-components/custom-hooks
 pub fn use_hook<InternalHook: 'static, Output, Tear: FnOnce(&mut InternalHook) + 'static>(
     initializer: impl FnOnce() -> InternalHook,
     runner: impl FnOnce(&mut InternalHook, HookUpdater) -> Output,

--- a/packages/yew-functional/src/lib.rs
+++ b/packages/yew-functional/src/lib.rs
@@ -12,7 +12,7 @@
 //! }
 //! ```
 //!
-//! More details about function components and Hooks can be found on [Yew Docs](https://yew.rs/docs/en/next/concepts/function-components)
+//! More details about function components and Hooks can be found on [Yew Docs](https://yew.rs/docs/next/concepts/function-components)
 
 use scoped_tls_hkt::scoped_thread_local;
 use std::cell::RefCell;

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -119,7 +119,7 @@ pub use yew_macro::classes;
 ///
 /// [`Html`]: ./html/type.Html.html
 /// [`html_nested!`]: ./macro.html_nested.html
-/// [Yew Docs]: https://yew.rs/docs/en/concepts/html/
+/// [Yew Docs]: https://yew.rs/docs/concepts/html/
 pub use yew_macro::html;
 
 /// This macro is similar to [`html!`], but preserves the component type instead
@@ -259,7 +259,7 @@ pub use yew_macro::html_nested;
 ///
 /// [`html!`]: ./macro.html.html
 /// [`Properties`]: ./html/trait.Properties.html
-/// [yew docs]: https://yew.rs/docs/en/concepts/components/properties
+/// [Yew Docs]: https://yew.rs/docs/concepts/components/properties
 pub use yew_macro::props;
 
 /// This module contains macros which implements html! macro and JSX-like templates


### PR DESCRIPTION
#### Description

The URL scheme for the documentation hosted on the website seems to be changed where the English documentation page's URL does not have `/en/`. I found four places in the doc comments where the link led to `Page Not Found` page and updated the URLs.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
