### PR TITLE
Add safe `first_node` fn

### DIFF
--- a/packages/yew/src/virtual_dom/vcomp.rs
+++ b/packages/yew/src/virtual_dom/vcomp.rs
@@ -391,7 +391,7 @@ mod tests {
         let test_node: Node = document().create_text_node("test").into();
         let test_node_ref = NodeRef::new(test_node);
         let check_node_ref = |vnode: VNode| {
-            assert_eq!(vnode.first_node(), test_node_ref.get().unwrap());
+            assert_eq!(vnode.unchecked_first_node(), test_node_ref.get().unwrap());
         };
 
         let props = Props {

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -521,7 +521,7 @@ impl VDiff for VTag {
                     }
                 } else {
                     let el = self.create_element(parent);
-                    super::insert_node(&el, parent, Some(&ancestor.first_node()));
+                    super::insert_node(&el, parent, ancestor.first_node().as_ref());
                     ancestor.detach(parent);
                     (None, el)
                 }


### PR DESCRIPTION
`first_node` function can fail, like when the VNode
is not mounted, so this adds a safe version that returns an
`Option<Node>` and refactors the previous version to use the "unchecked"
prefix as it can and should panic if the first node cannot be found.

This change resolves [@intendednull's particular issue](https://github.com/yewstack/yew/issues/1946#issuecomment-929800394) and there seems to be
a few different versions of panics that occur that all have this function in common
so it _might_ fix them all. I think the issue comes about when trying to insert a 
node before a component that is no longer mounted - trying to find that component's 
first node fails and causes the panic when we could just ignore it and then render the
node on its own.

#### Description

<!-- Please include a summary of the change. -->

Fixes #1946<!-- replace with issue number or remove if not applicable -->
If this is accepted before it is merged a caveat I have is - I can't accept the reward so
I don't know whether @intendednull can cancel the funded issue or whether
*we* have to? (not quite sure how it works 🙃) 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
