### PR TITLE
Add shorthand syntax for props

### DIFF
--- a/examples/boids/src/boid.rs
+++ b/examples/boids/src/boid.rs
@@ -130,7 +130,7 @@ impl Boid {
             points.push_str(&format!("{:.2},{:.2} ", x, y));
         }
 
-        html! { <polygon points={points} fill={color} /> }
+        html! { <polygon {points} fill={color} /> }
     }
 }
 

--- a/examples/boids/src/main.rs
+++ b/examples/boids/src/main.rs
@@ -73,7 +73,7 @@ impl Component for Model {
         html! {
             <>
                 <h1 class="title">{ "Boids" }</h1>
-                <Simulation settings={settings.clone()} generation={generation} paused={paused} />
+                <Simulation settings={settings.clone()} {generation} {paused} />
                 { self.view_panel() }
             </>
         }

--- a/examples/boids/src/slider.rs
+++ b/examples/boids/src/slider.rs
@@ -82,7 +82,7 @@ impl Component for Slider {
             <div class="slider">
                 <label for={id.clone()} class="slider__label">{ label }</label>
                 <input type="range"
-                    id={id}
+                    {id}
                     class="slider__input"
                     min={min.to_string()} max={max.to_string()} step={step.to_string()}
                     oninput={onchange.reform(|data: InputData| data.value.parse().unwrap())}

--- a/examples/nested_list/src/app.rs
+++ b/examples/nested_list/src/app.rs
@@ -48,22 +48,21 @@ impl Component for App {
         let sub_list_link = &self.sub_list_link;
 
         // note the use of `html_nested!` instead of `html!`.
-        let letters = ('A'..='C').map(
-            |letter| html_nested! { <ListItem name={letter.to_string()} on_hover={on_hover} /> },
-        );
+        let letters = ('A'..='C')
+            .map(|letter| html_nested! { <ListItem name={letter.to_string()} {on_hover} /> });
 
         html! {
-            <div class="main" onmouseenter={onmouseenter}>
+            <div class="main" {onmouseenter}>
                 <h1>{ "Nested List Demo" }</h1>
-                <List on_hover={on_hover} weak_link={list_link}>
-                    <ListHeader text="Calling all Rusties!" on_hover={on_hover} list_link={list_link} />
-                    <ListItem name="Rustin" on_hover={on_hover} />
-                    <ListItem hide=true name="Rustaroo" on_hover={on_hover} />
-                    <ListItem name="Rustifer" on_hover={on_hover}>
+                <List {on_hover} weak_link={list_link}>
+                    <ListHeader text="Calling all Rusties!" {on_hover} {list_link} />
+                    <ListItem name="Rustin" {on_hover} />
+                    <ListItem hide=true name="Rustaroo" {on_hover} />
+                    <ListItem name="Rustifer" {on_hover}>
                         <div class="sublist">{ "Sublist!" }</div>
-                        <List on_hover={on_hover} weak_link={sub_list_link}>
-                            <ListHeader text="Sub Rusties!" on_hover={on_hover} list_link={sub_list_link}/>
-                            <ListItem hide=true name="Hidden Sub" on_hover={on_hover} />
+                        <List {on_hover} weak_link={sub_list_link}>
+                            <ListHeader text="Sub Rusties!" {on_hover} list_link={sub_list_link}/>
+                            <ListItem hide=true name="Hidden Sub" {on_hover} />
                             { for letters }
                         </List>
                     </ListItem>

--- a/examples/nested_list/src/header.rs
+++ b/examples/nested_list/src/header.rs
@@ -44,7 +44,7 @@ impl Component for ListHeader {
         html! {
             <div
                 class="list-header"
-                onmouseover={onmouseover}
+                {onmouseover}
                 onclick={list_link.callback(|_| ListMsg::HeaderClick)}
             >
                 { &self.props.text }

--- a/examples/nested_list/src/item.rs
+++ b/examples/nested_list/src/item.rs
@@ -45,7 +45,7 @@ impl Component for ListItem {
             })
         };
         html! {
-            <div class="list-item" onmouseover={onmouseover}>
+            <div class="list-item" {onmouseover}>
                 { &self.props.name }
                 { self.view_details() }
             </div>

--- a/examples/nested_list/src/list.rs
+++ b/examples/nested_list/src/list.rs
@@ -102,7 +102,7 @@ impl Component for List {
         let onmouseover = self.props.on_hover.reform(|_| Hovered::List);
         let onmouseout = self.props.on_hover.reform(|_| Hovered::None);
         html! {
-            <div class="list-container" onmouseout={onmouseout} onmouseover={onmouseover}>
+            <div class="list-container" {onmouseout} {onmouseover}>
                 <div class={classes!("list", inactive)}>
                     { self.view_header() }
                     <div class="items">

--- a/examples/router/src/components/pagination.rs
+++ b/examples/router/src/components/pagination.rs
@@ -53,7 +53,7 @@ impl Pagination {
 
         html! {
             <li>
-                <a class={classes!("pagination-link", is_current_class)} aria-label={format!("Goto page {}", to_page)} onclick={onclick}>
+                <a class={classes!("pagination-link", is_current_class)} aria-label={format!("Goto page {}", to_page)} {onclick}>
                     { to_page }
                 </a>
             </li>

--- a/examples/router/src/pages/author_list.rs
+++ b/examples/router/src/pages/author_list.rs
@@ -42,7 +42,7 @@ impl Component for AuthorList {
             html! {
                 <div class="tile is-parent">
                     <div class="tile is-child">
-                        <AuthorCard seed={seed} />
+                        <AuthorCard {seed} />
                     </div>
                 </div>
             }

--- a/examples/router/src/pages/post_list.rs
+++ b/examples/router/src/pages/post_list.rs
@@ -48,7 +48,7 @@ impl Component for PostList {
                 <h2 class="subtitle">{ "All of our quality writing in one place" }</h2>
                 { self.view_posts() }
                 <Pagination
-                    page={page}
+                    {page}
                     total_pages={TOTAL_PAGES}
                     on_switch_page={self.link.callback(Msg::ShowPage)}
                 />

--- a/examples/store/src/main.rs
+++ b/examples/store/src/main.rs
@@ -67,7 +67,7 @@ impl Component for Model {
                 <TextInput value="New post" onsubmit={self.link.callback(Msg::CreatePost)} />
 
                 <div>
-                    { for self.post_ids.iter().map(|&id| html!{ <Post key={id} id={id} /> }) }
+                    { for self.post_ids.iter().map(|&id| html!{ <Post key={id} {id} /> }) }
                 </div>
             </>
         }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -209,7 +209,7 @@ impl Model {
             class.push(" completed");
         }
         html! {
-            <li class={class}>
+            <li {class}>
                 <div class="view">
                     <input
                         type="checkbox"

--- a/packages/yew-macro/src/derive_props/builder.rs
+++ b/packages/yew-macro/src/derive_props/builder.rs
@@ -41,13 +41,13 @@ impl ToTokens for PropsBuilder<'_> {
 
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let turbofish_generics = ty_generics.as_turbofish();
-        let generic_args = to_arguments(&generics, build_step.clone());
+        let generic_args = to_arguments(generics, build_step.clone());
 
         // Each builder step implements the `BuilderStep` trait and `step_generics` is used to
         // enforce that.
         let step_generic_param = Ident::new("YEW_PROPS_BUILDER_STEP", Span::call_site());
         let step_generics =
-            with_param_bounds(&generics, step_generic_param.clone(), (*step_trait).clone());
+            with_param_bounds(generics, step_generic_param.clone(), (*step_trait).clone());
 
         let builder = quote! {
             #(

--- a/packages/yew-macro/src/derive_props/mod.rs
+++ b/packages/yew-macro/src/derive_props/mod.rs
@@ -61,13 +61,13 @@ impl ToTokens for DerivePropsInput {
 
         // The wrapper is a new struct which wraps required props in `Option`
         let wrapper_name = Ident::new(&format!("{}Wrapper", props_name), Span::call_site());
-        let wrapper = PropsWrapper::new(&wrapper_name, &generics, &self.prop_fields);
+        let wrapper = PropsWrapper::new(&wrapper_name, generics, &self.prop_fields);
         tokens.extend(wrapper.into_token_stream());
 
         // The builder will only build if all required props have been set
         let builder_name = Ident::new(&format!("{}Builder", props_name), Span::call_site());
         let builder_step = Ident::new(&format!("{}BuilderStep", props_name), Span::call_site());
-        let builder = PropsBuilder::new(&builder_name, &builder_step, &self, &wrapper_name);
+        let builder = PropsBuilder::new(&builder_name, &builder_step, self, &wrapper_name);
         let builder_generic_args = builder.first_step_generic_args();
         tokens.extend(builder.into_token_stream());
 

--- a/packages/yew-macro/src/html_tree/html_dashed_name.rs
+++ b/packages/yew-macro/src/html_tree/html_dashed_name.rs
@@ -90,3 +90,12 @@ impl Stringify for HtmlDashedName {
         self.to_lit_str().stringify()
     }
 }
+
+impl From<Ident> for HtmlDashedName {
+    fn from(name: Ident) -> Self {
+        HtmlDashedName {
+            name,
+            extended: vec![],
+        }
+    }
+}

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -46,7 +46,7 @@ impl Prop {
             } else {
                 Err(syn::Error::new_spanned(
                     path,
-                    "only simple identifiers may be used with the shorthand property syntax",
+                    "only simple identifiers are allowed in the shorthand property syntax",
                 ))
             }
         } else {

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -46,7 +46,7 @@ impl Prop {
             } else {
                 Err(syn::Error::new_spanned(
                     path,
-                    "only simple identifiers are allowed in the shorthand property syntax",
+                    "only simple identifiers may be used with the shorthand property syntax",
                 ))
             }
         } else {

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -41,20 +41,18 @@ impl Prop {
             ref path,
         }) = expr
         {
-            let ident = path.get_ident();
-            if !attrs.is_empty() || ident.is_none() {
-                return Err(syn::Error::new_spanned(
+            if let (Some(ident), true) = (path.get_ident(), attrs.is_empty()) {
+                syn::Result::Ok(HtmlDashedName::from(ident.clone()))
+            } else {
+                Err(syn::Error::new_spanned(
                     path,
                     "only simple identifiers are allowed in the shorthand property syntax",
-                ));
+                ))
             }
-            // The above if-statement ensures that path is a simple identifier
-            // So this unwrap will never return None
-            syn::Result::Ok(HtmlDashedName::from(ident.unwrap().clone()))
         } else {
             return Err(syn::Error::new_spanned(
                 expr,
-                "misisng label for property value. If trying to use the shorthand property syntax, only identifiers may be used",
+                "missing label for property value. If trying to use the shorthand property syntax, only identifiers may be used",
             ));
         }?;
 

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -5,8 +5,10 @@ use std::{
     ops::{Deref, DerefMut},
 };
 use syn::{
+    braced,
     parse::{Parse, ParseStream},
-    Block, Expr, ExprBlock, Stmt, Token,
+    token::Brace,
+    Block, Expr, ExprBlock, ExprPath, Stmt, Token,
 };
 
 pub struct Prop {
@@ -16,6 +18,51 @@ pub struct Prop {
 }
 impl Parse for Prop {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(Brace) {
+            Self::parse_shorthand_prop_assignment(input)
+        } else {
+            Self::parse_prop_assignment(input)
+        }
+    }
+}
+
+/// Helpers for parsing props
+impl Prop {
+    /// Parse a prop using the shorthand syntax `{value}`, short for `value={value}`
+    /// This only allows for labels with no hyphens, as it would otherwise create
+    /// an ambiguity in the syntax
+    fn parse_shorthand_prop_assignment(input: ParseStream) -> syn::Result<Self> {
+        let value;
+        let _brace = braced!(value in input);
+        let expr = value.parse::<Expr>()?;
+        let label = if let Expr::Path(ExprPath {
+            ref attrs,
+            qself: None,
+            ref path,
+        }) = expr
+        {
+            let ident = path.get_ident();
+            if !attrs.is_empty() || ident.is_none() {
+                return Err(syn::Error::new_spanned(
+                    path,
+                    "only simple identifiers are allowed in the shorthand property syntax",
+                ));
+            }
+            // The above if-statement ensures that path is a simple identifier
+            // So this unwrap will never return None
+            syn::Result::Ok(HtmlDashedName::from(ident.unwrap().clone()))
+        } else {
+            return Err(syn::Error::new_spanned(
+                expr,
+                "misisng label for property value. If trying to use the shorthand property syntax, only identifiers may be used",
+            ));
+        }?;
+
+        Ok(Self { label, value: expr })
+    }
+
+    /// Parse a prop of the form `label={value}`
+    fn parse_prop_assignment(input: ParseStream) -> syn::Result<Self> {
         let label = input.parse::<HtmlDashedName>()?;
         let equals = input.parse::<Token![=]>().map_err(|_| {
             syn::Error::new_spanned(

--- a/packages/yew-macro/tests/html_macro/component-fail.rs
+++ b/packages/yew-macro/tests/html_macro/component-fail.rs
@@ -103,7 +103,7 @@ fn compile_fail() {
     // using `children` as a prop while simultaneously passing children using the syntactic sugar
     let children = ChildrenRenderer::new(vec![html_nested! { <Child int=0 /> }]);
     html! {
-        <ChildContainer children={children}>
+        <ChildContainer {children}>
             <Child int=1 />
         </ChildContainer>
     };

--- a/packages/yew-macro/tests/html_macro/component-fail.rs
+++ b/packages/yew-macro/tests/html_macro/component-fail.rs
@@ -112,6 +112,11 @@ fn compile_fail() {
         <span>{ 1 }</span>
         <span>{ 2 }</span>
     };
+
+    html! { <Child {std::f64::consts::PI} /> };
+    html! { <Child {7 + 6} /> };
+    html! { <Child {children.len()} /> };
+
 }
 
 fn main() {}

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -154,10 +154,10 @@ error: only one root html element is allowed (hint: you can wrap multiple html e
    |                            ^^^^^^^^^^^^^^^
 
 error: cannot specify the `children` prop when the component already has children
-   --> $DIR/component-fail.rs:106:25
+   --> $DIR/component-fail.rs:106:26
     |
-106 |         <ChildContainer children={children}>
-    |                         ^^^^^^^^
+106 |         <ChildContainer {children}>
+    |                          ^^^^^^^^
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
    --> $DIR/component-fail.rs:113:9

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -165,6 +165,24 @@ error: only one root html element is allowed (hint: you can wrap multiple html e
 113 |         <span>{ 2 }</span>
     |         ^^^^^^^^^^^^^^^^^^
 
+error: only simple identifiers are allowed in the shorthand property syntax
+   --> $DIR/component-fail.rs:116:21
+    |
+116 |     html! { <Child {std::f64::consts::PI} /> };
+    |                     ^^^^^^^^^^^^^^^^^^^^
+
+error: missing label for property value. If trying to use the shorthand property syntax, only identifiers may be used
+   --> $DIR/component-fail.rs:117:21
+    |
+117 |     html! { <Child {7 + 6} /> };
+    |                     ^^^^^
+
+error: missing label for property value. If trying to use the shorthand property syntax, only identifiers may be used
+   --> $DIR/component-fail.rs:118:21
+    |
+118 |     html! { <Child {children.len()} /> };
+    |                     ^^^^^^^^^^^^^^
+
 error[E0425]: cannot find value `blah` in this scope
   --> $DIR/component-fail.rs:69:25
    |

--- a/packages/yew-macro/tests/html_macro/component-pass.rs
+++ b/packages/yew-macro/tests/html_macro/component-pass.rs
@@ -177,6 +177,12 @@ fn compile_pass() {
         <Child int=1 string={name_expr} />
     };
 
+    let string = "child";
+    let int = 1;
+    html! {
+        <Child {int} {string} />
+    };
+
     html! {
         <>
             <Child int=1 />
@@ -192,6 +198,15 @@ fn compile_pass() {
             <Child int=1 ref={node_ref} />
         </>
     };
+
+    let int = 1;
+    let node_ref = NodeRef::default();
+    html! {
+        <>
+            <Child {int} ref={node_ref} />
+        </>
+    };
+
 
     let props = <Container as Component>::Properties::default();
     html! {

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -42,7 +42,7 @@ fn compile_pass() {
             </svg>
             <img class={classes!("avatar", "hidden")} src="http://pic.com" />
             <img class="avatar hidden" />
-            <button onclick={&onclick} onclick={onclick} />
+            <button onclick={&onclick} {onclick} />
             <a href="http://google.com" />
             <custom-tag-a>
                 <custom-tag-b />

--- a/packages/yew-router/tests/router.rs
+++ b/packages/yew-router/tests/router.rs
@@ -58,7 +58,7 @@ fn component() -> Html {
             Routes::Home => html! {
                 <>
                     <div id="result">{"Home"}</div>
-                    <a onclick={onclick}>{"click me"}</a>
+                    <a {onclick}>{"click me"}</a>
                 </>
             },
             Routes::No { id } => html! { <No id={*id} /> },

--- a/packages/yew/src/functional/hooks/use_effect.rs
+++ b/packages/yew/src/functional/hooks/use_effect.rs
@@ -31,7 +31,7 @@ struct UseEffect<Destructor> {
 ///     };
 ///
 ///     html! {
-///         <button onclick={onclick}>{ format!("Increment to {}", *counter) }</button>
+///         <button {onclick}>{ format!("Increment to {}", *counter) }</button>
 ///     }
 /// }
 /// ```

--- a/packages/yew/src/functional/hooks/use_ref.rs
+++ b/packages/yew/src/functional/hooks/use_ref.rs
@@ -41,8 +41,8 @@ use std::{cell::RefCell, rc::Rc};
 ///
 ///     html! {
 ///         <div>
-///             <input onchange={onchange} value={(*message).clone()} />
-///             <button onclick={onclick}>{ "Send" }</button>
+///             <input {onchange} value={(*message).clone()} />
+///             <button {onclick}>{ "Send" }</button>
 ///         </div>
 ///     }
 /// }

--- a/packages/yew/src/functional/hooks/use_state.rs
+++ b/packages/yew/src/functional/hooks/use_state.rs
@@ -25,7 +25,7 @@ struct UseState<T2> {
 ///
 ///     html! {
 ///         <div>
-///             <button onclick={onclick}>{ "Increment value" }</button>
+///             <button {onclick}>{ "Increment value" }</button>
 ///             <p>
 ///                 <b>{ "Current value: " }</b>
 ///                 { *counter }

--- a/packages/yew/tests/use_context.rs
+++ b/packages/yew/tests/use_context.rs
@@ -267,7 +267,7 @@ fn use_context_update_works() {
                 <MyContextProvider context={Rc::new((*ctx).clone())}>
                     <RenderCounter id="test-0">
                         <ContextOutlet id="test-1"/>
-                        <ContextOutlet id="test-2" magic={magic}/>
+                        <ContextOutlet id="test-2" {magic}/>
                     </RenderCounter>
                 </MyContextProvider>
             };

--- a/packages/yew/tests/use_effect.rs
+++ b/packages/yew/tests/use_effect.rs
@@ -60,7 +60,7 @@ fn use_effect_destroys_on_component_drop() {
             if *show {
                 let effect_called: Rc<dyn Fn()> = { Rc::new(move || show.set(false)) };
                 html! {
-                    <UseEffectComponent destroy_called={props.destroy_called.clone()} effect_called={effect_called} />
+                    <UseEffectComponent destroy_called={props.destroy_called.clone()} {effect_called} />
                 }
             } else {
                 html! {

--- a/website/docs/concepts/components.md
+++ b/website/docs/concepts/components.md
@@ -49,6 +49,7 @@ HTML-like code using Rust functions can become quite messy, so Yew provides a ma
 for declaring HTML and SVG nodes (as well as attaching attributes and event listeners to them) and a
 convenient way to render child components. The macro is somewhat similar to React's JSX (the
 differences in programming language aside).
+One difference is that Yew provides a shorthand syntax for properties, similar to Svelte, where instead of writing `onclick={onclick}`, you can just write `{onclick}`.
 
 ```rust
 impl Component for MyComponent {
@@ -57,7 +58,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         let onclick = self.link.callback(|_| Msg::Click);
         html! {
-            <button onclick={onclick}>{ self.props.button_text }</button>
+            <button {onclick}>{ self.props.button_text }</button>
         }
     }
 }

--- a/website/docs/concepts/components/callbacks.md
+++ b/website/docs/concepts/components/callbacks.md
@@ -71,7 +71,7 @@ A simple use of a callback might look something like this:
 ```rust
 let onclick = self.link.callback(|_| Msg::Clicked);
 html! {
-    <button onclick={onclick}>{ "Click" }</button>
+    <button {onclick}>{ "Click" }</button>
 }
 ```
 
@@ -89,7 +89,7 @@ let onkeypress = self.link.batch_callback(|event| {
 });
 
 html! {
-    <input type="text" onkeypress={onkeypress} />
+    <input type="text" {onkeypress} />
 }
 ```
 

--- a/website/docs/concepts/contexts.md
+++ b/website/docs/concepts/contexts.md
@@ -11,14 +11,14 @@ theme using props:
 // root
 let theme = // ...
 html! {
-    <Navbar theme={theme} />
+    <Navbar {theme} />
 }
 
 // Navbar component
 html! {
     <div>
-        <Title theme={theme}>{ "App title" }<Title>
-        <NavButton theme={theme}>{ "Somewhere" }</NavButton>
+        <Title {theme}>{ "App title" }<Title>
+        <NavButton {theme}>{ "Somewhere" }</NavButton>
     </div>
 }
 ```

--- a/website/docs/concepts/function-components/attribute.md
+++ b/website/docs/concepts/function-components/attribute.md
@@ -51,7 +51,7 @@ fn app() -> Html {
 
     html! {
         <div>
-            <button onclick={onclick}>{ "Increment value" }</button>
+            <button {onclick}>{ "Increment value" }</button>
             <p>
                 <b>{ "Current value: " }</b>
                 { counter }

--- a/website/docs/concepts/function-components/pre-defined-hooks.md
+++ b/website/docs/concepts/function-components/pre-defined-hooks.md
@@ -26,7 +26,7 @@ fn state() -> Html {
 
     html! {
         <div>
-            <button onclick={onclick}>{ "Increment value" }</button>
+            <button {onclick}>{ "Increment value" }</button>
             <p>
                 <b>{ "Current value: " }</b>
                 { *counter }
@@ -70,8 +70,8 @@ fn ref_hook() -> Html {
 
     html! {
         <div>
-            <input onchange={onchange} value={message} />
-            <button onclick={onclick}>{ "Send" }</button>
+            <input {onchange} value={message} />
+            <button {onclick}>{ "Send" }</button>
         </div>
     }
 }
@@ -191,7 +191,7 @@ fn effect() -> Html {
     };
 
     html! {
-        <button onclick={onclick}>{ format!("Increment to {}", counter) }</button>
+        <button {onclick}>{ format!("Increment to {}", counter) }</button>
     }
 }
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/components.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/components.md
@@ -55,7 +55,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         let onclick = self.link.callback(|_| Msg::Click);
         html! {
-            <button onclick={onclick}>{ self.props.button_text }</button>
+            <button {onclick}>{ self.props.button_text }</button>
         }
     }
 }

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/concepts/components.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/concepts/components.md
@@ -51,7 +51,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         let onclick = self.link.callback(|_| Msg::Click);
         html! {
-            <button onclick={onclick}>{ self.props.button_text }</button>
+            <button {onclick}>{ self.props.button_text }</button>
         }
     }
 }

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/current/concepts/components.md
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/current/concepts/components.md
@@ -51,7 +51,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         let onclick = self.link.callback(|_| Msg::Click);
         html! {
-            <button onclick={onclick}>{ self.props.button_text }</button>
+            <button {onclick}>{ self.props.button_text }</button>
         }
     }
 }


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->
Now that braces are required around props, we can allow the svelte-style shorthand syntax for props:
Instead of `my_prop={my_prop}`, this allows you to just write `{my_prop}`.

Mentioned in #1769  <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [X] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
- [X] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
