### PR TITLE
Router docs about set-only components

### DIFF
--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use serde::Serialize;
@@ -92,7 +91,7 @@ where
             e.prevent_default();
             Msg::OnClick
         });
-        let href: AttrValue = BrowserHistory::route_to_url(to).into();
+        let href = BrowserHistory::route_to_url(to).into();
         html! {
             <a class={classes}
                 {href}

--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -91,7 +91,7 @@ where
             e.prevent_default();
             Msg::OnClick
         });
-        let href = BrowserHistory::route_to_url(to);
+        let href: AttrValue = BrowserHistory::route_to_url(to).into();
         html! {
             <a class={classes}
                 {href}

--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -92,10 +92,7 @@ where
             e.prevent_default();
             Msg::OnClick
         });
-        let href: AttrValue = match BrowserHistory::route_to_url(to) {
-            Cow::Owned(href) => href.into(),
-            Cow::Borrowed(href) => href.into(),
-        };
+        let href: AttrValue = BrowserHistory::route_to_url(to).into();
         html! {
             <a class={classes}
                 {href}

--- a/website/docs/concepts/router.md
+++ b/website/docs/concepts/router.md
@@ -232,14 +232,11 @@ pub fn my_component() -> Html {
 }
 ```
 
-:::tip
+:::caution
 The example here uses `Callback::once`. Use a normal callback if the target route can be the same with the route
-the component is in. For example when you have a logo button on every page the that goes back to home when clicked,
-clicking that button twice on home page causes the code to panic because the second click pushes an identical Home route
-and won't trigger a re-render of the element.
-
-In other words, only use `Callback::once` when you are sure the target route is different. Or use normal callbacks only
-to be safe.
+the component is in, or just to play safe. For example, when you have a logo button on every page the that goes back to
+home when clicked, clicking that button twice on home page causes the code to panic because the second click pushes an
+identical Home route and the `use_history` hook won't trigger a re-render.
 :::
 
 If you want to replace the current history instead of pushing a new history onto the stack, use `history.replace()`
@@ -288,6 +285,12 @@ pub fn nav_items() -> Html {
     }
 }
 ```
+
+:::tip 
+If your component only needs to set the route without listening to the changes, instead of the `use_history`
+hook, `BrowserHistory::default()` can be used to acquire the global history instance. The latter also works in agent
+environments.
+:::
 
 ##### Struct Components
 

--- a/website/docs/concepts/router.md
+++ b/website/docs/concepts/router.md
@@ -288,8 +288,8 @@ pub fn nav_items() -> Html {
 
 :::tip 
 If your component only needs to set the route without listening to the changes, instead of the `use_history`
-hook, `BrowserHistory::default()` can be used to acquire the global history instance. The latter also works in agent
-environments.
+hook, `BrowserHistory::default()` can be used to acquire the global history instance. The latter also works in non-threaded agent
+environments (`Context` and `Job`). This is a hack and a more idiomatic hook version will come later.
 :::
 
 ##### Struct Components

--- a/website/docs/concepts/router.md
+++ b/website/docs/concepts/router.md
@@ -234,7 +234,7 @@ pub fn my_component() -> Html {
 
 :::caution
 The example here uses `Callback::once`. Use a normal callback if the target route can be the same with the route
-the component is in, or just to play safe. For example, when you have a logo button on every page the that goes back to
+the component is in, or just to play safe. For example, when you have a logo button on every page, that goes back to
 home when clicked, clicking that button twice on home page causes the code to panic because the second click pushes an
 identical Home route and the `use_history` hook won't trigger a re-render.
 :::

--- a/website/docs/concepts/router.md
+++ b/website/docs/concepts/router.md
@@ -287,9 +287,10 @@ pub fn nav_items() -> Html {
 ```
 
 :::tip 
-If your component only needs to set the route without listening to the changes, instead of the `use_history`
+This is a hack and a more idiomatic hook version will come in the future!
+But if your component only needs to set the route without listening to the changes, instead of the `use_history`
 hook, `BrowserHistory::default()` can be used to acquire the global history instance. The latter also works in non-threaded agent
-environments (`Context` and `Job`). This is a hack and a more idiomatic hook version will come later.
+environments (`Context` and `Job`).
 :::
 
 ##### Struct Components


### PR DESCRIPTION
#### Description

Router docs about set-only components.
Reword router docs, 
use implementation on AttrValue instead of reimplementing.

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

Set-only access to the history is often needed. In some cases, the `Router` and the `Switch` components can do all the work listening and rendering different components. 

Currently, the docs don't mention how to do it in the function component section. This can be done by calling `BrowserHistory::default()` which is part of the public API in the prelude. undocumented too ;)

@futursolo says he will work on a setter-only history API but probably won't make it to the 0.19 release. So I find it necessary to include it here. 

Note the API in the future will probably still use the current `BrowserHistory::default()` implementation, but provide it as an `AnyHistory` instead, for compatibility to other environments.


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [NA] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
