### PR TITLE
Update tutorial to use `use_effect_deps` instead of `use_effect`

### DIFF
--- a/website/docs/tutorial.md
+++ b/website/docs/tutorial.md
@@ -480,7 +480,7 @@ fn app() -> Html {
 +    let videos = use_state(|| vec![]);
 +    {
 +        let videos = videos.clone();
-+        use_effect(move || {
++        use_effect_with_deps(move |_| {
 +            let videos = videos.clone();
 +            wasm_bindgen_futures::spawn_local(async move {
 +                let fetched_videos: Vec<Video> = Request::get("https://yew.rs/tutorial/data.json")
@@ -493,7 +493,7 @@ fn app() -> Html {
 +                videos.set(fetched_videos);
 +            });
 +            || ()
-+        });
++        }, ());
 +    }
 
     // ...


### PR DESCRIPTION
#### Description

Very small update to the tutorial in the "Fetching data (using external REST API)" section to use `use_effect_deps` instead of `use_effect` to prevent an infinite loop of fetching data, updating state, rendering, fetching data, updating state etc.