### PR TITLE
Add imports to doc version 0.18.0 code blocks

### DIFF
--- a/website/versioned_docs/version-0.18.0/advanced-topics/optimizations.md
+++ b/website/versioned_docs/version-0.18.0/advanced-topics/optimizations.md
@@ -22,7 +22,7 @@ struct ExampleProps;
 
 struct Example {
     props: ExampleProps,
-};
+}
 
 impl Example {
     fn change(&mut self, props: ExampleProps) -> ShouldRender {

--- a/website/versioned_docs/version-0.18.0/concepts/components.md
+++ b/website/versioned_docs/version-0.18.0/concepts/components.md
@@ -25,6 +25,8 @@ It is common to store the props (data which can be passed from parent to child c
 `ComponentLink` in your component struct, like so:
 
 ```rust
+use yew::{Component, ComponentLink};
+
 pub struct MyComponent {
     props: Props,
     link: ComponentLink<Self>,
@@ -51,6 +53,8 @@ convenient way to render child components. The macro is somewhat similar to Reac
 differences in programming language aside).
 
 ```rust
+use yew::{html, Component, Html};
+
 impl Component for MyComponent {
     // ...
 
@@ -74,9 +78,7 @@ is also a parameter called `first_render` which can be used to determine whether
 being called on the first render, or instead a subsequent one.
 
 ```rust
-use stdweb::web::html_element::InputElement;
-use stdweb::web::IHtmlElement;
-use yew::prelude::*;
+use yew::{html, web_sys::HtmlInputElement, Component, Html, NodeRef};
 
 pub struct MyComponent {
     node_ref: NodeRef,
@@ -93,7 +95,7 @@ impl Component for MyComponent {
 
     fn rendered(&mut self, first_render: bool) {
         if first_render {
-            if let Some(input) = self.node_ref.cast::<InputElement>() {
+            if let Some(input) = self.node_ref.cast::<HtmlInputElement>() {
                 input.focus();
             }
         }
@@ -115,6 +117,8 @@ by event listeners, child components, Agents, Services, or Futures.
 Here's an example of what an implementation of `update` could look like:
 
 ```rust
+use yew::{Component, ShouldRender};
+
 pub enum Msg {
     SetInputEnabled(bool)
 }
@@ -148,6 +152,8 @@ changing the values of a property.
 A typical implementation would look something like:
 
 ```rust
+use yew::{Component, ShouldRender};
+
 impl Component for MyComponent {
     // ...
 
@@ -173,6 +179,8 @@ before it is destroyed. This method is optional and does nothing by default.
 The `Component` trait has two associated types: `Message` and `Properties`.
 
 ```rust
+use yew::Component;
+
 impl Component for MyComponent {
     type Message = Msg;
     type Properties = Props;

--- a/website/versioned_docs/version-0.18.0/concepts/components/callbacks.md
+++ b/website/versioned_docs/version-0.18.0/concepts/components/callbacks.md
@@ -69,6 +69,8 @@ They have an `emit` function that takes their `<IN>` type as an argument and con
 A simple use of a callback might look something like this:
 
 ```rust
+use yew::html;
+
 let onclick = self.link.callback(|_| Msg::Clicked);
 html! {
     <button onclick=onclick>{ "Click" }</button>
@@ -80,6 +82,8 @@ The function passed to `callback` must always take a parameter. For example, the
 If you need a callback that might not need to cause an update, use `batch_callback`.
 
 ```rust
+use yew::html;
+
 let onkeypress = self.link.batch_callback(|event| {
     if event.key() == "Enter" {
         Some(Msg::Submit)

--- a/website/versioned_docs/version-0.18.0/concepts/components/children.md
+++ b/website/versioned_docs/version-0.18.0/concepts/components/children.md
@@ -9,7 +9,7 @@ what type of children the component has. In such cases, the below example will
 suffice.
 
 ```rust
-use yew::prelude::*;
+use yew::{html, Children, Component, Html, Properties};
 
 #[derive(Properties, Clone)]
 pub struct ListProps {
@@ -42,8 +42,7 @@ In cases where you want one type of component to be passed as children to your c
 you can use `yew::html::ChildrenWithProps<T>`.
 
 ```rust
-use yew::html::ChildrenWithProps;
-use yew::prelude::*;
+use yew::{html, ChildrenWithProps, Component, Html, Properties};
 
 // ...
 
@@ -57,7 +56,7 @@ pub struct List {
     props: ListProps,
 }
 
-impl Component for ListProps {
+impl Component for List {
     type Properties = ListProps;
     // ...
 
@@ -80,9 +79,10 @@ for better ergonomics. If you don't want to use it, you can manually implement
 `From` for each variant.
 
 ```rust
-use yew::prelude::*;
-use yew::html::ChildrenRenderer;
-use yew::virtual_dom::{ VChild, VComp };
+use yew::{
+    html, html::ChildrenRenderer, virtual_dom::VChild, 
+    Component, Html, Properties
+};
 
 // `derive_more::From` implements `From<VChild<Primary>>` and
 // `From<VChild<Secondary>>` for `Item` automatically!
@@ -130,9 +130,7 @@ impl Component for List {
 You can also have a single optional child component of a specific type too: 
 
 ```rust
-use yew::prelude::*;
-use yew::virtual_dom::VChild;
-
+use yew::{html, virtual_dom::VChild, Component, Html, Properties};
 
 #[derive(Clone, Properties)]
 pub struct PageProps {
@@ -157,20 +155,18 @@ impl Component for Page {
         }
     }
 }
-```
 
-The page component can be called either with the sidebar or without: 
+// The page component can be called either with the sidebar or without: 
 
-```rust
-    // Page without sidebar
-    html! {
-        <Page />
-    }
+// Page without sidebar
+html! {
+    <Page />
+}
 
-    // Page with sidebar
-    html! {
-        <Page sidebar=html_nested! {
-            <PageSideBar />
-        } />
-    }
+// Page with sidebar
+html! {
+<Page sidebar=html_nested! {
+    <PageSideBar />
+    } />
+}
 ```

--- a/website/versioned_docs/version-0.18.0/concepts/components/properties.md
+++ b/website/versioned_docs/version-0.18.0/concepts/components/properties.md
@@ -98,6 +98,9 @@ The macro uses the same syntax as a struct expression except that you can't use 
 The type path can either point to the props directly (`path::to::Props`) or the associated properties of a component (`MyComp::Properties`).
 
 ```rust
+use std::rc::Rc;
+use yew::props;
+
 let props = yew::props!(LinkProps {
     href: "/",
     text: Rc::from("imagine this text being really long"),

--- a/website/versioned_docs/version-0.18.0/concepts/components/refs.md
+++ b/website/versioned_docs/version-0.18.0/concepts/components/refs.md
@@ -14,6 +14,8 @@ a canvas element after it has been rendered from `view`.
 The syntax is:
 
 ```rust
+use yew::{html, NodeRef, web_sys::Element};
+
 // In create
 self.node_ref = NodeRef::default();
 

--- a/website/versioned_docs/version-0.18.0/concepts/html.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html.md
@@ -28,6 +28,8 @@ Tags must either self-close `<... />` or have a corresponding end tag for each s
 <!--Open - Close-->
 
 ```rust
+use yew::html;
+
 html! {
   <div id="my_div"></div>
 }
@@ -36,6 +38,8 @@ html! {
 <!--Invalid-->
 
 ```rust
+use yew::html;
+
 html! {
   <div id="my_div"> // <- MISSING CLOSE TAG
 }
@@ -44,6 +48,8 @@ html! {
 <!--Self-closing-->
 
 ```rust
+use yew::html;
+
 html! {
   <input id="my_input" />
 }
@@ -52,6 +58,8 @@ html! {
 <!--Invalid-->
 
 ```rust
+use yew::html;
+
 html! {
   <input id="my_input"> // <- MISSING SELF-CLOSE
 }
@@ -71,6 +79,8 @@ Create complex nested HTML and SVG layouts with ease:
 <!--HTML-->
 
 ```rust
+use yew::html;
+
 html! {
     <div>
         <div data-key="abc"></div>
@@ -92,6 +102,8 @@ html! {
 <!--SVG-->
 
 ```rust
+use yew::html;
+
 html! {
     <svg width="149" height="147" viewBox="0 0 149 147" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M60.5776 13.8268L51.8673 42.6431L77.7475 37.331L60.5776 13.8268Z" fill="#DEB819"/>

--- a/website/versioned_docs/version-0.18.0/concepts/html/classes.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/classes.md
@@ -23,6 +23,8 @@ is that every expression implements `Into<Classes>`.
 <!--Literal-->
 
 ```rust
+use yew::{classes, html};
+
 html! {
   <div class=classes!("container")></div>
 }
@@ -31,6 +33,8 @@ html! {
 <!--Multiple-->
 
 ```rust
+use yew::{classes, html};
+
 html! {
   <div class=classes!("class-1", "class-2")></div>
 }
@@ -39,6 +43,8 @@ html! {
 <!--String-->
 
 ```rust
+use yew::{classes, html};
+
 let my_classes = String::from("class-1 class-2");
 
 html! {
@@ -49,6 +55,8 @@ html! {
 <!--Optional-->
 
 ```rust
+use yew::{classes, html};
+
 html! {
   <div class=classes!(Some("class")) />
 }
@@ -57,6 +65,8 @@ html! {
 <!--Vector-->
 
 ```rust
+use yew::{classes, html};
+
 html! {
   <div class=classes!(vec!["class-1", "class-2"])></div>
 }
@@ -65,6 +75,8 @@ html! {
 <!--Array-->
 
 ```rust
+use yew::{classes, html};
+
 let my_classes = ["class-1", "class-2"];
 
 html! {
@@ -78,6 +90,7 @@ html! {
 
 ```rust
 use boolinator::Boolinator;
+use yew::{classes, html, Children, Classes, Component, Html, Properties};
 
 #[derive(Clone, Properties)]
 struct Props {

--- a/website/versioned_docs/version-0.18.0/concepts/html/components.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/components.md
@@ -8,7 +8,9 @@ description: "Create complex layouts with component hierarchies"
 Any type that implements `Component` can be used in the `html!` macro:
 
 ```rust
-html!{
+use yew::html;
+
+html! {
     <>
         // No properties
         <MyComponent />
@@ -27,6 +29,8 @@ html!{
 Components can be passed children if they have a `children` field in their `Properties`.
 
 ```rust title="parent.rs"
+use yew::html;
+
 html! {
     <Container id="container">
         <h4>{ "Hi" }</h4>
@@ -38,6 +42,8 @@ html! {
 When using the `with props` syntax, the children passed in the `html!` macro overwrite the ones already present in the props.
 
 ```rust
+use yew::{html, props, Children};
+
 let props = yew::props!(Container::Properties {
     id: "container-2",
     children: Children::default(),
@@ -53,6 +59,8 @@ html! {
 Here's the implementation of `Container`:
 
 ```rust
+use yew::{html, Children, Component, Html, Properties};
+
 #[derive(Properties, Clone)]
 pub struct Props {
     pub id: String,
@@ -80,6 +88,8 @@ impl Component for Container {
 Nested component properties can be accessed and mutated if the containing component types its children. In the following example, the `List` component can wrap `ListItem` components. For a real world example of this pattern, check out the `yew-router` source code. For a more advanced example, check out the `nested-list` example in the main yew repository.
 
 ```rust
+use yew::html;
+
 html! {
     <List>
         <ListItem value="a" />
@@ -90,6 +100,8 @@ html! {
 ```
 
 ```rust
+use yew::{html, ChildrenWithProps, Component, Html, Properties};
+
 #[derive(Properties, Clone)]
 pub struct Props {
     pub children: ChildrenWithProps<ListItem>,

--- a/website/versioned_docs/version-0.18.0/concepts/html/elements.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/elements.md
@@ -12,19 +12,18 @@ Using `web-sys`, you can create DOM elements and convert them into a `Node` - wh
 used as a `Html` value using `VRef`:
 
 ```rust
-    // ...
-    fn view(&self) -> Html {
-        use yew::{utils::document, web_sys::{Element, Node}};
-
-        // Create a div element from the document
-        let div: Element = document().create_element("div").unwrap();
-        // Add content, classes etc.
-        div.set_inner_html("Hello, World!");
-        // Convert Element into a Node
-        let node: Node = div.into();
-        // Return that Node as a Html value
-        Html::VRef(node)
-    }
+use yew::{utils::document, web_sys::{Element, Node}, Html};
+// ...
+fn view(&self) -> Html {
+    // Create a div element from the document
+    let div: Element = document().create_element("div").unwrap();
+    // Add content, classes etc.
+    div.set_inner_html("Hello, World!");
+    // Convert Element into a Node
+    let node: Node = div.into();
+    // Return that Node as a Html value
+    Html::VRef(node)
+}
 ```
 
 ## Dynamic tag names
@@ -35,6 +34,8 @@ Instead of having to use a big match expression, Yew allows you to set the tag n
 using `@{name}` where `name` can be any expression that returns a string.
 
 ```rust
+use yew::html;
+
 let level = 5;
 let text = "Hello World!".to_owned()
 
@@ -49,35 +50,39 @@ Some content attributes (e.g checked, hidden, required) are called boolean attri
 boolean attributes need to be set to a bool value:
 
 ```rust
-    html! {
-        <div hidden=true>
-            { "This div is hidden." }
-        </div>
-    }
+use yew::html;
+
+html! {
+    <div hidden=true>
+        { "This div is hidden." }
+    </div>
+}
 ```
 
 This will result in **HTML** that's functionally equivalent to this:
 ```html
-    <div hidden>This div is hidden.</div>
+<div hidden>This div is hidden.</div>
 ```
 
 Setting a boolean attribute to false is equivalent to not using the attribute at all; values from 
 boolean expressions can be used:
 
 ```rust
-    let no = 1 + 1 != 2;
+use yew::html;
 
-    html! {
-        <div hidden=no>
-            { "This div is NOT hidden." }
-        </div>
-    }
+let no = 1 + 1 != 2;
+
+html! {
+    <div hidden=no>
+        { "This div is NOT hidden." }
+    </div>
+}
 ```
 
 This will result in the following **HTML**:
 
 ```html
-    <div>This div is NOT hidden.</div>
+<div>This div is NOT hidden.</div>
 ```
 
 ## Optional attributes for HTML elements
@@ -86,6 +91,8 @@ Most HTML attributes can use optional values (`Some(x)` or `None`). This allows 
 to omit the attribute if the attribute is marked as optional.
 
 ```rust
+use yew::html;
+
 let maybe_id = Some("foobar");
 
 html! {
@@ -99,6 +106,8 @@ Please note that it is also valid to give only the value as properties behave
 like `Into<Option<T>>`:
 
 ```rust
+use yew::html;
+
 let id = "foobar";
 
 html! {
@@ -114,6 +123,11 @@ Listener attributes need to be passed a `Callback` which is a wrapper around a c
 <!--Component handler-->
 
 ```rust
+use yew::{
+    events::MouseEvent, html, Component,
+    ComponentLink, Html, ShouldRender
+};
+
 struct MyComponent {
     link: ComponentLink<Self>,
 }
@@ -140,7 +154,7 @@ impl Component for MyComponent {
 
     fn view(&self) -> Html {
         // Create a callback from a component link to handle it in a component
-        let click_callback = self.link.callback(|_: ClickEvent| Msg::Click);
+        let click_callback = self.link.callback(|_: MouseEvent| Msg::Click);
         html! {
             <button onclick=click_callback>
                 { "Click me!" }
@@ -153,6 +167,11 @@ impl Component for MyComponent {
 <!--Agent Handler-->
 
 ```rust
+use yew::{
+    agent::Dispatcher, events::MouseEvent, html, Component,
+    ComponentLink, Html, ShouldRender,
+};
+
 struct MyComponent {
     worker: Dispatcher<MyWorker>,
 }
@@ -173,7 +192,7 @@ impl Component for MyComponent {
 
     fn view(&self) -> Html {
         // Create a callback from a worker to handle it in another context
-        let click_callback = self.worker.callback(|_: ClickEvent| WorkerMsg::Process);
+        let click_callback = self.worker.callback(|_: MouseEvent| WorkerMsg::Process);
         html! {
             <button onclick=click_callback>
                 { "Click me!" }
@@ -186,6 +205,11 @@ impl Component for MyComponent {
 <!--Other Cases-->
 
 ```rust
+use yew::{
+    html, services::ConsoleService, Callback, Component,
+    ComponentLink, Html, ShouldRender,
+};
+
 struct MyComponent;
 
 impl Component for MyComponent {
@@ -202,7 +226,7 @@ impl Component for MyComponent {
 
     fn view(&self) -> Html {
         // Create an ephemeral callback
-        let click_callback = Callback::from(|| {
+        let click_callback = Callback::from(|_| {
             ConsoleService::log("clicked!");
         });
 

--- a/website/versioned_docs/version-0.18.0/concepts/html/lists.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/lists.md
@@ -9,6 +9,8 @@ The `html!` macro always requires a single root node. In order to get around thi
 <!--DOCUSAURUS_CODE_TABS-->
 <!--Valid-->
 ```rust
+use yew::html;
+
 html! {
     <>
         <div></div>
@@ -19,8 +21,9 @@ html! {
 
 <!--Invalid-->
 ```rust
-/* error: only one root html element allowed */
+use yew::html;
 
+/* error: only one root html element allowed */
 html! {
     <div></div>
     <p></p>
@@ -36,6 +39,8 @@ Yew supports two different syntaxes for building html from an iterator:
 <!--DOCUSAURUS_CODE_TABS-->
 <!--Syntax Type 1-->
 ```rust
+use yew::{html, Html};
+
 html! {
     <ul class="item-list">
         { self.props.items.iter().map(renderItem).collect::<Html>() }
@@ -45,6 +50,8 @@ html! {
 
 <!--Syntax Type 2-->
 ```rust
+use yew::html;
+
 html! {
     <ul class="item-list">
         { for self.props.items.iter().map(renderItem) }

--- a/website/versioned_docs/version-0.18.0/concepts/html/literals-and-expressions.md
+++ b/website/versioned_docs/version-0.18.0/concepts/html/literals-and-expressions.md
@@ -9,6 +9,8 @@ All display text must be enclosed by `{}` blocks because text is handled as an e
 the largest deviation from normal HTML syntax that Yew makes.
 
 ```rust
+use yew::html;
+
 let text = "lorem ipsum";
 html!{
     <>
@@ -24,6 +26,8 @@ html!{
 You can insert expressions in your HTML using `{}` blocks, as long as they resolve to `Html`
 
 ```rust
+use yew::html;
+
 html! {
   <div>
     {
@@ -42,6 +46,8 @@ html! {
 It often makes sense to extract these expressions into functions or closures to optimize for readability:
 
 ```rust
+use yew::{html, Html};
+
 let show_link = true;
 let maybe_display_link = move || -> Html {
   if show_link {

--- a/website/versioned_docs/version-0.18.0/concepts/router.md
+++ b/website/versioned_docs/version-0.18.0/concepts/router.md
@@ -36,6 +36,8 @@ First, you want to create a type that represents all the states of your applicat
 Then you should derive `Switch` for your type. For enums, every variant must be annotated with `#[to = "/some/route"]`, or if you use a struct instead, that must appear outside the struct declaration.
 
 ```rust
+use yew_router::Switch;
+
 #[derive(Switch)]
 enum AppRoute {
   #[to="/login"]
@@ -61,6 +63,8 @@ if you defined the following `Switch`, the only route that would be matched woul
 `AppRoute::Home`.
 
 ```rust
+use yew_router::Switch;
+
 #[derive(Switch)]
 enum AppRoute {
   #[to="/"]

--- a/website/versioned_docs/version-0.18.0/concepts/services/fetch.md
+++ b/website/versioned_docs/version-0.18.0/concepts/services/fetch.md
@@ -67,10 +67,14 @@ implemented for `FormatDataType<Result<T, ::anyhow::Error>>` (not `FormatDataTyp
 
 This means that your callbacks should look like
 ```rust
+use yew::format::Json;
+
 self.link.callback(|response: Json<anyhow::Result<ResponseType>>|)
 ```
 rather than
 ```rust
+use yew::format::Json;
+
 self.link.callback(|response: Json<ResponseType>|)
 ```
 :::

--- a/website/versioned_docs/version-0.18.0/more/debugging.md
+++ b/website/versioned_docs/version-0.18.0/more/debugging.md
@@ -38,6 +38,7 @@ This service is included within Yew and is available when the "services" feature
 (the "services" feature is enabled by default):
 
 ```rust
+use yew::services::ConsoleService;
 // usage
 ConsoleService::info(format!("Update: {:?}", msg).as_ref());
 ```


### PR DESCRIPTION
#### Description
Adds the explicit imports for each code block of the 0.18.0 version
docs.

This doesn't just stick `yew::prelude::*` everywhere so that new users can understand 
where each type is coming from. prelude is still used in the getting started example
to show it off and for convenience.

Did some minor fixes to some of the code blocks too :)

<!-- Please include a summary of the change. -->

Closes #2012<!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- ~~I have added tests~~ N/A
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
