### PR TITLE
Fix `yew-agent` crate name in migration docs

### DIFF
--- a/website/versioned_docs/version-0.19.0/migration-guides/yew-agent/from-0_0_0-to-0_1_0.mdx
+++ b/website/versioned_docs/version-0.19.0/migration-guides/yew-agent/from-0_0_0-to-0_1_0.mdx
@@ -2,6 +2,6 @@
 title: "From 0.0.0 to 0.1.0"
 ---
 
-This is the first release of `yew-agents` being separated from `yew`
+This is the first release of `yew-agent` being separated from `yew`.
 
-The only thing you will need to do is change the import paths from `yew::*` to `yew_agents::*`
+The only thing you will need to do is change the import paths from `yew::*` to `yew_agent::*`.


### PR DESCRIPTION
#### Description

Fix `yew-agent` crate name in migration docs

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
