### PR TITLE
Remove unused braces from `html!` macro

### DIFF
--- a/packages/yew-macro/src/html_tree/html_component.rs
+++ b/packages/yew-macro/src/html_tree/html_component.rs
@@ -119,10 +119,8 @@ impl ToTokens for HtmlComponent {
         };
 
         tokens.extend(quote_spanned! {ty.span()=>
-            {
-                #[allow(clippy::unit_arg)]
-                ::yew::virtual_dom::VChild::<#ty>::new(#build_props, #node_ref, #key)
-            }
+            #[allow(clippy::unit_arg)]
+            ::yew::virtual_dom::VChild::<#ty>::new(#build_props, #node_ref, #key)
         });
     }
 }

--- a/packages/yew-macro/src/html_tree/html_component.rs
+++ b/packages/yew-macro/src/html_tree/html_component.rs
@@ -111,8 +111,11 @@ impl ToTokens for HtmlComponent {
         let key = if let Some(key) = &special_props.key {
             let value = &key.value;
             quote_spanned! {value.span()=>
-                #[allow(clippy::useless_conversion)]
-                Some(::std::convert::Into::<::yew::virtual_dom::Key>::into(#value))
+                #[allow(unused_braces)]
+                {
+                    #[allow(clippy::useless_conversion)]
+                    Some(::std::convert::Into::<::yew::virtual_dom::Key>::into(#value))
+                }
             }
         } else {
             quote! { ::std::option::Option::None }


### PR DESCRIPTION
#### Description

Remove unused braces from the macro's generated code.

Fixes https://github.com/yewstack/yew/issues/2157

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
