### PR TITLE
Remove `'static` lifetime from hook init functions

### DIFF
--- a/packages/yew/src/functional/hooks/use_reducer.rs
+++ b/packages/yew/src/functional/hooks/use_reducer.rs
@@ -118,7 +118,7 @@ where
     Action: 'static,
     State: 'static,
     InitialState: 'static,
-    InitFn: Fn(InitialState) -> State + 'static,
+    InitFn: Fn(InitialState) -> State,
 {
     let init = Box::new(init);
     let reducer = Rc::new(reducer);

--- a/packages/yew/src/functional/hooks/use_ref.rs
+++ b/packages/yew/src/functional/hooks/use_ref.rs
@@ -46,7 +46,7 @@ use std::{cell::RefCell, rc::Rc};
 ///     }
 /// }
 /// ```
-pub fn use_ref<T: 'static>(initial_value: impl FnOnce() -> T + 'static) -> Rc<RefCell<T>> {
+pub fn use_ref<T: 'static>(initial_value: impl FnOnce() -> T) -> Rc<RefCell<T>> {
     use_hook(
         || Rc::new(RefCell::new(initial_value())),
         |state, _| state.clone(),

--- a/packages/yew/src/functional/hooks/use_state.rs
+++ b/packages/yew/src/functional/hooks/use_state.rs
@@ -34,7 +34,7 @@ struct UseState<T2> {
 ///     }
 /// }
 /// ```
-pub fn use_state<T: 'static, F: FnOnce() -> T + 'static>(initial_state_fn: F) -> UseStateHandle<T> {
+pub fn use_state<T: 'static, F: FnOnce() -> T>(initial_state_fn: F) -> UseStateHandle<T> {
     use_hook(
         // Initializer
         move || UseState {


### PR DESCRIPTION
#### Description

Removes the initialization functions `'static` lifetime requirement for the following hooks:
- `use_state`
- `use_reducer_with_init`
- `use_ref`

`T` and `InitialState` still must be `'static` as they need to outlive the function
call.

<!-- Please include a summary of the change. -->

Fixes #2038 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests - I could add tests that proves the example above compiles?
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
