### PR TITLE
Add `services` removal in next version warning

### DIFF
--- a/website/versioned_docs/version-0.18.0/concepts/services.md
+++ b/website/versioned_docs/version-0.18.0/concepts/services.md
@@ -4,6 +4,28 @@ sidebar_label: Overview
 description: "Yew's glue to browser APIs"
 ---
 
-:::note
-This section is still a work in progress.
+:::caution
+Yew services will be removed in the next version of Yew `v0.19`.
+
+Recommended replacements:
+- `ConsoleService` - [weblog](https://crates.io/crates/weblog) or [gloo_console](https://crates.io/crates/gloo-console)
+- `DialogService` - [gloo_dialogs](https://crates.io/crates/gloo-dialogs)
+- `IntervalService` - [gloo-timers](https://crates.io/crates/gloo-timers)
+- `KeyboardService` - `onkeydown` / `onkeypress` / `onkeyup` like so:
+    ```rust
+    let callback = Callback::from(|e| {
+        e.prevent_default();
+        todo!("use `e`, like you would in service methods.");
+    });
+    html! {
+        <input onkeydown={callback} />
+    }
+    ```
+- `ResizeService` - use `EventListener` from [gloo_events](https://crates.io/crates/gloo-events)
+to attach the event listener instead.
+- `StorageService` - [gloo-storage](https://crates.io/crates/gloo-storage)
+- `TimeoutService` - [gloo-timers](https://crates.io/crates/gloo-timers)
+- `WebSocketService` - [wasm-sockets](https://crates.io/crates/wasm-sockets) or [reqwasm](https://crates.io/crates/reqwasm)
+- `FetchService` - [reqwest](https://crates.io/crates/reqwest) or [reqwasm](https://crates.io/crates/reqwasm)
+
 :::


### PR DESCRIPTION
#### Description

This adds a caution on the Services overview page that these services
will be removed in the next version of Yew.

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->
I keep seeing users of Yew recommend others away from using the services module
which I think is correct for them to do (and thank you to them ❤️) but I think we should
now add this as a caution in the versioned docs. 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- ~~I have added tests~~ N/A
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
