### PR TITLE
Implements into_string() for AttrValue

### DIFF
--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -97,7 +97,11 @@ impl AsRef<str> for AttrValue {
 
 impl fmt::Display for AttrValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        match self {
+            AttrValue::Static(s) => write!(f, "{}", s),
+            AttrValue::Owned(s) => write!(f, "{}", s),
+            AttrValue::Rc(s) => write!(f, "{}", s),
+        }
     }
 }
 


### PR DESCRIPTION
#### Description

AttrValue::into_string()

Consumes the AttrValue and returns the owned String from the AttrValue whenever possible.
For AttrValue::Rc the `<str>` is cloned to String in case there are other Rc or Weak pointers to the same allocation.

Fixes #2152

#### Checklist

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
