### PR TITLE
Add custom event support 

### DIFF
--- a/examples/boids/src/main.rs
+++ b/examples/boids/src/main.rs
@@ -81,9 +81,9 @@ impl Model {
             <div class="panel">
                 { self.view_settings(link) }
                 <div class="panel__buttons">
-                    <button onclick={link.callback(|_| Msg::TogglePause)}>{ pause_text }</button>
-                    <button onclick={link.callback(|_| Msg::ResetSettings)}>{ "Use Defaults" }</button>
-                    <button onclick={link.callback(|_| Msg::RestartSimulation)}>{ "Restart" }</button>
+                    <button on:click={link.callback(|_| Msg::TogglePause)}>{ pause_text }</button>
+                    <button on:click={link.callback(|_| Msg::ResetSettings)}>{ "Use Defaults" }</button>
+                    <button on:click={link.callback(|_| Msg::RestartSimulation)}>{ "Restart" }</button>
                 </div>
             </div>
         }

--- a/examples/boids/src/slider.rs
+++ b/examples/boids/src/slider.rs
@@ -70,7 +70,7 @@ impl Component for Slider {
             10f64.powi(-(p as i32))
         });
 
-        let oninput = onchange.reform(|e: InputEvent| {
+        let input = onchange.reform(|e: InputEvent| {
             let input: HtmlInputElement = e.target_unchecked_into();
             input.value_as_number()
         });
@@ -82,7 +82,7 @@ impl Component for Slider {
                     {id}
                     class="slider__input"
                     min={min.to_string()} max={max.to_string()} step={step.to_string()}
-                    {oninput}
+                    on:{input}
                 />
                 <span class="slider__value">{ display_value }</span>
             </div>

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -40,17 +40,17 @@ impl Component for Model {
             <div>
                 <div class="panel">
                     // A button to send the Increment message
-                    <button class="button" onclick={ctx.link().callback(|_| Msg::Increment)}>
+                    <button class="button" on:click={ctx.link().callback(|_| Msg::Increment)}>
                         { "+1" }
                     </button>
 
                     // A button to send the Decrement message
-                    <button onclick={ctx.link().callback(|_| Msg::Decrement)}>
+                    <button on:click={ctx.link().callback(|_| Msg::Decrement)}>
                         { "-1" }
                     </button>
 
                     // A button to send two Increment messages
-                    <button onclick={ctx.link().batch_callback(|_| vec![Msg::Increment, Msg::Increment])}>
+                    <button on:click={ctx.link().batch_callback(|_| vec![Msg::Increment, Msg::Increment])}>
                         { "+1, +1" }
                     </button>
 

--- a/examples/crm/src/add_client.rs
+++ b/examples/crm/src/add_client.rs
@@ -78,27 +78,27 @@ impl Component for AddClientForm {
                     <input
                         class={classes!("new-client", "firstname")}
                         placeholder="First name"
-                        onchange={update_name(Msg::UpdateFirstName)}
+                        on:change={update_name(Msg::UpdateFirstName)}
                     />
                     <input
                         class={classes!("new-client", "lastname")}
                         placeholder="Last name"
-                        onchange={update_name(Msg::UpdateLastName)}
+                        on:change={update_name(Msg::UpdateLastName)}
                     />
                     <textarea
                         class={classes!("new-client", "description")}
                         placeholder="Description"
-                        onchange={update_desc}
+                        on:change={update_desc}
                     />
                 </div>
 
                 <button
                     disabled={client.first_name.is_empty() || client.last_name.is_empty()}
-                    onclick={link.callback(|_| Msg::Add)}
+                    on:click={link.callback(|_| Msg::Add)}
                 >
                     { "Add New" }
                 </button>
-                <button onclick={link.callback(|_| Msg::Abort)}>
+                <button on:click={link.callback(|_| Msg::Abort)}>
                     { "Go Back" }
                 </button>
             </>

--- a/examples/crm/src/main.rs
+++ b/examples/crm/src/main.rs
@@ -91,8 +91,8 @@ impl Component for Model {
                     <div class="clients">
                         { for self.clients.iter().map(Client::render) }
                     </div>
-                    <button onclick={ctx.link().callback(|_| Msg::SwitchTo(Scene::NewClientForm))}>{ "Add New" }</button>
-                    <button onclick={ctx.link().callback(|_| Msg::SwitchTo(Scene::Settings))}>{ "Settings" }</button>
+                    <button on:click={ctx.link().callback(|_| Msg::SwitchTo(Scene::NewClientForm))}>{ "Add New" }</button>
+                    <button on:click={ctx.link().callback(|_| Msg::SwitchTo(Scene::Settings))}>{ "Settings" }</button>
                 </div>
             },
             Scene::NewClientForm => html! {
@@ -104,8 +104,8 @@ impl Component for Model {
             Scene::Settings => html! {
                 <div>
                     <h1>{"Settings"}</h1>
-                    <button onclick={ctx.link().callback(|_| Msg::ClearClients)}>{ "Remove all clients" }</button>
-                    <button onclick={ctx.link().callback(|_| Msg::SwitchTo(Scene::ClientsList))}>{ "Go Back" }</button>
+                    <button on:click={ctx.link().callback(|_| Msg::ClearClients)}>{ "Remove all clients" }</button>
+                    <button on:click={ctx.link().callback(|_| Msg::SwitchTo(Scene::ClientsList))}>{ "Go Back" }</button>
                 </div>
             },
         }

--- a/examples/dyn_create_destroy_apps/src/counter.rs
+++ b/examples/dyn_create_destroy_apps/src/counter.rs
@@ -53,7 +53,7 @@ impl Component for CounterModel {
                 </p>
 
                 // Add button to send a destroy command to the parent app
-                <button class="destroy" onclick={Callback::from(move |_| destroy_callback.emit(()))}>
+                <button class="destroy" on:click={Callback::from(move |_| destroy_callback.emit(()))}>
                     { "Destroy this app" }
                 </button>
             </>

--- a/examples/dyn_create_destroy_apps/src/main.rs
+++ b/examples/dyn_create_destroy_apps/src/main.rs
@@ -92,7 +92,7 @@ impl Component for Model {
                     // Create button to create a new app
                     <button
                         class="create"
-                        onclick={ctx.link().callback(|_| Msg::SpawnCounterAppInstance)}
+                        on:click={ctx.link().callback(|_| Msg::SpawnCounterAppInstance)}
                     >
                         { "Spawn new CounterModel app" }
                     </button>

--- a/examples/file_upload/src/main.rs
+++ b/examples/file_upload/src/main.rs
@@ -82,7 +82,7 @@ impl Component for Model {
             <div>
                 <div>
                     <p>{ "Choose a file to upload to see the uploaded bytes" }</p>
-                    <input type="file" multiple=true onchange={ctx.link().callback(move |e: Event| {
+                    <input type="file" multiple=true on:change={ctx.link().callback(move |e: Event| {
                             let mut result = Vec::new();
                             let input: HtmlInputElement = e.target_unchecked_into();
 
@@ -100,7 +100,7 @@ impl Component for Model {
                 </div>
                 <div>
                     <label>{ "Read bytes" }</label>
-                    <input type="checkbox" checked={flag} onclick={ctx.link().callback(|_| Msg::ToggleReadBytes)} />
+                    <input type="checkbox" checked={flag} on:click={ctx.link().callback(|_| Msg::ToggleReadBytes)} />
                 </div>
                 <ul>
                     { for self.files.iter().map(|f| Self::view_file(f)) }

--- a/examples/futures/src/main.rs
+++ b/examples/futures/src/main.rs
@@ -112,10 +112,10 @@ impl Component for Model {
         match &self.markdown {
             FetchState::NotFetching => html! {
                 <>
-                    <button onclick={ctx.link().callback(|_| Msg::GetMarkdown)}>
+                    <button on:click={ctx.link().callback(|_| Msg::GetMarkdown)}>
                         { "Get Markdown" }
                     </button>
-                    <button onclick={ctx.link().callback(|_| Msg::GetError)}>
+                    <button on:click={ctx.link().callback(|_| Msg::GetError)}>
                         { "Get using incorrect URL" }
                     </button>
                 </>

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -96,7 +96,7 @@ impl Model {
         };
         html! {
             <div key={idx} class={classes!("game-cellule", cellule_status)}
-                onclick={link.callback(move |_| Msg::ToggleCellule(idx))}>
+                on:click={link.callback(move |_| Msg::ToggleCellule(idx))}>
             </div>
         }
     }
@@ -193,11 +193,11 @@ impl Component for Model {
                             { for cell_rows }
                         </div>
                         <div class="game-buttons">
-                            <button class="game-button" onclick={ctx.link().callback(|_| Msg::Random)}>{ "Random" }</button>
-                            <button class="game-button" onclick={ctx.link().callback(|_| Msg::Step)}>{ "Step" }</button>
-                            <button class="game-button" onclick={ctx.link().callback(|_| Msg::Start)}>{ "Start" }</button>
-                            <button class="game-button" onclick={ctx.link().callback(|_| Msg::Stop)}>{ "Stop" }</button>
-                            <button class="game-button" onclick={ctx.link().callback(|_| Msg::Reset)}>{ "Reset" }</button>
+                            <button class="game-button" on:click={ctx.link().callback(|_| Msg::Random)}>{ "Random" }</button>
+                            <button class="game-button" on:click={ctx.link().callback(|_| Msg::Step)}>{ "Step" }</button>
+                            <button class="game-button" on:click={ctx.link().callback(|_| Msg::Start)}>{ "Start" }</button>
+                            <button class="game-button" on:click={ctx.link().callback(|_| Msg::Stop)}>{ "Stop" }</button>
+                            <button class="game-button" on:click={ctx.link().callback(|_| Msg::Reset)}>{ "Reset" }</button>
                         </div>
                     </section>
                 </section>

--- a/examples/js_callback/src/main.rs
+++ b/examples/js_callback/src/main.rs
@@ -51,16 +51,16 @@ impl Component for Model {
             <>
                 <textarea
                     class="code-block"
-                    oninput={ctx.link().callback(|e: InputEvent| {
+                    on:input={ctx.link().callback(|e: InputEvent| {
                         let input: HtmlTextAreaElement = e.target_unchecked_into();
                         Msg::Payload(input.value())
                     })}
                     value={self.payload.clone()}
                 />
-                <button onclick={ctx.link().callback(|_| Msg::Payload(bindings::get_payload()))}>
+                <button on:click={ctx.link().callback(|_| Msg::Payload(bindings::get_payload()))}>
                     { "Get the payload!" }
                 </button>
-                <button onclick={ctx.link().callback(|_| Msg::AsyncPayload)} >
+                <button on:click={ctx.link().callback(|_| Msg::AsyncPayload)} >
                     { "Get the payload later!" }
                 </button>
                 <p class="code-block">

--- a/examples/keyed_list/src/main.rs
+++ b/examples/keyed_list/src/main.rs
@@ -164,7 +164,7 @@ impl Model {
                             { self.build_component_ratio }
                         </p>
                         <input name="ratio" type="range" class="form-control-range" min="0.0" max="1.0" step="any"
-                            oninput={link.callback(|e: InputEvent| {
+                            on:input={link.callback(|e: InputEvent| {
                                 let input: HtmlInputElement = e.target_unchecked_into();
                                 Msg::ChangeRatio(input.value_as_number())
                             })}
@@ -179,74 +179,74 @@ impl Model {
             <>
                 <div class="row">
                     <div class="col">
-                        <button class="btn_size alert alert-danger" onclick={link.callback(|_| Msg::DeleteEverybody)}>
+                        <button class="btn_size alert alert-danger" on:click={link.callback(|_| Msg::DeleteEverybody)}>
                             { "Delete everybody" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-success" onclick={link.callback(|_| Msg::CreatePersons(1))}>
+                        <button class="btn_size alert alert-success" on:click={link.callback(|_| Msg::CreatePersons(1))}>
                             { "Create 1" }
                     </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-success" onclick={link.callback(|_| Msg::CreatePersons(5))}>
+                        <button class="btn_size alert alert-success" on:click={link.callback(|_| Msg::CreatePersons(5))}>
                             { "Create 5" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-success" onclick={link.callback(|_| Msg::CreatePersons(100))}>
+                        <button class="btn_size alert alert-success" on:click={link.callback(|_| Msg::CreatePersons(100))}>
                             { "Create 100" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-success" onclick={link.callback(|_| Msg::CreatePersons(500))}>
+                        <button class="btn_size alert alert-success" on:click={link.callback(|_| Msg::CreatePersons(500))}>
                             { "Create 500" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-success" onclick={link.callback(|_| Msg::CreatePersonsPrepend(1))}>
+                        <button class="btn_size alert alert-success" on:click={link.callback(|_| Msg::CreatePersonsPrepend(1))}>
                             { "Prepend 1" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-success" onclick={link.callback(|_| Msg::CreatePersonsPrepend(5))}>
+                        <button class="btn_size alert alert-success" on:click={link.callback(|_| Msg::CreatePersonsPrepend(5))}>
                             { "Prepend 5" }
                         </button>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col">
-                        <button class="btn_size alert alert-warning" onclick={link.callback(|_| Msg::ToggleKeyed)}>
+                        <button class="btn_size alert alert-warning" on:click={link.callback(|_| Msg::ToggleKeyed)}>
                             { if self.keyed { "Disable keys" } else { "Enable keys" } }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-info" onclick={link.callback(|_| Msg::SwapRandom)}>
+                        <button class="btn_size alert alert-info" on:click={link.callback(|_| Msg::SwapRandom)}>
                             { "Swap random" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-info" onclick={link.callback(|_| Msg::ReverseList)}>
+                        <button class="btn_size alert alert-info" on:click={link.callback(|_| Msg::ReverseList)}>
                             { "Reverse list" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-info" onclick={link.callback(|_| Msg::SortById)}>
+                        <button class="btn_size alert alert-info" on:click={link.callback(|_| Msg::SortById)}>
                             { "Sort by id" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-info" onclick={link.callback(|_| Msg::SortByName)}>
+                        <button class="btn_size alert alert-info" on:click={link.callback(|_| Msg::SortByName)}>
                             { "Sort by name" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-info" onclick={link.callback(|_| Msg::SortByAge)}>
+                        <button class="btn_size alert alert-info" on:click={link.callback(|_| Msg::SortByAge)}>
                             { "Sort by age" }
                         </button>
                     </div>
                     <div class="col">
-                        <button class="btn_size alert alert-info" onclick={link.callback(|_| Msg::SortByAddress)}>
+                        <button class="btn_size alert alert-info" on:click={link.callback(|_| Msg::SortByAddress)}>
                             { "Sort by address" }
                         </button>
                     </div>

--- a/examples/mount_point/src/main.rs
+++ b/examples/mount_point/src/main.rs
@@ -36,7 +36,7 @@ impl Component for Model {
             <div>
                 <input
                     value={self.name.clone()}
-                    oninput={ctx.link().callback(|e: InputEvent| {
+                    on:input={ctx.link().callback(|e: InputEvent| {
                         let input = e.target_unchecked_into::<HtmlInputElement>();
                         Msg::UpdateName(input.value())
                     })}

--- a/examples/multi_thread/src/lib.rs
+++ b/examples/multi_thread/src/lib.rs
@@ -71,9 +71,9 @@ impl Component for Model {
         html! {
             <div>
                 <nav class="menu">
-                    <button onclick={ctx.link().callback(|_| Msg::SendToWorker)}>{ "Send to Thread" }</button>
-                    <button onclick={ctx.link().callback(|_| Msg::SendToJob)}>{ "Send to Job" }</button>
-                    <button onclick={ctx.link().callback(|_| Msg::SendToContext)}>{ "Send to Context" }</button>
+                    <button on:click={ctx.link().callback(|_| Msg::SendToWorker)}>{ "Send to Thread" }</button>
+                    <button on:click={ctx.link().callback(|_| Msg::SendToJob)}>{ "Send to Job" }</button>
+                    <button on:click={ctx.link().callback(|_| Msg::SendToContext)}>{ "Send to Context" }</button>
                 </nav>
             </div>
         }

--- a/examples/nested_list/src/app.rs
+++ b/examples/nested_list/src/app.rs
@@ -37,7 +37,7 @@ impl Component for App {
 
     fn view(&self, ctx: &Context<Self>) -> Html {
         let on_hover = &ctx.link().callback(Msg::Hover);
-        let onmouseenter = &ctx.link().callback(|_| Msg::Hover(Hovered::None));
+        let mouseenter = &ctx.link().callback(|_| Msg::Hover(Hovered::None));
         let list_link = &self.list_link;
         let sub_list_link = &self.sub_list_link;
 
@@ -46,7 +46,7 @@ impl Component for App {
             .map(|letter| html_nested! { <ListItem name={letter.to_string()} {on_hover} /> });
 
         html! {
-            <div class="main" {onmouseenter}>
+            <div class="main" on:{mouseenter}>
                 <h1>{ "Nested List Demo" }</h1>
                 <List {on_hover} weak_link={list_link}>
                     <ListHeader text="Calling all Rusties!" {on_hover} {list_link} />

--- a/examples/nested_list/src/header.rs
+++ b/examples/nested_list/src/header.rs
@@ -21,7 +21,7 @@ impl Component for ListHeader {
 
     fn view(&self, ctx: &Context<Self>) -> Html {
         let list_link = ctx.props().list_link.borrow().clone().unwrap();
-        let onmouseover = ctx.props().on_hover.reform(|e: MouseEvent| {
+        let mouseover = ctx.props().on_hover.reform(|e: MouseEvent| {
             e.stop_propagation();
             Hovered::Header
         });
@@ -29,8 +29,8 @@ impl Component for ListHeader {
         html! {
             <div
                 class="list-header"
-                {onmouseover}
-                onclick={list_link.callback(|_| ListMsg::HeaderClick)}
+                on:{mouseover}
+                on:click={list_link.callback(|_| ListMsg::HeaderClick)}
             >
                 { &ctx.props().text }
             </div>

--- a/examples/nested_list/src/item.rs
+++ b/examples/nested_list/src/item.rs
@@ -22,7 +22,7 @@ impl Component for ListItem {
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
-        let onmouseover = {
+        let mouseover = {
             let name = ctx.props().name.clone();
             ctx.props().on_hover.reform(move |e: MouseEvent| {
                 e.stop_propagation();
@@ -30,7 +30,7 @@ impl Component for ListItem {
             })
         };
         html! {
-            <div class="list-item" {onmouseover}>
+            <div class="list-item" on:{mouseover}>
                 { &ctx.props().name }
                 { Self::view_details(&ctx.props().children) }
             </div>

--- a/examples/nested_list/src/list.rs
+++ b/examples/nested_list/src/list.rs
@@ -90,10 +90,10 @@ impl Component for List {
 
     fn view(&self, ctx: &Context<Self>) -> Html {
         let inactive = if self.inactive { "inactive" } else { "" };
-        let onmouseover = ctx.props().on_hover.reform(|_| Hovered::List);
-        let onmouseout = ctx.props().on_hover.reform(|_| Hovered::None);
+        let mouseover = ctx.props().on_hover.reform(|_| Hovered::List);
+        let mouseout = ctx.props().on_hover.reform(|_| Hovered::None);
         html! {
-            <div class="list-container" {onmouseout} {onmouseover}>
+            <div class="list-container" on:{mouseout} on:{mouseover}>
                 <div class={classes!("list", inactive)}>
                     { Self::view_header(&ctx.props().children) }
                     <div class="items">

--- a/examples/node_refs/src/input.rs
+++ b/examples/node_refs/src/input.rs
@@ -33,7 +33,7 @@ impl Component for InputComponent {
             <input
                 type="text"
                 class="input-component"
-                onmouseover={ctx.link().callback(|_| Msg::Hover)}
+                on:mouseover={ctx.link().callback(|_| Msg::Hover)}
             />
         }
     }

--- a/examples/node_refs/src/main.rs
+++ b/examples/node_refs/src/main.rs
@@ -61,7 +61,7 @@ impl Component for Model {
                         type="text"
                         ref={self.refs[0].clone()}
                         class="input-element"
-                        onmouseover={ctx.link().callback(|_| Msg::HoverIndex(0))}
+                        on:mouseover={ctx.link().callback(|_| Msg::HoverIndex(0))}
                     />
                 </div>
                 <div>

--- a/examples/pub_sub/src/producer.rs
+++ b/examples/pub_sub/src/producer.rs
@@ -32,7 +32,7 @@ impl Component for Producer {
 
     fn view(&self, ctx: &Context<Self>) -> Html {
         html! {
-            <button onclick={ctx.link().callback(|_| Msg::Clicked)}>
+            <button on:click={ctx.link().callback(|_| Msg::Clicked)}>
                 { "PRESS ME" }
             </button>
         }

--- a/examples/router/src/components/pagination.rs
+++ b/examples/router/src/components/pagination.rs
@@ -38,12 +38,12 @@ impl Pagination {
             ..
         } = *props;
 
-        let onclick = on_switch_page.reform(move |_| to_page);
+        let click = on_switch_page.reform(move |_| to_page);
         let is_current_class = if to_page == page { "is-current" } else { "" };
 
         html! {
             <li>
-                <a class={classes!("pagination-link", is_current_class)} aria-label={format!("Goto page {}", to_page)} {onclick}>
+                <a class={classes!("pagination-link", is_current_class)} aria-label={format!("Goto page {}", to_page)} on:{click}>
                     { to_page }
                 </a>
             </li>
@@ -107,13 +107,13 @@ impl Pagination {
             <>
                 <a class="pagination-previous"
                     disabled={page==1}
-                    onclick={on_switch_page.reform(move |_| page - 1)}
+                    on:click={on_switch_page.reform(move |_| page - 1)}
                 >
                     { "Previous" }
                 </a>
                 <a class="pagination-next"
                     disabled={page==total_pages}
-                    onclick={on_switch_page.reform(move |_| page + 1)}
+                    on:click={on_switch_page.reform(move |_| page + 1)}
                 >
                     { "Next page" }
                 </a>

--- a/examples/router/src/main.rs
+++ b/examples/router/src/main.rs
@@ -90,7 +90,7 @@ impl Model {
                     <a role="button"
                         class={classes!("navbar-burger", "burger", active_class)}
                         aria-label="menu" aria-expanded="false"
-                        onclick={link.callback(|_| Msg::ToggleNavbar)}
+                        on:click={link.callback(|_| Msg::ToggleNavbar)}
                     >
                         <span aria-hidden="true"></span>
                         <span aria-hidden="true"></span>

--- a/examples/store/src/post.rs
+++ b/examples/store/src/post.rs
@@ -76,7 +76,7 @@ impl Component for Post {
                 <p>{text}</p>
 
                 <TextInput value={text.to_owned()} onsubmit={ctx.link().callback(Msg::UpdateText)} />
-                <button onclick={ctx.link().callback(|_| Msg::Delete)}>
+                <button on:click={ctx.link().callback(|_| Msg::Delete)}>
                     { "Delete" }
                 </button>
             </div>

--- a/examples/store/src/text_input.rs
+++ b/examples/store/src/text_input.rs
@@ -40,7 +40,7 @@ impl Component for TextInput {
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
-        let onkeydown = ctx.link().batch_callback(|e: KeyboardEvent| {
+        let keydown = ctx.link().batch_callback(|e: KeyboardEvent| {
             e.stop_propagation();
             if e.key() == "Enter" {
                 let input: HtmlInputElement = e.target_unchecked_into();
@@ -56,7 +56,7 @@ impl Component for TextInput {
             <input
                 placeholder={ctx.props().value.clone()}
                 type="text"
-                {onkeydown}
+                on:{keydown}
             />
         }
     }

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -125,13 +125,13 @@ impl Component for Model {
         html! {
             <>
                 <div id="buttons">
-                    <button disabled={has_job} onclick={ctx.link().callback(|_| Msg::StartTimeout)}>
+                    <button disabled={has_job} on:click={ctx.link().callback(|_| Msg::StartTimeout)}>
                         { "Start Timeout" }
                     </button>
-                    <button disabled={has_job} onclick={ctx.link().callback(|_| Msg::StartInterval)}>
+                    <button disabled={has_job} on:click={ctx.link().callback(|_| Msg::StartInterval)}>
                         { "Start Interval" }
                     </button>
-                    <button disabled={!has_job} onclick={ctx.link().callback(|_| Msg::Cancel)}>
+                    <button disabled={!has_job} on:click={ctx.link().callback(|_| Msg::Cancel)}>
                         { "Cancel!" }
                     </button>
                 </div>

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -108,7 +108,7 @@ impl Component for Model {
                             class="toggle-all"
                             id="toggle-all"
                             checked={self.state.is_all_completed()}
-                            onclick={ctx.link().callback(|_| Msg::ToggleAll)}
+                            on:click={ctx.link().callback(|_| Msg::ToggleAll)}
                         />
                         <label for="toggle-all" />
                         <ul class="todo-list">
@@ -123,7 +123,7 @@ impl Component for Model {
                         <ul class="filters">
                             { for Filter::iter().map(|flt| self.view_filter(flt, ctx.link())) }
                         </ul>
-                        <button class="clear-completed" onclick={ctx.link().callback(|_| Msg::ClearCompleted)}>
+                        <button class="clear-completed" on:click={ctx.link().callback(|_| Msg::ClearCompleted)}>
                             { format!("Clear completed ({})", self.state.total_completed()) }
                         </button>
                     </footer>
@@ -149,7 +149,7 @@ impl Model {
             <li>
                 <a class={cls}
                    href={filter.as_href()}
-                   onclick={link.callback(move |_| Msg::SetFilter(filter))}
+                   on:click={link.callback(move |_| Msg::SetFilter(filter))}
                 >
                     { filter }
                 </a>
@@ -158,7 +158,7 @@ impl Model {
     }
 
     fn view_input(&self, link: &Scope<Self>) -> Html {
-        let onkeypress = link.batch_callback(|e: KeyboardEvent| {
+        let keypress = link.batch_callback(|e: KeyboardEvent| {
             if e.key() == "Enter" {
                 let input: InputElement = e.target_unchecked_into();
                 let value = input.value();
@@ -174,7 +174,7 @@ impl Model {
             <input
                 class="new-todo"
                 placeholder="What needs to be done?"
-                {onkeypress}
+                on:{keypress}
             />
             /* Or multiline:
             <ul>
@@ -199,10 +199,10 @@ impl Model {
                         type="checkbox"
                         class="toggle"
                         checked={entry.completed}
-                        onclick={link.callback(move |_| Msg::Toggle(idx))}
+                        on:click={link.callback(move |_| Msg::Toggle(idx))}
                     />
-                    <label ondblclick={link.callback(move |_| Msg::ToggleEdit(idx))}>{ &entry.description }</label>
-                    <button class="destroy" onclick={link.callback(move |_| Msg::Remove(idx))} />
+                    <label on:dblclick={link.callback(move |_| Msg::ToggleEdit(idx))}>{ &entry.description }</label>
+                    <button class="destroy" on:click={link.callback(move |_| Msg::Remove(idx))} />
                 </div>
                 { self.view_entry_edit_input((idx, entry), link) }
             </li>
@@ -216,9 +216,9 @@ impl Model {
             Msg::Edit((idx, value))
         };
 
-        let onblur = link.callback(move |e: FocusEvent| edit(e.target_unchecked_into()));
+        let blur = link.callback(move |e: FocusEvent| edit(e.target_unchecked_into()));
 
-        let onkeypress = link.batch_callback(move |e: KeyboardEvent| {
+        let keypress = link.batch_callback(move |e: KeyboardEvent| {
             (e.key() == "Enter").then(|| edit(e.target_unchecked_into()))
         });
 
@@ -229,9 +229,9 @@ impl Model {
                     type="text"
                     ref={self.focus_ref.clone()}
                     value={self.state.edit_value.clone()}
-                    onmouseover={link.callback(|_| Msg::Focus)}
-                    {onblur}
-                    {onkeypress}
+                    on:mouseover={link.callback(|_| Msg::Focus)}
+                    on:{blur}
+                    on:{keypress}
                 />
             }
         } else {

--- a/examples/two_apps/src/main.rs
+++ b/examples/two_apps/src/main.rs
@@ -60,10 +60,10 @@ impl Component for Model {
         html! {
             <div>
                 <h3>{ format!("{} received <{}>", self.selector, self.title) }</h3>
-                <button onclick={ctx.link().callback(|_| Msg::SendToOpposite("One".into()))}>{ "One" }</button>
-                <button onclick={ctx.link().callback(|_| Msg::SendToOpposite("Two".into()))}>{ "Two" }</button>
-                <button onclick={ctx.link().callback(|_| Msg::SendToOpposite("Three".into()))}>{ "Three" }</button>
-                <button onclick={ctx.link().callback(|_| Msg::SendToOpposite("Ping".into()))}>{ "Ping" }</button>
+                <button on:click={ctx.link().callback(|_| Msg::SendToOpposite("One".into()))}>{ "One" }</button>
+                <button on:click={ctx.link().callback(|_| Msg::SendToOpposite("Two".into()))}>{ "Two" }</button>
+                <button on:click={ctx.link().callback(|_| Msg::SendToOpposite("Three".into()))}>{ "Three" }</button>
+                <button on:click={ctx.link().callback(|_| Msg::SendToOpposite("Ping".into()))}>{ "Ping" }</button>
             </div>
         }
     }

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -26,6 +26,7 @@ syn = { version = "1.0", features = ["full", "extra-traits"] }
 rustversion = "1.0"
 trybuild = "1.0"
 yew = { path = "../yew" }
+wasm-bindgen = "0.2"
 
 [build-dependencies]
 

--- a/packages/yew-macro/src/custom_event.rs
+++ b/packages/yew-macro/src/custom_event.rs
@@ -105,7 +105,7 @@ pub fn custom_event_impl(name: CustomEventName, custom_event: CustomEvent) -> To
 
         impl ::wasm_bindgen::JsCast for #ident {
             fn instanceof(val: &::wasm_bindgen::JsValue) -> bool {
-                <#inner_type as wasm_bindgen::JsCast>::instanceof(val)
+                <#inner_type as ::wasm_bindgen::JsCast>::instanceof(val)
             }
 
             fn unchecked_from_js(val: ::wasm_bindgen::JsValue) -> Self {
@@ -124,7 +124,7 @@ pub fn custom_event_impl(name: CustomEventName, custom_event: CustomEvent) -> To
         #[doc(hidden)]
         #vis type #event_ident = #ident;
 
-        impl ::yew::EventMeta for #ident {
+        impl ::yew::StaticEvent for #ident {
             type Event = Self;
 
             fn event_name() -> &'static str {

--- a/packages/yew-macro/src/custom_event.rs
+++ b/packages/yew-macro/src/custom_event.rs
@@ -83,6 +83,12 @@ pub fn custom_event_impl(name: CustomEventName, custom_event: CustomEvent) -> To
             }
         }
 
+        impl ::std::convert::AsRef<::yew::web_sys::Event> for #ident {
+            fn as_ref(&self) -> &::yew::web_sys::Event {
+                &self.0
+            }
+        }
+
         impl ::std::convert::AsRef<::wasm_bindgen::JsValue> for #ident {
             fn as_ref(&self) -> &::wasm_bindgen::JsValue {
                 &self.0
@@ -118,7 +124,7 @@ pub fn custom_event_impl(name: CustomEventName, custom_event: CustomEvent) -> To
         #[doc(hidden)]
         #vis type #event_ident = #ident;
 
-        impl ::yew::CustomEventHandler for #ident {
+        impl ::yew::EventMeta for #ident {
             type Event = Self;
 
             fn event_name() -> &'static str {

--- a/packages/yew-macro/src/custom_event.rs
+++ b/packages/yew-macro/src/custom_event.rs
@@ -1,0 +1,129 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse::Parse, Fields, Ident, Item, LitStr, Token, Type, Visibility};
+
+pub struct CustomEvent {
+    base: Item,
+    ident: Ident,
+    vis: Visibility,
+    inner_type: Type,
+}
+
+const CUSTOM_EVENT_MSG: &str = "`custom_event` attribute can only be applied to NewType structs";
+
+impl Parse for CustomEvent {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let item = input.parse::<Item>()?;
+
+        match &item {
+            Item::Struct(item_struct) => {
+                match (&item_struct.fields, item_struct.generics.lt_token) {
+                    (Fields::Unnamed(ref uf), None) if uf.unnamed.len() == 1 => {
+                        // unwrap safe because we just checked len of fields.
+                        let inner_type = (uf.unnamed.first().unwrap().ty).clone();
+                        Ok(CustomEvent {
+                            ident: item_struct.ident.clone(),
+                            inner_type,
+                            vis: item_struct.vis.clone(),
+                            base: item,
+                        })
+                    }
+                    _ => Err(syn::Error::new_spanned(item_struct, CUSTOM_EVENT_MSG)),
+                }
+            }
+            _ => Err(syn::Error::new_spanned(item, CUSTOM_EVENT_MSG)),
+        }
+    }
+}
+
+pub struct CustomEventName {
+    event_ident: Ident,
+    event_name: String,
+}
+
+impl Parse for CustomEventName {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let event_ident = input.parse::<Ident>()?;
+        let event_name = if input.parse::<Token![=]>().is_ok() {
+            let event_name = input.parse::<LitStr>()?;
+            event_name.value()
+        } else {
+            event_ident.to_string()
+        };
+
+        Ok(CustomEventName {
+            event_ident,
+            event_name,
+        })
+    }
+}
+
+pub fn custom_event_impl(name: CustomEventName, custom_event: CustomEvent) -> TokenStream {
+    let CustomEventName {
+        event_ident,
+        event_name,
+    } = name;
+
+    let CustomEvent {
+        base,
+        ident,
+        vis,
+        inner_type,
+    } = custom_event;
+
+    quote! {
+
+        #base
+
+        impl ::std::ops::Deref for #ident{
+            type Target = #inner_type;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl ::std::convert::AsRef<::wasm_bindgen::JsValue> for #ident {
+            fn as_ref(&self) -> &::wasm_bindgen::JsValue {
+                &self.0
+            }
+        }
+
+        #[allow(clippy::from_over_into)]
+        impl ::std::convert::Into<::wasm_bindgen::JsValue> for #ident {
+            fn into(self) -> ::wasm_bindgen::JsValue {
+                use ::wasm_bindgen::JsCast;
+                self.0.unchecked_into()
+            }
+        }
+
+        impl ::wasm_bindgen::JsCast for #ident {
+            fn instanceof(val: &::wasm_bindgen::JsValue) -> bool {
+                <#inner_type as wasm_bindgen::JsCast>::instanceof(val)
+            }
+
+            fn unchecked_from_js(val: ::wasm_bindgen::JsValue) -> Self {
+                Self(<#inner_type as ::wasm_bindgen::JsCast>::unchecked_from_js(val))
+            }
+
+            fn unchecked_from_js_ref(val: &::wasm_bindgen::JsValue) -> &Self {
+                // SAFETY:
+                // #ident is a NewType around the #inner_type and thus at runtime is equivalent,
+                // this allows us to return a reference from the result of the internal call.
+                unsafe { ::std::mem::transmute(<#inner_type as ::wasm_bindgen::JsCast>::unchecked_from_js_ref(val)) }
+            }
+        }
+
+        #[allow(dead_code, non_camel_case_types)]
+        #[doc(hidden)]
+        #vis type #event_ident = #ident;
+
+        impl ::yew::CustomEventHandler for #ident {
+            type Event = Self;
+
+            fn event_name() -> &'static str {
+                #event_name
+            }
+        }
+    }
+}

--- a/packages/yew-macro/src/custom_event.rs
+++ b/packages/yew-macro/src/custom_event.rs
@@ -76,23 +76,15 @@ pub fn custom_event_impl(name: CustomEventName, custom_event: CustomEvent) -> To
 
         #base
 
-        impl ::std::ops::Deref for #ident{
-            type Target = #inner_type;
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
         impl ::std::convert::AsRef<::yew::web_sys::Event> for #ident {
             fn as_ref(&self) -> &::yew::web_sys::Event {
-                &self.0
+                self.0.as_ref()
             }
         }
 
         impl ::std::convert::AsRef<::wasm_bindgen::JsValue> for #ident {
             fn as_ref(&self) -> &::wasm_bindgen::JsValue {
-                &self.0
+                self.0.as_ref()
             }
         }
 

--- a/packages/yew-macro/src/custom_event.rs
+++ b/packages/yew-macro/src/custom_event.rs
@@ -9,7 +9,8 @@ pub struct CustomEvent {
     inner_type: Type,
 }
 
-const CUSTOM_EVENT_MSG: &str = "`custom_event` attribute can only be applied to NewType structs";
+const CUSTOM_EVENT_MSG: &str =
+    "custom_event attribute macro can only be applied to NewType structs";
 
 impl Parse for CustomEvent {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -4,7 +4,7 @@ use crate::stringify::{Stringify, Value};
 use crate::{non_capitalized_ascii, Peek, PeekValue};
 use boolinator::Boolinator;
 use proc_macro2::{Delimiter, TokenStream};
-use quote::{format_ident, quote, quote_spanned, ToTokens};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
@@ -275,15 +275,14 @@ impl ToTokens for HtmlElement {
                 let mut handler = String::from("on");
                 handler.push_str(&label.name.to_string());
 
+                let ty = &label.name;
                 if is_custom_event_handler(handler) {
-                    let ty = label.name.clone();
                     quote! {
-                        ::yew::html::oncustom::Wrapper::<#ty>::__macro_new(#value)
+                        ::yew::events::listener::Wrapper::<#ty>::__macro_new(#value)
                     }
                 } else {
-                    let handler = format_ident!("on{}", label.name);
                     quote! {
-                        ::yew::html::#handler::Wrapper::__macro_new(#value)
+                        ::yew::events::listener::Wrapper::<::yew::events::listener::#ty>::__macro_new(#value)
                     }
                 }
             });

--- a/packages/yew-macro/src/html_tree/html_list.rs
+++ b/packages/yew-macro/src/html_tree/html_list.rs
@@ -130,7 +130,7 @@ impl Parse for HtmlListProps {
                 return Err(input.error("only a single `key` prop is allowed on a fragment"));
             }
 
-            if prop.label.to_ascii_lowercase_string() != "key" {
+            if prop.label.to_string().to_ascii_lowercase() != "key" {
                 return Err(syn::Error::new_spanned(
                     prop.label,
                     "fragments only accept the `key` prop",

--- a/packages/yew-macro/src/lib.rs
+++ b/packages/yew-macro/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! html! {
 //!   <div>
-//!     <button onclick={ctx.link().callback(|_| Msg::Submit)}>
+//!     <button on:click={ctx.link().callback(|_| Msg::Submit)}>
 //!       { "Submit" }
 //!     </button>
 //!     <>

--- a/packages/yew-macro/src/lib.rs
+++ b/packages/yew-macro/src/lib.rs
@@ -47,12 +47,14 @@
 //! Please refer to [https://github.com/yewstack/yew](https://github.com/yewstack/yew) for how to set this up.
 
 mod classes;
+mod custom_event;
 mod derive_props;
 mod function_component;
 mod html_tree;
 mod props;
 mod stringify;
 
+use custom_event::CustomEvent;
 use derive_props::DerivePropsInput;
 use function_component::{function_component_impl, FunctionComponent, FunctionComponentName};
 use html_tree::{HtmlRoot, HtmlRootVNode};
@@ -60,6 +62,8 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::buffer::Cursor;
 use syn::parse_macro_input;
+
+use crate::custom_event::{custom_event_impl, CustomEventName};
 
 trait Peek<'a, T> {
     fn peek(cursor: Cursor<'a>) -> Option<(T, Cursor<'a>)>;
@@ -88,6 +92,16 @@ fn join_errors(mut it: impl Iterator<Item = syn::Error>) -> syn::Result<()> {
         }
         Err(err)
     })
+}
+
+#[proc_macro_attribute]
+pub fn custom_event(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let event_name = parse_macro_input!(attr as CustomEventName);
+    let custom_event = parse_macro_input!(item as CustomEvent);
+    TokenStream::from(custom_event_impl(event_name, custom_event))
 }
 
 #[proc_macro_derive(Properties, attributes(prop_or, prop_or_else, prop_or_default))]

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -1,4 +1,4 @@
-use super::{Prop, Props, SpecialProps};
+use super::{Prop, PropLabel, Props, SpecialProps};
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::{quote, quote_spanned, ToTokens};
 use std::convert::TryFrom;
@@ -197,14 +197,20 @@ impl TryFrom<Props> for ComponentProps {
     fn try_from(props: Props) -> Result<Self, Self::Error> {
         props.check_no_duplicates()?;
         props.check_all(|prop| {
-            if !prop.label.extended.is_empty() {
-                Err(syn::Error::new_spanned(
-                    &prop.label,
-                    "expected a valid Rust identifier",
-                ))
-            } else {
-                Ok(())
+            match &prop.label {
+                PropLabel::Static(label) if !label.extended.is_empty() => Err(
+                    syn::Error::new_spanned(&prop.label, "expected a valid Rust identifier"),
+                ),
+                _ => Ok(()),
             }
+            // if !prop.label.extended.is_empty() {
+            //     Err(syn::Error::new_spanned(
+            //         &prop.label,
+            //         "expected a valid Rust identifier",
+            //     ))
+            // } else {
+            //     Ok(())
+            // }
         })?;
 
         Ok(Self::List(props))

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -1,4 +1,4 @@
-use super::{Prop, PropLabel, Props, SpecialProps};
+use super::{Prop, Props, SpecialProps};
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::{quote, quote_spanned, ToTokens};
 use std::convert::TryFrom;
@@ -197,20 +197,14 @@ impl TryFrom<Props> for ComponentProps {
     fn try_from(props: Props) -> Result<Self, Self::Error> {
         props.check_no_duplicates()?;
         props.check_all(|prop| {
-            match &prop.label {
-                PropLabel::Static(label) if !label.extended.is_empty() => Err(
-                    syn::Error::new_spanned(&prop.label, "expected a valid Rust identifier"),
-                ),
-                _ => Ok(()),
+            if !prop.label.extended.is_empty() {
+                Err(syn::Error::new_spanned(
+                    &prop.label,
+                    "expected a valid Rust identifier",
+                ))
+            } else {
+                Ok(())
             }
-            // if !prop.label.extended.is_empty() {
-            //     Err(syn::Error::new_spanned(
-            //         &prop.label,
-            //         "expected a valid Rust identifier",
-            //     ))
-            // } else {
-            //     Ok(())
-            // }
         })?;
 
         Ok(Self::List(props))

--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -87,7 +87,7 @@ lazy_static! {
     };
 }
 
-pub(crate) fn is_custom(event_handler: String) -> bool {
+pub(crate) fn is_custom_event_handler(event_handler: String) -> bool {
     !LISTENER_SET.contains(event_handler.as_str())
 }
 

--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -87,7 +87,7 @@ lazy_static! {
     };
 }
 
-pub(crate) fn is_custom_event_handler(event_handler: String) -> bool {
+pub fn is_custom_event_handler(event_handler: String) -> bool {
     !LISTENER_SET.contains(event_handler.as_str())
 }
 

--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -32,8 +32,7 @@ impl Parse for ElementProps {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut props = input.parse::<Props>()?;
 
-        let listeners =
-            props.drain_filter(|prop| LISTENER_SET.contains(prop.label.to_string().as_str()));
+        let listeners = props.drain_filter(|prop| prop.is_listener);
 
         // Multiple listener attributes are allowed, but no others
         props.check_no_duplicates()?;
@@ -86,6 +85,10 @@ lazy_static! {
         .into_iter()
         .collect()
     };
+}
+
+pub(crate) fn is_custom(event_handler: String) -> bool {
+    !LISTENER_SET.contains(event_handler.as_str())
 }
 
 lazy_static! {

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -1,4 +1,4 @@
-use super::{ComponentProps, Prop, Props, SortedPropList};
+use super::{ComponentProps, Prop, PropLabel, Props, SortedPropList};
 use crate::html_tree::HtmlDashedName;
 use proc_macro2::TokenStream;
 use quote::{quote_spanned, ToTokens};
@@ -60,7 +60,11 @@ impl Parse for PropValue {
 impl From<PropValue> for Prop {
     fn from(prop_value: PropValue) -> Prop {
         let PropValue { label, value } = prop_value;
-        Prop { label, value }
+        Prop {
+            label: PropLabel::Static(label),
+            value,
+            is_listener: false,
+        }
     }
 }
 

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -1,4 +1,4 @@
-use super::{ComponentProps, Prop, PropLabel, Props, SortedPropList};
+use super::{ComponentProps, Prop, Props, SortedPropList};
 use crate::html_tree::HtmlDashedName;
 use proc_macro2::TokenStream;
 use quote::{quote_spanned, ToTokens};
@@ -61,7 +61,7 @@ impl From<PropValue> for Prop {
     fn from(prop_value: PropValue) -> Prop {
         let PropValue { label, value } = prop_value;
         Prop {
-            label: PropLabel::Static(label),
+            label,
             value,
             is_listener: false,
         }

--- a/packages/yew-macro/tests/custom_event/custom_event_fail.rs
+++ b/packages/yew-macro/tests/custom_event/custom_event_fail.rs
@@ -1,0 +1,29 @@
+mod attribute {
+    use yew::custom_event;
+
+    #[custom_event]
+    struct NoAttributeGiven(Event);
+
+    #[custom_event(ident = not a literal string value)]
+    struct AttributeValueNotALitStr(Event);
+
+    #[custom_event("string without ident")]
+    struct StringWithoutIdent(Event);
+}
+
+mod structs {
+    use yew::custom_event;
+
+    #[custom_event(unit_struct)]
+    struct UnitStruct;
+
+    #[custom_event(tuple_struct)]
+    struct TupleStruct(Event, Event);
+
+    #[custom_event(normal_struct)]
+    struct PlainOldStruct {
+        event: Event,
+    }
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/custom_event/custom_event_fail.stderr
+++ b/packages/yew-macro/tests/custom_event/custom_event_fail.stderr
@@ -1,0 +1,39 @@
+error: unexpected end of input, expected identifier
+ --> $DIR/custom_event_fail.rs:4:5
+  |
+4 |     #[custom_event]
+  |     ^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected string literal
+ --> $DIR/custom_event_fail.rs:7:28
+  |
+7 |     #[custom_event(ident = not a literal string value)]
+  |                            ^^^
+
+error: expected identifier
+  --> $DIR/custom_event_fail.rs:10:20
+   |
+10 |     #[custom_event("string without ident")]
+   |                    ^^^^^^^^^^^^^^^^^^^^^^
+
+error: custom_event attribute macro can only be applied to NewType structs
+  --> $DIR/custom_event_fail.rs:18:5
+   |
+18 |     struct UnitStruct;
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: custom_event attribute macro can only be applied to NewType structs
+  --> $DIR/custom_event_fail.rs:21:5
+   |
+21 |     struct TupleStruct(Event, Event);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: custom_event attribute macro can only be applied to NewType structs
+  --> $DIR/custom_event_fail.rs:24:5
+   |
+24 | /     struct PlainOldStruct {
+25 | |         event: Event,
+26 | |     }
+   | |_____^

--- a/packages/yew-macro/tests/custom_event/custom_event_pass.rs
+++ b/packages/yew-macro/tests/custom_event/custom_event_pass.rs
@@ -1,0 +1,30 @@
+// Inside a module as public custom events can be used outside the module they are defined in.
+mod events {
+    use yew::{custom_event, web_sys::Event};
+
+    // NewType with matching event type and ident - i.e. "custard" can be custard
+    #[custom_event(custard)]
+    pub struct CustardEvent(Event);
+
+    #[custom_event(pbj = "peanut butter jelly")]
+    pub struct PeanutButterJellyEvent(Event);
+}
+
+use yew::custom_event;
+
+// Expand on a custom event
+#[custom_event(dessert)]
+struct DessertEvent(events::CustardEvent);
+
+fn main() {
+    use events::*;
+    use yew::StaticEvent;
+    assert_eq!("custard", custard::event_name());
+    assert_eq!("custard", CustardEvent::event_name());
+
+    assert_eq!("peanut butter jelly", pbj::event_name());
+    assert_eq!("peanut butter jelly", PeanutButterJellyEvent::event_name());
+
+    assert_eq!("dessert", dessert::event_name());
+    assert_eq!("dessert", DessertEvent::event_name());
+}

--- a/packages/yew-macro/tests/custom_event_test.rs
+++ b/packages/yew-macro/tests/custom_event_test.rs
@@ -1,0 +1,7 @@
+#[allow(dead_code)]
+#[rustversion::attr(stable(1.51), test)]
+fn tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/custom_event/custom_event_pass.rs");
+    t.compile_fail("tests/custom_event/custom_event_fail.rs");
+}

--- a/packages/yew-macro/tests/html_macro/element-fail.rs
+++ b/packages/yew-macro/tests/html_macro/element-fail.rs
@@ -48,14 +48,14 @@ fn compile_fail() {
     html! { <a href={Some(5)} /> };
 
     // listener type mismatch
-    html! { <input onclick=1 /> };
-    html! { <input onclick={Callback::from(|a: String| ())} /> };
-    html! { <input onfocus={Some(5)} /> };
+    html! { <input on:click=1 /> };
+    html! { <input on:click={Callback::from(|a: String| ())} /> };
+    html! { <input on:focus={Some(5)} /> };
 
     // NodeRef type mismatch
     html! { <input ref={()} /> };
     html! { <input ref={Some(NodeRef::default())} /> };
-    html! { <input onclick={Callback::from(|a: String| ())} /> };
+    html! { <input on:click={Callback::from(|a: String| ())} /> };
 
     html! { <input string={NotToString} /> };
 
@@ -83,7 +83,7 @@ fn compile_fail() {
     html! { <div class=("deprecated", "warning") /> };
     html! { <input ref=() /> };
     html! { <input ref=() ref=() /> };
-    html! { <input onfocus=Some(5) /> };
+    html! { <input on:focus=Some(5) /> };
     html! { <input string=NotToString /> };
     html! { <a media=Some(NotToString) /> };
     html! { <a href=Some(5) /> };

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -302,69 +302,39 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<Cow<'stat
              <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
    = note: required by `into_prop_value`
 
-error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
-   --> $DIR/element-fail.rs:51:29
-    |
-51  |       html! { <input on:click=1 /> };
-    |                               ^ expected an `Fn<(MouseEvent,)>` closure, found `{integer}`
-    |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
-    |
-    | / impl_action! {
-3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
-4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
-...   |
-102 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-103 | | }
-    | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
-    |
-    = help: the trait `Fn<(MouseEvent,)>` is not implemented for `{integer}`
-    = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `{integer}`
+error[E0277]: the trait bound `{integer}: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
+  --> $DIR/element-fail.rs:51:29
+   |
+51 |     html! { <input on:click=1 /> };
+   |                             ^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `{integer}`
+   |
+   = help: the following implementations were found:
+             <&'static str as IntoPropValue<Cow<'static, str>>>
+             <&'static str as IntoPropValue<Option<Cow<'static, str>>>>
+             <&'static str as IntoPropValue<Option<String>>>
+             <&'static str as IntoPropValue<String>>
+           and 11 others
+   = note: required by `Wrapper::<T>::__macro_new`
 
-error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
-   --> $DIR/element-fail.rs:52:30
-    |
-52  |       html! { <input on:click={Callback::from(|a: String| ())} /> };
-    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                                |
-    |                                expected an implementor of trait `IntoEventCallback<MouseEvent>`
-    |                                help: consider borrowing here: `&Callback::from(|a: String| ())`
-    |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
-    |
-    | / impl_action! {
-3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
-4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
-...   |
-102 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-103 | | }
-    | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
-    |
-    = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
-    = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
+error[E0277]: the trait bound `yew::Callback<String>: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
+  --> $DIR/element-fail.rs:52:30
+   |
+52 |     html! { <input on:click={Callback::from(|a: String| ())} /> };
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `yew::Callback<String>`
+   |
+   = note: required by `Wrapper::<T>::__macro_new`
 
-error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>` is not satisfied
-   --> $DIR/element-fail.rs:53:30
-    |
-53  |       html! { <input on:focus={Some(5)} /> };
-    |                                ^^^^^^^ the trait `IntoEventCallback<FocusEvent>` is not implemented for `Option<{integer}>`
-    |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
-    |
-    | / impl_action! {
-3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
-4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
-...   |
-102 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-103 | | }
-    | |_- required by this bound in `yew::html::onfocus::Wrapper::__macro_new`
-    |
-    = help: the following implementations were found:
-              <Option<T> as IntoEventCallback<EVENT>>
-              <Option<yew::Callback<EVENT>> as IntoEventCallback<EVENT>>
+error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<yew::Callback<FocusEvent>>>` is not satisfied
+  --> $DIR/element-fail.rs:53:30
+   |
+53 |     html! { <input on:focus={Some(5)} /> };
+   |                              ^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<FocusEvent>>>` is not implemented for `Option<{integer}>`
+   |
+   = help: the following implementations were found:
+             <Option<&'static str> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
+   = note: required by `Wrapper::<T>::__macro_new`
 
 error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
   --> $DIR/element-fail.rs:56:25
@@ -386,28 +356,13 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
              <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
    = note: required by `into_prop_value`
 
-error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
-   --> $DIR/element-fail.rs:58:30
-    |
-58  |       html! { <input on:click={Callback::from(|a: String| ())} /> };
-    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                                |
-    |                                expected an implementor of trait `IntoEventCallback<MouseEvent>`
-    |                                help: consider borrowing here: `&Callback::from(|a: String| ())`
-    |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
-    |
-    | / impl_action! {
-3   | |     onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
-4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
-...   |
-102 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-103 | | }
-    | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
-    |
-    = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
-    = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
+error[E0277]: the trait bound `yew::Callback<String>: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
+  --> $DIR/element-fail.rs:58:30
+   |
+58 |     html! { <input on:click={Callback::from(|a: String| ())} /> };
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `yew::Callback<String>`
+   |
+   = note: required by `Wrapper::<T>::__macro_new`
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
   --> $DIR/element-fail.rs:60:28

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -302,38 +302,38 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<Cow<'stat
              <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
    = note: required by `into_prop_value`
 
-error[E0277]: the trait bound `{integer}: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
+error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
   --> $DIR/element-fail.rs:51:29
    |
 51 |     html! { <input on:click=1 /> };
-   |                             ^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `{integer}`
+   |                             ^ expected an `Fn<(MouseEvent,)>` closure, found `{integer}`
    |
-   = help: the following implementations were found:
-             <&'static str as IntoPropValue<Cow<'static, str>>>
-             <&'static str as IntoPropValue<Option<Cow<'static, str>>>>
-             <&'static str as IntoPropValue<Option<String>>>
-             <&'static str as IntoPropValue<String>>
-           and 11 others
+   = help: the trait `Fn<(MouseEvent,)>` is not implemented for `{integer}`
+   = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `{integer}`
    = note: required by `Wrapper::<T>::__macro_new`
 
-error[E0277]: the trait bound `yew::Callback<String>: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
+error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
   --> $DIR/element-fail.rs:52:30
    |
 52 |     html! { <input on:click={Callback::from(|a: String| ())} /> };
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `yew::Callback<String>`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              expected an implementor of trait `IntoEventCallback<MouseEvent>`
+   |                              help: consider borrowing here: `&Callback::from(|a: String| ())`
    |
+   = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
+   = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
    = note: required by `Wrapper::<T>::__macro_new`
 
-error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<yew::Callback<FocusEvent>>>` is not satisfied
+error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>` is not satisfied
   --> $DIR/element-fail.rs:53:30
    |
 53 |     html! { <input on:focus={Some(5)} /> };
-   |                              ^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<FocusEvent>>>` is not implemented for `Option<{integer}>`
+   |                              ^^^^^^^ the trait `IntoEventCallback<FocusEvent>` is not implemented for `Option<{integer}>`
    |
    = help: the following implementations were found:
-             <Option<&'static str> as IntoPropValue<Option<Cow<'static, str>>>>
-             <Option<&'static str> as IntoPropValue<Option<String>>>
-             <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<T> as IntoEventCallback<EVENT>>
+             <Option<yew::Callback<EVENT>> as IntoEventCallback<EVENT>>
    = note: required by `Wrapper::<T>::__macro_new`
 
 error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
@@ -356,12 +356,17 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
              <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
    = note: required by `into_prop_value`
 
-error[E0277]: the trait bound `yew::Callback<String>: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
+error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
   --> $DIR/element-fail.rs:58:30
    |
 58 |     html! { <input on:click={Callback::from(|a: String| ())} /> };
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `yew::Callback<String>`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              expected an implementor of trait `IntoEventCallback<MouseEvent>`
+   |                              help: consider borrowing here: `&Callback::from(|a: String| ())`
    |
+   = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
+   = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
    = note: required by `Wrapper::<T>::__macro_new`
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -1,3 +1,21 @@
+<<<<<<< HEAD
+=======
+error: this file contains an unclosed delimiter
+  --> $DIR/element-fail.rs:95:14
+   |
+5  | fn compile_fail() {
+   |                   - unclosed delimiter
+...
+52 |     html! { <input on:click={Callback::from(|a: String| ()) /> };
+   |           - this delimiter might not be properly closed...
+...
+93 | }
+   | - ...as it matches this but it has different indentation
+94 |
+95 | fn main() {}
+   |              ^
+
+>>>>>>> d00c22f6 (Add event listener syntax to support custom event)
 error: this opening tag has no corresponding closing tag
  --> $DIR/element-fail.rs:7:13
   |
@@ -127,6 +145,7 @@ error: the tag `<iNpUt>` is a void element and cannot have children (hint: rewri
 error: this dynamic tag is missing an expression block defining its value
   --> $DIR/element-fail.rs:71:14
    |
+<<<<<<< HEAD
 71 |     html! { <@></@> };
    |              ^
 
@@ -174,6 +193,16 @@ error: the property value must be either a literal or enclosed in braces. Consid
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
   --> $DIR/element-fail.rs:88:22
+=======
+52 | /     html! { <input on:click={Callback::from(|a: String| ()) /> };
+53 | |     html! { <input on:focus={Some(5)} /> };
+54 | |
+55 | |     // NodeRef type mismatch
+...  |
+92 | |     html! { <input string=NotToString /> };
+93 | | }
+   | |_^
+>>>>>>> d00c22f6 (Add event listener syntax to support custom event)
    |
 88 |     html! { <a media=Some(NotToString) /> };
    |                      ^^^^^^^^^^^^^^^^^
@@ -302,6 +331,7 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<Cow<'stat
              <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
    = note: required by `into_prop_value`
 
+<<<<<<< HEAD
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
    --> $DIR/element-fail.rs:51:28
     |
@@ -330,6 +360,13 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<Strin
     |                               |
     |                               expected an implementor of trait `IntoEventCallback<MouseEvent>`
     |                               help: consider borrowing here: `&Callback::from(|a: String| ())`
+=======
+error[E0277]: the trait bound `{integer}: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
+   --> $DIR/element-fail.rs:51:29
+    |
+51  |       html! { <input on:click=1 /> };
+    |                               ^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `{integer}`
+>>>>>>> d00c22f6 (Add event listener syntax to support custom event)
     |
    ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
     |

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -1,21 +1,3 @@
-<<<<<<< HEAD
-=======
-error: this file contains an unclosed delimiter
-  --> $DIR/element-fail.rs:95:14
-   |
-5  | fn compile_fail() {
-   |                   - unclosed delimiter
-...
-52 |     html! { <input on:click={Callback::from(|a: String| ()) /> };
-   |           - this delimiter might not be properly closed...
-...
-93 | }
-   | - ...as it matches this but it has different indentation
-94 |
-95 | fn main() {}
-   |              ^
-
->>>>>>> d00c22f6 (Add event listener syntax to support custom event)
 error: this opening tag has no corresponding closing tag
  --> $DIR/element-fail.rs:7:13
   |
@@ -145,7 +127,6 @@ error: the tag `<iNpUt>` is a void element and cannot have children (hint: rewri
 error: this dynamic tag is missing an expression block defining its value
   --> $DIR/element-fail.rs:71:14
    |
-<<<<<<< HEAD
 71 |     html! { <@></@> };
    |              ^
 
@@ -180,10 +161,10 @@ error: the property value must be either a literal or enclosed in braces. Consid
    |                        ^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:86:28
+  --> $DIR/element-fail.rs:86:29
    |
-86 |     html! { <input onfocus=Some(5) /> };
-   |                            ^^^^^^^
+86 |     html! { <input on:focus=Some(5) /> };
+   |                             ^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
   --> $DIR/element-fail.rs:87:27
@@ -193,16 +174,6 @@ error: the property value must be either a literal or enclosed in braces. Consid
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
   --> $DIR/element-fail.rs:88:22
-=======
-52 | /     html! { <input on:click={Callback::from(|a: String| ()) /> };
-53 | |     html! { <input on:focus={Some(5)} /> };
-54 | |
-55 | |     // NodeRef type mismatch
-...  |
-92 | |     html! { <input string=NotToString /> };
-93 | | }
-   | |_^
->>>>>>> d00c22f6 (Add event listener syntax to support custom event)
    |
 88 |     html! { <a media=Some(NotToString) /> };
    |                      ^^^^^^^^^^^^^^^^^
@@ -331,12 +302,11 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<Cow<'stat
              <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
    = note: required by `into_prop_value`
 
-<<<<<<< HEAD
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
-   --> $DIR/element-fail.rs:51:28
+   --> $DIR/element-fail.rs:51:29
     |
-51  |       html! { <input onclick=1 /> };
-    |                              ^ expected an `Fn<(MouseEvent,)>` closure, found `{integer}`
+51  |       html! { <input on:click=1 /> };
+    |                               ^ expected an `Fn<(MouseEvent,)>` closure, found `{integer}`
     |
    ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
@@ -353,20 +323,13 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
     = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `{integer}`
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
-   --> $DIR/element-fail.rs:52:29
+   --> $DIR/element-fail.rs:52:30
     |
-52  |       html! { <input onclick={Callback::from(|a: String| ())} /> };
-    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                               |
-    |                               expected an implementor of trait `IntoEventCallback<MouseEvent>`
-    |                               help: consider borrowing here: `&Callback::from(|a: String| ())`
-=======
-error[E0277]: the trait bound `{integer}: IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not satisfied
-   --> $DIR/element-fail.rs:51:29
-    |
-51  |       html! { <input on:click=1 /> };
-    |                               ^ the trait `IntoPropValue<Option<yew::Callback<MouseEvent>>>` is not implemented for `{integer}`
->>>>>>> d00c22f6 (Add event listener syntax to support custom event)
+52  |       html! { <input on:click={Callback::from(|a: String| ())} /> };
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                |
+    |                                expected an implementor of trait `IntoEventCallback<MouseEvent>`
+    |                                help: consider borrowing here: `&Callback::from(|a: String| ())`
     |
    ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
@@ -383,10 +346,10 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<Option<yew::Callback<Mou
     = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
 
 error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>` is not satisfied
-   --> $DIR/element-fail.rs:53:29
+   --> $DIR/element-fail.rs:53:30
     |
-53  |       html! { <input onfocus={Some(5)} /> };
-    |                               ^^^^^^^ the trait `IntoEventCallback<FocusEvent>` is not implemented for `Option<{integer}>`
+53  |       html! { <input on:focus={Some(5)} /> };
+    |                                ^^^^^^^ the trait `IntoEventCallback<FocusEvent>` is not implemented for `Option<{integer}>`
     |
    ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
@@ -424,13 +387,13 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
    = note: required by `into_prop_value`
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
-   --> $DIR/element-fail.rs:58:29
+   --> $DIR/element-fail.rs:58:30
     |
-58  |       html! { <input onclick={Callback::from(|a: String| ())} /> };
-    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                               |
-    |                               expected an implementor of trait `IntoEventCallback<MouseEvent>`
-    |                               help: consider borrowing here: `&Callback::from(|a: String| ())`
+58  |       html! { <input on:click={Callback::from(|a: String| ())} /> };
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                |
+    |                                expected an implementor of trait `IntoEventCallback<MouseEvent>`
+    |                                help: consider borrowing here: `&Callback::from(|a: String| ())`
     |
    ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
     |

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -1,12 +1,10 @@
 use std::borrow::Cow;
 use yew::prelude::*;
 
-yew::custom_event_handler! {
-    OnCustom {
-        type Event = CustomEvent;
-        custom: "custom"
-    }
-}
+use yew::macros::custom_event;
+
+#[custom_event(custom)]
+struct MyCustomEvent(yew::web_sys::Event);
 
 fn compile_pass() {
     let click = Callback::from(|_: MouseEvent| ());

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -1,6 +1,13 @@
 use std::borrow::Cow;
 use yew::prelude::*;
 
+yew::custom_event_handler! {
+    OnCustom {
+        type Event = CustomEvent;
+        custom: "custom"
+    }
+}
+
 fn compile_pass() {
     let click = Callback::from(|_: MouseEvent| ());
     let parent_ref = NodeRef::default();
@@ -65,7 +72,7 @@ fn compile_pass() {
             <track kind={Some(Cow::Borrowed("subtitles"))} src={cow_none.clone()} />
             <track kind={Some(Cow::Borrowed("5"))} mixed="works" />
             <input value={Some(Cow::Borrowed("value"))} on:blur={Some(Callback::from(|_| ()))} />
-            <div on:"custom event"={Callback::from(|_| ())}></div>
+            <div on:custom={Callback::from(|_| ())}></div>
         </div>
     };
 

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use yew::prelude::*;
 
 fn compile_pass() {
-    let onclick = Callback::from(|_: MouseEvent| ());
+    let click = Callback::from(|_: MouseEvent| ());
     let parent_ref = NodeRef::default();
 
     let dyn_tag = || String::from("test");
@@ -42,7 +42,7 @@ fn compile_pass() {
             </svg>
             <img class={classes!("avatar", "hidden")} src="http://pic.com" />
             <img class="avatar hidden" />
-            <button onclick={&onclick} {onclick} />
+            <button on:click={&click} on:{click} />
             <a href="http://google.com" />
             <custom-tag-a>
                 <custom-tag-b />
@@ -64,7 +64,8 @@ fn compile_pass() {
             <a href={Some(Cow::Borrowed("http://google.com"))} media={cow_none.clone()} />
             <track kind={Some(Cow::Borrowed("subtitles"))} src={cow_none.clone()} />
             <track kind={Some(Cow::Borrowed("5"))} mixed="works" />
-            <input value={Some(Cow::Borrowed("value"))} onblur={Some(Callback::from(|_| ()))} />
+            <input value={Some(Cow::Borrowed("value"))} on:blur={Some(Callback::from(|_| ()))} />
+            <div on:"custom event"={Callback::from(|_| ())}></div>
         </div>
     };
 

--- a/packages/yew-macro/tests/html_macro/node-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/node-fail.stderr
@@ -39,6 +39,13 @@ error[E0425]: cannot find value `invalid` in this scope
   |
 7 |     html! { invalid };
   |             ^^^^^^^ not found in this scope
+  |
+help: consider importing one of these items
+  |
+1 | use crate::listener::invalid;
+  |
+1 | use yew::listener::invalid;
+  |
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
  --> $DIR/node-fail.rs:6:13

--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -43,7 +43,7 @@ impl<R: Routable + Clone + PartialEq + 'static> Component for Link<R> {
         html! {
             <a class={ctx.props().classes.clone()}
                 href={ctx.props().route.to_path()}
-                onclick={ctx.link().callback(|e: MouseEvent| {
+                on:click={ctx.link().callback(|e: MouseEvent| {
                     e.prevent_default();
                     Msg::OnClick
                 })}

--- a/packages/yew-router/src/lib.rs
+++ b/packages/yew-router/src/lib.rs
@@ -33,7 +33,7 @@
 //!         Route::Secure => html! {
 //!             <div>
 //!                 <h1>{ "Secure" }</h1>
-//!                 <button onclick={onclick_callback}>{ "Go Home" }</button>
+//!                 <button on:click={onclick_callback}>{ "Go Home" }</button>
 //!             </div>
 //!         },
 //!         Route::NotFound => html! { <h1>{ "404" }</h1> },

--- a/packages/yew-router/tests/router.rs
+++ b/packages/yew-router/tests/router.rs
@@ -44,7 +44,7 @@ fn no(props: &NoProps) -> Html {
 #[function_component(Comp)]
 fn component() -> Html {
     let switch = Router::render(|routes| {
-        let onclick = Callback::from(|_| {
+        let click = Callback::from(|_| {
             yew_router::push_route_with_query(
                 Routes::No { id: 2 },
                 Query {
@@ -58,7 +58,7 @@ fn component() -> Html {
             Routes::Home => html! {
                 <>
                     <div id="result">{"Home"}</div>
-                    <a {onclick}>{"click me"}</a>
+                    <a on:{click}>{"click me"}</a>
                 </>
             },
             Routes::No { id } => html! { <No id={*id} /> },

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -47,7 +47,6 @@ features = [
   "Blob",
   "BlobPropertyBag",
   "console",
-  "CustomEvent",
   "DedicatedWorkerGlobalScope",
   "Document",
   "DomTokenList",

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -47,6 +47,7 @@ features = [
   "Blob",
   "BlobPropertyBag",
   "console",
+  "CustomEvent",
   "DedicatedWorkerGlobalScope",
   "Document",
   "DomTokenList",

--- a/packages/yew/src/functional/hooks/use_effect.rs
+++ b/packages/yew/src/functional/hooks/use_effect.rs
@@ -25,13 +25,13 @@ struct UseEffect<Destructor> {
 ///         || yew::utils::document().set_title(&format!("You clicked 0 times"))
 ///     });
 ///
-///     let onclick = {
+///     let click = {
 ///         let counter = counter.clone();
 ///         Callback::from(move |_| counter.set(*counter + 1))
 ///     };
 ///
 ///     html! {
-///         <button {onclick}>{ format!("Increment to {}", *counter) }</button>
+///         <button on:{click}>{ format!("Increment to {}", *counter) }</button>
 ///     }
 /// }
 /// ```

--- a/packages/yew/src/functional/hooks/use_reducer.rs
+++ b/packages/yew/src/functional/hooks/use_reducer.rs
@@ -56,8 +56,8 @@ struct UseReducer<State> {
 ///         <>
 ///             <div id="result">{ counter.counter }</div>
 ///
-///             <button onclick={double_onclick}>{ "Double" }</button>
-///             <button onclick={square_onclick}>{ "Square" }</button>
+///             <button on:click={double_onclick}>{ "Double" }</button>
+///             <button on:click={square_onclick}>{ "Square" }</button>
 ///         </>
 ///     }
 /// }
@@ -103,7 +103,7 @@ where
 ///         <>
 ///             <div id="result">{counter.counter}</div>
 ///
-///             <button onclick={Callback::from(move |_| counter.dispatch(10))}>{"Increment by 10"}</button>
+///             <button on:click={Callback::from(move |_| counter.dispatch(10))}>{"Increment by 10"}</button>
 ///         </>
 ///     }
 /// }

--- a/packages/yew/src/functional/hooks/use_ref.rs
+++ b/packages/yew/src/functional/hooks/use_ref.rs
@@ -19,7 +19,7 @@ use std::{cell::RefCell, rc::Rc};
 ///     let message = use_state(|| "".to_string());
 ///     let message_count = use_ref(|| 0);
 ///
-///     let onclick = Callback::from(move |e| {
+///     let click = Callback::from(move |e| {
 ///         let window = yew::utils::window();
 ///
 ///         if *message_count.borrow_mut() > 3 {
@@ -30,7 +30,7 @@ use std::{cell::RefCell, rc::Rc};
 ///         }
 ///     });
 ///
-///     let onchange = {
+///     let change = {
 ///         let message = message.clone();
 ///           Callback::from(move |e: Event| {
 ///             let input: HtmlInputElement = e.target_unchecked_into();
@@ -40,8 +40,8 @@ use std::{cell::RefCell, rc::Rc};
 ///
 ///     html! {
 ///         <div>
-///             <input {onchange} value={(*message).clone()} />
-///             <button {onclick}>{ "Send" }</button>
+///             <input on:{change} value={(*message).clone()} />
+///             <button on:{click}>{ "Send" }</button>
 ///         </div>
 ///     }
 /// }

--- a/packages/yew/src/functional/hooks/use_state.rs
+++ b/packages/yew/src/functional/hooks/use_state.rs
@@ -17,7 +17,7 @@ struct UseState<T2> {
 /// #[function_component(UseState)]
 /// fn state() -> Html {
 ///     let counter = use_state(|| 0);
-///     let onclick = {
+///     let click = {
 ///         let counter = counter.clone();
 ///         Callback::from(move |_| counter.set(*counter + 1))
 ///     };
@@ -25,7 +25,7 @@ struct UseState<T2> {
 ///
 ///     html! {
 ///         <div>
-///             <button {onclick}>{ "Increment value" }</button>
+///             <button on:{click}>{ "Increment value" }</button>
 ///             <p>
 ///                 <b>{ "Current value: " }</b>
 ///                 { *counter }

--- a/packages/yew/src/html/listener/events.rs
+++ b/packages/yew/src/html/listener/events.rs
@@ -1,111 +1,115 @@
-// Inspired by: http://package.elm-lang.org/packages/elm-lang/html/2.0.0/Html-Events
-impl_action! {
-    onabort(name: "abort", event: Event) -> web_sys::Event => |_, event| { event }
-    onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
-    oncancel(name: "cancel", event: Event) -> web_sys::Event => |_, event| { event }
-    oncanplay(name: "canplay", event: Event) -> web_sys::Event => |_, event| { event }
-    oncanplaythrough(name: "canplaythrough", event: Event) -> web_sys::Event => |_, event| { event }
-    onchange(name: "change", event: Event) -> web_sys::Event => |_, event| { event }
-    onclick(name: "click", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    onclose(name: "close", event: Event) -> web_sys::Event => |_, event| { event }
-    oncontextmenu(name: "contextmenu", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    oncuechange(name: "cuechange", event: Event) -> web_sys::Event => |_, event| { event }
-    ondblclick(name: "dblclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    ondrag(name: "drag", event: DragEvent) -> web_sys::DragEvent => |_, event| { event }
-    ondragend(name: "dragend", event: DragEvent) -> web_sys::DragEvent => |_, event| { event }
-    ondragenter(name: "dragenter", event: DragEvent) -> web_sys::DragEvent => |_, event| { event }
-    ondragexit(name: "dragexit", event: DragEvent) -> web_sys::DragEvent => |_, event| { event }
-    ondragleave(name: "dragleave", event: DragEvent) -> web_sys::DragEvent => |_, event| { event }
-    ondragover(name: "dragover", event: DragEvent) -> web_sys::DragEvent => |_, event| { event }
-    ondragstart(name: "dragstart", event: DragEvent) -> web_sys::DragEvent => |_, event| { event }
-    ondrop(name: "drop", event: DragEvent) -> web_sys::DragEvent => |_, event| { event }
-    ondurationchange(name: "durationchange", event: Event) -> web_sys::Event => |_, event| { event }
-    onemptied(name: "emptied", event: Event) -> web_sys::Event => |_, event| { event }
-    onended(name: "ended", event: Event) -> web_sys::Event => |_, event| { event }
-    onerror(name: "error", event: Event) -> web_sys::Event => |_, event| { event }
-    onfocus(name: "focus", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
-    onfocusin(name: "focusin", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
-    onfocusout(name: "focusout", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
-    // web_sys doesn't have a struct for `FormDataEvent`
-    onformdata(name: "formdata", event: Event) -> web_sys::Event => |_, event| { event }
-    oninput(name: "input", event: InputEvent) -> web_sys::InputEvent => |_, event| { event }
-    oninvalid(name: "invalid", event: Event) -> web_sys::Event => |_, event| { event }
-    onkeydown(name: "keydown", event: KeyboardEvent) -> web_sys::KeyboardEvent => |_, event| { event }
-    onkeypress(name: "keypress", event: KeyboardEvent) -> web_sys::KeyboardEvent => |_, event| { event }
-    onkeyup(name: "keyup", event: KeyboardEvent) -> web_sys::KeyboardEvent => |_, event| { event }
-    onload(name: "load", event: Event) -> web_sys::Event => |_, event| { event }
-    onloadeddata(name: "loadeddata", event: Event) -> web_sys::Event => |_, event| { event }
-    onloadedmetadata(name: "loadedmetadata", event: Event) -> web_sys::Event => |_, event| { event }
-    onloadstart(name: "loadstart", event: ProgressEvent) -> web_sys::ProgressEvent => |_, event| { event }
-    onmousedown(name: "mousedown", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    onmouseenter(name: "mouseenter", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    onmouseleave(name: "mouseleave", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    onmousemove(name: "mousemove", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    onmouseout(name: "mouseout", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    onmouseover(name: "mouseover", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    onmouseup(name: "mouseup", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
-    onpause(name: "pause", event: Event) -> web_sys::Event => |_, event| { event }
-    onplay(name: "play", event: Event) -> web_sys::Event => |_, event| { event }
-    onplaying(name: "playing", event: Event) -> web_sys::Event => |_, event| { event }
-    onprogress(name: "progress", event: ProgressEvent) -> web_sys::ProgressEvent => |_, event| { event }
-    onratechange(name: "ratechange", event: Event) -> web_sys::Event => |_, event| { event }
-    onreset(name: "reset", event: Event) -> web_sys::Event => |_, event| { event }
-    onresize(name: "resize", event: Event) -> web_sys::Event => |_, event| { event }
-    onscroll(name: "scroll", event: Event) -> web_sys::Event => |_, event| { event }
-    onsecuritypolicyviolation(name: "securitypolicyviolation", event: Event) -> web_sys::Event => |_, event| { event }
-    onseeked(name: "seeked", event: Event) -> web_sys::Event => |_, event| { event }
-    onseeking(name: "seeking", event: Event) -> web_sys::Event => |_, event| { event }
-    onselect(name: "select", event: Event) -> web_sys::Event => |_, event| { event }
-    onslotchange(name: "slotchange", event: Event) -> web_sys::Event => |_, event| { event }
-    onstalled(name: "stalled", event: Event) -> web_sys::Event => |_, event| { event }
-    // web_sys doesn't have a struct for `SubmitEvent`
-    onsubmit(name: "submit", event: Event) -> web_sys::Event => |_, event| { event }
-    onsuspend(name: "suspend", event: Event) -> web_sys::Event => |_, event| { event }
-    ontimeupdate(name: "timeupdate", event: Event) -> web_sys::Event => |_, event| { event }
-    ontoggle(name: "toggle", event: Event) -> web_sys::Event => |_, event| { event }
-    onvolumechange(name: "volumechange", event: Event) -> web_sys::Event => |_, event| { event }
-    onwaiting(name: "waiting", event: Event) -> web_sys::Event => |_, event| { event }
-    onwheel(name: "wheel", event: WheelEvent) -> web_sys::WheelEvent => |_, event| { event }
-
-    oncopy(name: "copy", event: Event) -> web_sys::Event => |_, event| { event }
-    oncut(name: "cut", event: Event) -> web_sys::Event => |_, event| { event }
-    onpaste(name: "paste", event: Event) -> web_sys::Event => |_, event| { event }
-
-    onanimationcancel(name: "animationcancel", event: AnimationEvent) -> web_sys::AnimationEvent => |_, event| { event }
-    onanimationend(name: "animationend", event: AnimationEvent) -> web_sys::AnimationEvent => |_, event| { event }
-    onanimationiteration(name: "animationiteration", event: AnimationEvent) -> web_sys::AnimationEvent => |_, event| { event }
-    onanimationstart(name: "animationstart", event: AnimationEvent) -> web_sys::AnimationEvent => |_, event| { event }
-    ongotpointercapture(name: "gotpointercapture", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onloadend(name: "loadend", event: ProgressEvent) -> web_sys::ProgressEvent => |_, event| { event }
-    onlostpointercapture(name: "lostpointercapture", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onpointercancel(name: "pointercancel", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onpointerdown(name: "pointerdown", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onpointerenter(name: "pointerenter", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onpointerleave(name: "pointerleave", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onpointerlockchange(name: "pointerlockchange", event: Event) -> web_sys::Event => |_, event| { event }
-    onpointerlockerror(name: "pointerlockerror", event: Event) -> web_sys::Event => |_, event| { event }
-    onpointermove(name: "pointermove", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onpointerout(name: "pointerout", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onpointerover(name: "pointerover", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onpointerup(name: "pointerup", event: PointerEvent) -> web_sys::PointerEvent => |_, event| { event }
-    onselectionchange(name: "selectionchange", event: Event) -> web_sys::Event => |_, event| { event }
-    onselectstart(name: "selectstart", event: Event) -> web_sys::Event => |_, event| { event }
-    onshow(name: "show", event: Event) -> web_sys::Event => |_, event| { event }
-    ontouchcancel(name: "touchcancel", event: TouchEvent) -> web_sys::TouchEvent => |_, event| { event }
-    ontouchend(name: "touchend", event: TouchEvent) -> web_sys::TouchEvent => |_, event| { event }
-    ontouchmove(name: "touchmove", event: TouchEvent) -> web_sys::TouchEvent => |_, event| { event }
-    ontouchstart(name: "touchstart", event: TouchEvent) -> web_sys::TouchEvent => |_, event| { event }
-    ontransitioncancel(name: "transitioncancel", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-    ontransitionend(name: "transitionend", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-    ontransitionrun(name: "transitionrun", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-    ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
+static_event_impl! {
+    abort => web_sys::Event,
+    auxclick => web_sys::MouseEvent,
+    blur => web_sys::FocusEvent,
+    cancel => web_sys::Event,
+    canplay => web_sys::Event,
+    canplaythrough => web_sys::Event,
+    change => web_sys::Event,
+    click => web_sys::MouseEvent,
+    close => web_sys::Event,
+    contextmenu => web_sys::MouseEvent,
+    cuechange => web_sys::Event,
+    dblclick => web_sys::MouseEvent,
+    drag => web_sys::DragEvent,
+    dragend => web_sys::DragEvent,
+    dragenter => web_sys::DragEvent,
+    dragexit => web_sys::DragEvent,
+    dragleave => web_sys::DragEvent,
+    dragover => web_sys::DragEvent,
+    dragstart => web_sys::DragEvent,
+    drop => web_sys::DragEvent,
+    durationchange => web_sys::Event,
+    emptied => web_sys::Event,
+    ended => web_sys::Event,
+    error => web_sys::Event,
+    focus => web_sys::FocusEvent,
+    focusin => web_sys::FocusEvent,
+    focusout => web_sys::FocusEvent,
+    /// [`web_sys`] doesn't have a supporting event type for `FormDataEvent` but does have a type
+    /// for `FormData`.
+    ///
+    /// Getting `FormData` from [`Event`](web_sys::Event) can be done using [`Reflect::get`](js_sys::Reflect::get)
+    /// from the [`js_sys`] crate.
+    formdata => web_sys::Event,
+    input => web_sys::InputEvent,
+    invalid => web_sys::Event,
+    keydown => web_sys::KeyboardEvent,
+    keypress => web_sys::KeyboardEvent,
+    keyup => web_sys::KeyboardEvent,
+    load => web_sys::Event,
+    loadeddata => web_sys::Event,
+    loadedmetadata => web_sys::Event,
+    loadstart => web_sys::ProgressEvent,
+    mousedown => web_sys::MouseEvent,
+    mouseenter => web_sys::MouseEvent,
+    mouseleave => web_sys::MouseEvent,
+    mousemove => web_sys::MouseEvent,
+    mouseout => web_sys::MouseEvent,
+    mouseover => web_sys::MouseEvent,
+    mouseup => web_sys::MouseEvent,
+    pause => web_sys::Event,
+    play => web_sys::Event,
+    playing => web_sys::Event,
+    progress => web_sys::ProgressEvent,
+    ratechange => web_sys::Event,
+    reset => web_sys::Event,
+    resize => web_sys::Event,
+    scroll => web_sys::Event,
+    securitypolicyviolation => web_sys::Event,
+    seeked => web_sys::Event,
+    seeking => web_sys::Event,
+    select => web_sys::Event,
+    slotchange => web_sys::Event,
+    stalled => web_sys::Event,
+    /// [`web_sys`] doesn't have a supporting event type for `SubmitEvent`.
+    ///
+    /// Getting `submitter` field from [`Event`](web_sys::Event) can be done using [`Reflect::get`](js_sys::Reflect::get)
+    /// from the [`js_sys`] crate.
+    submit => web_sys::Event,
+    suspend => web_sys::Event,
+    timeupdate => web_sys::Event,
+    toggle => web_sys::Event,
+    volumechange => web_sys::Event,
+    waiting => web_sys::Event,
+    wheel => web_sys::WheelEvent,
+    copy => web_sys::Event,
+    cut => web_sys::Event,
+    paste => web_sys::Event,
+    animationcancel => web_sys::AnimationEvent,
+    animationend => web_sys::AnimationEvent,
+    animationiteration => web_sys::AnimationEvent,
+    animationstart => web_sys::AnimationEvent,
+    gotpointercapture => web_sys::PointerEvent,
+    loadend => web_sys::ProgressEvent,
+    lostpointercapture => web_sys::PointerEvent,
+    pointercancel => web_sys::PointerEvent,
+    pointerdown => web_sys::PointerEvent,
+    pointerenter => web_sys::PointerEvent,
+    pointerleave => web_sys::PointerEvent,
+    pointerlockchange => web_sys::Event,
+    pointerlockerror => web_sys::Event,
+    pointermove => web_sys::PointerEvent,
+    pointerout => web_sys::PointerEvent,
+    pointerover => web_sys::PointerEvent,
+    pointerup => web_sys::PointerEvent,
+    selectionchange => web_sys::Event,
+    selectstart => web_sys::Event,
+    show => web_sys::Event,
+    touchcancel => web_sys::TouchEvent,
+    touchend => web_sys::TouchEvent,
+    touchmove => web_sys::TouchEvent,
+    touchstart => web_sys::TouchEvent,
+    transitioncancel => web_sys::TransitionEvent,
+    transitionend => web_sys::TransitionEvent,
+    transitionrun => web_sys::TransitionEvent,
+    transitionstart => web_sys::TransitionEvent,
 }
 
 use wasm_bindgen::JsCast;
 
-/// A trait to define event meta data statically.
-pub trait EventMeta {
+/// A trait to define event data statically.
+pub trait StaticEvent {
     /// Type of the event
     ///
     /// Event type must implement [`JsCast`] so that Yew can cast it to the correct type.
@@ -115,58 +119,53 @@ pub trait EventMeta {
     fn event_name() -> &'static str;
 }
 
-#[doc(hidden)]
-pub mod oncustom {
-    use super::EventMeta;
-    use crate::callback::Callback;
-    use crate::html::IntoPropValue;
-    use crate::virtual_dom::Listener;
-    use gloo::events::{EventListener, EventListenerOptions};
-    use std::rc::Rc;
-    use wasm_bindgen::JsCast;
-    use web_sys::{Element, EventTarget};
+use crate::callback::Callback;
+use crate::html::IntoPropValue;
+use crate::virtual_dom::Listener;
+use gloo::events::{EventListener, EventListenerOptions};
+use std::rc::Rc;
+use web_sys::{Element, EventTarget};
 
-    /// A wrapper for a callback which attaches event listeners to elements.
-    #[derive(Clone, Debug)]
-    pub struct Wrapper<T: EventMeta> {
-        callback: Callback<T::Event>,
+/// A wrapper for a callback which attaches event listeners to elements.
+#[derive(Clone, Debug)]
+pub struct Wrapper<T: StaticEvent> {
+    callback: Callback<T::Event>,
+}
+
+impl<T: StaticEvent + 'static> Wrapper<T> {
+    /// Create a wrapper for an event-typed callback
+    pub fn new(callback: Callback<T::Event>) -> Self {
+        Wrapper { callback }
     }
 
-    impl<T: EventMeta + 'static> Wrapper<T> {
-        /// Create a wrapper for an event-typed callback
-        pub fn new(callback: Callback<T::Event>) -> Self {
-            Wrapper { callback }
-        }
+    #[doc(hidden)]
+    #[inline]
+    pub fn __macro_new(
+        callback: impl IntoPropValue<Option<Callback<T::Event>>>,
+    ) -> Option<Rc<dyn Listener>> {
+        let callback = callback.into_prop_value()?;
+        Some(Rc::new(Self::new(callback)))
+    }
+}
 
-        #[doc(hidden)]
-        #[inline]
-        pub fn __macro_new(
-            callback: impl IntoPropValue<Option<Callback<T::Event>>>,
-        ) -> Option<Rc<dyn Listener>> {
-            let callback = callback.into_prop_value()?;
-            Some(Rc::new(Self::new(callback)))
-        }
+impl<T: StaticEvent> Listener for Wrapper<T> {
+    fn kind(&self) -> &'static str {
+        T::event_name()
     }
 
-    impl<T: EventMeta> Listener for Wrapper<T> {
-        fn kind(&self) -> &'static str {
-            T::event_name()
-        }
+    fn attach(&self, element: &Element) -> EventListener {
+        let event_name = T::event_name();
+        let callback = self.callback.clone();
+        let listener = move |event: &web_sys::Event| {
+            callback.emit(event.clone().unchecked_into());
+        };
 
-        fn attach(&self, element: &Element) -> EventListener {
-            let event_name = T::event_name();
-            let callback = self.callback.clone();
-            let listener = move |event: &web_sys::Event| {
-                callback.emit(event.clone().unchecked_into());
-            };
-
-            let options = EventListenerOptions::enable_prevent_default();
-            EventListener::new_with_options(
-                &EventTarget::from(element.clone()),
-                event_name,
-                options,
-                listener,
-            )
-        }
+        let options = EventListenerOptions::enable_prevent_default();
+        EventListener::new_with_options(
+            &EventTarget::from(element.clone()),
+            event_name,
+            options,
+            listener,
+        )
     }
 }

--- a/packages/yew/src/html/listener/events.rs
+++ b/packages/yew/src/html/listener/events.rs
@@ -120,11 +120,12 @@ pub trait StaticEvent {
 }
 
 use crate::callback::Callback;
-use crate::html::IntoPropValue;
 use crate::virtual_dom::Listener;
 use gloo::events::{EventListener, EventListenerOptions};
 use std::rc::Rc;
 use web_sys::{Element, EventTarget};
+
+use super::IntoEventCallback;
 
 /// A wrapper for a callback which attaches event listeners to elements.
 #[derive(Clone, Debug)]
@@ -140,10 +141,8 @@ impl<T: StaticEvent + 'static> Wrapper<T> {
 
     #[doc(hidden)]
     #[inline]
-    pub fn __macro_new(
-        callback: impl IntoPropValue<Option<Callback<T::Event>>>,
-    ) -> Option<Rc<dyn Listener>> {
-        let callback = callback.into_prop_value()?;
+    pub fn __macro_new(callback: impl IntoEventCallback<T::Event>) -> Option<Rc<dyn Listener>> {
+        let callback = callback.into_event_callback()?;
         Some(Rc::new(Self::new(callback)))
     }
 }

--- a/packages/yew/src/html/listener/events.rs
+++ b/packages/yew/src/html/listener/events.rs
@@ -104,20 +104,20 @@ impl_action! {
 
 use wasm_bindgen::JsCast;
 
-/// A trait to define custom event handling within the [`html`](crate::html!) macro
-pub trait CustomEventHandler {
-    /// Type of the custom event
+/// A trait to define event meta data statically.
+pub trait EventMeta {
+    /// Type of the event
     ///
     /// Event type must implement [`JsCast`] so that Yew can cast it to the correct type.
-    type Event: JsCast + 'static;
+    type Event: AsRef<web_sys::Event> + JsCast + 'static;
 
-    /// Name of the custom event
+    /// Name of the event
     fn event_name() -> &'static str;
 }
 
 #[doc(hidden)]
 pub mod oncustom {
-    use super::CustomEventHandler;
+    use super::EventMeta;
     use crate::callback::Callback;
     use crate::html::IntoPropValue;
     use crate::virtual_dom::Listener;
@@ -128,11 +128,11 @@ pub mod oncustom {
 
     /// A wrapper for a callback which attaches event listeners to elements.
     #[derive(Clone, Debug)]
-    pub struct Wrapper<T: CustomEventHandler> {
+    pub struct Wrapper<T: EventMeta> {
         callback: Callback<T::Event>,
     }
 
-    impl<T: CustomEventHandler + 'static> Wrapper<T> {
+    impl<T: EventMeta + 'static> Wrapper<T> {
         /// Create a wrapper for an event-typed callback
         pub fn new(callback: Callback<T::Event>) -> Self {
             Wrapper { callback }
@@ -148,9 +148,9 @@ pub mod oncustom {
         }
     }
 
-    impl<T: CustomEventHandler> Listener for Wrapper<T> {
+    impl<T: EventMeta> Listener for Wrapper<T> {
         fn kind(&self) -> &'static str {
-            stringify!($action)
+            T::event_name()
         }
 
         fn attach(&self, element: &Element) -> EventListener {

--- a/packages/yew/src/html/listener/macros.rs
+++ b/packages/yew/src/html/listener/macros.rs
@@ -1,64 +1,20 @@
-macro_rules! impl_action {
-    ($($action:ident(name: $name:literal, event: $type:ident) -> $ret:ty => $convert:expr)*) => {$(
-        /// An abstract implementation of a listener.
-        #[doc(hidden)]
-        pub mod $action {
-            use crate::callback::Callback;
-            #[allow(unused_imports)]
-            use crate::html::{listener::*, IntoPropValue};
-            use crate::virtual_dom::Listener;
-            use gloo::events::{EventListener, EventListenerOptions};
-            use wasm_bindgen::JsValue;
-            use web_sys::{$type as WebSysType, Element, EventTarget};
-            use std::rc::Rc;
+macro_rules! static_event_impl {
+    ($(
+        $(#[$event_doc:meta])*
+        $event_type:ident => $event:ty,)* $(,)?
+    ) => {
+        $(
+            $(#[$event_doc])*
+            #[allow(non_camel_case_types, missing_debug_implementations, missing_docs)]
+            pub struct $event_type;
 
-            /// A wrapper for a callback which attaches event listeners to elements.
-            #[derive(Clone, Debug)]
-            pub struct Wrapper {
-                callback: Callback<Event>,
-            }
+            impl StaticEvent for $event_type {
+                type Event = $event;
 
-            impl Wrapper {
-                /// Create a wrapper for an event-typed callback
-                pub fn new(callback: Callback<Event>) -> Self {
-                    Wrapper { callback }
-                }
-
-                #[doc(hidden)]
-                #[inline]
-                pub fn __macro_new(callback: impl IntoEventCallback<Event>) -> Option<Rc<dyn Listener>> {
-                    let callback = callback.into_event_callback()?;
-                    Some(Rc::new(Self::new(callback)))
+                fn event_name() -> &'static str {
+                    stringify!($event_type)
                 }
             }
-
-            /// And event type which keeps the returned type.
-            pub type Event = $ret;
-
-            impl Listener for Wrapper {
-                fn kind(&self) -> &'static str {
-                    stringify!($action)
-                }
-
-                fn attach(&self, element: &Element) -> EventListener {
-                    let this = element.clone();
-                    let callback = self.callback.clone();
-                    let listener = move |
-                        event: &web_sys::Event
-                    | {
-                        let event: WebSysType = JsValue::from(event).into();
-                        callback.emit($convert(&this, event));
-                    };
-                    // We should only set passive event listeners for `touchstart` and `touchmove`.
-                    // See here: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners
-                    if $name == "touchstart" || $name == "touchmove" {
-                        EventListener::new(&EventTarget::from(element.clone()), $name, listener)
-                    } else {
-                        let options = EventListenerOptions::enable_prevent_default();
-                        EventListener::new_with_options(&EventTarget::from(element.clone()), $name, options, listener)
-                    }
-                }
-            }
-        }
-    )*};
+        )*
+    };
 }

--- a/packages/yew/src/html/listener/mod.rs
+++ b/packages/yew/src/html/listener/mod.rs
@@ -40,7 +40,7 @@ where
     /// fn view(&self, ctx: &Context<Self>) -> Html {
     ///     html! {
     ///         <div
-    ///             onchange={ctx.link().batch_callback(|e: Event| {
+    ///             on:change={ctx.link().batch_callback(|e: Event| {
     ///                 if let Some(input) = e.target_dyn_into::<HtmlTextAreaElement>() {
     ///                     Some(Msg::Value(input.value()))
     ///                 } else {
@@ -96,7 +96,7 @@ where
     /// fn view(&self, ctx: &Context<Self>) -> Html {
     ///     html! {
     ///         <input type="text"
-    ///             onchange={ctx.link().callback(|e: Event| {
+    ///             on:change={ctx.link().callback(|e: Event| {
     ///                 // Safe to use as callback is on an `input` element so this event can
     ///                 // only come from this input!
     ///                 let input: HtmlInputElement = e.target_unchecked_into();

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -3,7 +3,8 @@
 mod classes;
 mod component;
 mod conversion;
-mod listener;
+#[doc(hidden)]
+pub mod listener;
 
 pub use classes::*;
 pub use component::*;

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -100,6 +100,67 @@ use std::{cell::Cell, panic::PanicInfo};
 /// ```
 pub use yew_macro::classes;
 
+/// This attribute will implement the supporting traits to support this custom event NewType.
+///
+/// The attribute can only be applied to NewType structs which wrap a type that implements
+/// [`JsCast`](wasm_bindgen::JsCast), this includes any [`web_sys`](web_sys) events and any type
+/// imported in a [wasm_bindgen] extern block.
+///
+/// The following traits will be implemented by this attribute macro on the NewType struct:
+/// - [`Deref`](std::ops::Deref) where Target is the type wrapped by this NewType.
+/// - [`AsRef<T>`](std::convert::AsRef) where T is [`JsValue`](wasm_bindgen::JsValue).
+/// - [`Into<T>`](std::convert::Into) where T is [`JsValue`](wasm_bindgen::JsValue).
+/// - [`JsCast`](wasm_bindgen::JsCast)
+/// - [`CustomEventHandler`](crate::html::CustomEventHandler) where [`Event`](crate::html::CustomEventHandler::Event)
+///   is Self.
+///
+/// # Examples
+///
+/// ## NewType around [`web_sys`](web_sys) Events
+///  
+/// ```
+/// use yew::{Callback, custom_event, web_sys::Event};
+///
+/// // when the ident will match the event name such as (custom = "custom") a shorthand can be used.
+/// #[custom_event(custom)]
+/// struct MyCustomEvent(Event);
+///
+/// let custom = Callback::from(|e: MyCustomEvent| ());
+///
+/// html! {
+///     <div on:{custom} on:custom={Callback::from(|_| ())} />
+/// };
+/// ```
+///
+///
+/// ## NewType around imported type
+///
+/// ```
+/// #[wasm_bindgen(module = "..")]
+/// extern "C" {
+///     #[wasm_bindgen(js_name = "MDCSnackbar:closed")]
+///     type RawSnackBarClosed;
+///
+///     #[wasm_bindgen(method, getter)]
+///     fn reason(this: &RawSnackBarClosed) -> String;
+/// }
+///
+/// #[custom_event(snackbarclosed = "MDCSnackbar:closed")]
+/// pub struct SnackBarClosed(RawSnackBarClosed);
+///
+/// let snackbarclosed = Callback::from(|e: SnackBarClosed| {
+///     let reason = e.reason();
+///     // do something with reason.
+/// });
+///
+/// html! {
+///     <div on:{snackbarclosed} />
+/// };
+///
+/// ```
+///
+pub use yew_macro::custom_event;
+
 /// This macro implements JSX-like templates.
 ///
 /// This macro always returns [`Html`].
@@ -251,6 +312,7 @@ pub use yew_macro::props;
 /// This module contains macros which implements html! macro and JSX-like templates
 pub mod macros {
     pub use crate::classes;
+    pub use crate::custom_event;
     pub use crate::html;
     pub use crate::html_nested;
     pub use crate::props;
@@ -273,9 +335,8 @@ pub mod events {
 
     #[doc(no_inline)]
     pub use web_sys::{
-        AnimationEvent, CustomEvent, DragEvent, ErrorEvent, Event, FocusEvent, InputEvent,
-        KeyboardEvent, MouseEvent, PointerEvent, ProgressEvent, TouchEvent, TransitionEvent,
-        UiEvent, WheelEvent,
+        AnimationEvent, DragEvent, ErrorEvent, Event, FocusEvent, InputEvent, KeyboardEvent,
+        MouseEvent, PointerEvent, ProgressEvent, TouchEvent, TransitionEvent, UiEvent, WheelEvent,
     };
 }
 

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -50,7 +50,7 @@
 //!     fn view(&self, ctx: &Context<Self>) -> Html {
 //!         html! {
 //!             <div>
-//!                 <button onclick={ctx.link().callback(|_| Msg::AddOne)}>{ "+1" }</button>
+//!                 <button on:click={ctx.link().callback(|_| Msg::AddOne)}>{ "+1" }</button>
 //!                 <p>{ self.value }</p>
 //!             </div>
 //!         }
@@ -273,8 +273,9 @@ pub mod events {
 
     #[doc(no_inline)]
     pub use web_sys::{
-        AnimationEvent, DragEvent, ErrorEvent, Event, FocusEvent, InputEvent, KeyboardEvent,
-        MouseEvent, PointerEvent, ProgressEvent, TouchEvent, TransitionEvent, UiEvent, WheelEvent,
+        AnimationEvent, CustomEvent, DragEvent, ErrorEvent, Event, FocusEvent, InputEvent,
+        KeyboardEvent, MouseEvent, PointerEvent, ProgressEvent, TouchEvent, TransitionEvent,
+        UiEvent, WheelEvent,
     };
 }
 

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -119,7 +119,7 @@ pub use yew_macro::classes;
 /// ## NewType around [`web_sys`](web_sys) Events
 ///  
 /// ```
-/// use yew::{Callback, custom_event, web_sys::Event};
+/// use yew::{Callback, custom_event, html, web_sys::Event};
 ///
 /// // when the ident will match the event name such as (custom = "custom") a shorthand can be used.
 /// #[custom_event(custom)]
@@ -135,7 +135,11 @@ pub use yew_macro::classes;
 ///
 /// ## NewType around imported type
 ///
-/// ```
+/// ```ignore
+/// # can't run this doc test because of wasm_bindgen
+/// use yew::{Callback, custom_event, html};
+/// use wasm_bindgen::prelude::*;
+///
 /// #[wasm_bindgen(module = "..")]
 /// extern "C" {
 ///     #[wasm_bindgen(js_name = "MDCSnackbar:closed")]

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -335,7 +335,8 @@ pub use web_sys;
 
 /// The module that contains all events available in the framework.
 pub mod events {
-    pub use crate::html::TargetCast;
+    pub use crate::html::listener;
+    pub use crate::html::{StaticEvent, TargetCast};
 
     #[doc(no_inline)]
     pub use web_sys::{

--- a/website/docs/concepts/components.md
+++ b/website/docs/concepts/components.md
@@ -46,16 +46,24 @@ HTML-like code using Rust functions can become quite messy, so Yew provides a ma
 for declaring HTML and SVG nodes (as well as attaching attributes and event listeners to them) and a
 convenient way to render child components. The macro is somewhat similar to React's JSX (the
 differences in programming language aside).
-One difference is that Yew provides a shorthand syntax for properties, similar to Svelte, where instead of writing `onclick={onclick}`, you can just write `{onclick}`.
+One difference is that Yew provides a shorthand syntax for properties, similar to Svelte, where 
+instead of writing `on:click={click}`, you can just write `on:{click}`.
 
 ```rust
 impl Component for MyComponent {
     // ...
 
+<<<<<<< HEAD
     fn view(&self, ctx: &Context<Self>) -> Html {
         let onclick = ctx.link().callback(|_| Msg::Click);
         html! {
             <button {onclick}>{ ctx.props().button_text }</button>
+=======
+    fn view(&self) -> Html {
+        let click = self.link.callback(|_| Msg::Click);
+        html! {
+            <button on:{click}>{ self.props.button_text }</button>
+>>>>>>> 3a6fe591 (Add event listener syntax to support custom event)
         }
     }
 }

--- a/website/docs/concepts/components/callbacks.md
+++ b/website/docs/concepts/components/callbacks.md
@@ -70,9 +70,13 @@ They have an `emit` function that takes their `<IN>` type as an argument and con
 A simple use of a callback might look something like this:
 
 ```rust
+<<<<<<< HEAD
 let onclick = link.callback(|_| Msg::Clicked);
+=======
+let click = self.link.callback(|_| Msg::Clicked);
+>>>>>>> 3a6fe591 (Add event listener syntax to support custom event)
 html! {
-    <button {onclick}>{ "Click" }</button>
+    <button on:{click}>{ "Click" }</button>
 }
 ```
 
@@ -81,7 +85,11 @@ The function passed to `callback` must always take a parameter. For example, the
 If you need a callback that might not need to cause an update, use `batch_callback`.
 
 ```rust
+<<<<<<< HEAD
 let onkeypress = link.batch_callback(|event| {
+=======
+let keypress = self.link.batch_callback(|event| {
+>>>>>>> 3a6fe591 (Add event listener syntax to support custom event)
     if event.key() == "Enter" {
         Some(Msg::Submit)
     } else {
@@ -90,7 +98,7 @@ let onkeypress = link.batch_callback(|event| {
 });
 
 html! {
-    <input type="text" {onkeypress} />
+    <input type="text" on:{keypress} />
 }
 ```
 

--- a/website/docs/concepts/function-components/attribute.md
+++ b/website/docs/concepts/function-components/attribute.md
@@ -44,14 +44,14 @@ pub fn rendered_at(props: &RenderedAtProps) -> Html {
 fn app() -> Html {
     let (counter, set_counter) = use_state(|| 0);
 
-    let onclick = {
+    let click = {
         let counter = Rc::clone(&counter);
         Callback::from(move |_| set_counter(*counter + 1))
     };
 
     html! {
         <div>
-            <button {onclick}>{ "Increment value" }</button>
+            <button on:{click}>{ "Increment value" }</button>
             <p>
                 <b>{ "Current value: " }</b>
                 { counter }

--- a/website/docs/concepts/function-components/pre-defined-hooks.md
+++ b/website/docs/concepts/function-components/pre-defined-hooks.md
@@ -18,7 +18,7 @@ This value remains up-to-date on subsequent renders.
 #[function_component(UseState)]
 fn state() -> Html {
     let counter = use_state(|| 0);
-    let onclick = {
+    let click = {
         let counter = counter.clone();
         Callback::from(move |_| counter.set(*counter + 1))
     };
@@ -26,7 +26,7 @@ fn state() -> Html {
 
     html! {
         <div>
-            <button {onclick}>{ "Increment value" }</button>
+            <button on:{click}>{ "Increment value" }</button>
             <p>
                 <b>{ "Current value: " }</b>
                 { *counter }
@@ -51,7 +51,7 @@ fn ref_hook() -> Html {
     let message = use_state(|| "".to_string());
     let message_count = use_ref(|| 0);
 
-    let onclick = Callback::from(move |e| {
+    let click = Callback::from(move |e| {
         let window = yew::utils::window();
 
         if *message_count.borrow_mut() > 3 {
@@ -62,7 +62,7 @@ fn ref_hook() -> Html {
         }
     });
 
-    let onchange = {
+    let change = {
         let message = message.clone();
         Callback::from(move |e: Event| {
             let input: HtmlInputElement = e.target_unchecked_into();
@@ -72,8 +72,8 @@ fn ref_hook() -> Html {
 
     html! {
         <div>
-            <input {onchange} value={message} />
-            <button {onclick}>{ "Send" }</button>
+            <input on:{change} value={message} />
+            <button on:{click}>{ "Send" }</button>
         </div>
     }
 }
@@ -133,8 +133,8 @@ fn reducer() -> Html {
         <>
             <div id="result">{ counter.counter }</div>
 
-            <button onclick={double_onclick}>{ "Double" }</button>
-            <button onclick={square_onclick}>{ "Square" }</button>
+            <button on:click={double_onclick}>{ "Double" }</button>
+            <button on:click={square_onclick}>{ "Square" }</button>
         </>
     }
 }
@@ -187,13 +187,13 @@ fn effect() -> Html {
             || yew::utils::document().set_title("You clicked 0 times")
         });
     }    
-    let onclick = {
+    let click = {
         let counter = Rc::clone(&counter);
         Callback::from(move |_| set_counter(*counter + 1))
     };
 
     html! {
-        <button {onclick}>{ format!("Increment to {}", counter) }</button>
+        <button on:{click}>{ format!("Increment to {}", counter) }</button>
     }
 }
 ```

--- a/website/docs/concepts/html/elements.md
+++ b/website/docs/concepts/html/elements.md
@@ -421,7 +421,6 @@ html! {
 #### Traits implemented
 
 The `custom_event` attribute macro implements the following traits:
-- [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) where `Target` is the type wrapped by this Newtype.
 - [`AsRef<T>`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) where `T` is:
     - [`JsValue`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/struct.JsValue.html)
     - [`Event`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Event.html)

--- a/website/docs/concepts/html/elements.md
+++ b/website/docs/concepts/html/elements.md
@@ -343,6 +343,8 @@ Imported types using `wasm_bindgen` extern blocks implement `JsCast`.
 :::caution
 The `custom_event` macro only accepts tuple structs with a single type and that type **MUST** implement
 `JsCast`.
+
+The `custom_event` macro requires `wasm_bindgen` to implement `JsCast` for the type applied to.
 :::
 
 This is where the `custom_event` attribute macro comes in to implement all the traits required on

--- a/website/docs/concepts/html/elements.md
+++ b/website/docs/concepts/html/elements.md
@@ -128,7 +128,7 @@ impl Component for MyComponent {
         // Create a callback from a component link to handle it in a component
         let click_callback = ctx.link().callback(|_: ClickEvent| Msg::Click);
         html! {
-            <button onclick={click_callback}>
+            <button on:click={click_callback}>
                 { "Click me!" }
             </button>
         }
@@ -157,7 +157,7 @@ impl Component for MyComponent {
         // Create a callback from a worker to handle it in another context
         let click_callback = self.worker.callback(|_: ClickEvent| WorkerMsg::Process);
         html! {
-            <button onclick={click_callback}>
+            <button on:click={click_callback}>
                 { "Click me!" }
             </button>
         }
@@ -185,7 +185,7 @@ impl Component for MyComponent {
         });
 
         html! {
-            <button onclick={click_callback}>
+            <button on:click={click_callback}>
                 { "Click me!" }
             </button>
         }
@@ -204,7 +204,7 @@ if you were to manually include `web-sys` as a dependency in your crate because 
 end up using a version which conflicts with the version that Yew specifies.
 :::
 
-| Event name                  | `web_sys` Event Type                                                                  |
+| Global event handler name   | `web_sys` Event Type                                                                  |
 | --------------------------- | ------------------------------------------------------------------------------------- |
 | `onabort`                   | [Event](https://docs.rs/web-sys/latest/web_sys/struct.Event.html)                     |
 | `onauxclick`                | [MouseEvent](https://docs.rs/web-sys/latest/web_sys/struct.MouseEvent.html)           |
@@ -302,6 +302,51 @@ end up using a version which conflicts with the version that Yew specifies.
 | `ontransitionend`           | [TransitionEvent](https://docs.rs/web-sys/latest/web_sys/struct.TransitionEvent.html) |
 | `ontransitionrun`           | [TransitionEvent](https://docs.rs/web-sys/latest/web_sys/struct.TransitionEvent.html) |
 | `ontransitionstart`         | [TransitionEvent](https://docs.rs/web-sys/latest/web_sys/struct.TransitionEvent.html) |
+
+
+## Custom Events 
+
+Yew can't know what type of event will be supplied at compile time so will use `web_sys::CustomEvent`.
+
+The syntax supported for custom events can mimic those for the events listed above using the shorthand
+with idents, however, to support custom events with names that cannot be represented in Rust a literal
+`str` can be used. 
+
+```rust
+struct MyComponent;
+
+impl Component for MyComponent {
+    type Message = ();
+    type Properties = ();
+
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+        MyComponent
+    }
+
+    fn update(&mut self, _: Self::Message) -> ShouldRender {
+        false
+    }
+
+    fn view(&self) -> Html {
+        let custard = self.link.callback(|e: CustomEvent| {
+            // we just got a `custard` event!
+        });
+
+        html! {
+            <dessert-web-comp 
+                on:{custard}
+                on:"Event T*hat Cou&&3^^ld never be parsed in rust"={self.link.callback(|e: CustomEvent| {
+                    // we just got a really bizarre event...
+                })}
+            >
+            </dessert-web-comp>
+        }
+    }
+}
+```
+
+This does allow for using `on:"click"' as if it is a custom event, however, Yew will pick this up and 
+will except a `Callback<web_sys::MouseEvent>`. 
 
 ## Relevant examples
 - [Inner HTML](https://github.com/yewstack/yew/tree/master/examples/inner_html)

--- a/website/docs/concepts/html/elements.md
+++ b/website/docs/concepts/html/elements.md
@@ -332,7 +332,7 @@ html! {
 ```
 Implementing the `CustomEventHandler` trait by hand adds boiler plate and in order to use the 
 `MyCustomEvent` type defined in the Callback the `CustomEventHandler::Event` would have to be set to
-`Self` which requires implementing [`JsCast`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html) for `MyCustomEvent` which is not trival. 
+`Self` which requires implementing [`JsCast`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html) for `MyCustomEvent` which is not trivial. 
 
 :::tip
 Imported types using `wasm_bindgen` extern blocks implement `JsCast`.
@@ -380,7 +380,7 @@ html! {
 ```
 
 :::tip
-Event types are case sensitive and contain whitespaces. 
+Event types are case sensitive and contain white spaces. 
 
 If your application is not catching custom events then check that the 
 event type matches the value in the `custom_event` attribute!

--- a/website/docs/concepts/html/elements.md
+++ b/website/docs/concepts/html/elements.md
@@ -318,7 +318,7 @@ struct MyCustomEvent(Event);
 impl CustomEventHandler for MyCustomEvent {
     type Event = Event;
 
-    fn event_name(&self) -> &'static str {
+    fn event_name() -> &'static str {
         "custom"
     }
 }

--- a/website/docs/concepts/router.md
+++ b/website/docs/concepts/router.md
@@ -53,7 +53,7 @@ fn switch(route: &Route) -> Html {
             html! {
                 <div>
                     <h1>{ "Secure" }</h1>
-                    <button onclick={callback}>{ "Go Home" }</button>
+                    <button on:click={callback}>{ "Go Home" }</button>
                 </div>
             }
         },

--- a/website/docs/getting-started/build-a-sample-app.md
+++ b/website/docs/getting-started/build-a-sample-app.md
@@ -92,7 +92,11 @@ impl Component for Model {
         let link = ctx.link();
         html! {
             <div>
+<<<<<<< HEAD
                 <button onclick={link.callback(|_| Msg::AddOne)}>{ "+1" }</button>
+=======
+                <button on:click={self.link.callback(|_| Msg::AddOne)}>{ "+1" }</button>
+>>>>>>> 3a6fe591 (Add event listener syntax to support custom event)
                 <p>{ self.value }</p>
             </div>
         }


### PR DESCRIPTION
### Adds assigning listener syntax:
```rust
let click = Callback::from(|_| ());
html! {
    <div 
        on:{click}
        on:click={Callback::from(|_| ())
    />
}
```

If / when we support adding event listeners onto `Component`s directly it will distinguish 
when an event listener is being assigned to a `Component` instead of being passed down as a prop:

```rust
// WON'T COMPILE TODAY (for anyone skimming through looking at examples)

// pretend I defined `click` and `onchange` correctly :)
<MyComp 
    // event handler being used on component
    on:{click}
    // callback being passed down to the component for internal use
    {onchange}
/>
```

### Add custom event support

Custom event support comes from implementing the `StaticEvent` trait: 

```rust
pub trait StaticEvent {

   type Event: JsCast + AsRef<web_sys::Event> + 'static;
   
   fn event_name() -> &'static str;
}
```

On it's own this would allow a user implement the trait with the `Event` 
type being the wrapped `web_sys` event. 

```rust
struct MyCustomEvent(web_sys::Event);

impl StaticEvent for MyCustomEvent {
    type Event = web_sys::Event;
    
    fn event_name() -> &'static str {
        "custom"
    }
}

html! {
    <div
        // here callback gets a web_sys::Event and not the MyCustomEvent type
        // but the user could just wrap the type MyCustomEvent(e) then call 
        // any useful functions. Not bad...but we can do better :)
        on:MyCustomEvent={Callback::from(|e: web_sys::Event| ())}
    />
}
```

A similar pattern is used to implement the [events supported by yew](https://yew.rs/concepts/html/elements#event-types), but with unit based structs as we just want the raw `web_sys` event passed in. 
This allows us to treat supported and custom events in the same way and reduces the need for multiple on[event] modules.
This also means that if Yew wanted to provide it's own events somewhen then we could easily utilise the `custom_event` macro to make NewTypes around the raw `web_sys` events and this would work the same internally. 

When implementing the trait like this if a user wanted to use a function on the NewType they would 
have to wrap the event type in that NewType first, which doesn't seem very ergonomic. 
It is possible for a user to use `Self` as the `Event` type but then they have 
to implement `JsCast` on that type, which is not trivial even when wrapping a `JsCast` type. 

To help with the boiler plate, this PR also adds the `custom_event` attribute macro which 
can be applied to NewTypes that wrap a type that implements `JsCast` + `AsRef<web_sys::Event>`, this includes any
type imported in a `wasm_bindgen` extern block that [extends](https://rustwasm.github.io/wasm-bindgen/reference/attributes/on-js-imports/extends.html) Event.

The `custom_event` macro has one attribute which is used to define the "event name" 
if this name is representable in Rust then a shorthand can be used: 

**Shorthand**
```rust
// bind ident to event name `custard` 
#[custom_event(custard)]
// Newtype here
```

**Normal**
```rust
#[custom_event(bizarre_event = "    represent ''' this in Rust")]
// Newtype here
```

The ident defined in the attribute can then be used in the same way as other events:
```rust
// each callback would be accepting the NewType that the custom_event macro
// was used on!

// can still use the shorthand in html too if the variable matches!
let bizarre_event = Callback::from(|_| ());
html! {
    <div
        on:custard={Callback::from(|_| ())}
        on:{bizarre_event}
    />
}
```

Putting it all together: 

```rust
#[custom_event(custom)]
struct MyCustomEvent(web_sys::Event);

// The shorthand works here when the variable name matches the type name
html! {
    let custom = Callback::from(|e: MyCustomEvent| ());
    <div
        on:{custom}
        // you can still use the struct name if you prefer!
        on:MyCustomEvent={Callback::from(|e: MyCustomEvent| ())}
    />
}
```

When implementing the `static_event_impl` macro I added optional comments and they display really well in the `html` macro for VSCode, I've only added a comment about the `formdata` event:
![image](https://user-images.githubusercontent.com/43726912/129788981-a11451a3-2cb5-4988-9798-ad2048e996b4.png)
This could be done as is with the modules but I think it's a nice touch so have added it here as I was using a new macro_rules macro anyways.

I have changed the syntax and implementation a few times over getting to this point 
but I don't think it's in bad shape (hopefully ;P) and look forward to hearing what 
people think :)


### Typed Custom Event 

I think it's worth just going over the example that triggered the linked issue and how a solution 
might look with this change. It was the ability to listen to the "MDCSnackbar:closing" event and others like it on
imported web components (in the example the `mwc-snackbar`).

How this example looks today:
[Snackbar in material-yew](https://github.com/hamza1311/material-yew/blob/master/material-yew/src/snackbar.rs)

A possible solution with this PR:

```rust

use wasm_bindgen::prelude::*;

// DetailsReason implements JsCast when imported in by wasm_bindgen
#[wasm_bindgen]
extern "C" {
    #[derive(Debug)]
    #[wasm_bindgen(extends = Object)]
    type DetailsReason;

    #[wasm_bindgen(method, getter)]
    fn reason(this: &DetailsReason) -> Option<String>;
}

use yew::custom_event;

#[custom_event(snackbarclosing = "MDCSnackbar:closing")]
struct SnackBarClosingEvent(web_sys::CustomEvent);

impl SnackBarClosingEvent {
    // web_sys::CustomEven` has a `detail` method which returns a JsValue, which is not very 
    // user friendly. As we have wrapped the CustomEvent in our new type we can now define our own
    // detail method that returns our imported type.
    pub fn detail(&self) -> DetailsReason {
        // JsCast::unchecked_into to jump from JsValue to DetailsReason
        self.0.detail().unchecked_into()
    }

    // You may just want to skip the detail call and provide a direct method to the reason
    pub fn reason(&self) -> Option<String> {
        self.0.detail().unchecked_into::<DetailsReason>().reason()
    } 
}

// Then inside the SnackBar Component a Callback can be used like any other supported event

use yew::prelude::*;

#[derive(Properties)]
pub struct SnackBarProps {
    #[prop_or_default]
    pub onclosing: Callback<Option<String>>,
    // rest omitted for clarity
}

impl Component for MatSnackBar {

    // create, update, etc omitted for clarity

    fn view(&self) -> Html {
        let snackbarclosing = self.props.onclosing.reform(|e: SnackBarClosingEvent| {
            e.detail().reason()
        });
        html! {
            <mwc-snackbar
                on:{snackbarclosing}
                // rest omitted
            >
                { self.props.children.clone() }
            </mwc-snackbar>
        }
    }
}

```
This `Component` could make the `SnackBarClosingEvent` and it's `snackbarclosing` alias public and 
change the onclosing property to accept this event. This approach means the event can be defined 
with the `Component` and imported by the user :)


<!-- Please include a summary of the change. -->

Fixes #1777 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->