### PR TITLE
Implement IntoPropValue for Rc<str>

### DIFF
--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -346,7 +346,7 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
              <&'static str as IntoPropValue<Classes>>
              <&'static str as IntoPropValue<Option<AttrValue>>>
              <&'static str as IntoPropValue<Option<String>>>
-           and 12 others
+           and 15 others
 
 error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfied
   --> tests/html_macro/component-fail.rs:79:34
@@ -359,7 +359,7 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
              <&'static str as IntoPropValue<Classes>>
              <&'static str as IntoPropValue<Option<AttrValue>>>
              <&'static str as IntoPropValue<Option<String>>>
-           and 12 others
+           and 15 others
 
 error[E0308]: mismatched types
   --> tests/html_macro/component-fail.rs:80:31

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -288,6 +288,7 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<AttrVal
              <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
              <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<String> as IntoPropValue<Option<AttrValue>>>
+             <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
    = note: required by `into_prop_value`
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<AttrValue>>` is not satisfied
@@ -300,6 +301,7 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<AttrValue
              <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
              <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<String> as IntoPropValue<Option<AttrValue>>>
+             <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
    = note: required by `into_prop_value`
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
@@ -384,6 +386,7 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
              <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
              <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<String> as IntoPropValue<Option<AttrValue>>>
+             <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
    = note: required by `into_prop_value`
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`

--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -98,5 +98,6 @@ mod test {
         let _: Option<String> = "foo".into_prop_value();
         let _: AttrValue = "foo".into_prop_value();
         let _: Option<AttrValue> = "foo".into_prop_value();
+        let _: Option<AttrValue> = Rc::<str>::from("foo").into_prop_value();
     }
 }

--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -86,6 +86,7 @@ impl_into_prop!(|value: &'static str| -> String { value.to_owned() });
 
 impl_into_prop!(|value: &'static str| -> AttrValue { AttrValue::Static(value) });
 impl_into_prop!(|value: String| -> AttrValue { AttrValue::Owned(value) });
+impl_into_prop!(|value: Rc<str>| -> AttrValue { AttrValue::Rc(value) });
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
#### Description

Add `impl_into_prop!` for `Rc<str>`.

`AttrValue` already has a variant for `Rc<str>`, but it's not currently possible to use that in Yew virtual DOM, because that requires `IntoPropValue<Option<AttrValue>>` which isn't implemented. This change adds a set of those implementations using the existing macro.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
    - If this is a feature, my tests prove that the feature works: yes, at least as well as the existing tests prove it works for `String` and `&'static str`.
