### PR TITLE
Remove warning about prop_or_else macro

### DIFF
--- a/website/docs/concepts/components/properties.md
+++ b/website/docs/concepts/components/properties.md
@@ -37,11 +37,6 @@ For example, to default a boolean prop to `true`, use the attribute `#[prop_or(t
 
 Call `function` to initialize the prop value. `function` should have the signature `FnMut() -> T` where `T` is the field type.
 
-:::warning
-The function is currently called even if the prop is explicitly set. If your function is performance intensive, consider using `Option` where `None` values are initialized in the `create` method.
-See [#1623](https://github.com/yewstack/yew/issues/1623)
-:::
-
 ## PartialEq
 
 It makes sense to derive `PartialEq` on your props if you can do so.

--- a/website/versioned_docs/version-0.18.0/concepts/components/properties.md
+++ b/website/versioned_docs/version-0.18.0/concepts/components/properties.md
@@ -37,11 +37,6 @@ For example, to default a boolean prop to `true`, use the attribute `#[prop_or(t
 
 Call `function` to initialize the prop value. `function` should have the signature `FnMut() -> T` where `T` is the field type.
 
-:::warning
-The function is currently called even if the prop is explicitly set. If your function is performance intensive, consider using `Option` where `None` values are initialized in the `create` method.
-See [#1623](https://github.com/yewstack/yew/issues/1623)
-:::
-
 ## PartialEq
 
 It makes sense to derive `PartialEq` on your props if you can do so.


### PR DESCRIPTION
#### Description

The warning no longer applies to either version (next,
0.18.0).

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->
#1623 was solved by #1637 but Github didn't seem to close the issue 🙃 - I think this can be closed now 🎉.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
