### PR TITLE
Update dependencies

### DIFF
--- a/packages/yew-agent/Cargo.toml
+++ b/packages/yew-agent/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 
 [dependencies]
 anymap = "0.12"
-bincode = { version = "1" }
-gloo-console = "0.1.0"
+bincode = "1"
+gloo-console = "0.1"
 js-sys = "0.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 slab = "0.4"
 wasm-bindgen = "0.2"
 yew = { path = "../yew" }
@@ -20,5 +20,8 @@ wasm-bindgen-futures = "0.4"
 [dependencies.web-sys]
 version = "0.3"
 features = [
-    "Worker"
+    "DedicatedWorkerGlobalScope",
+    "Url",
+    "Worker",
+    "WorkerOptions",
 ]

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -15,16 +15,16 @@ description = "A framework for making client-side single-page apps"
 proc-macro = true
 
 [dependencies]
-boolinator = "2.4.0"
-lazy_static = "1.3.0"
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "1.0", features = ["full", "extra-traits"] }
+boolinator = "2"
+lazy_static = "1"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["full", "extra-traits"] }
 
 # testing
 [dev-dependencies]
-rustversion = "1.0"
-trybuild = "1.0"
+rustversion = "1"
+trybuild = "1"
 yew = { path = "../yew" }
 
 [build-dependencies]

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -27,11 +27,11 @@ help: consider importing one of these items
 83 |     use crate::t9::foo;
    |
 
-error[E0277]: the trait bound `Value: std::default::Default` is not satisfied
+error[E0277]: the trait bound `Value: Default` is not satisfied
  --> $DIR/fail.rs:9:21
   |
 9 |     #[derive(Clone, Properties, PartialEq)]
-  |                     ^^^^^^^^^^ the trait `std::default::Default` is not implemented for `Value`
+  |                     ^^^^^^^^^^ the trait `Default` is not implemented for `Value`
   |
   = note: required by `Option::<T>::unwrap_or_default`
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-router-macro/Cargo.toml
+++ b/packages/yew-router-macro/Cargo.toml
@@ -11,12 +11,11 @@ repository = "https://github.com/yewstack/yew"
 proc-macro = true
 
 [dependencies]
-heck = "0.3.2"
-proc-macro2 = "1.0.24"
-quote = "1.0.9"
-syn = { version = "1.0.64", features = ["full","extra-traits"] }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["full","extra-traits"] }
 
 [dev-dependencies]
-rustversion = "1.0"
-trybuild = "1.0"
+rustversion = "1"
+trybuild = "1"
 yew-router = { path = "../yew-router" }

--- a/packages/yew-router/Cargo.toml
+++ b/packages/yew-router/Cargo.toml
@@ -19,9 +19,9 @@ yew-router-macro = { path = "../yew-router-macro" }
 
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-gloo = "0.3.0"
-route-recognizer = "0.3.0"
-serde = "1.0"
+gloo = "0.3"
+route-recognizer = "0.3"
+serde = "1"
 serde_urlencoded = "0.7"
 
 [dependencies.web-sys]
@@ -40,7 +40,7 @@ features = [
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies.web-sys]
 version = "0.3"

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -17,38 +17,23 @@ description = "A framework for making client-side single-page apps"
 
 [dependencies]
 anyhow = "1"
-anymap = "0.12"
 console_error_panic_hook = "0.1"
 gloo = "0.3"
-http = "0.2"
-indexmap = { version = "1.5", features = ["std"] }
+indexmap = { version = "1", features = ["std"] }
 js-sys = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 slab = "0.4"
-thiserror = "1"
-wasm-bindgen = "0.2.74"
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 yew-macro = { version = "^0.18.0", path = "../yew-macro" }
 
-scoped-tls-hkt = "0.1.2"
-
-# optional encodings
-bincode = { version = "1", optional = true }
+scoped-tls-hkt = "0.1"
 
 [dependencies.web-sys]
 version = "0.3"
 features = [
-  "AbortController",
-  "AbortSignal",
   "AnimationEvent",
-  "BinaryType",
-  "Blob",
-  "BlobPropertyBag",
   "console",
-  "DedicatedWorkerGlobalScope",
   "Document",
-  "DomTokenList",
   "DragEvent",
   "Element",
   "ErrorEvent",
@@ -59,7 +44,6 @@ features = [
   "FileList",
   "FileReader",
   "FocusEvent",
-  "Headers",
   "HtmlElement",
   "HtmlButtonElement",
   "HtmlInputElement",
@@ -69,50 +53,26 @@ features = [
   "InputEventInit",
   "KeyboardEvent",
   "Location",
-  "MessageEvent",
   "MouseEvent",
   "Node",
-  "ObserverCallback",
   "PointerEvent",
   "ProgressEvent",
-  "ReferrerPolicy",
-  "Request",
-  "RequestCache",
-  "RequestCredentials",
-  "RequestInit",
-  "RequestMode",
-  "RequestRedirect",
-  "Response",
-  "Storage",
   "Text",
   "TouchEvent",
   "TransitionEvent",
   "UiEvent",
-  "Url",
-  "WebSocket",
   "WheelEvent",
   "Window",
-  "Worker",
-  "WorkerGlobalScope",
-  "WorkerOptions",
 ]
 
 [dev-dependencies]
-base64 = "0.13.0"
-bincode = "1"
-easybench-wasm = "0.2.1"
-rmp-serde = "0.15.0"
-rustversion = "1.0"
-serde_derive = "1"
-trybuild = "1.0"
-wasm-bindgen-test = "0.3.24"
+easybench-wasm = "0.2"
+wasm-bindgen-test = "0.3"
 
 [features]
-default = ["agent"]
 doc_test = []
 wasm_test = []
 wasm_bench = []
-agent = ["bincode"]
 
 [package.metadata.docs.rs]
 features = ["doc_test"]


### PR DESCRIPTION
### Description

General review of dependencies, removing ones that are not used and
bumping up minor versions only to avoid breakage.

Consistent use of version so that we use the most recent minor/patch
version of a dependency when building Yew crates.

There were quite a few dependencies in the `yew` crate that aren't used, I'm guessing from
moving `yew_agent` module to `yew-agent` crate and from the removal of the services.

Removed from the `yew` crate:
- `agent` feature
- anymap - `yew_agent` module
- http - services
- serde - services & `yew_agent` module
- serde_json - services
- thiserror - services?
- bincode - `yew_agent` module
- base64 - services?
- rmp-serde - services
- rustversion - ?
- serde_derive - services?
- trybuild - ?
- Quite a few features removed from `web_sys` which were required
for services & `yew_agent` module.

Removed from the `yew-router-macro`:
- heck

After #2057 I did also review all the licences for the dependencies, most
of which have a "MIT or Apache-2.0" with some just having a "MIT"
only licence. So shouldn't have any more surprises on that front :) 

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->
Part of #2052
#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
~~I have added tests~~ N/A
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->

### Outstanding issues
- #1844 which is now only in `yew-agent` crate.
- #925 with #2058 as a possible solution