### PR TITLE
Remove ShouldRender type alias

### DIFF
--- a/examples/boids/src/main.rs
+++ b/examples/boids/src/main.rs
@@ -2,7 +2,7 @@ use settings::Settings;
 use simulation::Simulation;
 use slider::Slider;
 use yew::html::Scope;
-use yew::{html, Component, Context, Html, ShouldRender};
+use yew::{html, Component, Context, Html};
 
 mod boid;
 mod math;
@@ -34,7 +34,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Msg) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Msg) -> bool {
         match msg {
             Msg::ChangeSettings(settings) => {
                 self.settings = settings;

--- a/examples/boids/src/simulation.rs
+++ b/examples/boids/src/simulation.rs
@@ -2,7 +2,7 @@ use crate::boid::Boid;
 use crate::math::Vector2D;
 use crate::settings::Settings;
 use gloo::timers::callback::Interval;
-use yew::{html, Component, Context, Html, Properties, ShouldRender};
+use yew::{html, Component, Context, Html, Properties};
 
 pub const SIZE: Vector2D = Vector2D::new(1600.0, 1000.0);
 
@@ -45,7 +45,7 @@ impl Component for Simulation {
         Self { boids, interval }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Tick => {
                 let Props {
@@ -64,7 +64,7 @@ impl Component for Simulation {
         }
     }
 
-    fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
         self.boids.clear();
 
         let settings = &ctx.props().settings;

--- a/examples/boids/src/slider.rs
+++ b/examples/boids/src/slider.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 use yew::{
     html, web_sys::HtmlInputElement, Callback, Component, Context, Html, InputEvent, Properties,
-    ShouldRender, TargetCast,
+    TargetCast,
 };
 
 thread_local! {
@@ -40,7 +40,7 @@ impl Component for Slider {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         unimplemented!()
     }
 

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,6 +1,6 @@
 use js_sys::Date;
 use weblog::console_log;
-use yew::{html, Component, Context, Html, ShouldRender};
+use yew::{html, Component, Context, Html};
 
 // Define the possible messages which can be sent to the component
 pub enum Msg {
@@ -20,7 +20,7 @@ impl Component for Model {
         Self { value: 0 }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Increment => {
                 self.value += 1;

--- a/examples/crm/src/add_client.rs
+++ b/examples/crm/src/add_client.rs
@@ -1,8 +1,6 @@
 use crate::Client;
 use yew::web_sys::{Event, HtmlInputElement, HtmlTextAreaElement};
-use yew::{
-    classes, html, Callback, Component, Context, Html, Properties, ShouldRender, TargetCast,
-};
+use yew::{classes, html, Callback, Component, Context, Html, Properties, TargetCast};
 
 #[derive(Debug)]
 pub enum Msg {
@@ -32,7 +30,7 @@ impl Component for AddClientForm {
         }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         let client = &mut self.client;
         match msg {
             Msg::UpdateFirstName(value) => {

--- a/examples/crm/src/main.rs
+++ b/examples/crm/src/main.rs
@@ -1,7 +1,7 @@
 use add_client::AddClientForm;
 use gloo::storage::{LocalStorage, Storage};
 use serde::{Deserialize, Serialize};
-use yew::{html, Component, Context, Html, ShouldRender};
+use yew::{html, Component, Context, Html};
 
 mod add_client;
 
@@ -59,7 +59,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::SwitchTo(scene) => {
                 self.scene = scene;

--- a/examples/dyn_create_destroy_apps/src/counter.rs
+++ b/examples/dyn_create_destroy_apps/src/counter.rs
@@ -30,7 +30,7 @@ impl Component for CounterModel {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             // Count our internal state up by one
             Self::Message::Tick => {

--- a/examples/dyn_create_destroy_apps/src/main.rs
+++ b/examples/dyn_create_destroy_apps/src/main.rs
@@ -31,7 +31,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         let app_container = self
             .apps_container_ref
             .cast::<Element>()

--- a/examples/file_upload/src/main.rs
+++ b/examples/file_upload/src/main.rs
@@ -1,5 +1,5 @@
 use web_sys::{Event, HtmlInputElement};
-use yew::{html, html::TargetCast, Component, Context, Html, ShouldRender};
+use yew::{html, html::TargetCast, Component, Context, Html};
 
 use gloo::file::callbacks::FileReader;
 use gloo::file::File;
@@ -31,7 +31,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Loaded(file_name, data) => {
                 let info = format!("file_name: {}, data: {:?}", file_name, data);

--- a/examples/futures/src/main.rs
+++ b/examples/futures/src/main.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Request, RequestInit, RequestMode, Response};
-use yew::{html, Component, Context, Html, ShouldRender};
+use yew::{html, Component, Context, Html};
 
 mod markdown;
 
@@ -77,7 +77,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::SetMarkdownFetchState(fetch_state) => {
                 self.markdown = fetch_state;

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -2,7 +2,7 @@ use cell::Cellule;
 use gloo::timers::callback::Interval;
 use rand::Rng;
 use yew::html::Scope;
-use yew::{classes, html, Component, Context, Html, ShouldRender};
+use yew::{classes, html, Component, Context, Html};
 
 mod cell;
 
@@ -120,7 +120,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Random => {
                 self.random_mutate();

--- a/examples/js_callback/src/main.rs
+++ b/examples/js_callback/src/main.rs
@@ -25,7 +25,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Payload(payload) => {
                 if payload != self.payload {

--- a/examples/keyed_list/src/main.rs
+++ b/examples/keyed_list/src/main.rs
@@ -45,7 +45,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::CreatePersons(n) => {
                 for _ in 0..n {

--- a/examples/mount_point/src/main.rs
+++ b/examples/mount_point/src/main.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::JsValue;
 use web_sys::{
     CanvasRenderingContext2d, Document, HtmlCanvasElement, HtmlInputElement, InputEvent,
 };
-use yew::{html, Component, Context, Html, ShouldRender, TargetCast};
+use yew::{html, Component, Context, Html, TargetCast};
 
 pub enum Msg {
     UpdateName(String),
@@ -22,7 +22,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::UpdateName(new_name) => {
                 self.name = new_name;

--- a/examples/multi_thread/src/lib.rs
+++ b/examples/multi_thread/src/lib.rs
@@ -2,7 +2,7 @@ pub mod context;
 pub mod job;
 pub mod native_worker;
 
-use yew::{html, Component, Context, Html, ShouldRender};
+use yew::{html, Component, Context, Html};
 use yew_agent::{Bridge, Bridged};
 
 pub enum Msg {
@@ -45,7 +45,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::SendToWorker => {
                 self.worker.send(native_worker::Request::GetDataFromServer);

--- a/examples/nested_list/src/app.rs
+++ b/examples/nested_list/src/app.rs
@@ -26,7 +26,7 @@ impl Component for App {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Hover(hovered) => {
                 self.hovered = hovered;

--- a/examples/nested_list/src/list.rs
+++ b/examples/nested_list/src/list.rs
@@ -79,7 +79,7 @@ impl Component for List {
         Self { inactive: false }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::HeaderClick => {
                 self.inactive = !self.inactive;

--- a/examples/node_refs/src/input.rs
+++ b/examples/node_refs/src/input.rs
@@ -19,7 +19,7 @@ impl Component for InputComponent {
         Self
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Hover => {
                 ctx.props().on_hover.emit(());

--- a/examples/node_refs/src/main.rs
+++ b/examples/node_refs/src/main.rs
@@ -36,7 +36,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::HoverIndex(index) => {
                 self.focus_index = index;

--- a/examples/pub_sub/src/producer.rs
+++ b/examples/pub_sub/src/producer.rs
@@ -20,7 +20,7 @@ impl Component for Producer {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Clicked => {
                 self.event_bus

--- a/examples/pub_sub/src/subscriber.rs
+++ b/examples/pub_sub/src/subscriber.rs
@@ -1,5 +1,5 @@
 use super::event_bus::EventBus;
-use yew::{html, Component, Context, Html, ShouldRender};
+use yew::{html, Component, Context, Html};
 use yew_agent::{Bridge, Bridged};
 
 pub enum Msg {
@@ -22,7 +22,7 @@ impl Component for Subscriber {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::NewMessage(s) => {
                 self.message = s;

--- a/examples/router/src/components/author_card.rs
+++ b/examples/router/src/components/author_card.rs
@@ -20,7 +20,7 @@ impl Component for AuthorCard {
         }
     }
 
-    fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
         self.author = Author::generate_from_seed(ctx.props().seed);
         true
     }

--- a/examples/router/src/components/post_card.rs
+++ b/examples/router/src/components/post_card.rs
@@ -19,7 +19,7 @@ impl Component for PostCard {
             post: PostMeta::generate_from_seed(ctx.props().seed),
         }
     }
-    fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
         self.post = PostMeta::generate_from_seed(ctx.props().seed);
         true
     }

--- a/examples/router/src/components/progress_delay.rs
+++ b/examples/router/src/components/progress_delay.rs
@@ -37,7 +37,7 @@ impl Component for ProgressDelay {
         }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Tick => {
                 let duration = ctx.props().duration_ms;

--- a/examples/router/src/main.rs
+++ b/examples/router/src/main.rs
@@ -45,7 +45,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::ToggleNavbar => {
                 self.navbar_active = !self.navbar_active;

--- a/examples/router/src/pages/author.rs
+++ b/examples/router/src/pages/author.rs
@@ -19,7 +19,7 @@ impl Component for Author {
         }
     }
 
-    fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
         self.author = content::Author::generate_from_seed(ctx.props().seed);
         true
     }

--- a/examples/router/src/pages/author_list.rs
+++ b/examples/router/src/pages/author_list.rs
@@ -22,7 +22,7 @@ impl Component for AuthorList {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::NextAuthors => {
                 self.seeds = random_author_seeds();

--- a/examples/router/src/pages/post.rs
+++ b/examples/router/src/pages/post.rs
@@ -22,7 +22,7 @@ impl Component for Post {
         }
     }
 
-    fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
         self.post = content::Post::generate_from_seed(ctx.props().seed);
         true
     }

--- a/examples/router/src/pages/post_list.rs
+++ b/examples/router/src/pages/post_list.rs
@@ -25,7 +25,7 @@ impl Component for PostList {
         Self
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::ShowPage(page) => {
                 yew_router::push_route_with_query(Route::Posts, PageQuery { page }).unwrap();

--- a/examples/store/src/main.rs
+++ b/examples/store/src/main.rs
@@ -32,7 +32,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::CreatePost(text) => {
                 self.post_store.send(PostRequest::Create(text));

--- a/examples/store/src/post.rs
+++ b/examples/store/src/post.rs
@@ -34,7 +34,7 @@ impl Component for Post {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::UpdateText(text) => {
                 self.post_store.send(PostRequest::Update(self.id, text));
@@ -62,7 +62,7 @@ impl Component for Post {
         }
     }
 
-    fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
         self.id = ctx.props().id;
         true
     }

--- a/examples/store/src/text_input.rs
+++ b/examples/store/src/text_input.rs
@@ -25,7 +25,7 @@ impl Component for TextInput {
         }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Submit(text) => {
                 ctx.props().onsubmit.emit(text);
@@ -34,7 +34,7 @@ impl Component for TextInput {
         }
     }
 
-    fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
         self.text = ctx.props().value.clone();
         true
     }

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -1,7 +1,7 @@
 use gloo::console_timer::ConsoleTimer;
 use gloo::timers::callback::{Interval, Timeout};
 use weblog::*;
-use yew::{html, Component, Context, Html, ShouldRender};
+use yew::{html, Component, Context, Html};
 
 pub enum Msg {
     StartTimeout,
@@ -56,7 +56,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::StartTimeout => {
                 let handle = {

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -3,7 +3,7 @@ use state::{Entry, Filter, State};
 use strum::IntoEnumIterator;
 use yew::html::Scope;
 use yew::web_sys::HtmlInputElement as InputElement;
-use yew::{classes, html, Component, Context, FocusEvent, Html, NodeRef, ShouldRender, TargetCast};
+use yew::{classes, html, Component, Context, FocusEvent, Html, NodeRef, TargetCast};
 use yew::{events::KeyboardEvent, Classes};
 
 mod state;
@@ -42,7 +42,7 @@ impl Component for Model {
         Self { state, focus_ref }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Add(description) => {
                 if !description.is_empty() {

--- a/examples/two_apps/src/main.rs
+++ b/examples/two_apps/src/main.rs
@@ -1,5 +1,5 @@
 use yew::html::Scope;
-use yew::{html, AppHandle, Component, Context, Html, ShouldRender};
+use yew::{html, AppHandle, Component, Context, Html};
 
 pub enum Msg {
     SetOpposite(Scope<Model>),
@@ -25,7 +25,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::SetOpposite(opposite) => {
                 self.opposite = Some(opposite);

--- a/examples/webgl/src/main.rs
+++ b/examples/webgl/src/main.rs
@@ -2,7 +2,7 @@ use gloo_render::{request_animation_frame, AnimationFrame};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlCanvasElement, WebGlRenderingContext as GL};
 use yew::html::Scope;
-use yew::{html, Component, Context, Html, NodeRef, ShouldRender};
+use yew::{html, Component, Context, Html, NodeRef};
 
 pub enum Msg {
     Render(f64),
@@ -26,7 +26,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Render(timestamp) => {
                 // Render functions are likely to get quite large, so it is good practice to split

--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -30,7 +30,7 @@ impl<R: Routable + Clone + PartialEq + 'static> Component for Link<R> {
         Self { _data: PhantomData }
     }
 
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::OnClick => {
                 service::push_route(ctx.props().route.clone());

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -229,11 +229,11 @@ mod tests {
                 .push("child rendered".into());
         }
 
-        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> ShouldRender {
+        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
             false
         }
 
-        fn changed(&mut self, _ctx: &Context<Self>) -> ShouldRender {
+        fn changed(&mut self, _ctx: &Context<Self>) -> bool {
             false
         }
 
@@ -282,7 +282,7 @@ mod tests {
                 .push(format!("rendered({})", first_render));
         }
 
-        fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+        fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
             if let Some(msg) = ctx.props().update_message.borrow_mut().take() {
                 ctx.link().send_message(msg);
             }
@@ -293,7 +293,7 @@ mod tests {
             msg
         }
 
-        fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
+        fn changed(&mut self, ctx: &Context<Self>) -> bool {
             self.lifecycle = Rc::clone(&ctx.props().lifecycle);
             self.lifecycle.borrow_mut().push("change".into());
             false

--- a/packages/yew/src/html/component/mod.rs
+++ b/packages/yew/src/html/component/mod.rs
@@ -12,9 +12,6 @@ pub(crate) use scope::Scoped;
 pub use scope::{AnyScope, Scope, SendAsMessage};
 use std::rc::Rc;
 
-/// This type indicates that component should be rendered again.
-pub type ShouldRender = bool;
-
 /// The [`Component`]'s context. This contains component's [`Scope`] and and props and
 /// is passed to every lifecycle method.
 #[derive(Debug)]
@@ -61,14 +58,18 @@ pub trait Component: Sized + 'static {
     ///
     /// Components handle messages in their `update` method and commonly use this method
     /// to update their state and (optionally) re-render themselves.
+    ///
+    /// Returned bool indicates whether to render this Component after update.
     #[allow(unused_variables)]
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         false
     }
 
     /// Called when properties passed to the component change
+    ///
+    /// Returned bool indicates whether to render this Component after changed.
     #[allow(unused_variables)]
-    fn changed(&mut self, ctx: &Context<Self>) -> ShouldRender {
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
         true
     }
 

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -38,7 +38,7 @@
 //!         }
 //!     }
 //!
-//!     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+//!     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
 //!         match msg {
 //!             Msg::AddOne => {
 //!                 self.value += 1;
@@ -388,7 +388,6 @@ pub mod prelude {
     pub use crate::events::*;
     pub use crate::html::{
         Children, ChildrenWithProps, Classes, Component, Context, Html, NodeRef, Properties,
-        ShouldRender,
     };
     pub use crate::macros::{classes, html, html_nested};
 

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -398,7 +398,7 @@ pub(crate) fn insert_node(node: &Node, parent: &Element, next_sibling: Option<&N
 mod layout_tests {
     use super::*;
     use crate::html::{AnyScope, Scope};
-    use crate::{Component, Context, Html, ShouldRender};
+    use crate::{Component, Context, Html};
 
     struct Comp;
     impl Component for Comp {
@@ -409,11 +409,11 @@ mod layout_tests {
             unimplemented!()
         }
 
-        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> ShouldRender {
+        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
             unimplemented!();
         }
 
-        fn changed(&mut self, _ctx: &Context<Self>) -> ShouldRender {
+        fn changed(&mut self, _ctx: &Context<Self>) -> bool {
             unimplemented!()
         }
 

--- a/packages/yew/src/virtual_dom/vcomp.rs
+++ b/packages/yew/src/virtual_dom/vcomp.rs
@@ -215,10 +215,7 @@ impl<COMP: Component> fmt::Debug for VChild<COMP> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        html, utils::document, Children, Component, Context, Html, NodeRef, Properties,
-        ShouldRender,
-    };
+    use crate::{html, utils::document, Children, Component, Context, Html, NodeRef, Properties};
     use web_sys::Node;
 
     #[cfg(feature = "wasm_test")]
@@ -245,7 +242,7 @@ mod tests {
             Comp
         }
 
-        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> ShouldRender {
+        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
             unimplemented!();
         }
 
@@ -390,10 +387,10 @@ mod tests {
         fn create(_: &Context<Self>) -> Self {
             Self
         }
-        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> ShouldRender {
+        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
             unimplemented!();
         }
-        fn changed(&mut self, _ctx: &Context<Self>) -> ShouldRender {
+        fn changed(&mut self, _ctx: &Context<Self>) -> bool {
             unimplemented!();
         }
         fn view(&self, ctx: &Context<Self>) -> Html {
@@ -496,7 +493,7 @@ mod layout_tests {
 
     use crate::html;
     use crate::virtual_dom::layout_tests::{diff_layouts, TestLayout};
-    use crate::{Children, Component, Context, Html, Properties, ShouldRender};
+    use crate::{Children, Component, Context, Html, Properties};
     use std::marker::PhantomData;
 
     #[cfg(feature = "wasm_test")]
@@ -525,7 +522,7 @@ mod layout_tests {
             }
         }
 
-        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> ShouldRender {
+        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
             unimplemented!();
         }
 

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -450,7 +450,7 @@ mod layout_tests_keys {
     use crate::html;
     use crate::virtual_dom::layout_tests::{diff_layouts, TestLayout};
     use crate::virtual_dom::VNode;
-    use crate::{Children, Component, Context, Html, Properties, ShouldRender};
+    use crate::{Children, Component, Context, Html, Properties};
     use web_sys::Node;
 
     #[cfg(feature = "wasm_test")]
@@ -476,7 +476,7 @@ mod layout_tests_keys {
             Comp {}
         }
 
-        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> ShouldRender {
+        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
             unimplemented!();
         }
 
@@ -500,7 +500,7 @@ mod layout_tests_keys {
             Self()
         }
 
-        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> ShouldRender {
+        fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
             unimplemented!();
         }
 

--- a/website/docs/concepts/components.md
+++ b/website/docs/concepts/components.md
@@ -121,7 +121,7 @@ impl Component for MyComponent {
 
     // ...
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
        match msg {
            Msg::SetInputEnabled(enabled) => {
                if self.input_enabled != enabled {

--- a/website/docs/concepts/html/elements.md
+++ b/website/docs/concepts/html/elements.md
@@ -116,7 +116,7 @@ impl Component for MyComponent {
         MyComponent;
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, msg: Self::Message) -> bool {
         match msg {
             Msg::Click => {
                 // Handle Click

--- a/website/docs/getting-started/build-a-sample-app.md
+++ b/website/docs/getting-started/build-a-sample-app.md
@@ -76,7 +76,7 @@ impl Component for Model {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::AddOne => {
                 self.value += 1;


### PR DESCRIPTION
#### Description
Remove `ShouldRender` type alias for bool. 
In the Component trait an extra comment has been added to 
explain what the returned bools represents.


<!-- Please include a summary of the change. -->
This has been removed due to [this discussion](https://github.com/yewstack/yew/pull/1961#discussion_r687940888).
Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
