### PR TITLE
Fix case warning on derived properties

### DIFF
--- a/packages/yew-macro/src/derive_props/builder.rs
+++ b/packages/yew-macro/src/derive_props/builder.rs
@@ -120,7 +120,10 @@ impl PropsBuilder<'_> {
             .filter(|pf| pf.is_required())
             .map(|pf| pf.to_step_name(prefix))
             .collect();
-        step_names.push(Ident::new(&format!("{}_build", prefix), Span::call_site()));
+        step_names.push(Ident::new(
+            &format!("{}PropsBuilder", prefix),
+            prefix.span(),
+        ));
         step_names
     }
 

--- a/packages/yew-macro/tests/props_macro/props-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/props-fail.stderr
@@ -30,14 +30,14 @@ error[E0609]: no field `fail` on type `Props`
    |
    = note: available fields are: `a`
 
-error[E0599]: no method named `fail` found for struct `PropsBuilder<PropsBuilderStep_build>` in the current scope
+error[E0599]: no method named `fail` found for struct `PropsBuilder<PropsBuilderStepPropsBuilder>` in the current scope
   --> $DIR/props-fail.rs:10:31
    |
 3  | #[derive(Clone, Properties)]
    |                 ---------- method `fail` not found for this
 ...
 10 |     yew::props!(Props { a: 5, fail: 10 });
-   |                               ^^^^ method not found in `PropsBuilder<PropsBuilderStep_build>`
+   |                               ^^^^ method not found in `PropsBuilder<PropsBuilderStepPropsBuilder>`
 
 error[E0609]: no field `does_not_exist` on type `Props`
   --> $DIR/props-fail.rs:15:25


### PR DESCRIPTION
#### Description

Replace the `_build` suffix with a `PropsBuild` suffix to respect Camel-case types.

When deriving `Properties`, the compiler sometimes complains of the
non-Camel-case `Foo_build`. This fixes the issue.

#### Checklist

- [X] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
- [X] I have added tests