### PR TITLE
Fix scheduler main queue delay (#1953)

### DIFF
--- a/packages/yew/src/scheduler.rs
+++ b/packages/yew/src/scheduler.rs
@@ -116,3 +116,27 @@ impl Scheduler {
             .or_else(|| self.main.pop_front())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_executes_runnables_immediately() {
+        use std::cell::Cell;
+
+        thread_local! {
+            static FLAG: Cell<bool> = Default::default();
+        }
+
+        struct Test;
+        impl Runnable for Test {
+            fn run(self: Box<Self>) {
+                FLAG.with(|v| v.set(true));
+            }
+        }
+
+        push(Box::new(Test));
+        FLAG.with(|v| assert!(v.get()));
+    }
+}

--- a/packages/yew/src/scheduler.rs
+++ b/packages/yew/src/scheduler.rs
@@ -46,6 +46,9 @@ fn with(f: impl FnOnce(&mut Scheduler)) {
 #[inline]
 pub(crate) fn push(runnable: Box<dyn Runnable>) {
     with(|s| s.main.push_back(runnable));
+    // Execute pending immediately. Necessary for runnables added outside the component lifecycle,
+    // which would otherwise be delayed.
+    start();
 }
 
 /// Push a component creation Runnable to be executed


### PR DESCRIPTION
Fixes #1953

Executes pending runnables immediately after adding to the main queue. This was the previous behavior (before #1903).

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
