### PR TITLE
Add href to Link component

### DIFF
--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -46,7 +46,15 @@ impl<R: Routable + Clone + PartialEq + 'static> Component for Link<R> {
 
     fn view(&self) -> Html {
         html! {
-            <a class=self.props.classes.clone() onclick=self.link.callback(|_| Msg::OnClick)>{ self.props.children.clone() }</a>
+            <a class=self.props.classes.clone()
+                href=self.props.route.to_path()
+                onclick=self.link.callback(|e: MouseEvent| {
+                    e.prevent_default();
+                    Msg::OnClick
+                })
+            >
+                { self.props.children.clone() }
+            </a>
         }
     }
 }


### PR DESCRIPTION
#### Description

anchors with the href attribute have the implicit 'link' ARIA role and
this allows for better accessibility for screen readers and allows
tabbing to the anchor point.

<!-- Please include a summary of the change. -->

Fixes #1941 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
