### PR TITLE
Fix invalid yew-version in depdencies in onboarding-guide

### DIFF
--- a/website/versioned_docs/version-0.19.0/getting-started/build-a-sample-app.md
+++ b/website/versioned_docs/version-0.19.0/getting-started/build-a-sample-app.md
@@ -40,7 +40,7 @@ edition = "2018"
 
 [dependencies]
 # you can check the latest version here: https://crates.io/crates/yew
-yew = "0.19"
+yew = "0.18"
 ```
 
 ### Update main.rs

--- a/website/versioned_docs/version-0.19.0/getting-started/build-a-sample-app.md
+++ b/website/versioned_docs/version-0.19.0/getting-started/build-a-sample-app.md
@@ -40,7 +40,7 @@ edition = "2018"
 
 [dependencies]
 # you can check the latest version here: https://crates.io/crates/yew
-yew = "0.18"
+yew = "0.18.0"
 ```
 
 ### Update main.rs


### PR DESCRIPTION
The currently defined version is `0.19`, yet latest available is `0.18`.

Source: https://crates.io/crates/yew

#### Description

<!-- Please include a summary of the change. -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
