### PR TITLE
Add address of the webpage in the tutorial

### DIFF
--- a/website/docs/tutorial.md
+++ b/website/docs/tutorial.md
@@ -114,10 +114,12 @@ Now, let's create an `index.html` at the root of the project.
 Run the following command to build and serve the application locally.
 
 ```bash
-trunk serve
+trunk serve --open
 ```
 
-Trunk will watch the project directory and helpfully rebuild your application if you modify any source files.
+Trunk will open your application in your default browser, watch the project directory and helpfully rebuild your
+application if you modify any source files. If you are curious, you can run `trunk help` and `trunk help <subcommand>`
+for more details on what's happening.
 
 ### Congratulations
 


### PR DESCRIPTION
The line `server listening at 0.0.0.0:8080` isn’t very visible in the
logs of `trunk serve`, and can be easily be lost if the user does multiple
changes before looking at them. A beginner to web development may not
have the reflex to open this address, or may try to open
`dist/index.html` directly. In both cases he will not be able to see its
application.