### PR TITLE
Add "replace route" call as a companion to "push route"

### DIFF
--- a/packages/yew-router/Cargo.toml
+++ b/packages/yew-router/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["gui", "web-programming"]
 description = "A router implementation for the Yew framework"
 repository = "https://github.com/yewstack/yew"
 
+[features]
+wasm_test = []
+
 [dependencies]
 yew = { path = "../yew", default-features= false }
 yew-router-macro = { path = "../yew-router-macro" }

--- a/packages/yew-router/Makefile.toml
+++ b/packages/yew-router/Makefile.toml
@@ -1,0 +1,10 @@
+[tasks.test]
+extend = "core::wasm-pack-base"
+command = "wasm-pack"
+args = [
+    "test",
+    "@@split(YEW_TEST_FLAGS, )",
+    "--",
+    "--features",
+    "${YEW_TEST_FEATURES}",
+]

--- a/packages/yew-router/tests/router.rs
+++ b/packages/yew-router/tests/router.rs
@@ -44,11 +44,21 @@ fn no(props: &NoProps) -> Html {
 #[function_component(Comp)]
 fn component() -> Html {
     let switch = Router::render(|routes| {
-        let onclick = Callback::from(|_| {
-            yew_router::push_route_with_query(
+        let replace_route = Callback::from(|_| {
+            yew_router::replace_route_with_query(
                 Routes::No { id: 2 },
                 Query {
                     foo: "bar".to_string(),
+                },
+            )
+            .unwrap();
+        });
+
+        let push_route = Callback::from(|_| {
+            yew_router::replace_route_with_query(
+                Routes::No { id: 3 },
+                Query {
+                    foo: "baz".to_string(),
                 },
             )
             .unwrap();
@@ -58,10 +68,15 @@ fn component() -> Html {
             Routes::Home => html! {
                 <>
                     <div id="result">{"Home"}</div>
-                    <a {onclick}>{"click me"}</a>
+                    <a onclick={replace_route}>{"replace a route"}</a>
                 </>
             },
-            Routes::No { id } => html! { <No id={*id} /> },
+            Routes::No { id } => html! {
+                <>
+                    <No id={*id} />
+                    <a onclick={push_route}>{"push a route"}</a>
+                </>
+            },
             Routes::NotFound => html! { <div id="result">{"404"}</div> },
         }
     });
@@ -86,7 +101,15 @@ fn router_works() {
 
     assert_eq!("Home", obtain_result_by_id("result"));
 
-    click("a");
+    let initial_length = history_length();
+
+    click("a"); // replacing the current route
     assert_eq!("2", obtain_result_by_id("result-params"));
     assert_eq!("bar", obtain_result_by_id("result-query"));
+    assert_eq!(initial_length, history_length());
+
+    click("a"); // pushing a new route
+    assert_eq!("3", obtain_result_by_id("result-params"));
+    assert_eq!("baz", obtain_result_by_id("result-query"));
+    assert_eq!(initial_length + 1, history_length());
 }

--- a/packages/yew-router/tests/router.rs
+++ b/packages/yew-router/tests/router.rs
@@ -55,7 +55,7 @@ fn component() -> Html {
         });
 
         let push_route = Callback::from(|_| {
-            yew_router::replace_route_with_query(
+            yew_router::push_route_with_query(
                 Routes::No { id: 3 },
                 Query {
                     foo: "baz".to_string(),

--- a/packages/yew-router/tests/utils.rs
+++ b/packages/yew-router/tests/utils.rs
@@ -16,3 +16,11 @@ pub fn click(selector: &str) {
         .unwrap()
         .click();
 }
+
+pub fn history_length() -> u32 {
+    yew::utils::window()
+        .history()
+        .expect("No history found")
+        .length()
+        .expect("No history length found")
+}

--- a/website/docs/concepts/router.md
+++ b/website/docs/concepts/router.md
@@ -80,13 +80,13 @@ fn switch(route: &Route) -> Html {
 
 ### Navigation
 
-To navigate between pages, use either a `Link` component (which renders a `<a>` element) or the `yew_router::push_route` function.
+To navigate between pages, use either a `Link` component (which renders a `<a>` element), the `yew_router::push_route` function, or the `yew_router::replace_route` function, which replaces the current page in the user's browser history instead of pushing a new one onto the stack.
 
 ### Query Parameters
 
 #### Specifying query parameters when navigating
 
-In order to specify query parameters when navigating to a new route, use `yew_router::push_route_with_query` function.
+In order to specify query parameters when navigating to a new route, use either `yew_router::push_route_with_query` or the `yew_router::replace_route_with_query` functions.
 It uses `serde` to serialize the parameters into query string for the URL so any type that implements `Serialize` can be passed.
 In its simplest form this is just a `HashMap` containing string pairs.
 


### PR DESCRIPTION
#### Description

With the rewrite of the router, the ability to replace the current route (as opposed to pushing a new one) was dropped.  This restores that functionality.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [X] I have run `cargo make pr-flow`
- [X] I have reviewed my own code
- [X] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
