### PR TITLE
pass the first_render info comes from `rendered` to `use_effect` and …

### DIFF
--- a/examples/function_todomvc/src/hooks/use_bool_toggle.rs
+++ b/examples/function_todomvc/src/hooks/use_bool_toggle.rs
@@ -46,11 +46,10 @@ pub fn use_bool_toggle(default: bool) -> UseBoolToggleHandle {
     use_hook(
         || default,
         move |hook, updater| {
-            updater.post_render(move |state: &mut bool| {
+            updater.post_render(move |state: &mut bool, _| {
                 if *state != default {
                     *state = default;
                 }
-                false
             });
 
             let toggle = Rc::new(move || {

--- a/examples/function_todomvc/src/main.rs
+++ b/examples/function_todomvc/src/main.rs
@@ -23,7 +23,7 @@ fn app() -> Html {
 
     // Effect
     use_effect_with_deps(
-        move |state| {
+        move |state, _| {
             LocalStorage::set(KEY, &state.clone().entries).expect("failed to set");
             || ()
         },

--- a/packages/yew/src/functional/hooks/mod.rs
+++ b/packages/yew/src/functional/hooks/mod.rs
@@ -61,6 +61,7 @@ pub fn use_hook<InternalHook: 'static, Output, Tear: FnOnce(&mut InternalHook) +
         HookUpdater {
             hook,
             process_message: hook_state.process_message.clone(),
+            process_post_render_message: hook_state.process_post_render_message.clone(),
         }
     });
 

--- a/packages/yew/tests/use_context.rs
+++ b/packages/yew/tests/use_context.rs
@@ -242,7 +242,7 @@ fn use_context_update_works() {
             let magic: usize = *magic_rc;
             {
                 let ctx = ctx.clone();
-                use_effect(move || {
+                use_effect(move |_| {
                     let count = *rendered.borrow();
                     match count {
                         0 => {

--- a/packages/yew/tests/use_effect.rs
+++ b/packages/yew/tests/use_effect.rs
@@ -43,7 +43,7 @@ fn use_effect_destroys_on_component_drop() {
             let effect_called = props.effect_called.clone();
             let destroy_called = props.destroy_called.clone();
             use_effect_with_deps(
-                move |_| {
+                move |_, _| {
                     effect_called();
                     move || destroy_called()
                 },
@@ -91,7 +91,7 @@ fn use_effect_works_many_times() {
             let counter_clone = counter.clone();
 
             use_effect_with_deps(
-                move |_| {
+                move |_, _| {
                     if *counter_clone < 4 {
                         counter_clone.set(*counter_clone + 1);
                     }
@@ -129,7 +129,7 @@ fn use_effect_works_once() {
             let counter_clone = counter.clone();
 
             use_effect_with_deps(
-                move |_| {
+                move |_, _| {
                     counter_clone.set(*counter_clone + 1);
                     || panic!("Destructor should not have been called")
                 },
@@ -167,7 +167,7 @@ fn use_effect_refires_on_dependency_change() {
             let arg = *number_ref.borrow_mut().deref_mut();
             let counter = use_state(|| 0);
             use_effect_with_deps(
-                move |dep| {
+                move |dep, _| {
                     let mut ref_mut = number_ref_c.borrow_mut();
                     let inner_ref_mut = ref_mut.deref_mut();
                     if *inner_ref_mut < 1 {

--- a/packages/yew/tests/use_reducer.rs
+++ b/packages/yew/tests/use_reducer.rs
@@ -39,7 +39,7 @@ fn use_reducer_works() {
 
             let counter_clone = counter.clone();
             use_effect_with_deps(
-                move |_| {
+                move |_, _| {
                     counter_clone.dispatch(1);
                     || {}
                 },

--- a/packages/yew/tests/use_state.rs
+++ b/packages/yew/tests/use_state.rs
@@ -47,7 +47,7 @@ fn multiple_use_state_setters() {
             let counter = use_state(|| 0);
             let counter_clone = counter.clone();
             use_effect_with_deps(
-                move |_| {
+                move |_, _| {
                     // 1st location
                     counter_clone.set(*counter_clone + 1);
                     || {}


### PR DESCRIPTION
 Pass the first_render info comes from `rendered` to `use_effect` and `use_effect_deps`.

#### Description

When I create a component, I need to know if it is rendered for the first time.

Before this PR; I have to maintain this info by myself.

```rust
use web_sys::HtmlTextAreaElement;
use yew::prelude::*;

#[derive(Properties, PartialEq)]
pub struct Props {
    pub rows: Option<usize>,
    pub id: Option<String>,
    pub class: Option<Classes>,
    pub onchange: Option<Callback<String>>,
    pub oninput: Option<Callback<String>>,
}

#[function_component(RetracTextArea)]
pub fn retractable_textarea(
    Props {
        rows,
        id,
        class,
        onchange,
        oninput,
    }: &Props,
) -> Html {
    let textarea_node = use_ref(|| NodeRef::default());
    let first_render = use_ref(|| true);
    let textarea_node_ref: NodeRef = textarea_node.borrow().clone();
    use_effect(move || {
        if *first_render.borrow() {
            let textarea = textarea_node
                .borrow_mut()
                .cast::<HtmlTextAreaElement>()
                .unwrap();
            unsafe {
                crate::bindings::adjust_textarea_height(textarea);
            }
        }

        *first_render.borrow_mut() = false;

        || {}
    });

    let onchange = onchange
        .clone()
        .map(|h| h.reform(|e: Event| e.target_dyn_into::<HtmlTextAreaElement>().unwrap().value()));
    let oninput = oninput.clone().map(|h| {
        h.reform(|e: InputEvent| e.target_dyn_into::<HtmlTextAreaElement>().unwrap().value())
    });

    html! {
        <textarea ref={textarea_node_ref}
            id={id.clone()}
            {class}
            {onchange}
            {oninput}
            rows={rows.unwrap_or(1).to_string()}>
        </textarea>
    }
}
```

After this PR, I can get this info from yew.

```rust
use web_sys::HtmlTextAreaElement;
use yew::prelude::*;

#[derive(Properties, PartialEq)]
pub struct Props {
    pub rows: Option<usize>,
    pub id: Option<String>,
    pub class: Option<Classes>,
    pub onchange: Option<Callback<String>>,
    pub oninput: Option<Callback<String>>,
}

#[function_component(RetracTextArea)]
pub fn retractable_textarea(
    Props {
        rows,
        id,
        class,
        onchange,
        oninput,
    }: &Props,
) -> Html {
    let textarea_node = use_ref(|| NodeRef::default());
    let textarea_node_ref: NodeRef = textarea_node.borrow().clone();
    use_effect(move |first_render| {
        if first_render {
            let textarea = textarea_node
                .borrow_mut()
                .cast::<HtmlTextAreaElement>()
                .unwrap();
            unsafe {
                crate::bindings::adjust_textarea_height(textarea);
            }
        }

        || {}
    });

    let onchange = onchange
        .clone()
        .map(|h| h.reform(|e: Event| e.target_dyn_into::<HtmlTextAreaElement>().unwrap().value()));
    let oninput = oninput.clone().map(|h| {
        h.reform(|e: InputEvent| e.target_dyn_into::<HtmlTextAreaElement>().unwrap().value())
    });

    html! {
        <textarea ref={textarea_node_ref}
            id={id.clone()}
            {class}
            {onchange}
            {oninput}
            rows={rows.unwrap_or(1).to_string()}>
        </textarea>
    }
}
```

Another change: make the post_render msg running in `rendered` lifecycle to keep consistency.

Important note, please translate it:

由于我英语不好，上面的表述可能无法正确反映我的想法，这里用中文重新表述一下，如果您通过翻译软件翻译了这段文字，请以这段文字的意思为准。

我想用Yew的FunctionComponent来写一个可以自动调节行高的TextArea组件，但遇到了一个问题，如果每次组件渲染时都调用`adjust_textarea_height(textarea)`调整TextArea的高度，那么这个组件只能随换行增加高度，但在删除行后，组件不会减少高度，这不符合我的想法。

通过测试，如果只在组件首次渲染时调用这个方法调用TextArea高度，那么组件就可以实现自动增加或减少高度。但`use_effect`和`use_effect_deps`都无法获得组件是否是首次渲染的信息，只能自己维护一个状态（如上面的代码片段），但这个信息其实在Yew框架中是有的（而且是准确的）。

通过查看源码，我发现无法通过自定义hook来获取这个信息，于是产生了对框架进行调整的想法。

在代码调整过程中，我发现由 `post_render` 方法发送的消息会通过`ctx.link().send_message(msg)`转给`update`来执行，而且还可以通过消息返回的参数决定是否需要重新渲染组件，这与组件的`rendered`这个生命周期的约定不太一致，所以修改了post_render消息的格式，不需要返回是否需要重新渲染的信息。