### PR TITLE
Fixed pub_sub link to point to correct example

### DIFF
--- a/website/versioned_docs/version-0.19.0/concepts/agents.mdx
+++ b/website/versioned_docs/version-0.19.0/concepts/agents.mdx
@@ -68,5 +68,5 @@ UI thread \(i.e. Job or Context\).
 
 ## Further reading
 
-* The [pub\_sub](https://github.com/yewstack/yew/tree/master/examples/pub_sub) example shows how
+* The [pub\_sub](https://github.com/yewstack/yew/tree/yew-v0.19.3/examples/pub_sub) example shows how
 components can use agents to communicate with each other.


### PR DESCRIPTION
#### Description

The pub_sub example in the docs linked to the master branch, rather than the versioned branch, and resulted in a 404. This new link points to the pub_sub example for Version 0.19.3

Fixes #2323

#### Checklist

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
