### PR TITLE
Update web_worker_fib authors

### DIFF
--- a/examples/web_worker_fib/Cargo.toml
+++ b/examples/web_worker_fib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yew-worker-fib"
 version = "0.1.0"
 edition = "2018"
-authors = ["Shrey Somaiya"]
+authors = ["Shrey Somaiya", "Zac Kologlu"]
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Adding insou22 to the authors cargo TOML for the web_worker_fib example, as they wrote the majority of the original example. 
