### PR TITLE
Support const generics in `#[derive(Properties)]`

### DIFF
--- a/packages/yew-macro/src/derive_props/generics.rs
+++ b/packages/yew-macro/src/derive_props/generics.rs
@@ -8,7 +8,7 @@ use syn::{
 /// Alias for a comma-separated list of `GenericArgument`
 pub type GenericArguments = Punctuated<GenericArgument, Token![,]>;
 
-/// Finds the index of the first generic param with a default value.
+/// Finds the index of the first generic param with a default value or a const generic.
 fn first_default_or_const_param_position(generics: &Generics) -> Option<usize> {
     generics.params.iter().position(|param| match param {
         GenericParam::Type(param) => param.default.is_some(),

--- a/packages/yew-macro/src/derive_props/generics.rs
+++ b/packages/yew-macro/src/derive_props/generics.rs
@@ -9,9 +9,10 @@ use syn::{
 pub type GenericArguments = Punctuated<GenericArgument, Token![,]>;
 
 /// Finds the index of the first generic param with a default value.
-fn first_default_param_position(generics: &Generics) -> Option<usize> {
+fn first_default_or_const_param_position(generics: &Generics) -> Option<usize> {
     generics.params.iter().position(|param| match param {
         GenericParam::Type(param) => param.default.is_some(),
+        GenericParam::Const(_) => true,
         _ => false,
     })
 }
@@ -25,11 +26,11 @@ pub fn to_arguments(generics: &Generics, type_ident: Ident) -> GenericArguments 
         GenericParam::Lifetime(lifetime_param) => {
             GenericArgument::Lifetime(lifetime_param.lifetime.clone())
         }
-        _ => unimplemented!("const params are not supported in the derive macro"),
+        GenericParam::Const(const_param) => new_generic_type_arg(const_param.ident.clone()),
     }));
 
     let new_arg = new_generic_type_arg(type_ident);
-    if let Some(index) = first_default_param_position(generics) {
+    if let Some(index) = first_default_or_const_param_position(generics) {
         args.insert(index, new_arg);
     } else {
         args.push(new_arg);
@@ -44,7 +45,7 @@ pub fn with_param_bounds(generics: &Generics, param_ident: Ident, param_bounds: 
     let mut new_generics = generics.clone();
     let params = &mut new_generics.params;
     let new_param = new_param_bounds(param_ident, param_bounds);
-    if let Some(index) = first_default_param_position(generics) {
+    if let Some(index) = first_default_or_const_param_position(generics) {
         params.insert(index, new_param);
     } else {
         params.push(new_param);

--- a/packages/yew-macro/tests/derive_props/pass.rs
+++ b/packages/yew-macro/tests/derive_props/pass.rs
@@ -188,6 +188,20 @@ mod t10 {
 mod t11 {
     use super::*;
 
+    // this test makes sure that Yew handles generic params with const generics properly.
+
+    #[derive(Clone, Properties)]
+    pub struct Foo<T, const N: usize>
+    where
+        T: Clone,
+    {
+        bar: [T; N],
+    }
+}
+
+mod t12 {
+    use super::*;
+
     #[derive(Clone, Properties)]
     pub struct Props<T: Clone> {
         value: Option<T>,


### PR DESCRIPTION
#### Description

Adds support for deriving `Properties` on a struct with `const` generics.

Decided to use an `ArrayVec` in my props and run into this on my second day using Yew, turned out to be fairly straightforward fix.

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
