### PR TITLE
yew-agent: add missing web-sys features

### DIFF
--- a/packages/yew-agent/Cargo.toml
+++ b/packages/yew-agent/Cargo.toml
@@ -20,7 +20,10 @@ wasm-bindgen-futures = "0.4"
 [dependencies.web-sys]
 version = "0.3"
 features = [
+    "Blob",
+    "BlobPropertyBag",
     "DedicatedWorkerGlobalScope",
+    "MessageEvent",
     "Url",
     "Worker",
     "WorkerOptions",


### PR DESCRIPTION
#### Description

yew-agent uses several feature-gated parts of web-sys without specifying these features in Cargo.toml. This PR fixes this issue.

#### Checklist

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
