### PR TITLE
Fix uncought build errors

### DIFF
--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -252,9 +252,6 @@ mod tests {
     #[derive(Clone, Properties, Default, PartialEq)]
     struct Props {
         lifecycle: Rc<RefCell<Vec<String>>>,
-        #[allow(dead_code)]
-        #[cfg(feature = "wasm_test")]
-        create_message: Option<bool>,
         update_message: RefCell<Option<bool>>,
         view_message: RefCell<Option<bool>>,
         rendered_message: RefCell<Option<bool>>,
@@ -270,10 +267,6 @@ mod tests {
 
         fn create(ctx: &Context<Self>) -> Self {
             ctx.props().lifecycle.borrow_mut().push("create".into());
-            #[cfg(feature = "wasm_test")]
-            if let Some(msg) = ctx.props().create_message {
-                ctx.link().send_message(msg);
-            }
             Comp {
                 lifecycle: Rc::clone(&ctx.props().lifecycle),
             }
@@ -348,8 +341,6 @@ mod tests {
         test_lifecycle(
             Props {
                 lifecycle: lifecycle.clone(),
-                #[cfg(feature = "wasm_test")]
-                create_message: Some(false),
                 ..Props::default()
             },
             &[
@@ -429,8 +420,6 @@ mod tests {
         test_lifecycle(
             Props {
                 lifecycle,
-                #[cfg(feature = "wasm_test")]
-                create_message: Some(true),
                 update_message: RefCell::new(Some(true)),
                 ..Props::default()
             },

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -661,7 +661,7 @@ mod benchmarks {
         let static_ = Attributes::Static(&[]);
         let dynamic = Attributes::Dynamic {
             keys: &[],
-            values: vec![],
+            values: Box::new([]),
         };
         let map = Attributes::IndexMap(Default::default());
 


### PR DESCRIPTION
#### Description

In some uncommon configurations there is 1 clippy warning regarding `create_message` not being used and a build error in a wasm_bindgen_test

This PR fixes those

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
