### PR TITLE
Respect <base> href in Links href

### DIFF
--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -1,10 +1,12 @@
+use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use serde::Serialize;
 use wasm_bindgen::UnwrapThrowExt;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
-use crate::history::History;
+use crate::history::{BrowserHistory, History};
 use crate::scope_ext::RouterScopeExt;
 use crate::Routable;
 
@@ -90,9 +92,13 @@ where
             e.prevent_default();
             Msg::OnClick
         });
+        let href: AttrValue = match BrowserHistory::route_to_url(to) {
+            Cow::Owned(href) => href.into(),
+            Cow::Borrowed(href) => href.into(),
+        };
         html! {
             <a class={classes}
-                href={to.to_path()}
+                {href}
                 {onclick}
                 {disabled}
             >

--- a/packages/yew-router/src/history.rs
+++ b/packages/yew-router/src/history.rs
@@ -367,7 +367,7 @@ impl BrowserHistory {
         Self::default()
     }
 
-    fn route_to_url(route: impl Routable) -> Cow<'static, str> {
+    pub(crate) fn route_to_url(route: impl Routable) -> Cow<'static, str> {
         let base = base_url();
         let url = route.to_path();
 


### PR DESCRIPTION
#### Description

With this PR `Link<impl Routable>` sets the `href` attribute taking into account a given base path, in the same manner as the `BrowserHistory` component does. This should fix some screen reader setups.

Take for example the [router example](https://examples.yew.rs/router/posts). Hovering over the "Posts" link in the app bar should say `https://examples.yew.rs/router/posts` but before this patch displays `https://examples.yew.rs/posts` - navigation works fine in both cases though.

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests