### PR TITLE
Allow `function_component` creation based on function name

### DIFF
--- a/examples/function_todomvc/src/components/filter.rs
+++ b/examples/function_todomvc/src/components/filter.rs
@@ -8,8 +8,8 @@ pub struct FilterProps {
     pub onset_filter: Callback<FilterEnum>,
 }
 
-#[function_component(Filter)]
-pub fn filter(props: &FilterProps) -> Html {
+#[function_component]
+pub fn Filter(props: &FilterProps) -> Html {
     let filter = props.filter;
 
     let cls = if props.selected {

--- a/packages/yew-macro/src/function_component.rs
+++ b/packages/yew-macro/src/function_component.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
@@ -140,18 +140,22 @@ impl Parse for FunctionComponent {
 }
 
 pub struct FunctionComponentName {
-    component_name: Ident,
+    component_name: Option<Ident>,
 }
 
 impl Parse for FunctionComponentName {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         if input.is_empty() {
-            return Err(input.error("expected identifier for the component"));
+            return Ok(Self {
+                component_name: None,
+            });
         }
 
         let component_name = input.parse()?;
 
-        Ok(Self { component_name })
+        Ok(Self {
+            component_name: Some(component_name),
+        })
     }
 }
 
@@ -171,7 +175,8 @@ pub fn function_component_impl(
         name: function_name,
         return_type,
     } = component;
-
+    let component_name = component_name.unwrap_or_else(|| function_name.clone());
+    let function_name = format_ident!("{}FunctionProvider", function_name, span = function_name.span());
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     if function_name == component_name {

--- a/packages/yew-macro/src/function_component.rs
+++ b/packages/yew-macro/src/function_component.rs
@@ -176,7 +176,11 @@ pub fn function_component_impl(
         return_type,
     } = component;
     let component_name = component_name.unwrap_or_else(|| function_name.clone());
-    let function_name = format_ident!("{}FunctionProvider", function_name, span = function_name.span());
+    let function_name = format_ident!(
+        "{}FunctionProvider",
+        function_name,
+        span = function_name.span()
+    );
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     if function_name == component_name {

--- a/packages/yew-macro/tests/function_component_attr/bad-name-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/bad-name-fail.stderr
@@ -1,23 +1,25 @@
 error: expected identifier
- --> $DIR/bad-name-fail.rs:8:22
+ --> tests/function_component_attr/bad-name-fail.rs:8:22
   |
 8 | #[function_component(let)]
   |                      ^^^
 
 error: unexpected token
-  --> $DIR/bad-name-fail.rs:17:23
+  --> tests/function_component_attr/bad-name-fail.rs:17:23
    |
 17 | #[function_component(x, y, z)]
    |                       ^
 
 error: expected identifier
-  --> $DIR/bad-name-fail.rs:26:22
+  --> tests/function_component_attr/bad-name-fail.rs:26:22
    |
 26 | #[function_component(124)]
    |                      ^^^
 
-error: the component must not have the same name as the function
-  --> $DIR/bad-name-fail.rs:35:22
+warning: type `component` should have an upper camel case name
+  --> tests/function_component_attr/bad-name-fail.rs:35:22
    |
 35 | #[function_component(component)]
-   |                      ^^^^^^^^^
+   |                      ^^^^^^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Component`
+   |
+   = note: `#[warn(non_camel_case_types)]` on by default

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -22,13 +22,13 @@ error[E0277]: the trait bound `MissingTypeBounds: yew::Properties` is not satisf
 27 |     html! { <Comp<MissingTypeBounds> /> };
    |              ^^^^ the trait `yew::Properties` is not implemented for `MissingTypeBounds`
    |
-   = note: required because of the requirements on the impl of `FunctionProvider` for `comp<MissingTypeBounds>`
+   = note: required because of the requirements on the impl of `FunctionProvider` for `compFunctionProvider<MissingTypeBounds>`
 
-error[E0599]: the function or associated item `new` exists for struct `VChild<FunctionComponent<comp<MissingTypeBounds>>>`, but its trait bounds were not satisfied
+error[E0599]: the function or associated item `new` exists for struct `VChild<FunctionComponent<compFunctionProvider<MissingTypeBounds>>>`, but its trait bounds were not satisfied
   --> tests/function_component_attr/generic-props-fail.rs:27:14
    |
 27 |     html! { <Comp<MissingTypeBounds> /> };
-   |              ^^^^ function or associated item cannot be called on `VChild<FunctionComponent<comp<MissingTypeBounds>>>` due to unsatisfied trait bounds
+   |              ^^^^ function or associated item cannot be called on `VChild<FunctionComponent<compFunctionProvider<MissingTypeBounds>>>` due to unsatisfied trait bounds
    |
   ::: $WORKSPACE/packages/yew/src/functional/mod.rs
    |
@@ -36,7 +36,7 @@ error[E0599]: the function or associated item `new` exists for struct `VChild<Fu
    | ----------------------------------------------------------- doesn't satisfy `_: yew::Component`
    |
    = note: the following trait bounds were not satisfied:
-           `FunctionComponent<comp<MissingTypeBounds>>: yew::Component`
+           `FunctionComponent<compFunctionProvider<MissingTypeBounds>>: yew::Component`
 
 error[E0107]: missing generics for type alias `Comp`
   --> tests/function_component_attr/generic-props-fail.rs:30:14

--- a/packages/yew-macro/tests/function_component_attr/no-name-default-pass.rs
+++ b/packages/yew-macro/tests/function_component_attr/no-name-default-pass.rs
@@ -5,8 +5,8 @@ struct Props {
     a: usize,
 }
 
-#[function_component()]
-fn comp(props: &Props) -> Html {
+#[function_component]
+fn Comp(props: &Props) -> Html {
     html! {
         <p>
             { props.a }
@@ -14,4 +14,8 @@ fn comp(props: &Props) -> Html {
     }
 }
 
-fn main() {}
+fn main() {
+    let _ = html! {
+        <Comp a={0} />
+    };
+}

--- a/packages/yew-macro/tests/function_component_attr/no-name-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/no-name-fail.stderr
@@ -1,7 +1,0 @@
-error: unexpected end of input, expected identifier for the component
- --> $DIR/no-name-fail.rs:8:1
-  |
-8 | #[function_component()]
-  | ^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew/src/functional/mod.rs
+++ b/packages/yew/src/functional/mod.rs
@@ -23,6 +23,7 @@ use std::rc::Rc;
 mod hooks;
 pub use hooks::*;
 
+pub use self::function_component as fc;
 use crate::html::Context;
 /// This attribute creates a function component from a normal Rust function.
 ///

--- a/packages/yew/src/functional/mod.rs
+++ b/packages/yew/src/functional/mod.rs
@@ -23,7 +23,6 @@ use std::rc::Rc;
 mod hooks;
 pub use hooks::*;
 
-pub use self::function_component as fc;
 use crate::html::Context;
 /// This attribute creates a function component from a normal Rust function.
 ///

--- a/website/docs/concepts/function-components/attribute.mdx
+++ b/website/docs/concepts/function-components/attribute.mdx
@@ -11,7 +11,26 @@ Functions with the attribute have to return `Html` and may take a single paramet
 The parameter type needs to be a reference to a `Properties` type (ex. `props: &MyProps`).
 If the function doesn't have any parameters the resulting component doesn't accept any props.
 
-The attribute doesn't replace your original function with a component. You need to provide a name as an input to the attribute which will be the identifier of the component.
+Just mark the component with the attribute (also aliased as `#[fc]`). The component will be named after the function.
+
+```rust
+use yew::{fc, html, Html};
+
+#[fc]
+pub fn ChatContainer() -> Html {
+    html! {
+        // chat container impl
+    }
+}
+
+html! {
+    <ChatContainer />
+};
+```
+
+## Specifying a custom component name
+
+You need to provide a name as an input to the attribute which will be the identifier of the component.
 Assuming you have a function called `chat_container` and you add the attribute `#[function_component(ChatContainer)]` you can use the component like this:
 
 ```rust
@@ -42,8 +61,8 @@ pub struct RenderedAtProps {
     pub time: String,
 }
 
-#[function_component(RenderedAt)]
-pub fn rendered_at(props: &RenderedAtProps) -> Html {
+#[function_component]
+pub fn RenderedAt(props: &RenderedAtProps) -> Html {
     html! {
         <p>
             <b>{ "Rendered at: " }</b>
@@ -59,8 +78,8 @@ pub fn rendered_at(props: &RenderedAtProps) -> Html {
 ```rust
 use yew::{function_component, html, use_state, Callback};
 
-#[function_component(App)]
-fn app() -> Html {
+#[function_component]
+fn App() -> Html {
     let counter = use_state(|| 0);
 
     let onclick = {
@@ -99,8 +118,8 @@ where
     data: T,
 }
 
-#[function_component(MyGenericComponent)]
-pub fn my_generic_component<T>(props: &Props<T>) -> Html
+#[function_component]
+pub fn MyGenericComponent<T>(props: &Props<T>) -> Html
 where
     T: PartialEq + Display,
 {

--- a/website/docs/concepts/function-components/attribute.mdx
+++ b/website/docs/concepts/function-components/attribute.mdx
@@ -11,12 +11,12 @@ Functions with the attribute have to return `Html` and may take a single paramet
 The parameter type needs to be a reference to a `Properties` type (ex. `props: &MyProps`).
 If the function doesn't have any parameters the resulting component doesn't accept any props.
 
-Just mark the component with the attribute (also aliased as `#[fc]`). The component will be named after the function.
+Just mark the component with the attribute. The component will be named after the function.
 
 ```rust
-use yew::{fc, html, Html};
+use yew::{function_component, html, Html};
 
-#[fc]
+#[function_component]
 pub fn ChatContainer() -> Html {
     html! {
         // chat container impl

--- a/website/docs/concepts/function-components/introduction.mdx
+++ b/website/docs/concepts/function-components/introduction.mdx
@@ -13,13 +13,13 @@ implement the `Component` trait.
 
 ## Creating function components
 
-The easiest way to create a function component is to add the [`#[function_component]`](./../function-components/attribute.mdx) attribute to a function.
+The easiest way to create a function component is to add the [`#[function_component]`](./../function-components/attribute.mdx) attribute (also aliased as `#[fc]`) to a function.
 
 ```rust
-use yew::{function_component, html};
+use yew::{fc, html};
 
-#[function_component(HelloWorld)]
-fn hello_world() -> Html {
+#[fc]
+fn HelloWorld() -> Html {
     html! { "Hello world" }
 }
 ```

--- a/website/docs/concepts/function-components/introduction.mdx
+++ b/website/docs/concepts/function-components/introduction.mdx
@@ -13,12 +13,12 @@ implement the `Component` trait.
 
 ## Creating function components
 
-The easiest way to create a function component is to add the [`#[function_component]`](./../function-components/attribute.mdx) attribute (also aliased as `#[fc]`) to a function.
+The easiest way to create a function component is to add the [`#[function_component]`](./../function-components/attribute.mdx) attribute to a function.
 
 ```rust
-use yew::{fc, html};
+use yew::{function_component, html};
 
-#[fc]
+#[function_component]
 fn HelloWorld() -> Html {
     html! { "Hello world" }
 }


### PR DESCRIPTION
#### Description

This PR modifies the `function_component` macro to use the function name if no name is provided. 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
- [x] I have added docs
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
