### PR TITLE
Fix a problem with NodeRefs and vtags, ref #2206

### DIFF
--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -476,7 +476,11 @@ impl VDiff for VTag {
         if parent.remove_child(&node).is_err() {
             console::warn!("Node not found to remove VTag");
         }
-        self.node_ref.set(None);
+        // It could be that the ref was already reused when rendering another element.
+        // Only unset the ref it still belongs to our node
+        if self.node_ref.get().as_ref() == Some(&node) {
+            self.node_ref.set(None);
+        }
     }
 
     /// Renders virtual tag over DOM [Element], but it also compares this with an ancestor [VTag]
@@ -514,7 +518,9 @@ impl VDiff for VTag {
                         VNode::VTag(mut a) => {
                             // Preserve the reference that already exists
                             let el = a.reference.take().unwrap();
-                            a.node_ref.set(None);
+                            if self.node_ref.get().as_ref() == self.reference.as_deref() {
+                                a.node_ref.set(None);
+                            }
                             (Some(a), el)
                         }
                         _ => unsafe { unreachable_unchecked() },
@@ -1128,6 +1134,41 @@ mod tests {
         assert!(
             node_ref_a.get().is_none(),
             "node_ref_a should have been reset when the element was reused."
+        );
+    }
+
+    #[test]
+    fn vtag_should_not_touch_newly_bound_refs() {
+        let scope = test_scope();
+        let parent = document().create_element("div").unwrap();
+        document().body().unwrap().append_child(&parent).unwrap();
+
+        let test_ref = NodeRef::default();
+        let mut before = html! {
+            <>
+                <div ref={&test_ref} id="before" />
+            </>
+        };
+        let mut after = html! {
+            <>
+                <h6 />
+                <div ref={&test_ref} id="after" />
+            </>
+        };
+        // The point of this diff is to first render the "after" div and then detach the "before" div,
+        // while both should be bound to the same node ref
+
+        before.apply(&scope, &parent, NodeRef::default(), None);
+        after.apply(&scope, &parent, NodeRef::default(), Some(before));
+
+        assert_eq!(
+            test_ref
+                .get()
+                .unwrap()
+                .dyn_ref::<web_sys::Element>()
+                .unwrap()
+                .outer_html(),
+            "<div id=\"after\"></div>"
         );
     }
 }


### PR DESCRIPTION
#### Description

Fixes #2206

This is in some sense a very poor-mans local fix. It works and has a test case - good.

There is something deeper to fix: every `NodeRef` should be owned by exactly one rendered vnode. If that invariant is violated, this could lead to unexpected results - like here: Complicating the situation is that during rendering, new nodes are mounted and refs are set immediately, while another part of nodes might get detached later during the same render - "owning" the same ref - leading to a time window where a `NodeRef` is "owned" by two nodes.

There might be other, similar bugs lying dormant until a bigger effort is spent on developing a conceptual understanding of the above and adding some more debug assertions to check for the implicit invariant. Note that for example, there are currently no checks for the user reusing the same `NodeRef` multiple times:

```
<>
  <div ref={&some_ref} />
  <div ref={&some_ref} />
</>
```

Which of those divs is expected to be in `some_ref`? Imo, some `debug_assertion` should trigger and inform the user not to do this in debug builds.

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
