### PR TITLE
Add auth to changelog generation

### DIFF
--- a/.github/workflows/inspect_next_changelogs.yml
+++ b/.github/workflows/inspect_next_changelogs.yml
@@ -27,10 +27,10 @@ jobs:
         run: cargo build --release -p changelog
 
       - name: Read yew changelog in this step
-        run: ./target/release/changelog yew minor
+        run: ./target/release/changelog yew minor -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read yew-router changelog in this step
-        run: ./target/release/changelog yew-router minor
+        run: ./target/release/changelog yew-router minor -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read yew-agent changelog in this step
-        run: ./target/release/changelog yew-agent minor
+        run: ./target/release/changelog yew-agent minor -t ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-yew-agent.yml
+++ b/.github/workflows/publish-yew-agent.yml
@@ -49,7 +49,7 @@ jobs:
         uses: mathiasvr/command-output@v1
         id: changelog
         with:
-          run: ./target/release/changelog yew-agent ${{ github.event.inputs.level }}
+          run: ./target/release/changelog yew-agent ${{ github.event.inputs.level }} -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit changelog
         run: |

--- a/.github/workflows/publish-yew-only.yml
+++ b/.github/workflows/publish-yew-only.yml
@@ -50,7 +50,7 @@ jobs:
         uses: mathiasvr/command-output@v1
         id: changelog
         with:
-          run: ./target/release/changelog yew ${{ github.event.inputs.level }}
+          run: ./target/release/changelog yew ${{ github.event.inputs.level }} -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit changelog
         run: |

--- a/.github/workflows/publish-yew-router-only.yml
+++ b/.github/workflows/publish-yew-router-only.yml
@@ -49,7 +49,7 @@ jobs:
         uses: mathiasvr/command-output@v1
         id: changelog
         with:
-          run: ./target/release/changelog yew-router ${{ github.event.inputs.level }}
+          run: ./target/release/changelog yew-router ${{ github.event.inputs.level }} -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit changelog
         run: |

--- a/.github/workflows/publish-yew-router.yml
+++ b/.github/workflows/publish-yew-router.yml
@@ -49,7 +49,7 @@ jobs:
         uses: mathiasvr/command-output@v1
         id: changelog
         with:
-          run: ./target/release/changelog yew-router ${{ github.event.inputs.level }}
+          run: ./target/release/changelog yew-router ${{ github.event.inputs.level }} -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit changelog
         run: |

--- a/.github/workflows/publish-yew.yml
+++ b/.github/workflows/publish-yew.yml
@@ -49,7 +49,7 @@ jobs:
         uses: mathiasvr/command-output@v1
         id: changelog
         with:
-          run: ./target/release/changelog yew ${{ github.event.inputs.level }}
+          run: ./target/release/changelog yew ${{ github.event.inputs.level }} -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit changelog
         run: |

--- a/tools/changelog/src/cli.rs
+++ b/tools/changelog/src/cli.rs
@@ -23,7 +23,7 @@ pub struct Cli {
     pub from: Option<String>,
 
     /// To commit. (ex. commit hash or for tags "refs/tags/yew-v0.19.3")
-    #[structopt(short, long, default_value = "HEAD")]
+    #[structopt(short = "r", long, default_value = "HEAD")]
     pub to: String,
 
     /// Path to changelog file
@@ -37,6 +37,10 @@ pub struct Cli {
     /// Skip getting the next version
     #[structopt(short = "b", long)]
     pub skip_get_bump_version: bool,
+
+    /// Github token
+    #[structopt(short = "t", long)]
+    pub token: Option<String>,
 }
 
 impl Cli {
@@ -49,6 +53,7 @@ impl Cli {
             skip_file_write,
             new_version_level,
             skip_get_bump_version,
+            token,
         } = self;
         let package_labels = package.as_labels();
 
@@ -73,7 +78,7 @@ impl Cli {
         };
 
         // walk over each commit find text, user, issue
-        let log_lines = create_log_lines(from_ref, to, package_labels)?;
+        let log_lines = create_log_lines(from_ref, to, package_labels, token)?;
 
         // categorize logs
         let (fixes, features): (Vec<_>, Vec<_>) = log_lines

--- a/tools/changelog/src/create_log_line.rs
+++ b/tools/changelog/src/create_log_line.rs
@@ -23,6 +23,7 @@ pub fn create_log_line(
     repo: &Repository,
     package_labels: &'static [&'static str],
     oid: Result<Oid, Error>,
+    token: Option<String>,
 ) -> Result<Option<LogLine>> {
     let oid = oid?;
     let commit = repo.find_commit(oid)?;
@@ -67,14 +68,14 @@ pub fn create_log_line(
     let user = GITHUB_USERS_FETCHER
         .lock()
         .map_err(|err| anyhow!("Failed to lock GITHUB_USERS_FETCHER: {}", err))?
-        .fetch_user_by_commit_author(email, oid.to_string())
+        .fetch_user_by_commit_author(email, oid.to_string(), token.clone())
         .with_context(|| format!("Could not find GitHub user for commit: {}", oid))?
         .to_string();
 
     let issue_labels = GITHUB_ISSUE_LABELS_FETCHER
         .lock()
         .map_err(|err| anyhow!("Failed to lock GITHUB_ISSUE_LABELS_FETCHER: {}", err))?
-        .fetch_issue_labels(issue_id.clone())
+        .fetch_issue_labels(issue_id.clone(), token)
         .with_context(|| format!("Could not find GitHub labels for issue: {}", issue_id))?;
 
     let is_issue_for_this_package = issue_labels

--- a/tools/changelog/src/create_log_lines.rs
+++ b/tools/changelog/src/create_log_lines.rs
@@ -10,6 +10,7 @@ pub fn create_log_lines(
     from: String,
     to: String,
     package_labels: &'static [&'static str],
+    token: Option<String>,
 ) -> Result<Vec<LogLine>> {
     let repo = Repository::open_from_env()?;
 
@@ -30,6 +31,6 @@ pub fn create_log_lines(
 
     revwalk
         .into_iter()
-        .filter_map(|oid| create_log_line(&repo, package_labels, oid).transpose())
+        .filter_map(|oid| create_log_line(&repo, package_labels, oid, token.clone()).transpose())
         .collect()
 }

--- a/tools/changelog/src/github_fetch.rs
+++ b/tools/changelog/src/github_fetch.rs
@@ -1,3 +1,7 @@
+use reqwest::header::HeaderMap;
+use reqwest::header::ACCEPT;
+use reqwest::header::AUTHORIZATION;
+use reqwest::header::USER_AGENT;
 use serde::de::DeserializeOwned;
 use std::thread;
 use std::time::Duration;
@@ -5,13 +9,19 @@ use std::time::Duration;
 use anyhow::{bail, Result};
 use reqwest::blocking::Client;
 
-pub fn github_fetch<T: DeserializeOwned>(url: &str) -> Result<T> {
+pub fn github_fetch<T: DeserializeOwned>(url: &str, token: Option<String>) -> Result<T> {
     thread::sleep(Duration::from_secs(1));
+    let mut optional_headers = HeaderMap::new();
+    if let Some(token) = token {
+        optional_headers.insert(AUTHORIZATION, format!("Bearer {}", token).parse().unwrap());
+    }
+
     let request_client = Client::new();
     let resp = request_client
         .get(url)
-        .header("user-agent", "reqwest")
-        .header("accept", "application/vnd.github.v3+json")
+        .header(USER_AGENT, "reqwest")
+        .header(ACCEPT, "application/vnd.github.v3+json")
+        .headers(optional_headers)
         .send()?;
     let status = resp.status();
     if !status.is_success() {

--- a/tools/changelog/src/github_issue_labels_fetcher.rs
+++ b/tools/changelog/src/github_issue_labels_fetcher.rs
@@ -15,10 +15,14 @@ pub struct GitHubIssueLabelsFetcher {
 }
 
 impl GitHubIssueLabelsFetcher {
-    pub fn fetch_issue_labels(&mut self, issue: String) -> Option<Vec<String>> {
+    pub fn fetch_issue_labels(
+        &mut self,
+        issue: String,
+        token: Option<String>,
+    ) -> Option<Vec<String>> {
         self.cache
             .entry(issue.clone())
-            .or_insert_with(|| match Self::inner_fetch(&issue) {
+            .or_insert_with(|| match Self::inner_fetch(&issue, token) {
                 Ok(labels) => labels,
                 Err(err) => {
                     eprintln!("fetch_issue_labels Error: {}", err);
@@ -28,12 +32,12 @@ impl GitHubIssueLabelsFetcher {
             .clone()
     }
 
-    fn inner_fetch(q: &str) -> Result<Option<Vec<String>>> {
+    fn inner_fetch(q: &str, token: Option<String>) -> Result<Option<Vec<String>>> {
         let url = format!(
             "https://api.github.com/repos/yewstack/yew/issues/{}/labels",
             q,
         );
-        let body: Vec<BodyListItem> = github_fetch(&url)?;
+        let body: Vec<BodyListItem> = github_fetch(&url, token)?;
         let label_names: Vec<String> = body.into_iter().map(|label| label.name).collect();
         Ok(Some(label_names))
     }

--- a/tools/changelog/src/github_user_fetcher.rs
+++ b/tools/changelog/src/github_user_fetcher.rs
@@ -24,10 +24,11 @@ impl GitHubUsersFetcher {
         &mut self,
         key: impl Into<String>,
         commit: impl AsRef<str>,
+        token: Option<String>,
     ) -> Option<&str> {
         self.cache
             .entry(key.into())
-            .or_insert_with(|| match Self::inner_fetch(commit) {
+            .or_insert_with(|| match Self::inner_fetch(commit, token) {
                 Ok(value) => value,
                 Err(err) => {
                     eprintln!("fetch_user_by_commit_author Error: {}", err);
@@ -37,12 +38,12 @@ impl GitHubUsersFetcher {
             .as_deref()
     }
 
-    fn inner_fetch(commit: impl AsRef<str>) -> Result<Option<String>> {
+    fn inner_fetch(commit: impl AsRef<str>, token: Option<String>) -> Result<Option<String>> {
         let url = format!(
             "https://api.github.com/repos/yewstack/yew/commits/{}",
             commit.as_ref(),
         );
-        let body: ResponseBody = github_fetch(&url)?;
+        let body: ResponseBody = github_fetch(&url, token)?;
         Ok(Some(body.author.login))
     }
 }

--- a/tools/changelog/tests/generate_yew_changelog_file.rs
+++ b/tools/changelog/tests/generate_yew_changelog_file.rs
@@ -34,6 +34,7 @@ fn generate_yew_changelog_file() -> Result<()> {
         changelog_path: "tests/test_changelog.md".to_string(),
         skip_file_write: false,
         skip_get_bump_version: true,
+        token: None,
     };
 
     cli_args.run().unwrap();


### PR DESCRIPTION
#### Description

actions would reach github api limit without auth token

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
