### PR TITLE
Remove unused `ssri` dependency

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -104,7 +104,6 @@ easybench-wasm = "0.2.1"
 rmp-serde = "0.15.0"
 rustversion = "1.0"
 serde_derive = "1"
-ssri = "7.0.0"
 trybuild = "1.0"
 wasm-bindgen-test = "0.3.24"
 


### PR DESCRIPTION
#### Description

It got bumped recently but this dependency is never used 🙃.

I think when we approach SSRI we can add this dependency in that PR,
but until then I don't think we need a phantom dependency.

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
~I have added tests~ N/A
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
