### PR TITLE
Fix cargo tomls for release

### DIFF
--- a/packages/yew-agent/Cargo.toml
+++ b/packages/yew-agent/Cargo.toml
@@ -15,7 +15,7 @@ js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 slab = "0.4"
 wasm-bindgen = "0.2"
-yew = { path = "../yew" }
+yew = { version = "0.18.0" }
 wasm-bindgen-futures = "0.4"
 
 [dependencies.web-sys]

--- a/packages/yew-router/Cargo.toml
+++ b/packages/yew-router/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/yewstack/yew"
 wasm_test = []
 
 [dependencies]
-yew = { path = "../yew", default-features= false }
+yew = { version = "0.18.0", default-features= false }
 yew-router-macro = { path = "../yew-router-macro" }
 gloo-utils = "0.1"
 

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/yewstack/yew"
 homepage = "https://github.com/yewstack/yew"
 documentation = "https://docs.rs/yew/"
 license = "MIT OR Apache-2.0"
-readme = "../README.md"
 keywords = ["web", "webasm", "javascript"]
 categories = ["gui", "wasm", "web-programming"]
 description = "A framework for making client-side single-page apps"


### PR DESCRIPTION
#### Description

Build is supposed to fail because yew-agent and yew-router want yew 0.19 version and its going to get fixed when i can release after this PR

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
