### PR TITLE
Add fully qualified primitives in proc macro

### DIFF
--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -161,14 +161,14 @@ impl ToTokens for HtmlElement {
                                 return None;
                             }),
                             _ => Value::Dynamic(quote_spanned! {value.span()=> {
-                                ::yew::utils::__ensure_type::<bool>(#value);
+                                ::yew::utils::__ensure_type::<::std::primitive::bool>(#value);
                                 #key
                             }}),
                         },
                         expr => Value::Dynamic(quote_spanned! {expr.span()=>
                             if #expr {
                                 ::std::option::Option::Some(
-                                    ::std::borrow::Cow::<'static, str>::Borrowed(#key)
+                                    ::std::borrow::Cow::<'static, ::std::primitive::str>::Borrowed(#key)
                                 )
                             } else {
                                 ::std::option::Option::None
@@ -333,7 +333,7 @@ impl ToTokens for HtmlElement {
                             #[allow(clippy::redundant_clone, unused_braces)]
                             ::std::convert::Into::<::yew::virtual_dom::VNode>::into(
                                 ::yew::virtual_dom::VTag::__new_other(
-                                    ::std::borrow::Cow::<'static, str>::Borrowed(#name),
+                                    ::std::borrow::Cow::<'static, ::std::primitive::str>::Borrowed(#name),
                                     #node_ref,
                                     #key,
                                     #attributes,
@@ -363,7 +363,7 @@ impl ToTokens for HtmlElement {
                 // doesn't return a valid value
                 quote_spanned! {expr.span()=> {
                     let mut #vtag_name = ::std::convert::Into::<
-                        ::std::borrow::Cow::<'static, str>
+                        ::std::borrow::Cow::<'static, ::std::primitive::str>
                     >::into(#expr);
                     if !#vtag_name.is_ascii() {
                         ::std::panic!(
@@ -375,7 +375,7 @@ impl ToTokens for HtmlElement {
                     #vtag_name.to_mut().make_ascii_lowercase();
 
                     #[allow(clippy::redundant_clone, unused_braces, clippy::let_and_return)]
-                    let mut #vtag = match ::std::convert::AsRef::<str>::as_ref(&#vtag_name) {
+                    let mut #vtag = match ::std::convert::AsRef::<::std::primitive::str>::as_ref(&#vtag_name) {
                         "input" => {
                             ::yew::virtual_dom::VTag::__new_textarea(
                                 #value,

--- a/packages/yew-macro/src/stringify.rs
+++ b/packages/yew-macro/src/stringify.rs
@@ -6,7 +6,7 @@ use syn::{Expr, Lit, LitStr};
 /// Stringify a value at runtime.
 fn stringify_at_runtime(src: impl ToTokens) -> TokenStream {
     quote_spanned! {src.span()=>
-        ::std::convert::Into::<::std::borrow::Cow::<'static, str>>::into(#src)
+        ::std::convert::Into::<::std::borrow::Cow::<'static, ::std::primitive::str>>::into(#src)
     }
 }
 
@@ -71,7 +71,7 @@ impl Stringify for LitStr {
 
     fn stringify(&self) -> TokenStream {
         quote_spanned! {self.span()=>
-            ::std::borrow::Cow::<'static, str>::Borrowed(#self)
+            ::std::borrow::Cow::<'static, ::std::primitive::str>::Borrowed(#self)
         }
     }
 }

--- a/packages/yew-macro/tests/classes_macro/classes-pass.rs
+++ b/packages/yew-macro/tests/classes_macro/classes-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 fn compile_pass() {
     // multiple literals
     ::yew::classes!("one", "two");
@@ -16,7 +52,7 @@ fn compile_pass() {
     // optional classes
     ::yew::classes!(
         ::std::option::Option::Some("one"),
-        ::std::option::Option::None::<&'static str>,
+        ::std::option::Option::None::<&'static ::std::primitive::str>,
     );
 
     // mixed types

--- a/packages/yew-macro/tests/derive_props/pass.rs
+++ b/packages/yew-macro/tests/derive_props/pass.rs
@@ -1,6 +1,42 @@
 #![no_implicit_prelude]
 #![recursion_limit = "128"]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 mod t1 {
     #[derive(::std::clone::Clone, ::yew::Properties, ::std::cmp::PartialEq)]
     pub struct Props<T: ::std::clone::Clone + ::std::default::Default + ::std::cmp::PartialEq> {
@@ -11,8 +47,8 @@ mod t1 {
     fn optional_prop_generics_should_work() {
         use ::yew::Properties;
 
-        Props::<bool>::builder().build();
-        Props::<bool>::builder().value(true).build();
+        Props::<::std::primitive::bool>::builder().build();
+        Props::<::std::primitive::bool>::builder().value(true).build();
     }
 }
 
@@ -34,9 +70,9 @@ mod t2 {
 mod t3 {
     #[derive(::std::clone::Clone, ::yew::Properties, ::std::cmp::PartialEq)]
     pub struct Props {
-        b: i32,
+        b: ::std::primitive::i32,
         #[prop_or_default]
-        a: i32,
+        a: ::std::primitive::i32,
     }
 
     fn order_is_alphabetized() {
@@ -60,8 +96,8 @@ mod t4 {
     fn optional_prop_generics_should_work() {
         use ::yew::Properties;
 
-        Props::<bool>::builder().build();
-        Props::<bool>::builder().value(true).build();
+        Props::<::std::primitive::bool>::builder().build();
+        Props::<::std::primitive::bool>::builder().value(true).build();
     }
 }
 
@@ -72,7 +108,7 @@ mod t5 {
         T: ::std::clone::Clone + ::std::default::Default + ::std::cmp::PartialEq + 'a,
     > {
         #[prop_or_default]
-        static_value: &'static str,
+        static_value: &'static ::std::primitive::str,
         value: &'a T,
     }
 
@@ -134,7 +170,7 @@ mod t8 {
     #[derive(::std::clone::Clone, ::yew::Properties, ::std::cmp::PartialEq)]
     pub struct Props {
         #[prop_or_else(|| 123)]
-        value: i32,
+        value: ::std::primitive::i32,
     }
 
     fn prop_or_else_closure_should_work() {
@@ -169,7 +205,7 @@ mod t9 {
         use ::std::{assert_eq, result::Result::Ok};
         use ::yew::Properties;
 
-        let props = Props::<i32>::builder().build();
+        let props = Props::<::std::primitive::i32>::builder().build();
         assert_eq!(props.value, Ok(123));
         Props::<i32>::builder().value(Ok(456)).build();
     }
@@ -210,8 +246,8 @@ mod t12 {
     fn optional_prop_generics_should_work() {
         use ::yew::Properties;
 
-        Props::<bool>::builder().build();
-        Props::<bool>::builder().value(true).build();
+        Props::<::std::primitive::bool>::builder().build();
+        Props::<::std::primitive::bool>::builder().value(true).build();
     }
 }
 

--- a/packages/yew-macro/tests/function_component_attr/generic-pass.rs
+++ b/packages/yew-macro/tests/function_component_attr/generic-pass.rs
@@ -1,8 +1,44 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 #[derive(::std::clone::Clone, ::yew::Properties, ::std::cmp::PartialEq)]
 struct Props {
-    a: usize,
+    a: ::std::primitive::usize,
 }
 
 #[::yew::function_component(Comp)]
@@ -23,7 +59,7 @@ fn comp1<T1, T2>(_props: &()) -> ::yew::Html {
 }
 
 #[::yew::function_component(ConstGenerics)]
-fn const_generics<const N: i32>() -> ::yew::Html {
+fn const_generics<const N: ::std::primitive::i32>() -> ::yew::Html {
     ::yew::html! {
         <div>
             { N }
@@ -33,7 +69,7 @@ fn const_generics<const N: i32>() -> ::yew::Html {
 
 fn compile_pass() {
     ::yew::html! { <Comp<Props> a=10 /> };
-    ::yew::html! { <Comp1<usize, usize> /> };
+    ::yew::html! { <Comp1<::std::primitive::usize, ::std::primitive::usize> /> };
 
     ::yew::html! { <ConstGenerics<10> /> };
 }

--- a/packages/yew-macro/tests/function_component_attr/with-props-pass.rs
+++ b/packages/yew-macro/tests/function_component_attr/with-props-pass.rs
@@ -1,8 +1,44 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 #[derive(Clone, ::yew::Properties, PartialEq)]
 struct Props {
-    a: usize,
+    a: ::std::primitive::usize,
 }
 
 #[::yew::function_component(Comp)]

--- a/packages/yew-macro/tests/function_component_attr/without-props-pass.rs
+++ b/packages/yew-macro/tests/function_component_attr/without-props-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 #[::yew::function_component(Comp)]
 fn comp() -> ::yew::Html {
     ::yew::html! {

--- a/packages/yew-macro/tests/html_macro/block-pass.rs
+++ b/packages/yew-macro/tests/html_macro/block-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 fn main() {
     ::yew::html! { <>{ "Hi" }</> };
     ::yew::html! { <>{ ::std::format!("Hello") }</> };

--- a/packages/yew-macro/tests/html_macro/component-pass.rs
+++ b/packages/yew-macro/tests/html_macro/component-pass.rs
@@ -1,10 +1,46 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 #[derive(
     ::std::clone::Clone, ::yew::Properties, ::std::default::Default, ::std::cmp::PartialEq,
 )]
 pub struct ContainerProperties {
-    pub int: i32,
+    pub int: ::std::primitive::i32,
     #[prop_or_default]
     pub children: ::yew::Children,
 }
@@ -59,11 +95,11 @@ impl ::std::convert::Into<::yew::virtual_dom::VNode> for ChildrenVariants {
 pub struct ChildProperties {
     #[prop_or_default]
     pub string: ::std::string::String,
-    pub int: i32,
+    pub int: ::std::primitive::i32,
     #[prop_or_default]
     pub opt_str: ::std::option::Option<::std::string::String>,
     #[prop_or_default]
-    pub vec: ::std::vec::Vec<i32>,
+    pub vec: ::std::vec::Vec<::std::primitive::i32>,
     #[prop_or_default]
     pub optional_callback: ::std::option::Option<::yew::Callback<()>>,
 }
@@ -98,7 +134,7 @@ impl ::yew::Component for AltChild {
     ::std::clone::Clone, ::yew::Properties, ::std::default::Default, ::std::cmp::PartialEq,
 )]
 pub struct ChildContainerProperties {
-    pub int: i32,
+    pub int: ::std::primitive::i32,
     #[prop_or_default]
     pub children: ::yew::html::ChildrenRenderer<ChildrenVariants>,
 }
@@ -150,12 +186,12 @@ fn compile_pass() {
             <Child int=1 />
             <Child int={1+1} />
             <Child int=1 vec={::std::vec![1]} />
-            <Child string={<::std::string::String as ::std::convert::From<&'static str>>::from("child")} int=1 />
+            <Child string={<::std::string::String as ::std::convert::From<&'static ::std::primitive::str>>::from("child")} int=1 />
 
             <Child opt_str="child" int=1 />
-            <Child opt_str={<::std::string::String as ::std::convert::From<&'static str>>::from("child")} int=1 />
+            <Child opt_str={<::std::string::String as ::std::convert::From<&'static ::std::primitive::str>>::from("child")} int=1 />
             <Child opt_str={::std::option::Option::Some("child")} int=1 />
-            <Child opt_str={::std::option::Option::Some(<::std::string::String as ::std::convert::From<&'static str>>::from("child"))} int=1 />
+            <Child opt_str={::std::option::Option::Some(<::std::string::String as ::std::convert::From<&'static ::std::primitive::str>>::from("child"))} int=1 />
         </>
     };
 

--- a/packages/yew-macro/tests/html_macro/dyn-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/dyn-element-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 fn main() {
     let dyn_tag = || ::std::string::ToString::to_string("test");
     let mut next_extra_tag = {

--- a/packages/yew-macro/tests/html_macro/generic-component-pass.rs
+++ b/packages/yew-macro/tests/html_macro/generic-component-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 pub struct Generic<T> {
     marker: ::std::marker::PhantomData<T>,
 }
@@ -46,8 +82,8 @@ fn compile_pass() {
     ::yew::html! { <Generic<::std::vec::Vec<::std::string::String>> /> };
     ::yew::html! { <Generic<::std::vec::Vec<::std::string::String>>></ Generic<::std::vec::Vec<::std::string::String>>> };
 
-    ::yew::html! { <Generic<usize> /> };
-    ::yew::html! { <Generic<usize>></Generic<usize>> };
+    ::yew::html! { <Generic<::std::primitive::usize> /> };
+    ::yew::html! { <Generic<::std::primitive::usize>></Generic<::std::primitive::usize>> };
     ::yew::html! { <Generic<::std::string::String, > /> };
     ::yew::html! { <Generic<::std::string::String, >></Generic<::std::string::String,>> };
 

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -1,15 +1,51 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 fn compile_pass() {
     let onclick = <::yew::Callback<::yew::MouseEvent> as ::std::convert::From<_>>::from(
         |_: ::yew::MouseEvent| (),
     );
     let parent_ref = <::yew::NodeRef as ::std::default::Default>::default();
 
-    let dyn_tag = || <::std::string::String as ::std::convert::From<&str>>::from("test");
+    let dyn_tag = || <::std::string::String as ::std::convert::From<&::std::primitive::str>>::from("test");
     let mut extra_tags_iter = ::std::iter::IntoIterator::into_iter(::std::vec!["a", "b"]);
 
-    let cow_none: ::std::option::Option<::std::borrow::Cow<'static, str>> =
+    let cow_none: ::std::option::Option<::std::borrow::Cow<'static, ::std::primitive::str>> =
         ::std::option::Option::None;
 
     ::yew::html! {

--- a/packages/yew-macro/tests/html_macro/html-node-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-node-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 fn compile_pass() {
     ::yew::html! { "" };
     ::yew::html! { 'a' };
@@ -14,7 +50,7 @@ fn compile_pass() {
     ::yew::html! { <span>{ 1.234 }</span> };
 
     ::yew::html! { ::std::format!("Hello") };
-    ::yew::html! { {<::std::string::String as ::std::convert::From<&str>>::from("Hello") } };
+    ::yew::html! { {<::std::string::String as ::std::convert::From<&::std::primitive::str>>::from("Hello") } };
 
     let msg = "Hello";
     ::yew::html! { msg };

--- a/packages/yew-macro/tests/html_macro/iterable-pass.rs
+++ b/packages/yew-macro/tests/html_macro/iterable-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 fn empty_vec() -> ::std::vec::Vec<::yew::Html> {
     ::std::vec::Vec::<::yew::Html>::new()
 }

--- a/packages/yew-macro/tests/html_macro/list-pass.rs
+++ b/packages/yew-macro/tests/html_macro/list-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 fn main() {
     ::yew::html! {};
     ::yew::html! { <></> };

--- a/packages/yew-macro/tests/html_macro/node-pass.rs
+++ b/packages/yew-macro/tests/html_macro/node-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 fn main() {
     ::yew::html! { "" };
     ::yew::html! { 'a' };

--- a/packages/yew-macro/tests/html_macro/svg-pass.rs
+++ b/packages/yew-macro/tests/html_macro/svg-pass.rs
@@ -1,5 +1,41 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 fn main() {
     // Ensure Rust keywords can be used as element names.
     // See: #1771

--- a/packages/yew-macro/tests/props_macro/props-pass.rs
+++ b/packages/yew-macro/tests/props_macro/props-pass.rs
@@ -1,10 +1,46 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 #[derive(::std::clone::Clone, ::yew::Properties, ::std::cmp::PartialEq)]
 struct Props {
-    a: usize,
+    a: ::std::primitive::usize,
     #[prop_or_default]
-    b: usize,
+    b: ::std::primitive::usize,
 }
 
 fn compile_pass() {

--- a/packages/yew-macro/tests/props_macro/resolve-prop-pass.rs
+++ b/packages/yew-macro/tests/props_macro/resolve-prop-pass.rs
@@ -1,8 +1,44 @@
 #![no_implicit_prelude]
 
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
 #[derive(::std::clone::Clone, ::yew::Properties, ::std::cmp::PartialEq)]
 struct Props {
-    n: i32,
+    n: ::std::primitive::i32,
 }
 
 struct MyComp;


### PR DESCRIPTION
#### Description
Adds shadowing of primitives in the proc macro tests.
Fixes a few cases where primitive types are not fully qualified. 
<!-- Please include a summary of the change. -->

Another Part of #1633 :)
Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [x] I have added tests - I think adding shadowing of primitives counts 🤔
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
