### PR TITLE
add redirection to crm example

### DIFF
--- a/examples/crm/src/main.rs
+++ b/examples/crm/src/main.rs
@@ -68,13 +68,16 @@ impl Component for Model {
             Msg::AddClient(client) => {
                 self.clients.push(client);
                 LocalStorage::set(KEY, &self.clients).expect("failed to set");
-                // we only need to re-render if we're currently displaying the clients
-                matches!(self.scene, Scene::ClientsList)
+                // redirect to client_list after save
+                self.scene = Scene::ClientsList;
+                true
             }
             Msg::ClearClients => {
                 if gloo::dialogs::confirm("Do you really want to clear the data?") {
                     self.clients.clear();
                     LocalStorage::delete(KEY);
+                    // redirect to client_list after clear
+                    self.scene = Scene::ClientsList;
                     true
                 } else {
                     false


### PR DESCRIPTION
#### Description

Hey, I'm new here, but I tought why not conribute something.

Though, the CRM example was informative for me, the workflow seemed a bit off in it. In my understanding, that deleted line cannot be true at all.
So I added a redirect after succesful addition or wiping.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests

(the `pr-flow` throws a warning for dead code in `packages/yew/src/html/component/lifeycle.rs:257:9`)
