### PR TITLE
Fix basename handling in router

### DIFF
--- a/packages/yew-router/src/macro_helpers.rs
+++ b/packages/yew-router/src/macro_helpers.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
-
-use crate::utils::{base_url, strip_slash_suffix};
+use crate::utils::strip_slash_suffix;
 use crate::Routable;
 
 // re-export Router because the macro needs to access it
@@ -8,16 +6,9 @@ pub type Router = route_recognizer::Router<String>;
 
 /// Build a `route_recognizer::Router` from a `Routable` type.
 pub fn build_router<R: Routable>() -> Router {
-    let base = base_url();
     let mut router = Router::new();
     R::routes().iter().for_each(|path| {
-        let route = match base {
-            Some(ref base) => Cow::from(format!("{}{}", base, path)),
-            None => (*path).into(),
-        };
-
-        let stripped_route = strip_slash_suffix(&route);
-
+        let stripped_route = strip_slash_suffix(path);
         router.add(stripped_route, path.to_string());
     });
 


### PR DESCRIPTION
#### Description

`Switch` component no longer also adds base name in the URL to be matched so we don't add it behind the URL passed to `route_recognizer::Router`.

It would be nice to have tests for this but I don't think we can apply base name in tests.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
