### PR TITLE
deps: bump to ssri 7.0 for more permissive license

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -104,7 +104,7 @@ easybench-wasm = "0.2.1"
 rmp-serde = "0.15.0"
 rustversion = "1.0"
 serde_derive = "1"
-ssri = "6.0.0"
+ssri = "7.0.0"
 trybuild = "1.0"
 wasm-bindgen-test = "0.3.24"
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This just bumps the ssri version to a "safe" version. It has no breaking API changes.

Fixes: #2057 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
