### PR TITLE
Update ChangeData::Select documentation

### DIFF
--- a/packages/yew/src/html/listener/mod.rs
+++ b/packages/yew/src/html/listener/mod.rs
@@ -33,8 +33,9 @@ pub enum ChangeData {
     /// Value of the element in cases of `<input>`, `<textarea>`
     Value(String),
     /// SelectElement in case of `<select>` element. You can use one of methods of SelectElement
-    /// to collect your required data such as: `value`, `selected_index`, `selected_indices` or
-    /// `selected_values`. You can also iterate throught `selected_options` yourself.
+    /// to collect your required data such as `value` and `selected_index`.
+    /// You can also iterate throught `selected_options` yourself, this does require adding the
+    /// [web-sys](https://crates.io/crates/web-sys) crate with the `HtmlCollection` feature.
     Select(SelectElement),
     /// Files
     Files(FileList),


### PR DESCRIPTION
#### Description
- Removed the `selected_values`, `selected_indices` methods that are no longer available on web-sys latest (0.3.51).
- Added a note that the `selected_options` method requires the `HtmlCollection` feature from the `web-sys` crate.

<!-- Please include a summary of the change. -->

Fixes #1017 <!-- replace with issue number or remove if not applicable -->
I don't think Yew needs to add an example for the `selected_options` method here, as it comes from `web-sys` crate?
It might be useful to add the example from #1017 in #1460  
#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
