### PR TITLE
Add support for missing boolean attributes

### DIFF
--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -65,6 +65,11 @@ impl Parse for ElementProps {
 lazy_static! {
     static ref BOOLEAN_SET: HashSet<&'static str> = {
         vec![
+            // Living Standard
+            // From: https://html.spec.whatwg.org/#attributes-3
+            // where `Value` = Boolean attribute
+            // Note: `checked` is uniquely handled in the html! macro.
+            "allowfullscreen",
             "async",
             "autofocus",
             "autoplay",
@@ -72,16 +77,22 @@ lazy_static! {
             "default",
             "defer",
             "disabled",
+            "formnovalidate",
             "hidden",
             "ismap",
+            "itemscope",
             "loop",
             "multiple",
             "muted",
+            "nomodule",
             "novalidate",
             "open",
+            "playsinline",
             "readonly",
             "required",
+            "reversed",
             "selected",
+            "truespeed",
         ]
         .into_iter()
         .collect()


### PR DESCRIPTION
#### Description
Adds the missing boolean attributes as per the [Living Standard](https://html.spec.whatwg.org/#attributes-3).

Added a comment with a link to the standard, and a note about `checked` as it [looks like its missing](https://discord.com/channels/701068342760570933/701068343431528490/886444840332705801).

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->
Prompted by [this message on Discord](https://discord.com/channels/701068342760570933/701068343431528490/886445466454204447) from @lukechu10 (thanks again! 🎉).
#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
~~I have added tests~~ N/A
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
