### PR TITLE
Fix misleading information on events page

### DIFF
--- a/website/docs/concepts/html/events.md
+++ b/website/docs/concepts/html/events.md
@@ -142,8 +142,7 @@ In this section **target ([Event.target](https://developer.mozilla.org/en-US/doc
 is always referring to the element at which the event was dispatched from.
 
 
-This will **not** always be the element at which the `Callback` is placed, that is the
-[Event.currentTarget](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget)
+This will **not** always be the element at which the `Callback` is placed.
 :::
 
 In event `Callback`s you may want to get the target of that event. For example, the


### PR DESCRIPTION
#### Description

The events page made a specific reference to the `currentTarget` of an
event and provided a link to MDN, however, Yew events have the
`currentTarget` of `body` when using the `html!` macro because of the
global mutliplexer.

Only applies to `master`/`next` as the global multiplexer is not in `v0.18`.

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

~~I have run `cargo make pr-flow`~~ N/A
- [x] I have reviewed my own code
~~I have added tests~~ N/A
