### PR TITLE
Add hook used in wrong scope error message

### DIFF
--- a/packages/yew/src/functional/hooks/mod.rs
+++ b/packages/yew/src/functional/hooks/mod.rs
@@ -33,6 +33,10 @@ pub fn use_hook<InternalHook: 'static, Output, Tear: FnOnce(&mut InternalHook) +
     runner: impl FnOnce(&mut InternalHook, HookUpdater) -> Output,
     destructor: Tear,
 ) -> Output {
+    if !CURRENT_HOOK.is_set() {
+        panic!("Hooks can only be used in the scope of a function component");
+    }
+
     // Extract current hook
     let updater = CURRENT_HOOK.with(|hook_state| {
         // Determine which hook position we're at and increment for the next hook


### PR DESCRIPTION
#### Description

This checks if the `CURRENT_HOOK` has been set and if not provides a
specific error message for why the hook state has not been set. The
stack trace when throwing here is better too. 

This is only expected to occur when a user is using a hook outside of
a function component.

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->
Prompted by messages on Discord:
- [Issue found](https://discord.com/channels/701068342760570933/703449306497024049/885105203974639626)
- [Cause of issue and want for a better error message](https://discord.com/channels/701068342760570933/703449306497024049/885336177203347476)


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
