### PR TITLE
Remove underscore prefix for Component trait fns

### DIFF
--- a/packages/yew/src/html/component/mod.rs
+++ b/packages/yew/src/html/component/mod.rs
@@ -61,12 +61,14 @@ pub trait Component: Sized + 'static {
     ///
     /// Components handle messages in their `update` method and commonly use this method
     /// to update their state and (optionally) re-render themselves.
-    fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> ShouldRender {
+    #[allow(unused_variables)]
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
         false
     }
 
     /// Called when properties passed to the component change
-    fn changed(&mut self, _ctx: &Context<Self>) -> ShouldRender {
+    #[allow(unused_variables)]
+    fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
         true
     }
 
@@ -77,8 +79,10 @@ pub trait Component: Sized + 'static {
 
     /// The `rendered` method is called after each time a Component is rendered but
     /// before the browser updates the page.
-    fn rendered(&mut self, _ctx: &Context<Self>, _first_render: bool) {}
+    #[allow(unused_variables)]
+    fn rendered(&mut self, ctx: &Context<Self>, first_render: bool) {}
 
     /// Called right before a Component is unmounted.
-    fn destroy(&mut self, _ctx: &Context<Self>) {}
+    #[allow(unused_variables)]
+    fn destroy(&mut self, ctx: &Context<Self>) {}
 }


### PR DESCRIPTION
#### Description
Removed underscore prefix for the Component trait fn parameters as this is not IDE friendly.

<!-- Please include a summary of the change. -->
This was [mentioned in another PR](https://github.com/yewstack/yew/pull/1961#discussion_r687925088).
Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
