### PR TITLE
Add documentation for `wasm-bindgen`

### DIFF
--- a/packages/website-test/Cargo.toml
+++ b/packages/website-test/Cargo.toml
@@ -26,6 +26,7 @@ features = [
 	"EventTarget",
 	"HtmlElement",
 	"HtmlInputElement",
+    "HtmlSelectElement",
 	"DomRect",
 ]
 

--- a/packages/website-test/Cargo.toml
+++ b/packages/website-test/Cargo.toml
@@ -12,7 +12,9 @@ yew-agent = { path = "../../packages/yew-agent/" }
 boolinator = "2.4"
 derive_more = "0.99"
 gloo-events = "0.1"
+js-sys = "0.3"
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 weblog = "0.3.0"
 yew = { path = "../../packages/yew/" }
 yew-router = { path = "../../packages/yew-router/" }
@@ -24,6 +26,7 @@ features = [
 	"EventTarget",
 	"HtmlElement",
 	"HtmlInputElement",
+	"DomRect",
 ]
 
 [build-dependencies]

--- a/packages/website-test/Cargo.toml
+++ b/packages/website-test/Cargo.toml
@@ -22,12 +22,12 @@ yew-router = { path = "../../packages/yew-router/" }
 [dev-dependencies.web-sys]
 version = "0.3"
 features = [
-	"Element",
-	"EventTarget",
-	"HtmlElement",
-	"HtmlInputElement",
+    "Element",
+    "EventTarget",
+    "HtmlElement",
+    "HtmlInputElement",
     "HtmlSelectElement",
-	"DomRect",
+    "DomRect",
 ]
 
 [build-dependencies]

--- a/website/docs/concepts/wasm-bindgen.md
+++ b/website/docs/concepts/wasm-bindgen.md
@@ -6,7 +6,7 @@ title: Introduction
 high-level interactions between Wasm modules and JavaScript; it is built with Rust by
 [The Rust and WebAssembly Working Group](https://rustwasm.github.io/).
 
-Yew builds off wasm-bindgen and specifically uses the following of it's crates:
+Yew builds off wasm-bindgen and specifically uses the following of its crates:
 - [`js-sys`](https://crates.io/crates/js-sys)
 - [`wasm-bindgen`](https://crates.io/crates/wasm-bindgen)
 - [`wasm-bindgen-futures`](https://crates.io/crates/wasm-bindgen-futures)
@@ -16,7 +16,7 @@ This section will explore some of these crates in a high level in order to make 
 and use `wasm-bindgen` APIs with Yew. For a more in-depth guide into `wasm-bindgen` and it's associated
 crates then check out [The `wasm-bindgen` Guide](https://rustwasm.github.io/docs/wasm-bindgen/).
 
-For documentation on the above crates then check out [`wasm-bindgen docs.rs`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/index.html).
+For documentation on the above crates check out [`wasm-bindgen docs.rs`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/index.html).
 
 :::tip
 Use the `wasm-bindgen` doc.rs search to find browser APIs and JavaScript types that have been imported
@@ -50,7 +50,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 extern "C" {
 
-	// Use `js_namespace` here to bind `console.log(..)` instead of just
+    // Use `js_namespace` here to bind `console.log(..)` instead of just
     // `log(..)`
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
@@ -76,12 +76,13 @@ _This example was adapted from [1.2 Using console.log of The `wasm-bindgen` Guid
 ### Simulating inheritance
 
 Inheritance between JavaScript classes is a big part of the language and is a major part of how the
-Document Object Model (DOM) works on the web. When types are imported using `wasm-bindgen` you can
+Document Object Model (DOM). When types are imported using `wasm-bindgen` you can
 also add attributes that describe it's inheritance.
 
-In Rust this inheritance is simulated using [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html)
+In Rust this inheritance is simulated using the [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html)
 and [`AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) traits. An example of this
-might help; so say you have three types `A`, `B`, and `C` where `C` extends `B` which extends `A`.
+might help; so say you have three types `A`, `B`, and `C` where `C` extends `B` which in turn
+extends `A`.
 When importing these types the `#[wasm-bindgen]` macro will implement the `Deref` and `AsRef`
 traits in the following way:
 
@@ -93,9 +94,9 @@ traits in the following way:
 These implementations allow you to call a method from `A` on an instance of `C` and to use `C` as if
 it was `&B` or `&A`.
 
-It's important to note that every single type imported using `#[wasm-bindgen]` has the same root type,
+Its important to note that every single type imported using `#[wasm-bindgen]` has the same root type,
 you can think of it as the `A` in the example above, this type is [`JsValue`](#jsvalue) which has
-it's own section
+its own section
 below.
 
 _[extends section in The `wasm-bindgen` Guide](https://rustwasm.github.io/docs/wasm-bindgen/reference/attributes/on-js-imports/extends.html)_
@@ -103,10 +104,10 @@ _[extends section in The `wasm-bindgen` Guide](https://rustwasm.github.io/docs/w
 ### [`JsValue`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/struct.JsValue.html)
 
 This is a representation of an object owned by JavaScript, this is a root catch-all type for `wasm-bindgen`.
-Any other type that comes from `wasm-bindgen` is a `JsValue` and this is because JavaScript doesn't have
-a strong type system so any function that accepts a variable `x` doesn't define it's type so `x` can be
-an valid JavaScript value; hence `JsValue`. So when you are working with imported functions or types that
-accept a `JsValue` then any value is _technically_ valid.
+Any type that comes from `wasm-bindgen` is a `JsValue` and this is because JavaScript doesn't have
+a strong type system so any function that accepts a variable `x` doesn't define its type so `x` can be
+a valid JavaScript value; hence `JsValue`. So when you are working with imported functions or types that
+accept a `JsValue`, then any imported value is _technically_ valid.
 
 `JsValue` can be accepted by a function but that function may still only expect certain types and this
 can lead to panics - so when using raw `wasm-bindgen` APIs check the documentation of the JavaScript
@@ -118,7 +119,7 @@ _[`JsValue` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bind
 
 Rust has a strong type system and JavaScript...doesn't 😞 So in order for Rust to maintain these
 strong types but still be convenient the web assembly group came up with a pretty neat trait `JsCast`.
-It's job is to help you move from one JavaScript "type" to another, which sounds vague but it means
+Its job is to help you move from one JavaScript "type" to another, which sounds vague but it means
 that if you have one type which you know is really another then you can use the functions of `JsCast`
 to jump from one type to the other. It's a nice trait to get to know when working with `web-sys`,
 `wasm_bindgen`, `js-sys` - you'll notice lots of types will implement `JsCast` from those crates.
@@ -126,7 +127,7 @@ to jump from one type to the other. It's a nice trait to get to know when workin
 `JsCast` provides both checked and unchecked methods of casting - so that at runtime if you are
 unsure what type a certain object is you can try to cast it which returns possible failure types like
 [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html) and
-[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html()).
+[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html).
 
 A common example of this in [`web-sys`](wasm-bindgen/web-sys) is when you are trying to get the
 target of an event, you might know what the target element is but the
@@ -140,18 +141,18 @@ use yew::web_sys::{Event, EventTarget, HtmlInputElement, HtmlSelectElement};
 use wasm_bindgen::JsCast;
 
 fn handle_event(event: Event) {
-	let target: EventTarget = event
-		.target()
-		.expect("I'm sure this event has a target!");
+    let target: EventTarget = event
+        .target()
+        .expect("I'm sure this event has a target!");
 	
-	// maybe the target is a select element?
-	if let Some(select_element) = target.dyn_ref::<HtmlSelectElement>() {
-		// do something amazing here
-		return;
-	}
+    // maybe the target is a select element?
+    if let Some(select_element) = target.dyn_ref::<HtmlSelectElement>() {
+        // do something amazing here
+        return;
+    }
 
-	// if it wasn't a select element then I KNOW it's a input element!
-	let input_element: HtmlInputElement = target.unchecked_into();
+    // if it wasn't a select element then I KNOW it's a input element!
+    let input_element: HtmlInputElement = target.unchecked_into();
 }
 ```
 
@@ -226,10 +227,10 @@ use wasm_bindgen_futures::spawn_local;
 async fn my_async_fn() -> String { String::from("Hello") }
 
 spawn_local(async {
-	let mut string = my_async_fn().await;
-	string.push_str(", world!");
-	// console log "Hello, world!"
-	console::log_1(&string.into());
+    let mut string = my_async_fn().await;
+    string.push_str(", world!");
+    // console log "Hello, world!"
+    console::log_1(&string.into());
 });
 ```
 

--- a/website/docs/concepts/wasm-bindgen.md
+++ b/website/docs/concepts/wasm-bindgen.md
@@ -1,0 +1,239 @@
+---
+title: Introduction
+---
+
+[`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) is a library and tool to facilitate
+high-level interactions between Wasm modules and JavaScript; it is built with Rust by
+[The Rust and WebAssembly Working Group](https://rustwasm.github.io/).
+
+Yew builds off wasm-bindgen and specifically uses the following of it's crates:
+- [`js-sys`](https://crates.io/crates/js-sys)
+- [`wasm-bindgen`](https://crates.io/crates/wasm-bindgen)
+- [`wasm-bindgen-futures`](https://crates.io/crates/wasm-bindgen-futures)
+- [`web-sys`](https://crates.io/crates/web-sys)
+
+This section will explore some of these crates in a high level in order to make it easier to understand
+and use `wasm-bindgen` APIs with Yew. For a more in-depth guide into `wasm-bindgen` and it's associated
+crates then check out [The `wasm-bindgen` Guide](https://rustwasm.github.io/docs/wasm-bindgen/).
+
+For documentation on the above crates then check out [`wasm-bindgen docs.rs`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/index.html).
+
+:::tip
+Use the `wasm-bindgen` doc.rs search to find browser APIs and JavaScript types that have been imported
+over using `wasm-bindgen`.
+:::
+
+## [`wasm-bindgen`](https://crates.io/crates/wasm-bindgen)
+
+This crate provides many of the building blocks for the rest of the crates above. In this section we
+are only going to cover two main areas of the `wasm-bindgen` crate and that is the macro and some of
+the types / traits you will see pop up again and again.
+
+### `#[wasm_bindgen]` macro
+
+The `#[wasm_bindgen]` macro, in a high level view, is your translator between Rust and JavaScript, it
+allows you to describe imported JavaScript types in terms of Rust and vice versa. Using this macro
+is more advanced and you shouldn't need to reach for it unless you are trying to interop with an
+external JavaScript library. The `js-sys` and `web-sys` crates are essentially imported types using
+this macro for JavaScript types and the browser API respectively.
+
+Let's go over a simple example of using the `#[wasm-bindgen]` macro to import some specific flavours
+of the [`console.log`](https://developer.mozilla.org/en-US/docs/Web/API/Console/log).
+
+```rust ,no_run
+use wasm_bindgen::prelude::*;
+
+// First up let's take a look of binding `console.log` manually, without the
+// help of `web_sys`. Here we're writing the `#[wasm_bindgen]` annotations
+// manually ourselves, and the correctness of our program relies on the
+// correctness of these annotations!
+#[wasm_bindgen]
+extern "C" {
+
+	// Use `js_namespace` here to bind `console.log(..)` instead of just
+    // `log(..)`
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+
+    // The `console.log` is quite polymorphic, so we can bind it with multiple
+    // signatures. Note that we need to use `js_name` to ensure we always call
+    // `log` in JS.
+    #[wasm_bindgen(js_namespace = console, js_name = log)]
+    fn log_u32(a: u32);
+
+    // Multiple arguments too!
+    #[wasm_bindgen(js_namespace = console, js_name = log)]
+    fn log_many(a: &str, b: &str);
+}
+
+// using the imported functions!
+log("Hello from Rust!");
+log_u32(42);
+log_many("Logging", "many values!");
+```
+_This example was adapted from [1.2 Using console.log of The `wasm-bindgen` Guide](https://rustwasm.github.io/docs/wasm-bindgen/examples/console-log.html)_.
+
+### Simulating inheritance
+
+Inheritance between JavaScript classes is a big part of the language and is a major part of how the
+Document Object Model (DOM) works on the web. When types are imported using `wasm-bindgen` you can
+also add attributes that describe it's inheritance.
+
+In Rust this inheritance is simulated using [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html)
+and [`AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html) traits. An example of this
+might help; so say you have three types `A`, `B`, and `C` where `C` extends `B` which extends `A`.
+When importing these types the `#[wasm-bindgen]` macro will implement the `Deref` and `AsRef`
+traits in the following way:
+
+- `C` can `Deref` to `B`
+- `B` can `Deref` to `A`
+- `C` can be `AsRef` to `B`
+- Both `C` & `B` can be `AsRef` to `A`
+
+These implementations allow you to call a method from `A` on an instance of `C` and to use `C` as if
+it was `&B` or `&A`.
+
+It's important to note that every single type imported using `#[wasm-bindgen]` has the same root type,
+you can think of it as the `A` in the example above, this type is [`JsValue`](#jsvalue) which has
+it's own section
+below.
+
+_[extends section in The `wasm-bindgen` Guide](https://rustwasm.github.io/docs/wasm-bindgen/reference/attributes/on-js-imports/extends.html)_
+
+### [`JsValue`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/struct.JsValue.html)
+
+This is a representation of an object owned by JavaScript, this is a root catch-all type for `wasm-bindgen`.
+Any other type that comes from `wasm-bindgen` is a `JsValue` and this is because JavaScript doesn't have
+a strong type system so any function that accepts a variable `x` doesn't define it's type so `x` can be
+an valid JavaScript value; hence `JsValue`. So when you are working with imported functions or types that
+accept a `JsValue` then any value is _technically_ valid.
+
+`JsValue` can be accepted by a function but that function may still only expect certain types and this
+can lead to panics - so when using raw `wasm-bindgen` APIs check the documentation of the JavaScript
+being imported whether an exception will be caused if that value is not a certain type.
+
+_[`JsValue` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/struct.JsValue.html)._
+
+### [`JsCast`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html)
+
+Rust has a strong type system and JavaScript...doesn't 😞 So in order for Rust to maintain these
+strong types but still be convenient the web assembly group came up with a pretty neat trait `JsCast`.
+It's job is to help you move from one JavaScript "type" to another, which sounds vague but it means
+that if you have one type which you know is really another then you can use the functions of `JsCast`
+to jump from one type to the other. It's a nice trait to get to know when working with `web-sys`,
+`wasm_bindgen`, `js-sys` - you'll notice lots of types will implement `JsCast` from those crates.
+
+`JsCast` provides both checked and unchecked methods of casting - so that at runtime if you are
+unsure what type a certain object is you can try to cast it which returns possible failure types like
+[`Option`](https://doc.rust-lang.org/std/option/enum.Option.html) and
+[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html()).
+
+A common example of this in [`web-sys`](wasm-bindgen/web-sys) is when you are trying to get the
+target of an event, you might know what the target element is but the
+[`web_sys::Event`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Event.html) API will always return an [`Option<web_sys::EventTarget>`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Event.html#method.target)
+so you will need to cast it to the element type so you can call it's methods.
+
+```rust
+// yew exports some of web_sys
+use yew::web_sys::{Event, EventTarget, HtmlInputElement, HtmlSelectElement};
+// need to import the trait.
+use wasm_bindgen::JsCast;
+
+fn handle_event(event: Event) {
+	let target: EventTarget = event
+		.target()
+		.expect("I'm sure this event has a target!");
+	
+	// maybe the target is a select element?
+	if let Some(select_element) = target.dyn_ref::<HtmlSelectElement>() {
+		// do something amazing here
+		return;
+	}
+
+	// if it wasn't a select element then I KNOW it's a input element!
+	let input_element: HtmlInputElement = target.unchecked_into();
+}
+```
+
+The [`dyn_ref`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html#method.dyn_ref)
+method is a checked cast that returns an `Option<&T>` which means the original type
+can be used again if the cast failed and thus returned `None`. The
+[`dyn_into`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html#method.dyn_into)
+method will consume `self`, as per convention for into methods in Rust, and the type returned is
+`Result<T, Self>` this means if the casting fails then the value in `Err` is so you can try again
+or do something else with the original type.
+
+_[`JsCast` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html)._
+
+### [`Closure`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html)
+
+The `Closure` type provides a way to transfer Rust closures to JavaScript, the closures past to
+JavaScript must have a `'static` lifetime for soundness reasons.
+
+This type is a "handle" in the sense that whenever it is dropped it will invalidate the JS
+closure that it refers to. Any usage of the closure in JS after the Closure has been dropped will
+raise an exception.
+
+`Closure` is often used when you are working with a `js-sys` or `web-sys` API that accepts a type
+[`&js_sys::Function`](https://rustwasm.github.io/wasm-bindgen/api/js_sys/struct.Function.html).
+An example of using a `Closure` in Yew can be found in the [Using `Closure` section](html/events#using-closure-verbose) on the [Events](html/events) page.
+
+_[`Closure` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html)._
+
+## [`js-sys`](https://crates.io/crates/js-sys)
+
+The `js-sys` crate provides bindings / imports of JavaScript's standard, built-in objects, including
+their methods and properties.
+
+This does not include any web APIs as this is what [`web-sys`](wasm-bindgen/web-sys) is for!
+
+_[`js-sys` documentation](https://rustwasm.github.io/wasm-bindgen/api/js_sys/index.html)._
+
+## [`wasm-bindgen-futures`](https://crates.io/crates/wasm-bindgen-futures)
+
+The `wasm-bindgen-futures` crate provides a bridge for working with JavaScript Promise types as a
+Rust Future, and similarly contains utilities to turn a rust Future into a JavaScript Promise.
+This can be useful when working with asynchronous or otherwise blocking work in Rust (wasm),
+and provides the ability to interoperate with JavaScript events and JavaScript I/O primitives.
+
+There are three main interfaces in this crate currently:
+
+1. [`JsFuture`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/struct.JsFuture.html) -
+A type that is constructed with a [`Promise`](https://rustwasm.github.io/wasm-bindgen/api/js_sys/struct.Promise.html)
+and can then be used as a `Future<Output=Result<JsValue, JsValue>>`. This Rust future will resolve
+or reject with the value coming out of the `Promise`.
+
+2. [`future_to_promise`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.future_to_promise.html) -
+Converts a Rust `Future<Output=Result<JsValue, JsValue>>` into a
+JavaScript `Promise`. The future’s result will translate to either a resolved or rejected
+`Promise` in JavaScript.
+
+3. [`spawn_local`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html) -
+Spawns a `Future<Output = ()>` on the current thread. This is the best way
+to run a Future in Rust without sending it to JavaScript.
+
+_[`wasm-bindgen-futures` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/index.html)._
+
+### [`spawn_local`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html)
+
+`spawn_local` is going to be the most commonly used part of the `wasm-bindgen-futures` crate in Yew
+as this helps when using libraries that have async APIs.
+
+```rust ,no_run
+use web_sys::console;
+use wasm_bindgen_futures::spawn_local;
+
+async fn my_async_fn() -> String { String::from("Hello") }
+
+spawn_local(async {
+	let mut string = my_async_fn().await;
+	string.push_str(", world!");
+	// console log "Hello, world!"
+	console::log_1(&string.into());
+});
+```
+
+Yew has also added support for futures in certain APIs, most notably you can create a 
+`callback_future` which accepts an `async` block - this uses `spawn_local` internally.
+
+_[`spawn_local` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html)._

--- a/website/docs/concepts/wasm-bindgen.md
+++ b/website/docs/concepts/wasm-bindgen.md
@@ -135,10 +135,9 @@ target of an event, you might know what the target element is but the
 so you will need to cast it to the element type so you can call it's methods.
 
 ```rust
-// yew exports some of web_sys
-use yew::web_sys::{Event, EventTarget, HtmlInputElement, HtmlSelectElement};
 // need to import the trait.
 use wasm_bindgen::JsCast;
+use web_sys::{Event, EventTarget, HtmlInputElement, HtmlSelectElement};
 
 fn handle_event(event: Event) {
     let target: EventTarget = event

--- a/website/docs/concepts/wasm-bindgen/web-sys.md
+++ b/website/docs/concepts/wasm-bindgen/web-sys.md
@@ -1,0 +1,174 @@
+
+The [`web-sys` crate](https://crates.io/crates/web-sys) provides bindings for Web APIs. This is
+procedurally generated from browser WebIDL which is why some of the names are so long and why
+some of the types are vague.
+
+## Features in `web-sys`
+
+The `web-sys` crate with all of it's features enabled can add lots of bloat to a Wasm application,
+in order to get around this issue most types are feature gated so that you only include the types
+you require for your application. Yew includes quite a number of features from `web-sys` and
+re-exports them, but you will often find that you need to add `web-sys` as a dependency yourself
+so you can enable features for APIs not used by Yew internally.
+
+## Inheritance in `web-sys`
+
+In the [Simulating inheritance section](../wasm-bindgen#simulating-inheritance) you can read how in
+general Rust provides an approach to simulate inheritance in JavaScript. This is very important in
+`web-sys` as understanding what methods are available on a type means understanding it's inheritance.
+
+This section is going to look at a specific element and list out it's inheritance using Rust by
+calling [`Deref::deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html#tymethod.deref) until
+the value is [`JsValue`](../wasm-bindgen#jsvalue):
+
+```rust
+use std::ops::Deref;
+use web_sys::{
+	Element,
+	EventTarget,
+	HtmlElement,
+	HtmlTextAreaElement,
+	Node,
+};
+
+fn inheritance_of_text_area(text_area: HtmlTextAreaElement) {
+	// HtmlTextAreaElement is <textarea> in html.
+	let html_element: &HtmlElement = text_area.deref();
+
+	let element: &Element = html_element.deref();
+
+	let node: &Node = element.deref();
+
+	let event_target: &EventTarget = node.deref();
+
+	// Notice we've moved from web-sys types now into built-in
+	// JavaScript types which are in the js-sys crate.
+	let object: &js_sys::Object = event_target.deref();
+
+	// Notice we've moved from js-sys type to the root JsValue from
+	// the wasm-bindgen crate.
+	let js_value: &wasm_bindgen::JsValue = object.deref();
+
+	// Using deref like this means we have to manually traverse
+	// the inheritance tree, however, you can call JsValue methods
+	// on the HtmlTextAreaElement type.
+	// The `is_string` method comes from JsValue.
+	assert!(!text_area.is_string());
+
+	// The AsRef implementations allow you to treat the HtmlTextAreaElement
+	// as an &EventTarget.
+
+	// empty function just to prove we can pass HtmlTextAreaElement as a
+	// &EventTarget.
+	fn this_function_only_takes_event_targets(targets: &EventTarget) {};
+
+	// If you are reading this then it compiled because we check the website
+	// code blocks :)
+	this_function_only_takes_event_targets(&text_area);
+}
+```
+
+_[Inheritance in `web-sys` in The `wasm-bindgen` Guide](https://rustwasm.github.io/wasm-bindgen/web-sys/inheritance.html)._
+
+## The `Node` in `NodeRef`
+
+Yew uses a [`NodeRef`](../components/refs) in order to provide a way for keeping a reference to
+a `Node` made by the [`html!`](../html) macro. The `Node` part of `NodeRef` is referring to
+[`web_sys::Node`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Node.html). The
+`NodeRef::get` method will return a `Option<Node>` value, however, most of the time in Yew you want
+to cast this value to a specific element so you can use it's specific methods. This casting
+can be done using [`JsCast`](../wasm-bindgen#JsCast) on the `Node` value, if present, but Yew
+provides the `NodeRef::cast` method to perform this casting for convenience and so that you don't
+necessarily have to include the `wasm-bindgen` dependency for the `JsCast` trait.
+
+The two code blocks below do essentially the same thing, the first is using `NodeRef::cast` and
+the second is using [`JsCast::dyn_into`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html#method.dyn_into)
+on the `web_sys::Node` returned from `NodeRef::get`.
+
+```rust
+use yew::{web_sys::HtmlInputElement, NodeRef};
+
+fn with_node_ref_cast(node_ref: NodeRef) {
+	if let Some(input) = node_ref.cast::<HtmlInputElement>() {
+		// do something with HtmlInputElement
+	}
+}
+```
+
+```rust
+use yew::{web_sys::HtmlInputElement, NodeRef};
+use wasm_bindgen::JsCast;
+
+fn with_jscast(node_ref: NodeRef) {
+	if let Some(input) = node_ref
+		.get()
+		.and_then(|node| node.dyn_into::<HtmlInputElement>().ok()) {
+		// do something with HtmlInputElement
+	}
+}
+```
+
+## JavaScript example to Rust
+
+This section is to help show that any examples that use JavaScript to interact with the Web APIs
+can be adapted and written using Rust with `web-sys`.
+
+The JavaScript example:
+
+```js
+document.getElementById('mousemoveme').onmousemove = (e) => {
+    // e = Mouse event.
+    var rect = e.target.getBoundingClientRect();
+    var x = e.clientX - rect.left; //x position within the element.
+    var y = e.clientY - rect.top;  //y position within the element.
+    console.log("Left? : " + x + " ; Top? : " + y + ".");
+}
+```
+
+In Yew you will mostly be creating [`Callback`](../components/callbacks)s to use in the
+[`html!`](../html) macro so the example is going to use this approach instead of completely copying
+the approach above (but you could still do it!):
+
+```toml title=Cargo.toml
+[dependencies.web-sys]
+version = "0.3"
+# We need to enable the `DomRect` feature in order to use the
+# `get_bounding_client_rect` method.
+features = [
+	"DomRect"
+]
+
+```
+
+```rust
+use yew::{
+    html,
+	web_sys::{console, HtmlElement},
+    Callback, MouseEvent, TargetCast,
+};
+
+let onmousemove = Callback::from(|e: MouseEvent| {
+    if let Some(target) = e.target_dyn_into::<HtmlElement>() {
+        let rect = target.get_bounding_client_rect();
+        let x = (e.client_x() as f64) - rect.left();
+        let y = (e.client_y() as f64) - rect.top();
+        console::log_1(&format!("Left? : {} ; Top? : {}", x, y).into());
+    }
+});
+
+html! {
+    <div id="mousemoveme" {onmousemove}></div>
+};
+```
+
+The `web-sys` feature kicks in even though the [`HtmlElement`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.HtmlElement.html)
+is used from the re-exported version of `web-sys` by Yew, this works but because features are
+additive but it's important that both versions of `web-sys` are compatible.
+
+## External libraries
+
+`web-sys` is a raw binding to the Web API so it comes with some pain in Rust because it was not
+designed with Rust or even a strong type system in mind, this is where community crates come in to
+provide abstractions over `web-sys` to provide more idiomatic Rust APIs.
+
+_[External libraries page](../../more/external-libs)_

--- a/website/docs/concepts/wasm-bindgen/web-sys.md
+++ b/website/docs/concepts/wasm-bindgen/web-sys.md
@@ -54,16 +54,18 @@ fn inheritance_of_text_area(text_area: HtmlTextAreaElement) {
     // The `is_string` method comes from JsValue.
     assert!(!text_area.is_string());
 
-    // The AsRef implementations allow you to treat the HtmlTextAreaElement
-    // as an &EventTarget.
-
     // empty function just to prove we can pass HtmlTextAreaElement as a
     // &EventTarget.
     fn this_function_only_takes_event_targets(targets: &EventTarget) {};
 
-    // If you are reading this then it compiled because we check the website
-    // code blocks :)
+    // The compiler will walk down the deref chain in order to match the types here.
     this_function_only_takes_event_targets(&text_area);
+
+    // The AsRef implementations allow you to treat the HtmlTextAreaElement
+    // as an &EventTarget.
+
+    let event_target: &EventTarget = text_area.as_ref();
+
 }
 ```
 

--- a/website/docs/concepts/wasm-bindgen/web-sys.md
+++ b/website/docs/concepts/wasm-bindgen/web-sys.md
@@ -24,47 +24,47 @@ the value is [`JsValue`](../wasm-bindgen#jsvalue):
 ```rust
 use std::ops::Deref;
 use web_sys::{
-	Element,
-	EventTarget,
-	HtmlElement,
-	HtmlTextAreaElement,
-	Node,
+    Element,
+    EventTarget,
+    HtmlElement,
+    HtmlTextAreaElement,
+    Node,
 };
 
 fn inheritance_of_text_area(text_area: HtmlTextAreaElement) {
-	// HtmlTextAreaElement is <textarea> in html.
-	let html_element: &HtmlElement = text_area.deref();
+    // HtmlTextAreaElement is <textarea> in html.
+    let html_element: &HtmlElement = text_area.deref();
 
-	let element: &Element = html_element.deref();
+    let element: &Element = html_element.deref();
 
-	let node: &Node = element.deref();
+    let node: &Node = element.deref();
 
-	let event_target: &EventTarget = node.deref();
+    let event_target: &EventTarget = node.deref();
 
-	// Notice we've moved from web-sys types now into built-in
-	// JavaScript types which are in the js-sys crate.
-	let object: &js_sys::Object = event_target.deref();
+    // Notice we've moved from web-sys types now into built-in
+    // JavaScript types which are in the js-sys crate.
+    let object: &js_sys::Object = event_target.deref();
 
-	// Notice we've moved from js-sys type to the root JsValue from
-	// the wasm-bindgen crate.
-	let js_value: &wasm_bindgen::JsValue = object.deref();
+    // Notice we've moved from js-sys type to the root JsValue from
+    // the wasm-bindgen crate.
+    let js_value: &wasm_bindgen::JsValue = object.deref();
 
-	// Using deref like this means we have to manually traverse
-	// the inheritance tree, however, you can call JsValue methods
-	// on the HtmlTextAreaElement type.
-	// The `is_string` method comes from JsValue.
-	assert!(!text_area.is_string());
+    // Using deref like this means we have to manually traverse
+    // the inheritance tree, however, you can call JsValue methods
+    // on the HtmlTextAreaElement type.
+    // The `is_string` method comes from JsValue.
+    assert!(!text_area.is_string());
 
-	// The AsRef implementations allow you to treat the HtmlTextAreaElement
-	// as an &EventTarget.
+    // The AsRef implementations allow you to treat the HtmlTextAreaElement
+    // as an &EventTarget.
 
-	// empty function just to prove we can pass HtmlTextAreaElement as a
-	// &EventTarget.
-	fn this_function_only_takes_event_targets(targets: &EventTarget) {};
+    // empty function just to prove we can pass HtmlTextAreaElement as a
+    // &EventTarget.
+    fn this_function_only_takes_event_targets(targets: &EventTarget) {};
 
-	// If you are reading this then it compiled because we check the website
-	// code blocks :)
-	this_function_only_takes_event_targets(&text_area);
+    // If you are reading this then it compiled because we check the website
+    // code blocks :)
+    this_function_only_takes_event_targets(&text_area);
 }
 ```
 
@@ -89,9 +89,9 @@ on the `web_sys::Node` returned from `NodeRef::get`.
 use yew::{web_sys::HtmlInputElement, NodeRef};
 
 fn with_node_ref_cast(node_ref: NodeRef) {
-	if let Some(input) = node_ref.cast::<HtmlInputElement>() {
-		// do something with HtmlInputElement
-	}
+    if let Some(input) = node_ref.cast::<HtmlInputElement>() {
+        // do something with HtmlInputElement
+    }
 }
 ```
 
@@ -100,11 +100,11 @@ use yew::{web_sys::HtmlInputElement, NodeRef};
 use wasm_bindgen::JsCast;
 
 fn with_jscast(node_ref: NodeRef) {
-	if let Some(input) = node_ref
-		.get()
-		.and_then(|node| node.dyn_into::<HtmlInputElement>().ok()) {
-		// do something with HtmlInputElement
-	}
+    if let Some(input) = node_ref
+        .get()
+        .and_then(|node| node.dyn_into::<HtmlInputElement>().ok()) {
+        // do something with HtmlInputElement
+    }
 }
 ```
 
@@ -135,7 +135,7 @@ version = "0.3"
 # We need to enable the `DomRect` feature in order to use the
 # `get_bounding_client_rect` method.
 features = [
-	"DomRect"
+    "DomRect"
 ]
 
 ```
@@ -143,7 +143,7 @@ features = [
 ```rust
 use yew::{
     html,
-	web_sys::{console, HtmlElement},
+    web_sys::{console, HtmlElement},
     Callback, MouseEvent, TargetCast,
 };
 

--- a/website/docs/concepts/wasm-bindgen/web-sys.md
+++ b/website/docs/concepts/wasm-bindgen/web-sys.md
@@ -7,9 +7,8 @@ some of the types are vague.
 
 The `web-sys` crate with all of it's features enabled can add lots of bloat to a Wasm application,
 in order to get around this issue most types are feature gated so that you only include the types
-you require for your application. Yew includes quite a number of features from `web-sys` and
-re-exports them, but you will often find that you need to add `web-sys` as a dependency yourself
-so you can enable features for APIs not used by Yew internally.
+you require for your application. Yew includes a number of features from `web-sys` and
+exposes some types in it's public API, you will often need to add `web-sys` as a dependency yourself.
 
 ## Inheritance in `web-sys`
 
@@ -86,7 +85,8 @@ the second is using [`JsCast::dyn_into`](https://rustwasm.github.io/wasm-bindgen
 on the `web_sys::Node` returned from `NodeRef::get`.
 
 ```rust
-use yew::{web_sys::HtmlInputElement, NodeRef};
+use web_sys::HtmlInputElement;
+use yew::NodeRef;
 
 fn with_node_ref_cast(node_ref: NodeRef) {
     if let Some(input) = node_ref.cast::<HtmlInputElement>() {
@@ -96,8 +96,9 @@ fn with_node_ref_cast(node_ref: NodeRef) {
 ```
 
 ```rust
-use yew::{web_sys::HtmlInputElement, NodeRef};
 use wasm_bindgen::JsCast;
+use web_sys::HtmlInputElement;
+use yew::NodeRef;
 
 fn with_jscast(node_ref: NodeRef) {
     if let Some(input) = node_ref
@@ -197,11 +198,11 @@ features = [
 ```
 
 ```rust
+use web_sys::{console, HtmlElement, MouseEvent};
 use yew::{
     html,
     Callback, TargetCast,
 };
-use web_sys::{console, HtmlElement, MouseEvent};
 
 let onmousemove = Callback::from(|e: MouseEvent| {
     if let Some(target) = e.target_dyn_into::<HtmlElement>() {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -40,6 +40,14 @@ module.exports = {
             items: [
                 {
                     type: "category",
+                    label: "wasm-bindgen",
+                    items: [
+                        "concepts/wasm-bindgen",
+                        "concepts/wasm-bindgen/web-sys",
+                    ]
+                },
+                {
+                    type: "category",
                     label: "Components",
                     items: [
                         "concepts/components",


### PR DESCRIPTION
Adds a wasm-bindgen section to docs and gives a high level
description of it's crates and how they are used with Yew.

It's such a big topic with lots of rabbit holes to go down so
I'm sure this doesn't cover everything even at a high level but
hopefully covers some of the FAQ stuff and provides a base to
build off (both in this PR and in future) :)

Just `master`/`next` docs in this PR to avoid tweaking two sets
once this one lands I'll move it over to `v0.18` which I don't think
will need much adapting.

#### Description

<!-- Please include a summary of the change. -->

Fixes #1460 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- ~~I have added tests~~ N/A (but technically I did because of website tests 😏)
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
