### PR TITLE
Add explicit permisions for publish workflows

### DIFF
--- a/.github/workflows/publish-yew-agent.yml
+++ b/.github/workflows/publish-yew-agent.yml
@@ -1,4 +1,6 @@
 name: Publish yew-agent
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-yew-router.yml
+++ b/.github/workflows/publish-yew-router.yml
@@ -1,4 +1,6 @@
 name: Publish yew-router & yew-router-macro
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-yew.yml
+++ b/.github/workflows/publish-yew.yml
@@ -1,4 +1,6 @@
 name: Publish yew & yew-macro
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
#### Description

When testing previous actions i had my repository settings to allow actions write access.
Our yew repo allows only read access thus explicit permissions need to be specified.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
