### PR TITLE
Fix ConsoleService::new().log() in doc examples

### DIFF
--- a/website/i18n/ja/docusaurus-plugin-content-docs/0.17.3/concepts/html/elements.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/0.17.3/concepts/html/elements.md
@@ -233,7 +233,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // Create an ephemeral callback
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/i18n/ja/docusaurus-plugin-content-docs/0.17.3/more/debugging.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/0.17.3/more/debugging.md
@@ -35,7 +35,7 @@ log::info!("Update: {:?}", msg);
 
 ```rust
 // 使用方法
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## ソースマップ

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/html/elements.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/html/elements.md
@@ -233,7 +233,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // Create an ephemeral callback
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/more/debugging.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/more/debugging.md
@@ -35,7 +35,7 @@ log::info!("Update: {:?}", msg);
 
 ```rust
 // 使用方法
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## ソースマップ

--- a/website/i18n/ja/docusaurus-plugin-content-docs/version-0.18.0/concepts/html/elements.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/version-0.18.0/concepts/html/elements.md
@@ -233,7 +233,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // Create an ephemeral callback
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/i18n/ja/docusaurus-plugin-content-docs/version-0.18.0/more/debugging.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/version-0.18.0/more/debugging.md
@@ -35,7 +35,7 @@ log::info!("Update: {:?}", msg);
 
 ```rust
 // 使用方法
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## ソースマップ

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/concepts/html/elements.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/concepts/html/elements.md
@@ -231,7 +231,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // 创建一个短暂的回调
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/more/debugging.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/more/debugging.md
@@ -28,7 +28,7 @@ This service is included within yew and is available when the `"services"` featu
 
 ```rust
 // usage
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## Source Maps

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.17.3/concepts/html/elements.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.17.3/concepts/html/elements.md
@@ -231,7 +231,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // 创建一个短暂的回调
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.17.3/more/debugging.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.17.3/more/debugging.md
@@ -28,7 +28,7 @@ This service is included within yew and is available when the `"services"` featu
 
 ```rust
 // usage
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## Source Maps

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.18.0/concepts/html/elements.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.18.0/concepts/html/elements.md
@@ -231,7 +231,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // 创建一个短暂的回调
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.18.0/more/debugging.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.18.0/more/debugging.md
@@ -28,7 +28,7 @@ This service is included within yew and is available when the `"services"` featu
 
 ```rust
 // usage
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## Source Maps

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/current/concepts/html/elements.md
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/current/concepts/html/elements.md
@@ -231,7 +231,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // 建立一個臨時的 callback
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/current/more/debugging.md
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/current/more/debugging.md
@@ -28,7 +28,7 @@ Yew 包含了這個 service，而且如果 `"services"` 這個 feaure 有被打�
 
 ```rust
 // 使用
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## Source Maps

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.17.3/concepts/html/elements.md
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.17.3/concepts/html/elements.md
@@ -231,7 +231,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // 建立一個臨時的 callback
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.17.3/more/debugging.md
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.17.3/more/debugging.md
@@ -28,7 +28,7 @@ Yew 包含了這個 service，而且如果 `"services"` 這個 feaure 有被打�
 
 ```rust
 // 使用
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## Source Maps

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.18.0/concepts/html/elements.md
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.18.0/concepts/html/elements.md
@@ -231,7 +231,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // 建立一個臨時的 callback
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.18.0/more/debugging.md
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.18.0/more/debugging.md
@@ -28,7 +28,7 @@ Yew 包含了這個 service，而且如果 `"services"` 這個 feaure 有被打�
 
 ```rust
 // 使用
-ConsoleService::new()::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## Source Maps

--- a/website/versioned_docs/version-0.18.0/concepts/html/elements.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/elements.md
@@ -203,7 +203,7 @@ impl Component for MyComponent {
     fn view(&self) -> Html {
         // Create an ephemeral callback
         let click_callback = Callback::from(|| {
-            ConsoleService::new().log("clicked!");
+            ConsoleService::log("clicked!");
         });
 
         html! {

--- a/website/versioned_docs/version-0.18.0/more/debugging.md
+++ b/website/versioned_docs/version-0.18.0/more/debugging.md
@@ -39,7 +39,7 @@ This service is included within Yew and is available when the "services" feature
 
 ```rust
 // usage
-ConsoleService::info(format!("Update: {:?}", msg));
+ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```
 
 ## Source Maps


### PR DESCRIPTION
#### Description

A few examples in the web site docs use `ConsoleService::new().log()` or similar calls, but the correct call is `ConsoleService::log()`. This change fixes all such instances.

This also fixes uses of `format!()` as a parameter to `ConsoleService` logging. `log()` and friends require a ref, so the following is correct:

```rust
ConsoleService::info(format!("Update: {:?}", msg).as_ref());
```

I fixed examples for current even though I cannot find `ConsoleService` in the master branch. I figure my change is no less correct than what was already there.

Fixes #2017

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- ~~I have added tests~~ N/A
