### PR TITLE
Fix default passive option

### DIFF
--- a/packages/yew/src/virtual_dom/listeners.rs
+++ b/packages/yew/src/virtual_dom/listeners.rs
@@ -358,9 +358,8 @@ impl GlobalHandlers {
                         &{
                             let mut opts = web_sys::AddEventListenerOptions::new();
                             opts.capture(true);
-                            if desc.passive {
-                                opts.passive(true);
-                            }
+                            // We need to explicitly set passive to override any browser defaults
+                            opts.passive(desc.passive);
                             opts
                         },
                     )


### PR DESCRIPTION
#### Description

This PR sets the passive option explicitly in order to override any defaults the browsers might have - this is especially needed because with #1542 we attach listeners to the body element which is at the document level. 
[See this article section about default passive behaviour on some document level events](https://developers.google.com/web/updates/2017/01/scrolling-intervention#the_intervention).

<!-- Please include a summary of the change. -->

Fixes #2110<!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
