### PR TITLE
Fix multiple field enum tokens

### DIFF
--- a/packages/yew-router-macro/src/routable_derive.rs
+++ b/packages/yew-router-macro/src/routable_derive.rs
@@ -119,7 +119,7 @@ impl Routable {
                         //named fields have idents
                         it.ident.as_ref().unwrap()
                     });
-                    quote! { Self::#ident { #(#fields: params.get(stringify!(#fields))?.parse().ok()?)*, } }
+                    quote! { Self::#ident { #(#fields: params.get(stringify!(#fields))?.parse().ok()?,)* } }
                 }
                 Fields::Unnamed(_) => unreachable!(), // already checked
             };

--- a/packages/yew-router-macro/tests/routable_derive/valid-pass.rs
+++ b/packages/yew-router-macro/tests/routable_derive/valid-pass.rs
@@ -6,6 +6,8 @@ enum Routes {
     One,
     #[at("/two/:id")]
     Two { id: u32 },
+    #[at("/:a/:b")]
+    Three { a: u32, b: u32 },
     #[at("/404")]
     #[not_found]
     NotFound,


### PR DESCRIPTION
#### Description

A small change so that enums with multiple fields are comma seperated.

Added a trybuild test to check that multi field routes compile now :)

<!-- Please include a summary of the change. -->

Fixes #1987 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
