### PR TITLE
Fix versioned doc links

### DIFF
--- a/website/versioned_docs/version-0.18.0/concepts/agents.md
+++ b/website/versioned_docs/version-0.18.0/concepts/agents.md
@@ -46,4 +46,4 @@ Agents that live in their own separate web worker \(Private and Public\) incur s
 
 ## Further reading
 
-* The [pub\_sub](https://github.com/yewstack/yew/tree/master/examples/pub_sub) example shows how components can use agents to communicate with each other.
+* The [pub\_sub](https://github.com/yewstack/yew/tree/v0.18/examples/pub_sub) example shows how components can use agents to communicate with each other.

--- a/website/versioned_docs/version-0.18.0/concepts/components/callbacks.md
+++ b/website/versioned_docs/version-0.18.0/concepts/components/callbacks.md
@@ -94,5 +94,5 @@ html! {
 ```
 
 ## Relevant examples
-- [Counter](https://github.com/yewstack/yew/tree/master/examples/counter)
-- [Timer](https://github.com/yewstack/yew/tree/master/examples/timer)
+- [Counter](https://github.com/yewstack/yew/tree/v0.18/examples/counter)
+- [Timer](https://github.com/yewstack/yew/tree/v0.18/examples/timer)

--- a/website/versioned_docs/version-0.18.0/concepts/components/refs.md
+++ b/website/versioned_docs/version-0.18.0/concepts/components/refs.md
@@ -27,4 +27,4 @@ let has_attributes = self.node_ref.cast::<Element>().unwrap().has_attributes();
 ```
 
 ## Relevant examples
-- [Node Refs](https://github.com/yewstack/yew/tree/master/examples/node_refs)
+- [Node Refs](https://github.com/yewstack/yew/tree/v0.18/examples/node_refs)

--- a/website/versioned_docs/version-0.18.0/concepts/html/components.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/components.md
@@ -113,6 +113,6 @@ impl Component for List {
 ```
 
 ## Relevant examples
-- [Boids](https://github.com/yewstack/yew/tree/master/examples/boids)
-- [Router](https://github.com/yewstack/yew/tree/master/examples/router)
-- [Store](https://github.com/yewstack/yew/tree/master/examples/store)
+- [Boids](https://github.com/yewstack/yew/tree/v0.18/examples/boids)
+- [Router](https://github.com/yewstack/yew/tree/v0.18/examples/router)
+- [Store](https://github.com/yewstack/yew/tree/v0.18/examples/store)

--- a/website/versioned_docs/version-0.18.0/concepts/html/elements.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/elements.md
@@ -326,4 +326,4 @@ Using the types from `yew::events` makes it easier to ensure version compatibili
 | `ontransitionstart`         | [TransitionEvent](https://docs.rs/web-sys/latest/web_sys/struct.TransitionEvent.html) | Unsupported                                                                                                   |
 
 ## Relevant examples
-- [Inner HTML](https://github.com/yewstack/yew/tree/master/examples/inner_html)
+- [Inner HTML](https://github.com/yewstack/yew/tree/v0.18/examples/inner_html)

--- a/website/versioned_docs/version-0.18.0/concepts/html/lists.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/lists.md
@@ -54,6 +54,6 @@ html! {
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Relevant examples
-- [TodoMVC](https://github.com/yewstack/yew/tree/master/examples/todomvc)
-- [Keyed List](https://github.com/yewstack/yew/tree/master/examples/keyed_list)
-- [Router](https://github.com/yewstack/yew/tree/master/examples/router)
+- [TodoMVC](https://github.com/yewstack/yew/tree/v0.18/examples/todomvc)
+- [Keyed List](https://github.com/yewstack/yew/tree/v0.18/examples/keyed_list)
+- [Router](https://github.com/yewstack/yew/tree/v0.18/examples/router)

--- a/website/versioned_docs/version-0.18.0/concepts/router.md
+++ b/website/versioned_docs/version-0.18.0/concepts/router.md
@@ -86,4 +86,4 @@ For structs and enums with named fields, you must specify the field's name withi
 The Switch trait works with capture groups that are more structured than just Strings. You can specify any type that implements `Switch`. So you can specify that the capture group is a `usize`, and if the captured section of the URL can't be converted to it, then the variant won't match.
 
 ## Relevant examples
-- [Router](https://github.com/yewstack/yew/tree/master/examples/router)
+- [Router](https://github.com/yewstack/yew/tree/v0.18/examples/router)

--- a/website/versioned_docs/version-0.18.0/concepts/services/fetch.md
+++ b/website/versioned_docs/version-0.18.0/concepts/services/fetch.md
@@ -241,7 +241,6 @@ The Rust Wasm Book also contains [useful debugging tips](https://rustwasm.github
 for Wasm applications.
 
 ## Further reading
-* [The API documentation](https://docs.rs/yew/0.14.3/yew/services/fetch/index.html)
-* The [dashboard](https://github.com/yewstack/yew/tree/master/examples/dashboard) and 
-[npm_and_rest](https://github.com/yewstack/yew/tree/master/examples/web_sys/npm_and_rest) examples.
+* [The API documentation](https://docs.rs/yew/0.18.0/yew/services/fetch/index.html)
+* The [dashboard](https://github.com/yewstack/yew/tree/v0.18/examples/dashboard) example
 * [The Rust Wasm Book on debugging Wasm applications](https://rustwasm.github.io/book/reference/debugging.html)

--- a/website/versioned_docs/version-0.18.0/getting-started/examples.md
+++ b/website/versioned_docs/version-0.18.0/getting-started/examples.md
@@ -8,4 +8,4 @@ We also welcome Pull Requests and issues for when they inevitably get neglected 
 
 For more details including a list of examples, refer to the [README][examples].
 
-[examples]: https://github.com/yewstack/yew/tree/master/examples
+[examples]: https://github.com/yewstack/yew/tree/v0.18/examples


### PR DESCRIPTION
#### Description
Not only fixes #1951 but all the links to examples from the version docs to the master branch.
Removed link to `npm_and_rest` example as it doesn't exist. 
Updated a doc.rs link to 0.18.0 too :D 
<!-- Please include a summary of the change. -->

Fixes #1951 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
