### PR TITLE
Raw field names in property structs

### DIFF
--- a/packages/yew-macro/src/derive_props/builder.rs
+++ b/packages/yew-macro/src/derive_props/builder.rs
@@ -8,7 +8,7 @@
 use super::generics::{to_arguments, with_param_bounds, GenericArguments};
 use super::{DerivePropsInput, PropField};
 use proc_macro2::{Ident, Span};
-use quote::{quote, ToTokens};
+use quote::{format_ident, quote, ToTokens};
 
 pub struct PropsBuilder<'a> {
     builder_name: &'a Ident,
@@ -121,9 +121,10 @@ impl PropsBuilder<'_> {
             .filter(|pf| pf.is_required())
             .map(|pf| pf.to_step_name(prefix))
             .collect();
-        step_names.push(Ident::new(
-            &format!("{}PropsBuilder", prefix),
-            prefix.span(),
+        step_names.push(format_ident!(
+            "{}PropsBuilder",
+            prefix,
+            span = prefix.span(),
         ));
         step_names
     }

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -1,6 +1,6 @@
 use super::generics::GenericArguments;
 use proc_macro2::{Ident, Span};
-use quote::{quote, quote_spanned};
+use quote::{format_ident, quote, quote_spanned};
 use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::convert::TryFrom;
 use syn::parse::Result;
@@ -32,9 +32,11 @@ impl PropField {
 
     /// This step name is descriptive to help a developer realize they missed a required prop
     pub fn to_step_name(&self, props_name: &Ident) -> Ident {
-        Ident::new(
-            &format!("{}_missing_required_prop_{}", props_name, self.name),
-            Span::call_site(),
+        format_ident!(
+            "{}_missing_required_prop_{}",
+            props_name,
+            self.name,
+            span = Span::call_site(),
         )
     }
 
@@ -172,7 +174,7 @@ impl PropField {
             Ok(PropAttr::Option)
         } else {
             let ident = named_field.ident.as_ref().unwrap();
-            let wrapped_name = Ident::new(&format!("{}_wrapper", ident), Span::call_site());
+            let wrapped_name = format_ident!("{}_wrapper", ident, span = Span::call_site());
             Ok(PropAttr::Required { wrapped_name })
         }
     }

--- a/packages/yew-macro/src/derive_props/mod.rs
+++ b/packages/yew-macro/src/derive_props/mod.rs
@@ -6,7 +6,7 @@ mod wrapper;
 use builder::PropsBuilder;
 use field::PropField;
 use proc_macro2::{Ident, Span};
-use quote::{quote, ToTokens};
+use quote::{format_ident, quote, ToTokens};
 use std::convert::TryInto;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::{DeriveInput, Generics, Visibility};
@@ -60,13 +60,13 @@ impl ToTokens for DerivePropsInput {
         } = self;
 
         // The wrapper is a new struct which wraps required props in `Option`
-        let wrapper_name = Ident::new(&format!("{}Wrapper", props_name), Span::call_site());
+        let wrapper_name = format_ident!("{}Wrapper", props_name, span = Span::call_site());
         let wrapper = PropsWrapper::new(&wrapper_name, generics, &self.prop_fields);
         tokens.extend(wrapper.into_token_stream());
 
         // The builder will only build if all required props have been set
-        let builder_name = Ident::new(&format!("{}Builder", props_name), Span::call_site());
-        let builder_step = Ident::new(&format!("{}BuilderStep", props_name), Span::call_site());
+        let builder_name = format_ident!("{}Builder", props_name, span = Span::call_site());
+        let builder_step = format_ident!("{}BuilderStep", props_name, span = Span::call_site());
         let builder = PropsBuilder::new(&builder_name, &builder_step, self, &wrapper_name);
         let builder_generic_args = builder.first_step_generic_args();
         tokens.extend(builder.into_token_stream());

--- a/packages/yew-macro/tests/derive_props/pass.rs
+++ b/packages/yew-macro/tests/derive_props/pass.rs
@@ -251,4 +251,12 @@ mod t12 {
     }
 }
 
+mod raw_field_names {
+    #[derive(::yew::Properties, ::std::cmp::PartialEq)]
+    pub struct Props {
+        r#true: u32,
+        r#pointless_raw_name: u32,
+    }
+}
+
 fn main() {}

--- a/packages/yew-macro/tests/html_macro/component-pass.rs
+++ b/packages/yew-macro/tests/html_macro/component-pass.rs
@@ -95,6 +95,8 @@ impl ::std::convert::Into<::yew::virtual_dom::VNode> for ChildrenVariants {
 pub struct ChildProperties {
     #[prop_or_default]
     pub string: ::std::string::String,
+    #[prop_or_default]
+    pub r#fn: ::std::primitive::i32,
     pub int: ::std::primitive::i32,
     #[prop_or_default]
     pub opt_str: ::std::option::Option<::std::string::String>,
@@ -159,6 +161,7 @@ mod scoped {
 
 fn compile_pass() {
     ::yew::html! { <Child int=1 /> };
+    ::yew::html! { <Child int=1 r#fn=1 /> };
 
     ::yew::html! {
         <>

--- a/packages/yew-macro/tests/props_macro/props-pass.rs
+++ b/packages/yew-macro/tests/props_macro/props-pass.rs
@@ -43,10 +43,20 @@ struct Props {
     b: ::std::primitive::usize,
 }
 
+#[derive(::yew::Properties, ::std::cmp::PartialEq)]
+pub struct RawIdentProps {
+    r#true: ::std::primitive::usize,
+    #[prop_or_default]
+    r#pointless_raw_name: ::std::primitive::usize,
+}
+
 fn compile_pass() {
     ::yew::props!(Props { a: 5 });
     let (a, b) = (3, 5);
     ::yew::props!(Props { a, b });
+    ::yew::props!(RawIdentProps { r#true: 5 });
+    let (r#true, r#pointless_raw_name) = (3, 5);
+    ::yew::props!(RawIdentProps { r#true, r#pointless_raw_name });
 }
 
 fn main() {}


### PR DESCRIPTION
#### Description

Allows the fields of `#[derive(Properties)]` structs to be raw names, `r#raw_ident`. The main tool is to use `quote::format_ident!()` instead of `Ident::new(format!())` which correctly passes on the raw nature of identifiers instead of rejecting them.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
