### PR TITLE
Refactor vlist to use less macros and unsafe

### DIFF
--- a/examples/web_worker_fib/Cargo.toml
+++ b/examples/web_worker_fib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yew-worker-fib"
 version = "0.1.0"
 edition = "2018"
-author = "Shrey Somaiya"
+authors = ["Shrey Somaiya"]
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
#### Description

Refactors `yew::virtual_dom::vlist` to be more idiomatic rust.

An `ElementWriter` struct keeps track of the place where to insert elements, instead of the previous `apply!` macro.
The `Vec::drain` API is used to consume ancestors. This removes a previous worry where panic doesn't drop the remaining elements.

No changes to algorithmic nor runtime behaviour in this PR.

Additional small fix, cause I noticed a warning: author -> authors in `web_worker_fib`.

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
