### PR TITLE
Add pending event listener on the VTag

### DIFF
--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::cmp::PartialEq;
 use std::hint::unreachable_unchecked;
 use std::marker::PhantomData;
+use std::mem;
 use std::ops::Deref;
 use std::rc::Rc;
 use wasm_bindgen::JsCast;
@@ -430,8 +431,28 @@ impl VTag {
             .insert(key, value.into_prop_value());
     }
 
-    /// Set event listeners on the [VTag]'s  [Element]
+    /// Add pending event listener on the [VTag]'s  [Element]
+    pub fn add_pending_listener(&mut self, listener: Rc<dyn Listener>) -> bool {
+        if let Listeners::Pending(listeners) = &mut self.listeners {
+            let mut listeners = mem::take(listeners).into_vec();
+            listeners.push(Some(listener));
+
+            self.set_listeners(listeners.into_boxed_slice());
+            true
+        } else {
+            false
+        }
+    }
+
+    #[deprecated(
+        note = "The `set_listener` method is deprecated and will be removed in the future. Use the `set_listeners` method instead."
+    )]
     pub fn set_listener(&mut self, listeners: Box<[Option<Rc<dyn Listener>>]>) {
+        self.set_listeners(listeners)
+    }
+
+    /// Set event listeners on the [VTag]'s  [Element]
+    pub fn set_listeners(&mut self, listeners: Box<[Option<Rc<dyn Listener>>]>) {
         self.listeners = Listeners::Pending(listeners);
     }
 

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -431,8 +431,8 @@ impl VTag {
             .insert(key, value.into_prop_value());
     }
 
-    /// Add pending event listener on the [VTag]'s  [Element]
-    pub fn add_pending_listener(&mut self, listener: Rc<dyn Listener>) -> bool {
+    /// Add event listener on the [VTag]'s  [Element]
+    pub fn add_listener(&mut self, listener: Rc<dyn Listener>) -> bool {
         if let Listeners::Pending(listeners) = &mut self.listeners {
             let mut listeners = mem::take(listeners).into_vec();
             listeners.push(Some(listener));
@@ -442,13 +442,6 @@ impl VTag {
         } else {
             false
         }
-    }
-
-    #[deprecated(
-        note = "The `set_listener` method is deprecated and will be removed in the future. Use the `set_listeners` method instead."
-    )]
-    pub fn set_listener(&mut self, listeners: Box<[Option<Rc<dyn Listener>>]>) {
-        self.set_listeners(listeners)
     }
 
     /// Set event listeners on the [VTag]'s  [Element]

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -431,7 +431,8 @@ impl VTag {
             .insert(key, value.into_prop_value());
     }
 
-    /// Add event listener on the [VTag]'s  [Element]
+    /// Add event listener on the [VTag]'s  [Element].
+    /// Returns `true` if the listener has been added, `false` otherwise.
     pub fn add_listener(&mut self, listener: Rc<dyn Listener>) -> bool {
         if let Listeners::Pending(listeners) = &mut self.listeners {
             let mut listeners = mem::take(listeners).into_vec();


### PR DESCRIPTION
#### Description

Add new methods `add_pending_listener` and `set_listeners` on the `VTag`, also deprecate old `set_listener` method.

Fixes #2298 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
