### PR TITLE
Implementation of portals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "examples/multi_thread",
   "examples/nested_list",
   "examples/node_refs",
+  "examples/portals",
   "examples/pub_sub",
   "examples/router",
   "examples/store",

--- a/examples/portals/Cargo.toml
+++ b/examples/portals/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "portals"
+version = "0.1.0"
+authors = ["Martin Molzer <worldsbegin@gmx.de>"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+yew = { path = "../../packages/yew" }
+gloo-utils = "0.1"
+
+[dependencies.web-sys]
+version = "0.3"
+features = ["Document", "Element", "Node", "HtmlHeadElement"]

--- a/examples/portals/Cargo.toml
+++ b/examples/portals/Cargo.toml
@@ -8,7 +8,16 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 yew = { path = "../../packages/yew" }
 gloo-utils = "0.1"
+wasm-bindgen = "0.2"
 
 [dependencies.web-sys]
 version = "0.3"
-features = ["Document", "Element", "Node", "HtmlHeadElement"]
+features = [
+    "Document",
+    "Element",
+    "Node",
+    "HtmlHeadElement",
+    "ShadowRoot",
+    "ShadowRootInit",
+    "ShadowRootMode",
+]

--- a/examples/portals/README.md
+++ b/examples/portals/README.md
@@ -1,0 +1,10 @@
+# Portals Example
+
+[![Demo](https://img.shields.io/website?label=demo&url=https%3A%2F%2Fexamples.yew.rs%2Fportals)](https://examples.yew.rs/portals)
+
+This example renders elements into out-of-tree nodes with the help of portals.
+
+## Concepts
+
+- Manually creating `Html` without the `html!` macro.
+- Using `web-sys` to manipulate the DOM.

--- a/examples/portals/index.html
+++ b/examples/portals/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Yew • Portals</title>
+  </head>
+
+  <body></body>
+</html>

--- a/examples/portals/src/main.rs
+++ b/examples/portals/src/main.rs
@@ -1,4 +1,71 @@
-use yew::{create_portal, html, Component, Context, Html};
+use wasm_bindgen::JsCast;
+use web_sys::{Element, ShadowRootInit, ShadowRootMode};
+use yew::{create_portal, html, Children, Component, Context, Html, NodeRef, Properties};
+
+#[derive(Properties, PartialEq)]
+pub struct ShadowDOMProps {
+    #[prop_or_default]
+    pub children: Children,
+}
+
+pub struct ShadowDOMHost {
+    host_ref: NodeRef,
+    inner_host: Option<Element>,
+}
+
+impl Component for ShadowDOMHost {
+    type Message = ();
+    type Properties = ShadowDOMProps;
+
+    fn create(_: &Context<Self>) -> Self {
+        Self {
+            host_ref: NodeRef::default(),
+            inner_host: None,
+        }
+    }
+
+    fn rendered(&mut self, ctx: &Context<Self>, first_render: bool) {
+        if first_render {
+            let shadow_root = self
+                .host_ref
+                .get()
+                .expect("rendered host")
+                .unchecked_into::<Element>()
+                .attach_shadow(&ShadowRootInit::new(ShadowRootMode::Closed))
+                .expect("installing shadow root succeeds");
+            let inner_host = gloo_utils::document()
+                .create_element("div")
+                .expect("can create inner wrapper");
+            shadow_root
+                .append_child(&inner_host)
+                .expect("can attach inner host");
+            self.inner_host = Some(inner_host);
+            ctx.link().send_message(());
+        }
+    }
+
+    fn update(&mut self, _: &Context<Self>, _: Self::Message) -> bool {
+        true
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let contents = if let Some(ref inner_host) = self.inner_host {
+            create_portal(
+                html! {
+                    {for ctx.props().children.iter()}
+                },
+                inner_host.clone(),
+            )
+        } else {
+            html! { <></> }
+        };
+        html! {
+            <div ref={self.host_ref.clone()}>
+                {contents}
+            </div>
+        }
+    }
+}
 
 pub struct Model {
     pub style_html: Html,
@@ -26,6 +93,9 @@ impl Component for Model {
             <>
             {self.style_html.clone()}
             <p>{"This paragraph is colored red, and its style is mounted into "}<pre>{"document.head"}</pre>{" with a portal"}</p>
+            <ShadowDOMHost>
+                <p>{"This paragraph is rendered in a shadow dom and thus not affected by the surrounding styling context"}</p>
+            </ShadowDOMHost>
             </>
         }
     }

--- a/examples/portals/src/main.rs
+++ b/examples/portals/src/main.rs
@@ -1,0 +1,36 @@
+use yew::{create_portal, html, Component, Context, Html};
+
+pub struct Model {
+    pub style_html: Html,
+}
+
+impl Component for Model {
+    type Message = ();
+    type Properties = ();
+
+    fn create(_ctx: &Context<Self>) -> Self {
+        let document_head = gloo_utils::document()
+            .head()
+            .expect("head element to be present");
+        let style_html = create_portal(
+            html! {
+                <style>{"p { color: red; }"}</style>
+            },
+            document_head.into(),
+        );
+        Self { style_html }
+    }
+
+    fn view(&self, _ctx: &Context<Self>) -> Html {
+        html! {
+            <>
+            {self.style_html.clone()}
+            <p>{"This paragraph is colored red, and its style is mounted into "}<pre>{"document.head"}</pre>{" with a portal"}</p>
+            </>
+        }
+    }
+}
+
+fn main() {
+    yew::start_app::<Model>();
+}

--- a/packages/website-test/Cargo.toml
+++ b/packages/website-test/Cargo.toml
@@ -23,6 +23,7 @@ yew-router = { path = "../../packages/yew-router/" }
 [dev-dependencies.web-sys]
 version = "0.3"
 features = [
+    "Document",
     "Element",
     "EventTarget",
     "HtmlElement",

--- a/packages/website-test/build.rs
+++ b/packages/website-test/build.rs
@@ -16,12 +16,17 @@ fn main() {
     let pattern = format!("{}/../../website/docs/**/*.md", home);
     let base = format!("{}/../../website", home);
     let base = Path::new(&base).canonicalize().unwrap();
+    let dir_pattern = format!("{}/../../website/docs/**", home);
+    for dir in glob(&dir_pattern).unwrap() {
+        println!("cargo:rerun-if-changed={}", dir.unwrap().display());
+    }
 
     let mut level = Level::default();
 
     for entry in glob(&pattern).unwrap() {
         let path = entry.unwrap();
         let path = Path::new(&path).canonicalize().unwrap();
+        println!("cargo:rerun-if-changed={}", path.display());
         let rel = path.strip_prefix(&base).unwrap();
 
         let mut parts = vec![];

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -10,11 +10,11 @@ pub use component::*;
 pub use conversion::*;
 pub use listener::*;
 
-use crate::virtual_dom::VNode;
+use crate::virtual_dom::{VNode, VPortal};
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::JsValue;
-use web_sys::Node;
+use web_sys::{Element, Node};
 
 /// A type which expected as a result of `view` function implementation.
 pub type Html = VNode;
@@ -134,6 +134,14 @@ impl NodeRef {
         this.node = existing.node.clone();
         this.link = existing.link.clone();
     }
+}
+
+/// Render children into a DOM node that exists outside the hierarchy of the parent
+/// component.
+/// ## Relevant examples
+/// - [Portals](https://github.com/yewstack/yew/tree/master/examples/portals)
+pub fn create_portal(child: Html, host: Element) -> Html {
+    VNode::VPortal(VPortal::new(child, host))
 }
 
 #[cfg(test)]

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -387,7 +387,8 @@ pub mod prelude {
     pub use crate::context::ContextProvider;
     pub use crate::events::*;
     pub use crate::html::{
-        Children, ChildrenWithProps, Classes, Component, Context, Html, NodeRef, Properties,
+        create_portal, Children, ChildrenWithProps, Classes, Component, Context, Html, NodeRef,
+        Properties,
     };
     pub use crate::macros::{classes, html, html_nested};
 

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -11,6 +11,8 @@ pub mod vlist;
 #[doc(hidden)]
 pub mod vnode;
 #[doc(hidden)]
+pub mod vportal;
+#[doc(hidden)]
 pub mod vtag;
 #[doc(hidden)]
 pub mod vtext;
@@ -30,6 +32,8 @@ pub use self::vcomp::{VChild, VComp};
 pub use self::vlist::VList;
 #[doc(inline)]
 pub use self::vnode::VNode;
+#[doc(inline)]
+pub use self::vportal::VPortal;
 #[doc(inline)]
 pub use self::vtag::VTag;
 #[doc(inline)]

--- a/packages/yew/src/virtual_dom/vnode.rs
+++ b/packages/yew/src/virtual_dom/vnode.rs
@@ -1,6 +1,6 @@
 //! This module contains the implementation of abstract virtual node.
 
-use super::{Key, VChild, VComp, VDiff, VList, VTag, VText};
+use super::{Key, VChild, VComp, VDiff, VList, VPortal, VTag, VText};
 use crate::html::{AnyScope, Component, NodeRef};
 use gloo::console;
 use std::cmp::PartialEq;
@@ -21,6 +21,8 @@ pub enum VNode {
     VComp(VComp),
     /// A holder for a list of other nodes.
     VList(VList),
+    /// A portal to another part of the document
+    VPortal(VPortal),
     /// A holder for any `Node` (necessary for replacing node).
     VRef(Node),
 }
@@ -33,6 +35,7 @@ impl VNode {
             VNode::VRef(_) => None,
             VNode::VTag(vtag) => vtag.key.clone(),
             VNode::VText(_) => None,
+            VNode::VPortal(vportal) => vportal.node.key(),
         }
     }
 
@@ -43,6 +46,7 @@ impl VNode {
             VNode::VList(vlist) => vlist.key.is_some(),
             VNode::VRef(_) | VNode::VText(_) => false,
             VNode::VTag(vtag) => vtag.key.is_some(),
+            VNode::VPortal(vportal) => vportal.node.has_key(),
         }
     }
 
@@ -58,6 +62,7 @@ impl VNode {
             VNode::VComp(vcomp) => vcomp.node_ref.get(),
             VNode::VList(vlist) => vlist.get(0).and_then(VNode::first_node),
             VNode::VRef(node) => Some(node.clone()),
+            VNode::VPortal(vportal) => vportal.sibling_ref.get(),
         }
     }
 
@@ -88,6 +93,7 @@ impl VNode {
                 .expect("VList is not mounted")
                 .unchecked_first_node(),
             VNode::VRef(node) => node.clone(),
+            VNode::VPortal(_) => panic!("portals have no first node, they are empty inside"),
         }
     }
 
@@ -104,6 +110,7 @@ impl VNode {
                     .expect("VComp has no root vnode")
                     .move_before(parent, next_sibling);
             }
+            VNode::VPortal(_) => {} // no need to move portals
             _ => super::insert_node(&self.unchecked_first_node(), parent, next_sibling.as_ref()),
         };
     }
@@ -122,6 +129,7 @@ impl VDiff for VNode {
                     console::warn!("Node not found to remove VRef");
                 }
             }
+            VNode::VPortal(ref mut vportal) => vportal.detach(parent),
         }
     }
 
@@ -154,6 +162,9 @@ impl VDiff for VNode {
                 }
                 super::insert_node(node, parent, next_sibling.get().as_ref());
                 NodeRef::new(node.clone())
+            }
+            VNode::VPortal(ref mut vportal) => {
+                vportal.apply(parent_scope, parent, next_sibling, ancestor)
             }
         }
     }
@@ -225,6 +236,7 @@ impl fmt::Debug for VNode {
             VNode::VComp(ref vcomp) => vcomp.fmt(f),
             VNode::VList(ref vlist) => vlist.fmt(f),
             VNode::VRef(ref vref) => write!(f, "VRef ( \"{}\" )", crate::utils::print_node(vref)),
+            VNode::VPortal(ref vportal) => vportal.fmt(f),
         }
     }
 }

--- a/packages/yew/src/virtual_dom/vnode.rs
+++ b/packages/yew/src/virtual_dom/vnode.rs
@@ -62,7 +62,7 @@ impl VNode {
             VNode::VComp(vcomp) => vcomp.node_ref.get(),
             VNode::VList(vlist) => vlist.get(0).and_then(VNode::first_node),
             VNode::VRef(node) => Some(node.clone()),
-            VNode::VPortal(vportal) => vportal.sibling_ref.get(),
+            VNode::VPortal(vportal) => vportal.next_sibling(),
         }
     }
 

--- a/packages/yew/src/virtual_dom/vportal.rs
+++ b/packages/yew/src/virtual_dom/vportal.rs
@@ -1,0 +1,147 @@
+//! This module contains the implementation of a portal `VPortal`.
+
+use super::{VDiff, VNode};
+use crate::html::{AnyScope, NodeRef};
+use web_sys::Element;
+
+#[derive(Debug, Clone)]
+pub struct VPortal {
+    /// The element under which the content is inserted.
+    pub host: Element,
+    /// The next sibling after the inserted content
+    pub next_sibling: NodeRef,
+    /// The inserted node
+    pub node: Box<VNode>,
+    /// The next sibling after the portal. Set when rendered
+    pub sibling_ref: NodeRef,
+}
+
+impl VDiff for VPortal {
+    fn detach(&mut self, _: &Element) {
+        self.node.detach(&self.host);
+        self.sibling_ref.set(None);
+    }
+
+    fn apply(
+        &mut self,
+        parent_scope: &AnyScope,
+        parent: &Element,
+        next_sibling: NodeRef,
+        ancestor: Option<VNode>,
+    ) -> NodeRef {
+        let inner_ancestor = match ancestor {
+            Some(VNode::VPortal(old_portal)) => {
+                let VPortal {
+                    host: old_host,
+                    next_sibling: old_sibling,
+                    mut node,
+                    ..
+                } = old_portal;
+                if old_host != self.host {
+                    // Remount the inner node somewhere else instead of diffing
+                    node.detach(&old_host);
+                    None
+                } else if old_sibling != self.next_sibling {
+                    // Move the node, but keep the state
+                    node.move_before(&self.host, &self.next_sibling.get());
+                    Some(*node)
+                } else {
+                    Some(*node)
+                }
+            }
+            Some(mut node) => {
+                node.detach(parent);
+                None
+            }
+            None => None,
+        };
+
+        self.node.apply(
+            parent_scope,
+            &self.host,
+            self.next_sibling.clone(),
+            inner_ancestor,
+        );
+        self.sibling_ref = next_sibling.clone();
+        next_sibling
+    }
+}
+
+impl VPortal {
+    pub fn create(host: Element, content: VNode) -> Self {
+        Self {
+            host,
+            next_sibling: NodeRef::default(),
+            node: Box::new(content),
+            sibling_ref: NodeRef::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod layout_tests {
+    extern crate self as yew;
+
+    use crate::html;
+    use crate::virtual_dom::layout_tests::{diff_layouts, TestLayout};
+    use crate::virtual_dom::VNode;
+    use yew::virtual_dom::VPortal;
+
+    #[cfg(feature = "wasm_test")]
+    use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+    #[cfg(feature = "wasm_test")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[test]
+    fn diff() {
+        let mut layouts = vec![];
+        let first_target = gloo_utils::document().create_element("i").unwrap();
+        let second_target = gloo_utils::document().create_element("o").unwrap();
+
+        layouts.push(TestLayout {
+            name: "Portal - first target",
+            node: html! {
+                <div>
+                    {VNode::VRef(first_target.clone().into())}
+                    {VNode::VRef(second_target.clone().into())}
+                    {VNode::VPortal(VPortal::create(
+                        first_target.clone(),
+                        html! { {"PORTAL"} }
+                    ))}
+                    {"AFTER"}
+                </div>
+            },
+            expected: "<div><i>PORTAL</i><o></o>AFTER</div>",
+        });
+        layouts.push(TestLayout {
+            name: "Portal - second target",
+            node: html! {
+                <div>
+                    {VNode::VRef(first_target.clone().into())}
+                    {VNode::VRef(second_target.clone().into())}
+                    {VNode::VPortal(VPortal::create(
+                        second_target.clone(),
+                        html! { {"PORTAL"} }
+                    ))}
+                    {"AFTER"}
+                </div>
+            },
+            expected: "<div><i></i><o>PORTAL</o>AFTER</div>",
+        });
+        layouts.push(TestLayout {
+            name: "Portal replaced by text",
+            node: html! {
+                <div>
+                    {VNode::VRef(first_target.clone().into())}
+                    {VNode::VRef(second_target.clone().into())}
+                    {"FOO"}
+                    {"AFTER"}
+                </div>
+            },
+            expected: "<div><i></i><o></o>FOOAFTER</div>",
+        });
+
+        diff_layouts(layouts)
+    }
+}

--- a/website/docs/advanced-topics/portals.md
+++ b/website/docs/advanced-topics/portals.md
@@ -1,0 +1,41 @@
+---
+title: "Portals"
+description: "Rendering into out-of-tree DOM nodes"
+---
+
+## How to think about portals?
+
+Portals provide a first-class way to render children into a DOM node that exists outside the DOM hierarchy of the parent component.
+`yew::create_portal(child, host)` returns a `Html` value that renders `child` not hierarchically under its parent component,
+but as a child of the `host` element.
+
+## Usage
+
+Typical uses of portals can include modal dialogs and hovercards, as well as more technical applications such as controlling the contents of an element's [`shadowRoot`](https://developer.mozilla.org/en-US/docs/Web/API/Element/shadowRoot), appending stylesheets to the surrounding document's `<head>` and collecting referenced elements inside a central `<defs>` element of an `<svg>`.
+
+Note that `yew::create_portal` is a rather low-level building block, on which other components should be built that provide the interface for your specific use case. As an example, here is a simple modal dialogue that renders its `children` into an element outside `yew`'s control, identified by the `id="modal_host"`.
+
+```rust
+use yew::{html, create_portal, function_component, Children, Properties};
+
+#[derive(Properties, PartialEq)]
+pub struct ModalProps {
+    #[prop_or_default]
+    pub children: Children,
+}
+
+#[function_component(Modal)]
+fn modal(props: &ModalProps) -> Html {
+    let modal_host = gloo_utils::document()
+        .get_element_by_id("modal_host")
+        .expect("a #modal_host element");
+
+    create_portal(
+        html!{ {for props.children.iter()} },
+        modal_host.into(),
+    )
+}
+```
+
+## Further reading
+- [Portals example](https://github.com/yewstack/yew/tree/master/examples/portals)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -91,6 +91,7 @@ module.exports = {
             items: [
                 "advanced-topics/how-it-works",
                 "advanced-topics/optimizations",
+                "advanced-topics/portals",
             ]
         },
         {


### PR DESCRIPTION
#### Description

Portals, as provided in React with `React.createPortal`, are a first-class way to render children into a DOM node that exists outside the DOM hierarchy of the parent component.

There are two major properties an implementation should have.
1. An arbitrary, third-party element can be used to mount a subtree of the virtual dom.
2. Event bubbling (and moving the exit of the portal) should respect (and preserve) the virtual dom.

This POC contains the primitive `VNode::VPortal` and `VPortal::create` to implement components that for example mount their children into an iframe (have to wait for the document to be ready), or to attach a shadow dom to an element. Yet, the implementation as components is not contained in this PR. Not sure where this part belongs, actually, probably in third-party libs or utils.

Fixes #1992

#### Checklist

- [x] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a feature, my tests prove that the feature works -->

PS: ~I'm running `cargo make pr-flow` and getting erros comparing compile-errs in `yew-macro/tests/html_macro`, everything else works, including the tests in this PR. Can someone tell me what I might be doing wrong?~ After running `cargo update`, this also works locally.