### PR TITLE
Remove trailing semicolon in macro used in expression position

### DIFF
--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -286,7 +286,7 @@ impl Apply for Attributes {
                     }
                     macro_rules! set {
                         ($new:expr) => {
-                            Self::set_attribute(el, key!(), $new);
+                            Self::set_attribute(el, key!(), $new)
                         };
                     }
 


### PR DESCRIPTION
#### Description

While this currently builds without problems, using trailing semicolons in a macro used in expression positions is set to become a compilation error in a future release

See [rust-lang/rust #79813](<https://github.com/rust-lang/rust/issues/79813>) for more info