### PR TITLE
Remove unused punct field from props

### DIFF
--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -1,6 +1,4 @@
 use crate::html_tree::HtmlDashedName;
-use proc_macro2::TokenStream;
-use quote::ToTokens;
 use std::{
     cmp::Ordering,
     convert::TryFrom,
@@ -11,23 +9,9 @@ use syn::{
     Block, Expr, ExprBlock, Stmt, Token,
 };
 
-pub enum PropPunct {
-    Eq(Token![=]),
-    Colon(Token![:]),
-}
-impl ToTokens for PropPunct {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self {
-            Self::Eq(p) => p.to_tokens(tokens),
-            Self::Colon(p) => p.to_tokens(tokens),
-        }
-    }
-}
-
 pub struct Prop {
     pub label: HtmlDashedName,
     /// Punctuation between `label` and `value`.
-    pub punct: Option<PropPunct>,
     pub value: Expr,
 }
 impl Parse for Prop {
@@ -46,11 +30,7 @@ impl Parse for Prop {
             ));
         }
         let value = strip_braces(input.parse::<Expr>()?)?;
-        Ok(Self {
-            label,
-            punct: Some(PropPunct::Eq(equals)),
-            value,
-        })
+        Ok(Self { label, value })
     }
 }
 

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -1,4 +1,4 @@
-use super::{ComponentProps, Prop, PropPunct, Props, SortedPropList};
+use super::{ComponentProps, Prop, Props, SortedPropList};
 use crate::html_tree::HtmlDashedName;
 use proc_macro2::TokenStream;
 use quote::{quote_spanned, ToTokens};
@@ -42,40 +42,25 @@ fn is_associated_properties(ty: &TypePath) -> bool {
 
 struct PropValue {
     label: HtmlDashedName,
-    colon_token: Option<Token![:]>,
     value: Expr,
 }
 impl Parse for PropValue {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let label = input.parse()?;
-        let (colon_token, value) = if input.peek(Token![:]) {
-            let colon_token = input.parse()?;
-            let value = input.parse()?;
-            (Some(colon_token), value)
+        let value = if input.peek(Token![:]) {
+            let _colon_token: Token![:] = input.parse()?;
+            input.parse()?
         } else {
-            let value = syn::parse_quote!(#label);
-            (None, value)
+            syn::parse_quote!(#label)
         };
-        Ok(Self {
-            label,
-            colon_token,
-            value,
-        })
+        Ok(Self { label, value })
     }
 }
 
 impl From<PropValue> for Prop {
     fn from(prop_value: PropValue) -> Prop {
-        let PropValue {
-            label,
-            colon_token,
-            value,
-        } = prop_value;
-        Prop {
-            label,
-            punct: colon_token.map(PropPunct::Colon),
-            value,
-        }
+        let PropValue { label, value } = prop_value;
+        Prop { label, value }
     }
 }
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->
The `punct` field is unused now that the `=?` syntax has been removed. This PR code that handles different punctuation since it is not used for anything.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [X] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
