### PR TITLE
Update strum_macros

### DIFF
--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 strum = "0.22"
-strum_macros = "0.21"
+strum_macros = "0.22"
 serde = "1"
 serde_derive = "1"
 yew = { path = "../../packages/yew" }

--- a/examples/todomvc/src/state.rs
+++ b/examples/todomvc/src/state.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
-use strum_macros::{EnumIter, ToString};
+use strum_macros::{Display, EnumIter};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct State {
@@ -117,7 +117,7 @@ pub struct Entry {
     pub editing: bool,
 }
 
-#[derive(Clone, Copy, Debug, EnumIter, ToString, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, EnumIter, Display, PartialEq, Serialize, Deserialize)]
 pub enum Filter {
     All,
     Active,


### PR DESCRIPTION
#### Description

Manual update following: #2114

The `ToString` is deprecated and the recommendation is to use `Display` which is what this PR does :)

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
