### PR TITLE
Add custom type for attribute values

### DIFF
--- a/examples/keyed_list/Cargo.toml
+++ b/examples/keyed_list/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-fake = "2.2"
+fake = "=2.4.1"
 getrandom = { version = "0.2", features = ["js"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = "0.4"
@@ -17,6 +17,6 @@ yew = { path = "../../packages/yew" }
 [dependencies.web-sys]
 version = "0.3"
 features = [
-	"HtmlElement",
-	"HtmlInputElement",
+    "HtmlElement",
+    "HtmlInputElement",
 ]

--- a/examples/router/src/pages/post.rs
+++ b/examples/router/src/pages/post.rs
@@ -1,6 +1,5 @@
 use crate::{content, generator::Generated, Route};
 use content::PostPart;
-use std::borrow::Cow;
 use yew::prelude::*;
 use yew_router::prelude::*;
 
@@ -39,7 +38,7 @@ impl Component for Post {
         html! {
             <>
                 <section class="hero is-medium is-light has-background">
-                    <img class="hero-background is-transparent" src={Cow::Owned(post.meta.image_url.clone())} />
+                    <img class="hero-background is-transparent" src={post.meta.image_url.clone()} />
                     <div class="hero-body">
                         <div class="container">
                             <h1 class="title">
@@ -70,7 +69,7 @@ impl Post {
             <article class="media block box my-6">
                 <figure class="media-left">
                     <p class="image is-64x64">
-                        <img src={Cow::Owned(quote.author.image_url.clone())} loading="lazy" />
+                        <img src={quote.author.image_url.clone()} loading="lazy" />
                     </p>
                 </figure>
                 <div class="media-content">
@@ -90,7 +89,7 @@ impl Post {
     fn render_section_hero(&self, section: &content::Section) -> Html {
         html! {
             <section class="hero is-dark has-background mt-6 mb-3">
-                <img class="hero-background is-transparent" src={Cow::Owned(section.image_url.clone())} loading="lazy" />
+                <img class="hero-background is-transparent" src={section.image_url.clone()} loading="lazy" />
                 <div class="hero-body">
                     <div class="container">
                         <h2 class="subtitle">{ &section.title }</h2>

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -168,7 +168,7 @@ impl ToTokens for HtmlElement {
                         expr => Value::Dynamic(quote_spanned! {expr.span()=>
                             if #expr {
                                 ::std::option::Option::Some(
-                                    ::std::borrow::Cow::<'static, ::std::primitive::str>::Borrowed(#key)
+                                    ::yew::virtual_dom::AttrValue::Static(#key)
                                 )
                             } else {
                                 ::std::option::Option::None

--- a/packages/yew-macro/src/stringify.rs
+++ b/packages/yew-macro/src/stringify.rs
@@ -6,17 +6,17 @@ use syn::{Expr, Lit, LitStr};
 /// Stringify a value at runtime.
 fn stringify_at_runtime(src: impl ToTokens) -> TokenStream {
     quote_spanned! {src.span()=>
-        ::std::convert::Into::<::std::borrow::Cow::<'static, ::std::primitive::str>>::into(#src)
+        ::std::convert::Into::<::yew::virtual_dom::AttrValue>::into(#src)
     }
 }
 
-/// Create `Cow<'static, str>` construction calls.
+/// Create `AttrValue` construction calls.
 ///
 /// This is deliberately not implemented for strings to preserve spans.
 pub trait Stringify {
     /// Try to turn the value into a string literal.
     fn try_into_lit(&self) -> Option<LitStr>;
-    /// Create `Cow<'static, str>` however possible.
+    /// Create `AttrValue` however possible.
     fn stringify(&self) -> TokenStream;
 
     /// Optimize literals to `&'static str`, otherwise keep the value as is.
@@ -71,7 +71,7 @@ impl Stringify for LitStr {
 
     fn stringify(&self) -> TokenStream {
         quote_spanned! {self.span()=>
-            ::std::borrow::Cow::<'static, ::std::primitive::str>::Borrowed(#self)
+            ::yew::virtual_dom::AttrValue::Static(#self)
         }
     }
 }

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -342,8 +342,8 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
    |                                 ^ the trait `IntoPropValue<String>` is not implemented for `{integer}`
    |
    = help: the following implementations were found:
-             <&'static str as IntoPropValue<Cow<'static, str>>>
-             <&'static str as IntoPropValue<Option<Cow<'static, str>>>>
+             <&'static str as IntoPropValue<AttrValue>>
+             <&'static str as IntoPropValue<Option<AttrValue>>>
              <&'static str as IntoPropValue<Option<String>>>
              <&'static str as IntoPropValue<String>>
            and 11 others
@@ -355,8 +355,8 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
    |                                  ^ the trait `IntoPropValue<String>` is not implemented for `{integer}`
    |
    = help: the following implementations were found:
-             <&'static str as IntoPropValue<Cow<'static, str>>>
-             <&'static str as IntoPropValue<Option<Cow<'static, str>>>>
+             <&'static str as IntoPropValue<AttrValue>>
+             <&'static str as IntoPropValue<Option<AttrValue>>>
              <&'static str as IntoPropValue<Option<String>>>
              <&'static str as IntoPropValue<String>>
            and 11 others

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -1,209 +1,209 @@
 error: this opening tag has no corresponding closing tag
- --> $DIR/element-fail.rs:7:13
+ --> tests/html_macro/element-fail.rs:7:13
   |
 7 |     html! { <div> };
   |             ^^^^^
 
 error: this opening tag has no corresponding closing tag
- --> $DIR/element-fail.rs:8:18
+ --> tests/html_macro/element-fail.rs:8:18
   |
 8 |     html! { <div><div> };
   |                  ^^^^^
 
 error: this opening tag has no corresponding closing tag
- --> $DIR/element-fail.rs:9:13
+ --> tests/html_macro/element-fail.rs:9:13
   |
 9 |     html! { <div><div></div> };
   |             ^^^^^
 
 error: this closing tag has no corresponding opening tag
-  --> $DIR/element-fail.rs:12:13
+  --> tests/html_macro/element-fail.rs:12:13
    |
 12 |     html! { </div> };
    |             ^^^^^^
 
 error: this closing tag has no corresponding opening tag
-  --> $DIR/element-fail.rs:13:18
+  --> tests/html_macro/element-fail.rs:13:18
    |
 13 |     html! { <div></span></div> };
    |                  ^^^^^^^
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
-  --> $DIR/element-fail.rs:14:20
+  --> tests/html_macro/element-fail.rs:14:20
    |
 14 |     html! { <img /></img> };
    |                    ^^^^^^
 
 error: this closing tag has no corresponding opening tag
-  --> $DIR/element-fail.rs:17:18
+  --> tests/html_macro/element-fail.rs:17:18
    |
 17 |     html! { <div></span> };
    |                  ^^^^^^^
 
 error: this closing tag has no corresponding opening tag
-  --> $DIR/element-fail.rs:18:20
+  --> tests/html_macro/element-fail.rs:18:20
    |
 18 |     html! { <tag-a></tag-b> };
    |                    ^^^^^^^^
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
-  --> $DIR/element-fail.rs:21:24
+  --> tests/html_macro/element-fail.rs:21:24
    |
 21 |     html! { <div></div><div></div> };
    |                        ^^^^^^^^^^^
 
 error: expected a valid html element
-  --> $DIR/element-fail.rs:23:18
+  --> tests/html_macro/element-fail.rs:23:18
    |
 23 |     html! { <div>Invalid</div> };
    |                  ^^^^^^^
 
 error: `attr` can only be specified once but is given here again
-  --> $DIR/element-fail.rs:26:27
+  --> tests/html_macro/element-fail.rs:26:27
    |
 26 |     html! { <input attr=1 attr=2 /> };
    |                           ^^^^
 
 error: `value` can only be specified once but is given here again
-  --> $DIR/element-fail.rs:27:32
+  --> tests/html_macro/element-fail.rs:27:32
    |
 27 |     html! { <input value="123" value="456" /> };
    |                                ^^^^^
 
 error: `kind` can only be specified once but is given here again
-  --> $DIR/element-fail.rs:28:36
+  --> tests/html_macro/element-fail.rs:28:36
    |
 28 |     html! { <input kind="checkbox" kind="submit" /> };
    |                                    ^^^^
 
 error: `checked` can only be specified once but is given here again
-  --> $DIR/element-fail.rs:29:33
+  --> tests/html_macro/element-fail.rs:29:33
    |
 29 |     html! { <input checked=true checked=false /> };
    |                                 ^^^^^^^
 
 error: `disabled` can only be specified once but is given here again
-  --> $DIR/element-fail.rs:30:34
+  --> tests/html_macro/element-fail.rs:30:34
    |
 30 |     html! { <input disabled=true disabled=false /> };
    |                                  ^^^^^^^^
 
 error: `selected` can only be specified once but is given here again
-  --> $DIR/element-fail.rs:31:35
+  --> tests/html_macro/element-fail.rs:31:35
    |
 31 |     html! { <option selected=true selected=false /> };
    |                                   ^^^^^^^^
 
 error: `class` can only be specified once but is given here again
-  --> $DIR/element-fail.rs:32:32
+  --> tests/html_macro/element-fail.rs:32:32
    |
 32 |     html! { <div class="first" class="second" /> };
    |                                ^^^^^
 
 error: `ref` can only be specified once
-  --> $DIR/element-fail.rs:33:20
+  --> tests/html_macro/element-fail.rs:33:20
    |
 33 |     html! { <input ref={()} ref={()} /> };
    |                    ^^^
 
 error: `ref` can only be specified once
-  --> $DIR/element-fail.rs:63:20
+  --> tests/html_macro/element-fail.rs:63:20
    |
 63 |     html! { <input ref={()} ref={()} /> };
    |                    ^^^
 
 error: the tag `<input>` is a void element and cannot have children (hint: rewrite this as `<input/>`)
-  --> $DIR/element-fail.rs:66:13
+  --> tests/html_macro/element-fail.rs:66:13
    |
 66 |     html! { <input type="text"></input> };
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: the tag `<iNpUt>` is a void element and cannot have children (hint: rewrite this as `<iNpUt/>`)
-  --> $DIR/element-fail.rs:68:13
+  --> tests/html_macro/element-fail.rs:68:13
    |
 68 |     html! { <iNpUt type="text"></iNpUt> };
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: this dynamic tag is missing an expression block defining its value
-  --> $DIR/element-fail.rs:71:14
+  --> tests/html_macro/element-fail.rs:71:14
    |
 71 |     html! { <@></@> };
    |              ^
 
 error: this dynamic tag is missing an expression block defining its value
-  --> $DIR/element-fail.rs:72:14
+  --> tests/html_macro/element-fail.rs:72:14
    |
 72 |     html! { <@/> };
    |              ^
 
 error: dynamic closing tags must not have a body (hint: replace it with just `</@>`)
-  --> $DIR/element-fail.rs:75:27
+  --> tests/html_macro/element-fail.rs:75:27
    |
 75 |     html! { <@{"test"}></@{"test"}> };
    |                           ^^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:83:24
+  --> tests/html_macro/element-fail.rs:83:24
    |
 83 |     html! { <div class=("deprecated", "warning") /> };
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:84:24
+  --> tests/html_macro/element-fail.rs:84:24
    |
 84 |     html! { <input ref=() /> };
    |                        ^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:85:24
+  --> tests/html_macro/element-fail.rs:85:24
    |
 85 |     html! { <input ref=() ref=() /> };
    |                        ^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:86:28
+  --> tests/html_macro/element-fail.rs:86:28
    |
 86 |     html! { <input onfocus=Some(5) /> };
    |                            ^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:87:27
+  --> tests/html_macro/element-fail.rs:87:27
    |
 87 |     html! { <input string=NotToString /> };
    |                           ^^^^^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:88:22
+  --> tests/html_macro/element-fail.rs:88:22
    |
 88 |     html! { <a media=Some(NotToString) /> };
    |                      ^^^^^^^^^^^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:89:21
+  --> tests/html_macro/element-fail.rs:89:21
    |
 89 |     html! { <a href=Some(5) /> };
    |                     ^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:90:25
+  --> tests/html_macro/element-fail.rs:90:25
    |
 90 |     html! { <input type=() /> };
    |                         ^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:91:26
+  --> tests/html_macro/element-fail.rs:91:26
    |
 91 |     html! { <input value=() /> };
    |                          ^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/element-fail.rs:92:27
+  --> tests/html_macro/element-fail.rs:92:27
    |
 92 |     html! { <input string=NotToString /> };
    |                           ^^^^^^^^^^^
 
 warning: use of deprecated function `compile_fail::deprecated_use_of_class`: the use of `(...)` with the attribute `class` is deprecated and will be removed in version 0.19. Use the `classes!` macro instead.
-  --> $DIR/element-fail.rs:80:25
+  --> tests/html_macro/element-fail.rs:80:25
    |
 80 |     html! { <div class={("deprecated", "warning")} /> };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -211,13 +211,13 @@ warning: use of deprecated function `compile_fail::deprecated_use_of_class`: the
    = note: `#[warn(deprecated)]` on by default
 
 error[E0308]: mismatched types
-  --> $DIR/element-fail.rs:36:28
+  --> tests/html_macro/element-fail.rs:36:28
    |
 36 |     html! { <input checked=1 /> };
    |                            ^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/element-fail.rs:37:29
+  --> tests/html_macro/element-fail.rs:37:29
    |
 37 |     html! { <input checked={Some(false)} /> };
    |                             ^^^^^^^^^^^ expected `bool`, found enum `Option`
@@ -226,13 +226,13 @@ error[E0308]: mismatched types
               found enum `Option<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/element-fail.rs:38:29
+  --> tests/html_macro/element-fail.rs:38:29
    |
 38 |     html! { <input disabled=1 /> };
    |                             ^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/element-fail.rs:39:30
+  --> tests/html_macro/element-fail.rs:39:30
    |
 39 |     html! { <input disabled={Some(true)} /> };
    |                              ^^^^^^^^^^ expected `bool`, found enum `Option`
@@ -241,13 +241,13 @@ error[E0308]: mismatched types
               found enum `Option<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/element-fail.rs:40:30
+  --> tests/html_macro/element-fail.rs:40:30
    |
 40 |     html! { <option selected=1 /> };
    |                              ^ expected `bool`, found integer
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> $DIR/element-fail.rs:43:26
+  --> tests/html_macro/element-fail.rs:43:26
    |
 43 |     html! { <input type={()} /> };
    |                          ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
@@ -255,7 +255,7 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not sati
    = note: required by `into_prop_value`
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> $DIR/element-fail.rs:44:27
+  --> tests/html_macro/element-fail.rs:44:27
    |
 44 |     html! { <input value={()} /> };
    |                           ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
@@ -263,7 +263,7 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not sati
    = note: required by `into_prop_value`
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> $DIR/element-fail.rs:45:22
+  --> tests/html_macro/element-fail.rs:45:22
    |
 45 |     html! { <a href={()} /> };
    |                      ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
@@ -271,7 +271,7 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not sati
    = note: required by `into_prop_value`
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> $DIR/element-fail.rs:46:28
+  --> tests/html_macro/element-fail.rs:46:28
    |
 46 |     html! { <input string={NotToString} /> };
    |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `NotToString`
@@ -279,7 +279,7 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is
    = note: required by `into_prop_value`
 
 error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> $DIR/element-fail.rs:47:23
+  --> tests/html_macro/element-fail.rs:47:23
    |
 47 |     html! { <a media={Some(NotToString)} /> };
    |                       ^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `Option<NotToString>`
@@ -291,7 +291,7 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<AttrVal
    = note: required by `into_prop_value`
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> $DIR/element-fail.rs:48:22
+  --> tests/html_macro/element-fail.rs:48:22
    |
 48 |     html! { <a href={Some(5)} /> };
    |                      ^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `Option<{integer}>`
@@ -303,7 +303,7 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<AttrValue
    = note: required by `into_prop_value`
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
-   --> $DIR/element-fail.rs:51:28
+   --> tests/html_macro/element-fail.rs:51:28
     |
 51  |       html! { <input onclick=1 /> };
     |                              ^ expected an `Fn<(MouseEvent,)>` closure, found `{integer}`
@@ -311,19 +311,19 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
    ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
     | / impl_short! {
-133 | |     onauxclick(MouseEvent)
-134 | |     onclick(MouseEvent)
-135 | |
+    | |     onauxclick(MouseEvent)
+    | |     onclick(MouseEvent)
+    | |
 ...   |
-196 | |     ontransitionstart(TransitionEvent)
-197 | | }
+    | |     ontransitionstart(TransitionEvent)
+    | | }
     | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
     |
     = help: the trait `Fn<(MouseEvent,)>` is not implemented for `{integer}`
     = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `{integer}`
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
-   --> $DIR/element-fail.rs:52:29
+   --> tests/html_macro/element-fail.rs:52:29
     |
 52  |       html! { <input onclick={Callback::from(|a: String| ())} /> };
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -334,19 +334,19 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<Strin
    ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
     | / impl_short! {
-133 | |     onauxclick(MouseEvent)
-134 | |     onclick(MouseEvent)
-135 | |
+    | |     onauxclick(MouseEvent)
+    | |     onclick(MouseEvent)
+    | |
 ...   |
-196 | |     ontransitionstart(TransitionEvent)
-197 | | }
+    | |     ontransitionstart(TransitionEvent)
+    | | }
     | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
     |
     = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
     = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
 
 error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>` is not satisfied
-   --> $DIR/element-fail.rs:53:29
+   --> tests/html_macro/element-fail.rs:53:29
     |
 53  |       html! { <input onfocus={Some(5)} /> };
     |                               ^^^^^^^ the trait `IntoEventCallback<FocusEvent>` is not implemented for `Option<{integer}>`
@@ -354,12 +354,12 @@ error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>`
    ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
     | / impl_short! {
-133 | |     onauxclick(MouseEvent)
-134 | |     onclick(MouseEvent)
-135 | |
+    | |     onauxclick(MouseEvent)
+    | |     onclick(MouseEvent)
+    | |
 ...   |
-196 | |     ontransitionstart(TransitionEvent)
-197 | | }
+    | |     ontransitionstart(TransitionEvent)
+    | | }
     | |_- required by this bound in `yew::html::onfocus::Wrapper::__macro_new`
     |
     = help: the following implementations were found:
@@ -367,7 +367,7 @@ error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>`
               <Option<yew::Callback<EVENT>> as IntoEventCallback<EVENT>>
 
 error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
-  --> $DIR/element-fail.rs:56:25
+  --> tests/html_macro/element-fail.rs:56:25
    |
 56 |     html! { <input ref={()} /> };
    |                         ^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
@@ -375,7 +375,7 @@ error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
    = note: required by `into_prop_value`
 
 error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>` is not satisfied
-  --> $DIR/element-fail.rs:57:25
+  --> tests/html_macro/element-fail.rs:57:25
    |
 57 |     html! { <input ref={Some(NodeRef::default())} /> };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `Option<yew::NodeRef>`
@@ -387,7 +387,7 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
    = note: required by `into_prop_value`
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
-   --> $DIR/element-fail.rs:58:29
+   --> tests/html_macro/element-fail.rs:58:29
     |
 58  |       html! { <input onclick={Callback::from(|a: String| ())} /> };
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -398,19 +398,19 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<Strin
    ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
     | / impl_short! {
-133 | |     onauxclick(MouseEvent)
-134 | |     onclick(MouseEvent)
-135 | |
+    | |     onauxclick(MouseEvent)
+    | |     onclick(MouseEvent)
+    | |
 ...   |
-196 | |     ontransitionstart(TransitionEvent)
-197 | | }
+    | |     ontransitionstart(TransitionEvent)
+    | | }
     | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
     |
     = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
     = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> $DIR/element-fail.rs:60:28
+  --> tests/html_macro/element-fail.rs:60:28
    |
 60 |     html! { <input string={NotToString} /> };
    |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `NotToString`
@@ -418,7 +418,7 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is
    = note: required by `into_prop_value`
 
 error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
-  --> $DIR/element-fail.rs:62:25
+  --> tests/html_macro/element-fail.rs:62:25
    |
 62 |     html! { <input ref={()} /> };
    |                         ^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
@@ -426,7 +426,7 @@ error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
    = note: required by `into_prop_value`
 
 error[E0277]: the trait bound `Cow<'static, str>: From<{integer}>` is not satisfied
-  --> $DIR/element-fail.rs:77:15
+  --> tests/html_macro/element-fail.rs:77:15
    |
 77 |     html! { <@{55}></@> };
    |               ^^^^ the trait `From<{integer}>` is not implemented for `Cow<'static, str>`

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -246,60 +246,60 @@ error[E0308]: mismatched types
 40 |     html! { <option selected=1 /> };
    |                              ^ expected `bool`, found integer
 
-error[E0277]: the trait bound `(): IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
+error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
   --> $DIR/element-fail.rs:43:26
    |
 43 |     html! { <input type={()} /> };
-   |                          ^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `()`
+   |                          ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
    |
    = note: required by `into_prop_value`
 
-error[E0277]: the trait bound `(): IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
+error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
   --> $DIR/element-fail.rs:44:27
    |
 44 |     html! { <input value={()} /> };
-   |                           ^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `()`
+   |                           ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
    |
    = note: required by `into_prop_value`
 
-error[E0277]: the trait bound `(): IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
+error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
   --> $DIR/element-fail.rs:45:22
    |
 45 |     html! { <a href={()} /> };
-   |                      ^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `()`
+   |                      ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
    |
    = note: required by `into_prop_value`
 
-error[E0277]: the trait bound `NotToString: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
+error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is not satisfied
   --> $DIR/element-fail.rs:46:28
    |
 46 |     html! { <input string={NotToString} /> };
-   |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `NotToString`
+   |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `NotToString`
    |
    = note: required by `into_prop_value`
 
-error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
+error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<AttrValue>>` is not satisfied
   --> $DIR/element-fail.rs:47:23
    |
 47 |     html! { <a media={Some(NotToString)} /> };
-   |                       ^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `Option<NotToString>`
+   |                       ^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `Option<NotToString>`
    |
    = help: the following implementations were found:
-             <Option<&'static str> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
              <Option<&'static str> as IntoPropValue<Option<String>>>
-             <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<String> as IntoPropValue<Option<AttrValue>>>
    = note: required by `into_prop_value`
 
-error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
+error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<AttrValue>>` is not satisfied
   --> $DIR/element-fail.rs:48:22
    |
 48 |     html! { <a href={Some(5)} /> };
-   |                      ^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `Option<{integer}>`
+   |                      ^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `Option<{integer}>`
    |
    = help: the following implementations were found:
-             <Option<&'static str> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
              <Option<&'static str> as IntoPropValue<Option<String>>>
-             <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<String> as IntoPropValue<Option<AttrValue>>>
    = note: required by `into_prop_value`
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
@@ -381,9 +381,9 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `Option<yew::NodeRef>`
    |
    = help: the following implementations were found:
-             <Option<&'static str> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
              <Option<&'static str> as IntoPropValue<Option<String>>>
-             <Option<String> as IntoPropValue<Option<Cow<'static, str>>>>
+             <Option<String> as IntoPropValue<Option<AttrValue>>>
    = note: required by `into_prop_value`
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
@@ -409,11 +409,11 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<Strin
     = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
     = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
 
-error[E0277]: the trait bound `NotToString: IntoPropValue<Option<Cow<'static, str>>>` is not satisfied
+error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is not satisfied
   --> $DIR/element-fail.rs:60:28
    |
 60 |     html! { <input string={NotToString} /> };
-   |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<Cow<'static, str>>>` is not implemented for `NotToString`
+   |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `NotToString`
    |
    = note: required by `into_prop_value`
 

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -45,7 +45,7 @@ fn compile_pass() {
     let dyn_tag = || <::std::string::String as ::std::convert::From<&::std::primitive::str>>::from("test");
     let mut extra_tags_iter = ::std::iter::IntoIterator::into_iter(::std::vec!["a", "b"]);
 
-    let cow_none: ::std::option::Option<::std::borrow::Cow<'static, ::std::primitive::str>> =
+    let cow_none: ::std::option::Option<::yew::virtual_dom::AttrValue> =
         ::std::option::Option::None;
 
     ::yew::html! {
@@ -99,10 +99,10 @@ fn compile_pass() {
                 }
             }/>
 
-            <a href={::std::option::Option::Some(::std::borrow::Cow::Borrowed("http://google.com"))} media={::std::clone::Clone::clone(&cow_none)} />
-            <track kind={::std::option::Option::Some(::std::borrow::Cow::Borrowed("subtitles"))} src={::std::clone::Clone::clone(&cow_none)} />
-            <track kind={::std::option::Option::Some(::std::borrow::Cow::Borrowed("5"))} mixed="works" />
-            <input value={::std::option::Option::Some(::std::borrow::Cow::Borrowed("value"))}
+            <a href={::std::option::Option::Some(::yew::virtual_dom::AttrValue("http://google.com"))} media={::std::clone::Clone::clone(&cow_none)} />
+            <track kind={::std::option::Option::Some(::yew::virtual_dom::AttrValue("subtitles"))} src={::std::clone::Clone::clone(&cow_none)} />
+            <track kind={::std::option::Option::Some(::yew::virtual_dom::AttrValue("5"))} mixed="works" />
+            <input value={::std::option::Option::Some(::yew::virtual_dom::AttrValue("value"))}
                 onblur={::std::option::Option::Some(<::yew::Callback<::yew::FocusEvent> as ::std::convert::From<_>>::from(|_| ()))}
             />
         </div>

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -99,10 +99,10 @@ fn compile_pass() {
                 }
             }/>
 
-            <a href={::std::option::Option::Some(::yew::virtual_dom::AttrValue("http://google.com"))} media={::std::clone::Clone::clone(&cow_none)} />
-            <track kind={::std::option::Option::Some(::yew::virtual_dom::AttrValue("subtitles"))} src={::std::clone::Clone::clone(&cow_none)} />
-            <track kind={::std::option::Option::Some(::yew::virtual_dom::AttrValue("5"))} mixed="works" />
-            <input value={::std::option::Option::Some(::yew::virtual_dom::AttrValue("value"))}
+            <a href={::std::option::Option::Some(::yew::virtual_dom::AttrValue::Static("http://google.com"))} media={::std::clone::Clone::clone(&cow_none)} />
+            <track kind={::std::option::Option::Some(::yew::virtual_dom::AttrValue::Static("subtitles"))} src={::std::clone::Clone::clone(&cow_none)} />
+            <track kind={::std::option::Option::Some(::yew::virtual_dom::AttrValue::Static("5"))} mixed="works" />
+            <input value={::std::option::Option::Some(::yew::virtual_dom::AttrValue::Static("value"))}
                 onblur={::std::option::Option::Some(<::yew::Callback<::yew::FocusEvent> as ::std::convert::From<_>>::from(|_| ()))}
             />
         </div>

--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -1,6 +1,7 @@
 use super::IntoPropValue;
 use crate::virtual_dom::AttrValue;
 use indexmap::IndexSet;
+use std::rc::Rc;
 use std::{
     borrow::{Borrow, Cow},
     hint::unreachable_unchecked,
@@ -70,12 +71,12 @@ impl IntoPropValue<AttrValue> for Classes {
     fn into_prop_value(mut self) -> AttrValue {
         if self.set.len() == 1 {
             match self.set.pop() {
-                Some(attr) => attr,
+                Some(attr) => AttrValue::ReferenceCounted(Rc::from(attr)),
                 // SAFETY: the collection is checked to be non-empty above
                 None => unsafe { unreachable_unchecked() },
             }
         } else {
-            Cow::Owned(self.to_string())
+            AttrValue::Owned(self.to_string())
         }
     }
 }

--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -71,7 +71,7 @@ impl IntoPropValue<AttrValue> for Classes {
     fn into_prop_value(mut self) -> AttrValue {
         if self.set.len() == 1 {
             match self.set.pop() {
-                Some(attr) => AttrValue::ReferenceCounted(Rc::from(attr)),
+                Some(attr) => AttrValue::Rc(Rc::from(attr)),
                 // SAFETY: the collection is checked to be non-empty above
                 None => unsafe { unreachable_unchecked() },
             }

--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -95,7 +95,7 @@ mod test {
     fn test_str() {
         let _: String = "foo".into_prop_value();
         let _: Option<String> = "foo".into_prop_value();
-        let _: Cow<'static, str> = "foo".into_prop_value();
-        let _: Option<Cow<'static, str>> = "foo".into_prop_value();
+        let _: AttrValue = "foo".into_prop_value();
+        let _: Option<AttrValue> = "foo".into_prop_value();
     }
 }

--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -1,4 +1,5 @@
 use super::{Component, NodeRef, Scope};
+use crate::virtual_dom::AttrValue;
 use std::{borrow::Cow, rc::Rc};
 
 /// Marker trait for types that the [`html!`] macro may clone implicitly.
@@ -83,8 +84,8 @@ macro_rules! impl_into_prop {
 // implemented with literals in mind
 impl_into_prop!(|value: &'static str| -> String { value.to_owned() });
 
-impl_into_prop!(|value: &'static str| -> Cow<'static, str> { Cow::Borrowed(value) });
-impl_into_prop!(|value: String| -> Cow<'static, str> { Cow::Owned(value) });
+impl_into_prop!(|value: &'static str| -> AttrValue { AttrValue::Static(value) });
+impl_into_prop!(|value: String| -> AttrValue { AttrValue::Owned(value) });
 
 #[cfg(test)]
 mod test {

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -89,12 +89,6 @@ impl Clone for AttrValue {
     }
 }
 
-impl PartialEq<String> for AttrValue {
-    fn eq(&self, other: &String) -> bool {
-        self.as_ref() == other.as_str()
-    }
-}
-
 impl AsRef<str> for AttrValue {
     fn as_ref(&self) -> &str {
         &*self

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -46,7 +46,7 @@ pub enum AttrValue {
     /// Owned string
     Owned(String),
     /// Reference counted string
-    ReferenceCounted(Rc<str>),
+    Rc(Rc<str>),
 }
 
 impl Deref for AttrValue {
@@ -56,7 +56,7 @@ impl Deref for AttrValue {
         match self {
             AttrValue::Static(s) => *s,
             AttrValue::Owned(s) => s.as_str(),
-            AttrValue::ReferenceCounted(s) => &*s,
+            AttrValue::Rc(s) => &*s,
         }
     }
 }
@@ -75,7 +75,7 @@ impl From<String> for AttrValue {
 
 impl From<Rc<str>> for AttrValue {
     fn from(s: Rc<str>) -> Self {
-        AttrValue::ReferenceCounted(s)
+        AttrValue::Rc(s)
     }
 }
 
@@ -84,7 +84,7 @@ impl Clone for AttrValue {
         match self {
             AttrValue::Static(s) => AttrValue::Static(s),
             AttrValue::Owned(s) => AttrValue::Owned(s.clone()),
-            AttrValue::ReferenceCounted(s) => AttrValue::ReferenceCounted(Rc::clone(s)),
+            AttrValue::Rc(s) => AttrValue::Rc(Rc::clone(s)),
         }
     }
 }

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -44,7 +44,7 @@ impl<T: AccessValue> Apply for Value<T> {
         match (&self.0, &ancestor.0) {
             (Some(new), Some(_)) => {
                 // Refresh value from the DOM. It might have changed.
-                if new != &el.value() {
+                if new.as_ref() != el.value() {
                     el.set_value(new);
                 }
             }

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -1075,7 +1075,7 @@ mod tests {
             <@{"input"} value="World"/>
         };
         let input_vtag = assert_vtag_mut(&mut input_el);
-        assert_eq!(input_vtag.value(), Some(&Cow::Borrowed("World")));
+        assert_eq!(input_vtag.value(), Some(&AttrValue::Static("World")));
         assert!(!input_vtag.attributes.iter().any(|(k, _)| k == "value"));
     }
 


### PR DESCRIPTION
#### Description

This PR introduces a new type, `AttrValue`, for attribute values. This is a replacement for `Cow<'static, str>` so that:
- We provide our own type for attribute values
- Reasons described in #1851 

Fixes https://github.com/yewstack/yew/issues/1851

#### Unsolved questions

- [ ] Should `VTag` also use this for the tag's name
- [ ] Should `Classes` use this instead of `Cow<'static, str>`

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
