### PR TITLE
Fix onsubmit handler to take Event

### DIFF
--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -315,8 +315,8 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
 ...   |
-101 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-102 | | }
+102 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
+103 | | }
     | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
     |
     = help: the trait `Fn<(MouseEvent,)>` is not implemented for `{integer}`
@@ -338,8 +338,8 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<Strin
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
 ...   |
-101 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-102 | | }
+102 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
+103 | | }
     | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
     |
     = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
@@ -358,8 +358,8 @@ error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>`
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
 ...   |
-101 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-102 | | }
+102 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
+103 | | }
     | |_- required by this bound in `yew::html::onfocus::Wrapper::__macro_new`
     |
     = help: the following implementations were found:
@@ -402,8 +402,8 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<Strin
 4   | |     onauxclick(name: "auxclick", event: MouseEvent) -> web_sys::MouseEvent => |_, event| { event }
 5   | |     onblur(name: "blur", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
 ...   |
-101 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
-102 | | }
+102 | |     ontransitionstart(name: "transitionstart", event: TransitionEvent) -> web_sys::TransitionEvent => |_, event| { event }
+103 | | }
     | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
     |
     = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied

--- a/packages/yew/src/html/listener/events.rs
+++ b/packages/yew/src/html/listener/events.rs
@@ -59,7 +59,8 @@ impl_action! {
     onselect(name: "select", event: Event) -> web_sys::Event => |_, event| { event }
     onslotchange(name: "slotchange", event: Event) -> web_sys::Event => |_, event| { event }
     onstalled(name: "stalled", event: Event) -> web_sys::Event => |_, event| { event }
-    onsubmit(name: "submit", event: FocusEvent) -> web_sys::FocusEvent => |_, event| { event }
+    // web_sys doesn't have a struct for `SubmitEvent`
+    onsubmit(name: "submit", event: Event) -> web_sys::Event => |_, event| { event }
     onsuspend(name: "suspend", event: Event) -> web_sys::Event => |_, event| { event }
     ontimeupdate(name: "timeupdate", event: Event) -> web_sys::Event => |_, event| { event }
     ontoggle(name: "toggle", event: Event) -> web_sys::Event => |_, event| { event }


### PR DESCRIPTION
#### Description

`onsubmit` currently takes a `web_sys::FocusEvent` which is not correct 
as the actual event is supposed to be a `SubmitEvent` which doesn't
have a `web_sys` type. This means that if a user uses the event and 
calls `FocusEvent::related_target` and evaluates the `Option` returned this
will panic! 

As with `onformdata`, `onsubmit` will use `Event` to remain safe and requires
users to define their own type or use Reflect api.

Trybuild test change because of the new comment for `onsubmit` in the macro.

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->
No issue but [mentioned in Discord](https://discord.com/channels/701068342760570933/703449306497024049/878716173875826708) 
#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
