### PR TITLE
ci, docs: fix CI benchmarks and benchmarking docs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,18 +3,15 @@ name: Benchmark
 on:
   pull_request:
     branches: [master]
-    # TODO: restore after made sure the CI runs this on a PR
-    # types: [labeled, synchronize]
-    types: [synchronize]
+    types: [labeled, synchronize]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    # TODO: restore after made sure the CI runs this on a PR
-    # if: >-
-    #   (github.event.action == 'labeled' && github.event.label.name == 'performance') ||
-    #   (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'performance'))
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'performance') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'performance'))
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,7 +3,9 @@ name: Benchmark
 on:
   pull_request:
     branches: [master]
-    types: [labeled, synchronize]
+    # TODO: restore after made sure the CI runs this on a PR
+    # types: [labeled, synchronize]
+    types: [synchronize]
 
 jobs:
   build:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,18 +9,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'performance') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'performance'))
+    # TODO: restore after made sure the CI runs this on a PR
+    # if: >-
+    #   (github.event.action == 'labeled' && github.event.label.name == 'performance') ||
+    #   (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'performance'))
 
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: yewstack/js-framework-benchmark
+          repository: bakape/js-framework-benchmark
 
       - name: Configure benchmark
         run: |
-          search="{ git = \"https://github.com/yewstack/yew\", branch = \"master\" }"
+          search="{path = \"PATH\"}"
           replace="{ git = \"${{ github.event.pull_request.head.repo.html_url }}\", branch = \"${{ github.event.pull_request.head.ref }}\" }"
           input=$(cat frameworks/keyed/yew/Cargo.toml)
           output=${input//"$search"/"$replace"}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Alternatively, you can set the `ECHO_SERVER_URL` environment variable to the URL
 
 When adding or updating tests, please make sure to update the appropriate `stderr` file, which you can find [here](https://github.com/yewstack/yew/tree/master/packages/yew-macro/tests/macro) for the `html!` macro.
 These files ensure that macro compilation errors are correct and easy to understand.
-These errors can change with each release of the compiler so they should be generated with the Rust version 1.51 
+These errors can change with each release of the compiler so they should be generated with the Rust version 1.51
 (because some tests make use of const generics which were stabilized in that version).
 
 To update or generate a new `stderr` file you can run `cargo make test-overwrite` in the `yew-macro` directory.
@@ -85,11 +85,9 @@ Some components of Yew have dedicated benchmarks which can be run with the follo
 cargo make benchmarks
 ```
 
-There's also a benchmark for the framework as a whole. Running it is a bit more involved:
-
-1. Fork and clone [yewstack/js-framework-benchmark](https://github.com/yewstack/js-framework-benchmark)
-2. Update `frameworks/yew/Cargo.toml` with your fork of Yew and the branch for your changes
-3. Open a new PR with your `Cargo.toml` changes
+There's also a benchmark for the framework as a whole.
+Simply clone [bakape/js-framework-benchmark](https://github.com/bakape/js-framework-benchmark)
+and follow the repository's README.
 
 Feel free to add new benchmark tests if the current benchmark coverage is insufficient!
 


### PR DESCRIPTION
#### Description

Fixes CI benchmarking with the `performance` label and updates the docs for whole project benchmarks. 
Uses [bakape/js-framework-benchmark](https://github.com/bakape/js-framework-benchmark) which is updated to work with the current yew master branch and has a helper script for much simpler change benchmarking.  

Successful CI benchmark run can be seen here: https://github.com/yewstack/yew/runs/3098300831?check_suite_focus=true

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
