### PR TITLE
Remove extra braces in html_nested macro

### DIFF
--- a/packages/yew-macro/Makefile.toml
+++ b/packages/yew-macro/Makefile.toml
@@ -2,7 +2,8 @@
 clear = true
 toolchain = "1.51"
 command = "cargo"
-args = ["test"]
+# test target can be optionally specified like `cargo make test html_macro`,
+args = ["test", "${@}"]
 
 [tasks.test-overwrite]
 extend = "test"

--- a/packages/yew-macro/src/html_tree/html_component.rs
+++ b/packages/yew-macro/src/html_tree/html_component.rs
@@ -120,8 +120,8 @@ impl ToTokens for HtmlComponent {
 
         tokens.extend(quote_spanned! {ty.span()=>
             {
-                #[allow(clippy::unit_arg)]
-                ::yew::virtual_dom::VChild::<#ty>::new(#build_props, #node_ref, #key)
+                let __yew_props = #build_props;
+                ::yew::virtual_dom::VChild::<#ty>::new(__yew_props, #node_ref, #key)
             }
         });
     }

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -363,6 +363,9 @@ impl ToTokens for HtmlElement {
                 // doesn't return a valid value
                 quote_spanned! {expr.span()=> {
                     #[allow(unused_braces)]
+                    // e.g. html!{<@{"div"}/>} will set `#expr` to `{"div"}`
+                    // (note the extra braces). Hence the need for the `allow`.
+                    // Anyways to remove the braces?
                     let mut #vtag_name = ::std::convert::Into::<
                         ::std::borrow::Cow::<'static, ::std::primitive::str>
                     >::into(#expr);

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -362,6 +362,7 @@ impl ToTokens for HtmlElement {
                 // this way we get a nice error message (with the correct span) when the expression
                 // doesn't return a valid value
                 quote_spanned! {expr.span()=> {
+                    #[allow(unused_braces)]
                     let mut #vtag_name = ::std::convert::Into::<
                         ::std::borrow::Cow::<'static, ::std::primitive::str>
                     >::into(#expr);

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -346,7 +346,6 @@ impl ToTokens for HtmlElement {
                 }
             }
             TagName::Expr(name) => {
-                #[allow(unused_braces)]
                 let vtag = Ident::new("__yew_vtag", name.span());
                 let expr = &name.expr;
                 let vtag_name = Ident::new("__yew_vtag_name", expr.span());

--- a/packages/yew-macro/src/html_tree/mod.rs
+++ b/packages/yew-macro/src/html_tree/mod.rs
@@ -168,7 +168,7 @@ impl ToTokens for HtmlRootVNode {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let new_tokens = self.0.to_token_stream();
         tokens.extend(quote! {{
-            #[allow(clippy::useless_conversion, unused_braces)]
+            #[allow(clippy::useless_conversion)]
             <::yew::virtual_dom::VNode as ::std::convert::From<_>>::from(#new_tokens)
         }});
     }

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -1,5 +1,5 @@
 error[E0412]: cannot find type `INVALID` in this scope
-  --> $DIR/generic-props-fail.rs:25:19
+  --> tests/function_component_attr/generic-props-fail.rs:25:19
    |
 20 | fn compile_fail() {
    |                - help: you might be missing a type parameter: `<INVALID>`
@@ -8,7 +8,7 @@ error[E0412]: cannot find type `INVALID` in this scope
    |                   ^^^^^^^ not found in this scope
 
 error[E0599]: no method named `build` found for struct `PropsBuilder<PropsBuilderStep_missing_required_prop_a>` in the current scope
-  --> $DIR/generic-props-fail.rs:22:14
+  --> tests/function_component_attr/generic-props-fail.rs:22:14
    |
 3  | #[derive(Clone, Properties, PartialEq)]
    |                 ---------- method `build` not found for this
@@ -16,8 +16,16 @@ error[E0599]: no method named `build` found for struct `PropsBuilder<PropsBuilde
 22 |     html! { <Comp<Props> /> };
    |              ^^^^ method not found in `PropsBuilder<PropsBuilderStep_missing_required_prop_a>`
 
+error[E0277]: the trait bound `MissingTypeBounds: yew::Properties` is not satisfied
+  --> tests/function_component_attr/generic-props-fail.rs:27:14
+   |
+27 |     html! { <Comp<MissingTypeBounds> /> };
+   |              ^^^^ the trait `yew::Properties` is not implemented for `MissingTypeBounds`
+   |
+   = note: required because of the requirements on the impl of `FunctionProvider` for `comp<MissingTypeBounds>`
+
 error[E0599]: the function or associated item `new` exists for struct `VChild<FunctionComponent<comp<MissingTypeBounds>>>`, but its trait bounds were not satisfied
-  --> $DIR/generic-props-fail.rs:27:14
+  --> tests/function_component_attr/generic-props-fail.rs:27:14
    |
 27 |     html! { <Comp<MissingTypeBounds> /> };
    |              ^^^^ function or associated item cannot be called on `VChild<FunctionComponent<comp<MissingTypeBounds>>>` due to unsatisfied trait bounds
@@ -30,22 +38,14 @@ error[E0599]: the function or associated item `new` exists for struct `VChild<Fu
    = note: the following trait bounds were not satisfied:
            `FunctionComponent<comp<MissingTypeBounds>>: yew::Component`
 
-error[E0277]: the trait bound `MissingTypeBounds: yew::Properties` is not satisfied
-  --> $DIR/generic-props-fail.rs:27:14
-   |
-27 |     html! { <Comp<MissingTypeBounds> /> };
-   |              ^^^^ the trait `yew::Properties` is not implemented for `MissingTypeBounds`
-   |
-   = note: required because of the requirements on the impl of `FunctionProvider` for `comp<MissingTypeBounds>`
-
 error[E0107]: missing generics for type alias `Comp`
-  --> $DIR/generic-props-fail.rs:30:14
+  --> tests/function_component_attr/generic-props-fail.rs:30:14
    |
 30 |     html! { <Comp /> };
    |              ^^^^ expected 1 type argument
    |
 note: type alias defined here, with 1 type parameter: `P`
-  --> $DIR/generic-props-fail.rs:8:22
+  --> tests/function_component_attr/generic-props-fail.rs:8:22
    |
 8  | #[function_component(Comp)]
    |                      ^^^^

--- a/packages/yew-macro/tests/html_macro/as-return-value-pass.rs
+++ b/packages/yew-macro/tests/html_macro/as-return-value-pass.rs
@@ -48,10 +48,14 @@ impl ::yew::Component for MyComponent {
     }
 }
 
+// can test "unused braces" warning inside the macro
+// https://github.com/yewstack/yew/issues/2157
 fn make_my_component()-> ::yew::virtual_dom::VChild<MyComponent>{
     ::yew::html_nested!{<MyComponent/>}
 }
 
+// can test "unused braces" warning inside the macro
+// https://github.com/yewstack/yew/issues/2157
 fn make_my_component_html()-> ::yew::Html{
     ::yew::html!{<MyComponent/>}
 }

--- a/packages/yew-macro/tests/html_macro/component-unimplemented-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-unimplemented-fail.stderr
@@ -1,5 +1,11 @@
+error[E0277]: the trait bound `Unimplemented: yew::Component` is not satisfied
+ --> tests/html_macro/component-unimplemented-fail.rs:6:14
+  |
+6 |     html! { <Unimplemented /> };
+  |              ^^^^^^^^^^^^^ the trait `yew::Component` is not implemented for `Unimplemented`
+
 error[E0599]: the function or associated item `new` exists for struct `VChild<Unimplemented>`, but its trait bounds were not satisfied
- --> $DIR/component-unimplemented-fail.rs:6:14
+ --> tests/html_macro/component-unimplemented-fail.rs:6:14
   |
 3 | struct Unimplemented;
   | --------------------- doesn't satisfy `Unimplemented: yew::Component`
@@ -9,9 +15,3 @@ error[E0599]: the function or associated item `new` exists for struct `VChild<Un
   |
   = note: the following trait bounds were not satisfied:
           `Unimplemented: yew::Component`
-
-error[E0277]: the trait bound `Unimplemented: yew::Component` is not satisfied
- --> $DIR/component-unimplemented-fail.rs:6:14
-  |
-6 |     html! { <Unimplemented /> };
-  |              ^^^^^^^^^^^^^ the trait `yew::Component` is not implemented for `Unimplemented`

--- a/packages/yew-macro/tests/html_macro/html-nested-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-nested-pass.rs
@@ -52,4 +52,8 @@ fn make_my_component()-> ::yew::virtual_dom::VChild<MyComponent>{
     ::yew::html_nested!{<MyComponent/>}
 }
 
+fn make_my_component_html()-> ::yew::Html{
+    ::yew::html!{<MyComponent/>}
+}
+
 fn main(){}

--- a/packages/yew-macro/tests/html_macro/html-nested-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-nested-pass.rs
@@ -1,0 +1,55 @@
+#![no_implicit_prelude]
+
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
+pub struct MyComponent;
+impl ::yew::Component for MyComponent {
+    type Message = ();
+    type Properties = ();
+    fn create(_ctx: &::yew::Context<Self>) -> Self {
+        ::std::unimplemented!()
+    }
+    fn view(&self, _ctx: &::yew::Context<Self>) -> ::yew::Html {
+        ::std::unimplemented!()
+    }
+}
+
+fn make_my_component()-> ::yew::virtual_dom::VChild<MyComponent>{
+    ::yew::html_nested!{<MyComponent/>}
+}
+
+fn main(){}


### PR DESCRIPTION
#### Description

Refactored the `html_nested` macro to avoid extra braces

Fixes #2157

#### Checklist


- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
