### PR TITLE
Fix not removing readers in file upload example

### DIFF
--- a/examples/file_upload/src/main.rs
+++ b/examples/file_upload/src/main.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use web_sys::{Event, HtmlInputElement};
 use yew::{html, html::TargetCast, Component, Context, Html};
 
@@ -14,7 +16,7 @@ pub enum Msg {
 }
 
 pub struct Model {
-    readers: Vec<FileReader>,
+    readers: HashMap<String, FileReader>,
     files: Vec<String>,
     read_bytes: bool,
 }
@@ -25,7 +27,7 @@ impl Component for Model {
 
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
-            readers: vec![],
+            readers: HashMap::default(),
             files: vec![],
             read_bytes: false,
         }
@@ -36,17 +38,20 @@ impl Component for Model {
             Msg::Loaded(file_name, data) => {
                 let info = format!("file_name: {}, data: {:?}", file_name, data);
                 self.files.push(info);
+                self.readers.remove(&file_name);
                 true
             }
             Msg::LoadedBytes(file_name, data) => {
                 let info = format!("file_name: {}, data: {:?}", file_name, data);
                 self.files.push(info);
+                self.readers.remove(&file_name);
                 true
             }
             Msg::Files(files, bytes) => {
                 for file in files.into_iter() {
+                    let file_name = file.name();
                     let task = {
-                        let file_name = file.name();
+                        let file_name = file_name.clone();
                         let link = ctx.link().clone();
 
                         if bytes {
@@ -65,7 +70,7 @@ impl Component for Model {
                             })
                         }
                     };
-                    self.readers.push(task);
+                    self.readers.insert(file_name, task);
                 }
                 true
             }


### PR DESCRIPTION
#### Description

A bit of deja vu for you but this fixes the same issue as #2054 but on `master` :) 

In the file upload example we store the FileReaders while reading from
the uploaded file but once read we never remove them from the vec.

<!-- Please include a summary of the change. -->

Closes #2035 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
