### PR TITLE
Those slashes do not work

### DIFF
--- a/website/docs/concepts/router.md
+++ b/website/docs/concepts/router.md
@@ -199,13 +199,13 @@ The `<Link/>` element also passes its children to the `<a>` element. Consider it
 routes. Except you supply a `to` attribute instead of a `href`. An example usage:
 
 ```rust ,ignore
-<Link<Route> to={Route::Home}>{ "click here to go home" }</Link</Route>>
+<Link<Route> to={Route::Home}>{ "click here to go home" }</Link<Route>>
 ```
 
 Struct variants work as expected too:
 
 ```rust ,ignore
-<Link<Route> to={Route::Post { id: "new-yew-release".to_string() }}>{ "Yew v0.19 out now!" }</Link</Route>>
+<Link<Route> to={Route::Post { id: "new-yew-release".to_string() }}>{ "Yew v0.19 out now!" }</Link<Route>>
 ```
 
 #### History API


### PR DESCRIPTION
#### Description
I had an error in my code that was rather cryptic and I finally found that in the router example there are no closing slashes in the "type of Link"

#### Checklist
 - [x] documentation only
