### PR TITLE
Bump MSRV to 1.56

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -147,7 +147,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.54.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
 
     steps:
@@ -188,7 +188,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.54.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
           - nightly
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -147,7 +147,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.49.0 # MSRV
+          - 1.54.0 # MSRV
           - stable
 
     steps:
@@ -188,7 +188,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.51.0 # min version with const generics
+          - 1.54.0 # MSRV
           - stable
           - nightly
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Alternatively, you can set the `ECHO_SERVER_URL` environment variable to the URL
 
 When adding or updating tests, please make sure to update the appropriate `stderr` file, which you can find [here](https://github.com/yewstack/yew/tree/master/packages/yew-macro/tests/macro) for the `html!` macro.
 These files ensure that macro compilation errors are correct and easy to understand.
-These errors can change with each release of the compiler, so they should be generated with the Rust version 1.54
+These errors can change with each release of the compiler, so they should be generated with the Rust version 1.56
 (because some tests make use of const generics which were stabilized in that version).
 
 To update or generate a new `stderr` file you can run `cargo make test-overwrite` in the `yew-macro` directory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Alternatively, you can set the `ECHO_SERVER_URL` environment variable to the URL
 
 When adding or updating tests, please make sure to update the appropriate `stderr` file, which you can find [here](https://github.com/yewstack/yew/tree/master/packages/yew-macro/tests/macro) for the `html!` macro.
 These files ensure that macro compilation errors are correct and easy to understand.
-These errors can change with each release of the compiler so they should be generated with the Rust version 1.51
+These errors can change with each release of the compiler, so they should be generated with the Rust version 1.54
 (because some tests make use of const generics which were stabilized in that version).
 
 To update or generate a new `stderr` file you can run `cargo make test-overwrite` in the `yew-macro` directory.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <a href="https://docs.rs/yew/"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-yew-green"/></a>
     <a href="https://discord.gg/VQck8X4"><img alt="Discord Chat" src="https://img.shields.io/discord/701068342760570933"/></a>
     <a href="https://gitlocalize.com/repo/4999"> <img src="https://gitlocalize.com/repo/4999/whole_project/badge.svg" /> </a>
-    <a href="https://blog.rust-lang.org/2020/12/31/Rust-1.54.0.html"><img alt="Rustc Version 1.54.0+" src="https://img.shields.io/badge/rustc-1.54%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2020/12/31/Rust-1.56.0.html"><img alt="Rustc Version 1.56.0+" src="https://img.shields.io/badge/rustc-1.56%2B-lightgrey.svg"/></a>
   </p>
 
   <h4>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <a href="https://docs.rs/yew/"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-yew-green"/></a>
     <a href="https://discord.gg/VQck8X4"><img alt="Discord Chat" src="https://img.shields.io/discord/701068342760570933"/></a>
     <a href="https://gitlocalize.com/repo/4999"> <img src="https://gitlocalize.com/repo/4999/whole_project/badge.svg" /> </a>
-    <a href="https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html"><img alt="Rustc Version 1.49.0+" src="https://img.shields.io/badge/rustc-1.49%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2020/12/31/Rust-1.54.0.html"><img alt="Rustc Version 1.54.0+" src="https://img.shields.io/badge/rustc-1.54%2B-lightgrey.svg"/></a>
   </p>
 
   <h4>

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["web", "wasm", "frontend", "webasm", "webassembly"]
 categories = ["gui", "web-programming", "wasm"]
 description = "A framework for making client-side single-page apps"
+rust-version = "1.54.0"
 
 [lib]
 proc-macro = true

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["web", "wasm", "frontend", "webasm", "webassembly"]
 categories = ["gui", "web-programming", "wasm"]
 description = "A framework for making client-side single-page apps"
-rust-version = "1.54.0"
+rust-version = "1.56.0"
 
 [lib]
 proc-macro = true

--- a/packages/yew-macro/Makefile.toml
+++ b/packages/yew-macro/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.test]
 clear = true
-toolchain = "1.51"
+toolchain = ""
 command = "cargo"
 # test target can be optionally specified like `cargo make test html_macro`,
 args = ["test", "${@}"]

--- a/packages/yew-macro/tests/classes_macro_test.rs
+++ b/packages/yew-macro/tests/classes_macro_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.51), test)]
+#[rustversion::attr(stable(1.54), test)]
 fn classes_macro() {
     let t = trybuild::TestCases::new();
     t.pass("tests/classes_macro/*-pass.rs");

--- a/packages/yew-macro/tests/classes_macro_test.rs
+++ b/packages/yew-macro/tests/classes_macro_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.54), test)]
+#[rustversion::attr(stable(1.56), test)]
 fn classes_macro() {
     let t = trybuild::TestCases::new();
     t.pass("tests/classes_macro/*-pass.rs");

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -1,18 +1,14 @@
 error: unexpected end of input, expected expression
-  --> tests/derive_props/fail.rs:57:18
+  --> tests/derive_props/fail.rs:57:19
    |
 57 |         #[prop_or()]
-   |                  ^^
+   |                   ^
 
 error: cannot find attribute `props` in this scope
   --> tests/derive_props/fail.rs:22:11
    |
 22 |         #[props(default)]
    |           ^^^^^
-   |
-   = note: consider importing one of these items:
-           yew::props
-           yew_macro::props
 
 error[E0425]: cannot find value `foo` in this scope
   --> tests/derive_props/fail.rs:87:24
@@ -26,33 +22,6 @@ help: consider importing one of these items
    |
 83 |     use crate::t9::foo;
    |
-
-error[E0277]: the trait bound `Value: Default` is not satisfied
- --> tests/derive_props/fail.rs:9:21
-  |
-9 |     #[derive(Clone, Properties, PartialEq)]
-  |                     ^^^^^^^^^^ the trait `Default` is not implemented for `Value`
-  |
-  = note: required by `Option::<T>::unwrap_or_default`
-  = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0369]: binary operation `==` cannot be applied to type `Value`
-  --> tests/derive_props/fail.rs:13:9
-   |
-13 |         value: Value,
-   |         ^^^^^^^^^^^^
-   |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Value`
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0369]: binary operation `!=` cannot be applied to type `Value`
-  --> tests/derive_props/fail.rs:13:9
-   |
-13 |         value: Value,
-   |         ^^^^^^^^^^^^
-   |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Value`
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `build` found for struct `t3::PropsBuilder<t3::PropsBuilderStep_missing_required_prop_value>` in the current scope
   --> tests/derive_props/fail.rs:35:26
@@ -75,6 +44,39 @@ error[E0599]: no method named `b` found for struct `t4::PropsBuilder<PropsBuilde
 48 |         Props::builder().b(1).a(2).build();
    |                          ^ help: there is an associated function with a similar name: `a`
 
+error[E0277]: the trait bound `Value: Default` is not satisfied
+    --> tests/derive_props/fail.rs:9:21
+     |
+9    |     #[derive(Clone, Properties, PartialEq)]
+     |                     ^^^^^^^^^^ the trait `Default` is not implemented for `Value`
+     |
+note: required by `Option::<T>::unwrap_or_default`
+     = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0369]: binary operation `==` cannot be applied to type `Value`
+  --> tests/derive_props/fail.rs:13:9
+   |
+9  |     #[derive(Clone, Properties, PartialEq)]
+   |                                 --------- in this derive macro expansion
+...
+13 |         value: Value,
+   |         ^^^^^^^^^^^^
+   |
+   = note: an implementation of `std::cmp::PartialEq` might be missing for `Value`
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0369]: binary operation `!=` cannot be applied to type `Value`
+  --> tests/derive_props/fail.rs:13:9
+   |
+9  |     #[derive(Clone, Properties, PartialEq)]
+   |                                 --------- in this derive macro expansion
+...
+13 |         value: Value,
+   |         ^^^^^^^^^^^^
+   |
+   = note: an implementation of `std::cmp::PartialEq` might be missing for `Value`
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0308]: mismatched types
   --> tests/derive_props/fail.rs:67:19
    |
@@ -84,9 +86,9 @@ error[E0308]: mismatched types
 help: try using a conversion method
    |
 67 |         #[prop_or(123.to_string())]
-   |                   ^^^^^^^^^^^^^^^
+   |                      ++++++++++++
 67 |         #[prop_or(123.to_string())]
-   |                   ^^^^^^^^^^^^^^^
+   |                      ++++++++++++
 
 error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
    --> tests/derive_props/fail.rs:77:24
@@ -96,6 +98,7 @@ error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
     |
     = help: the trait `FnOnce<()>` is not implemented for `{integer}`
     = note: wrap the `{integer}` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `Option::<T>::unwrap_or_else`
 
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
    --> tests/derive_props/fail.rs:97:24
@@ -105,6 +108,8 @@ error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
 ...
 101 |     fn foo(bar: i32) -> String {
     |     -------------------------- takes 1 argument
+    |
+note: required by a bound in `Option::<T>::unwrap_or_else`
 
 error[E0271]: type mismatch resolving `<fn() -> i32 {t10::foo} as FnOnce<()>>::Output == String`
    --> tests/derive_props/fail.rs:111:24
@@ -112,4 +117,4 @@ error[E0271]: type mismatch resolving `<fn() -> i32 {t10::foo} as FnOnce<()>>::O
 111 |         #[prop_or_else(foo)]
     |                        ^^^ expected struct `String`, found `i32`
     |
-    = note: required by `Option::<T>::unwrap_or_else`
+note: required by `Option::<T>::unwrap_or_else`

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -1,11 +1,11 @@
 error: unexpected end of input, expected expression
-  --> $DIR/fail.rs:57:18
+  --> tests/derive_props/fail.rs:57:18
    |
 57 |         #[prop_or()]
    |                  ^^
 
 error: cannot find attribute `props` in this scope
-  --> $DIR/fail.rs:22:11
+  --> tests/derive_props/fail.rs:22:11
    |
 22 |         #[props(default)]
    |           ^^^^^
@@ -15,7 +15,7 @@ error: cannot find attribute `props` in this scope
            yew_macro::props
 
 error[E0425]: cannot find value `foo` in this scope
-  --> $DIR/fail.rs:87:24
+  --> tests/derive_props/fail.rs:87:24
    |
 87 |         #[prop_or_else(foo)]
    |                        ^^^ not found in this scope
@@ -28,43 +28,46 @@ help: consider importing one of these items
    |
 
 error[E0277]: the trait bound `Value: Default` is not satisfied
- --> $DIR/fail.rs:9:21
+ --> tests/derive_props/fail.rs:9:21
   |
 9 |     #[derive(Clone, Properties, PartialEq)]
   |                     ^^^^^^^^^^ the trait `Default` is not implemented for `Value`
   |
   = note: required by `Option::<T>::unwrap_or_default`
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `==` cannot be applied to type `Value`
-  --> $DIR/fail.rs:13:9
+  --> tests/derive_props/fail.rs:13:9
    |
 13 |         value: Value,
    |         ^^^^^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Value`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `Value`
-  --> $DIR/fail.rs:13:9
+  --> tests/derive_props/fail.rs:13:9
    |
 13 |         value: Value,
    |         ^^^^^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Value`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `build` found for struct `t3::PropsBuilder<t3::PropsBuilderStep_missing_required_prop_value>` in the current scope
-  --> $DIR/fail.rs:35:26
+  --> tests/derive_props/fail.rs:35:26
    |
 29 |     #[derive(Clone, Properties, PartialEq)]
    |                     ---------- method `build` not found for this
 ...
 35 |         Props::builder().build();
    |                          ^^^^^ method not found in `t3::PropsBuilder<t3::PropsBuilderStep_missing_required_prop_value>`
+   |
+   = note: the method was found for
+           - `t3::PropsBuilder<t3::PropsBuilderStepPropsBuilder>`
 
 error[E0599]: no method named `b` found for struct `t4::PropsBuilder<PropsBuilderStep_missing_required_prop_a>` in the current scope
-  --> $DIR/fail.rs:48:26
+  --> tests/derive_props/fail.rs:48:26
    |
 41 |     #[derive(Clone, Properties, PartialEq)]
    |                     ---------- method `b` not found for this
@@ -73,7 +76,7 @@ error[E0599]: no method named `b` found for struct `t4::PropsBuilder<PropsBuilde
    |                          ^ help: there is an associated function with a similar name: `a`
 
 error[E0308]: mismatched types
-  --> $DIR/fail.rs:67:19
+  --> tests/derive_props/fail.rs:67:19
    |
 67 |         #[prop_or(123)]
    |                   ^^^ expected struct `String`, found integer
@@ -86,7 +89,7 @@ help: try using a conversion method
    |                   ^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
-   --> $DIR/fail.rs:77:24
+   --> tests/derive_props/fail.rs:77:24
     |
 77  |         #[prop_or_else(123)]
     |                        ^^^ expected an `FnOnce<()>` closure, found `{integer}`
@@ -95,7 +98,7 @@ error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
     = note: wrap the `{integer}` in a closure with no arguments: `|| { /* code */ }`
 
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
-   --> $DIR/fail.rs:97:24
+   --> tests/derive_props/fail.rs:97:24
     |
 97  |         #[prop_or_else(foo)]
     |                        ^^^ expected function that takes 0 arguments
@@ -104,7 +107,7 @@ error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
     |     -------------------------- takes 1 argument
 
 error[E0271]: type mismatch resolving `<fn() -> i32 {t10::foo} as FnOnce<()>>::Output == String`
-   --> $DIR/fail.rs:111:24
+   --> tests/derive_props/fail.rs:111:24
     |
 111 |         #[prop_or_else(foo)]
     |                        ^^^ expected struct `String`, found `i32`

--- a/packages/yew-macro/tests/derive_props_test.rs
+++ b/packages/yew-macro/tests/derive_props_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.51), test)]
+#[rustversion::attr(stable(1.54), test)]
 fn derive_props() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_props/pass.rs");

--- a/packages/yew-macro/tests/derive_props_test.rs
+++ b/packages/yew-macro/tests/derive_props_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.54), test)]
+#[rustversion::attr(stable(1.56), test)]
 fn derive_props() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_props/pass.rs");

--- a/packages/yew-macro/tests/function_attr_test.rs
+++ b/packages/yew-macro/tests/function_attr_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.51), test)]
+#[rustversion::attr(stable(1.54), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/function_component_attr/*-pass.rs");

--- a/packages/yew-macro/tests/function_attr_test.rs
+++ b/packages/yew-macro/tests/function_attr_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.54), test)]
+#[rustversion::attr(stable(1.56), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/function_component_attr/*-pass.rs");

--- a/packages/yew-macro/tests/function_component_attr/bad-return-type-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/bad-return-type-fail.stderr
@@ -11,4 +11,4 @@ error[E0277]: the trait bound `u32: IntoHtmlResult` is not satisfied
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoHtmlResult` is not implemented for `u32`
    |
    = note: required by `into_html_result`
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `function_component` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-macro/tests/function_component_attr/bad-return-type-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/bad-return-type-fail.stderr
@@ -10,5 +10,9 @@ error[E0277]: the trait bound `u32: IntoHtmlResult` is not satisfied
 11 | #[function_component(Comp)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoHtmlResult` is not implemented for `u32`
    |
-   = note: required by `into_html_result`
+note: required by `into_html_result`
+  --> $WORKSPACE/packages/yew/src/html/mod.rs
+   |
+   |     fn into_html_result(self) -> HtmlResult;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `function_component` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -15,6 +15,9 @@ error[E0599]: no method named `build` found for struct `PropsBuilder<PropsBuilde
 ...
 22 |     html! { <Comp<Props> /> };
    |              ^^^^ method not found in `PropsBuilder<PropsBuilderStep_missing_required_prop_a>`
+   |
+   = note: the method was found for
+           - `PropsBuilder<PropsBuilderStepPropsBuilder>`
 
 error[E0277]: the trait bound `FunctionComponent<CompFunctionProvider<MissingTypeBounds>>: BaseComponent` is not satisfied
   --> tests/function_component_attr/generic-props-fail.rs:27:14
@@ -50,22 +53,27 @@ error[E0277]: the trait bound `MissingTypeBounds: yew::Properties` is not satisf
    | pub struct FunctionComponent<T: FunctionProvider + 'static> {
    |                                 ---------------- required by this bound in `FunctionComponent`
    |
-   = note: required because of the requirements on the impl of `FunctionProvider` for `CompFunctionProvider<MissingTypeBounds>`
+note: required because of the requirements on the impl of `FunctionProvider` for `CompFunctionProvider<MissingTypeBounds>`
+  --> tests/function_component_attr/generic-props-fail.rs:8:1
+   |
+8  | #[function_component(Comp)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `function_component` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0107]: missing generics for type alias `Comp`
   --> tests/function_component_attr/generic-props-fail.rs:30:14
    |
 30 |     html! { <Comp /> };
-   |              ^^^^ expected 1 type argument
+   |              ^^^^ expected 1 generic argument
    |
-note: type alias defined here, with 1 type parameter: `P`
+note: type alias defined here, with 1 generic parameter: `P`
   --> tests/function_component_attr/generic-props-fail.rs:8:22
    |
 8  | #[function_component(Comp)]
    |                      ^^^^
 9  | fn comp<P>(_props: &P) -> Html
    |         -
-help: use angle brackets to add missing type argument
+help: add missing generic argument
    |
 30 |     html! { <Comp<P> /> };
-   |                  ^^^
+   |              ^^^^^^^

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -48,16 +48,16 @@ error[E0277]: the trait bound `MissingTypeBounds: yew::Properties` is not satisf
 27 |     html! { <Comp<MissingTypeBounds> /> };
    |              ^^^^ the trait `yew::Properties` is not implemented for `MissingTypeBounds`
    |
-  ::: $WORKSPACE/packages/yew/src/functional/mod.rs
-   |
-   | pub struct FunctionComponent<T: FunctionProvider + 'static> {
-   |                                 ---------------- required by this bound in `FunctionComponent`
-   |
 note: required because of the requirements on the impl of `FunctionProvider` for `CompFunctionProvider<MissingTypeBounds>`
   --> tests/function_component_attr/generic-props-fail.rs:8:1
    |
 8  | #[function_component(Comp)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `FunctionComponent`
+  --> $WORKSPACE/packages/yew/src/functional/mod.rs
+   |
+   | pub struct FunctionComponent<T: FunctionProvider + 'static> {
+   |                                 ^^^^^^^^^^^^^^^^ required by this bound in `FunctionComponent`
    = note: this error originates in the attribute macro `function_component` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0107]: missing generics for type alias `Comp`
@@ -76,4 +76,4 @@ note: type alias defined here, with 1 generic parameter: `P`
 help: add missing generic argument
    |
 30 |     html! { <Comp<P> /> };
-   |              ^^^^^^^
+   |              ~~~~~~~

--- a/packages/yew-macro/tests/html_macro/block-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/block-fail.stderr
@@ -1,46 +1,46 @@
 error[E0277]: `()` doesn't implement `std::fmt::Display`
- --> $DIR/block-fail.rs:6:15
-  |
-6 |             { () }
-  |               ^^ `()` cannot be formatted with the default formatter
-  |
-  = help: the trait `std::fmt::Display` is not implemented for `()`
-  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: required because of the requirements on the impl of `ToString` for `()`
-  = note: required because of the requirements on the impl of `From<()>` for `VNode`
-  = note: required because of the requirements on the impl of `Into<VNode>` for `()`
-  = note: 2 redundant requirements hidden
-  = note: required because of the requirements on the impl of `Into<NodeSeq<(), VNode>>` for `()`
-  = note: required by `into`
+   --> tests/html_macro/block-fail.rs:6:15
+    |
+6   |             { () }
+    |               ^^ `()` cannot be formatted with the default formatter
+    |
+    = help: the trait `std::fmt::Display` is not implemented for `()`
+    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+    = note: required because of the requirements on the impl of `ToString` for `()`
+    = note: required because of the requirements on the impl of `From<()>` for `VNode`
+    = note: required because of the requirements on the impl of `Into<VNode>` for `()`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `Into<NodeSeq<(), VNode>>` for `()`
+note: required by `into`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> $DIR/block-fail.rs:12:16
-   |
-12 |         <div>{ not_tree() }</div>
-   |                ^^^^^^^^ `()` cannot be formatted with the default formatter
-   |
-   = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `ToString` for `()`
-   = note: required because of the requirements on the impl of `From<()>` for `VNode`
-   = note: required because of the requirements on the impl of `Into<VNode>` for `()`
-   = note: 2 redundant requirements hidden
-   = note: required because of the requirements on the impl of `Into<NodeSeq<(), VNode>>` for `()`
-   = note: required by `into`
+   --> tests/html_macro/block-fail.rs:12:16
+    |
+12  |         <div>{ not_tree() }</div>
+    |                ^^^^^^^^ `()` cannot be formatted with the default formatter
+    |
+    = help: the trait `std::fmt::Display` is not implemented for `()`
+    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+    = note: required because of the requirements on the impl of `ToString` for `()`
+    = note: required because of the requirements on the impl of `From<()>` for `VNode`
+    = note: required because of the requirements on the impl of `Into<VNode>` for `()`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `Into<NodeSeq<(), VNode>>` for `()`
+note: required by `into`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> $DIR/block-fail.rs:15:17
+  --> tests/html_macro/block-fail.rs:15:17
    |
 15 |         <>{ for (0..3).map(|_| not_tree()) }</>
    |                 ^^^^^^ `()` cannot be formatted with the default formatter
    |
-  ::: $WORKSPACE/packages/yew/src/utils/mod.rs
-   |
-   |     T: Into<R>,
-   |        ------- required by this bound in `into_node_iter`
-   |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required because of the requirements on the impl of `ToString` for `()`
    = note: required because of the requirements on the impl of `From<()>` for `VNode`
    = note: required because of the requirements on the impl of `Into<VNode>` for `()`
+note: required by a bound in `into_node_iter`
+  --> $WORKSPACE/packages/yew/src/utils/mod.rs
+   |
+   |     T: Into<R>,
+   |        ^^^^^^^ required by this bound in `into_node_iter`

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -196,10 +196,10 @@ error: `int` can only be specified once but is given here again
    |                                ^^^
 
 error: `ref` can only be specified once
-  --> tests/html_macro/component-fail.rs:81:26
+  --> tests/html_macro/component-fail.rs:81:35
    |
 81 |     html! { <Child int=1 ref={()} ref={()} /> };
-   |                          ^^^
+   |                                   ^^^
 
 error: this closing tag has no corresponding opening tag
   --> tests/html_macro/component-fail.rs:84:13
@@ -303,7 +303,7 @@ error[E0609]: no field `r#type` on type `ChildProperties`
    |
    = note: available fields are: `string`, `int`
 
-error[E0599]: no method named `r#type` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
+error[E0599]: no method named `r#type` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:71:20
    |
 4  | #[derive(Clone, Properties, PartialEq)]
@@ -320,7 +320,7 @@ error[E0609]: no field `unknown` on type `ChildProperties`
    |
    = note: available fields are: `string`, `int`
 
-error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
+error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:74:20
    |
 4  | #[derive(Clone, Properties, PartialEq)]
@@ -381,6 +381,9 @@ error[E0599]: no method named `string` found for struct `ChildPropertiesBuilder<
 ...
 83 |     html! { <Child string="abc" /> };
    |                    ^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
+   |
+   = note: the method was found for
+           - `ChildPropertiesBuilder<ChildPropertiesBuilderStepPropsBuilder>`
 
 error[E0609]: no field `children` on type `ChildProperties`
   --> tests/html_macro/component-fail.rs:87:14
@@ -390,7 +393,7 @@ error[E0609]: no field `children` on type `ChildProperties`
    |
    = note: available fields are: `string`, `int`
 
-error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
+error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:87:14
    |
 4  | #[derive(Clone, Properties, PartialEq)]
@@ -415,6 +418,9 @@ error[E0599]: no method named `build` found for struct `ChildContainerProperties
 ...
 99 |     html! { <ChildContainer /> };
    |              ^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
+   |
+   = note: the method was found for
+           - `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStepPropsBuilder>`
 
 error[E0599]: no method named `build` found for struct `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
    --> tests/html_macro/component-fail.rs:100:14
@@ -424,6 +430,9 @@ error[E0599]: no method named `build` found for struct `ChildContainerProperties
 ...
 100 |     html! { <ChildContainer></ChildContainer> };
     |              ^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
+    |
+    = note: the method was found for
+            - `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStepPropsBuilder>`
 
 error[E0277]: the trait bound `VChild<Child>: From<yew::virtual_dom::VText>` is not satisfied
    --> tests/html_macro/component-fail.rs:101:31

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -35,10 +35,10 @@ error: expected base props expression after `..`
    |                    ^^
 
 error: unexpected end of input, expected expression
-  --> tests/html_macro/component-fail.rs:47:22
+  --> tests/html_macro/component-fail.rs:47:28
    |
 47 |     html! { <Child ..{ 5 + } /> };
-   |                      ^^^^^^^
+   |                            ^
 
 error: `props` doesn't have a value. (hint: set the value to `true` or `false` for boolean attributes)
   --> tests/html_macro/component-fail.rs:48:20
@@ -163,7 +163,7 @@ error: expected identifier, found keyword `type`
 help: you can escape reserved keywords to use them as identifiers
    |
 71 |     html! { <Child r#type=0 /> };
-   |                    ^^^^^^
+   |                    ~~~~~~
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
   --> tests/html_macro/component-fail.rs:72:24
@@ -441,7 +441,7 @@ error[E0277]: the trait bound `VChild<Child>: From<yew::virtual_dom::VText>` is 
     |                               ^^^^^^^^^^^^^ the trait `From<yew::virtual_dom::VText>` is not implemented for `VChild<Child>`
     |
     = note: required because of the requirements on the impl of `Into<VChild<Child>>` for `yew::virtual_dom::VText`
-    = note: required by `into`
+note: required by `into`
 
 error[E0277]: the trait bound `VChild<Child>: From<VNode>` is not satisfied
    --> tests/html_macro/component-fail.rs:102:29
@@ -450,7 +450,7 @@ error[E0277]: the trait bound `VChild<Child>: From<VNode>` is not satisfied
     |                             ^ the trait `From<VNode>` is not implemented for `VChild<Child>`
     |
     = note: required because of the requirements on the impl of `Into<VChild<Child>>` for `VNode`
-    = note: required by `into`
+note: required by `into`
 
 error[E0277]: the trait bound `VChild<Child>: From<VNode>` is not satisfied
    --> tests/html_macro/component-fail.rs:103:30
@@ -459,4 +459,4 @@ error[E0277]: the trait bound `VChild<Child>: From<VNode>` is not satisfied
     |                              ^^^^^ the trait `From<VNode>` is not implemented for `VChild<Child>`
     |
     = note: required because of the requirements on the impl of `Into<VChild<Child>>` for `VNode`
-    = note: required by `into`
+note: required by `into`

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -252,7 +252,11 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not sati
 43 |     html! { <input type={()} /> };
    |                          ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
    |
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
   --> tests/html_macro/element-fail.rs:44:27
@@ -260,7 +264,11 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not sati
 44 |     html! { <input value={()} /> };
    |                           ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
    |
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
   --> tests/html_macro/element-fail.rs:45:22
@@ -268,7 +276,11 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not sati
 45 |     html! { <a href={()} /> };
    |                      ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
    |
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is not satisfied
   --> tests/html_macro/element-fail.rs:46:28
@@ -276,7 +288,11 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is
 46 |     html! { <input string={NotToString} /> };
    |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `NotToString`
    |
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<AttrValue>>` is not satisfied
   --> tests/html_macro/element-fail.rs:47:23
@@ -289,7 +305,11 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<AttrVal
              <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<String> as IntoPropValue<Option<AttrValue>>>
              <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<AttrValue>>` is not satisfied
   --> tests/html_macro/element-fail.rs:48:22
@@ -302,15 +322,22 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<AttrValue
              <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<String> as IntoPropValue<Option<AttrValue>>>
              <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
    --> tests/html_macro/element-fail.rs:51:28
     |
-51  |       html! { <input onclick=1 /> };
-    |                              ^ expected an `Fn<(MouseEvent,)>` closure, found `{integer}`
+51  |     html! { <input onclick=1 /> };
+    |                            ^ expected an `Fn<(MouseEvent,)>` closure, found `{integer}`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
+    = help: the trait `Fn<(MouseEvent,)>` is not implemented for `{integer}`
+    = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `{integer}`
+note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
+   --> $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
     | / impl_short! {
     | |     onauxclick(MouseEvent)
@@ -319,21 +346,22 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
 ...   |
     | |     ontransitionstart(TransitionEvent)
     | | }
-    | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
-    |
-    = help: the trait `Fn<(MouseEvent,)>` is not implemented for `{integer}`
-    = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `{integer}`
+    | |_^ required by this bound in `yew::html::onclick::Wrapper::__macro_new`
+    = note: this error originates in the macro `impl_action` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
    --> tests/html_macro/element-fail.rs:52:29
     |
-52  |       html! { <input onclick={Callback::from(|a: String| ())} /> };
-    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                               |
-    |                               expected an implementor of trait `IntoEventCallback<MouseEvent>`
-    |                               help: consider borrowing here: `&Callback::from(|a: String| ())`
+52  |     html! { <input onclick={Callback::from(|a: String| ())} /> };
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                             |
+    |                             expected an implementor of trait `IntoEventCallback<MouseEvent>`
+    |                             help: consider borrowing here: `&Callback::from(|a: String| ())`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
+    = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
+    = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
+note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
+   --> $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
     | / impl_short! {
     | |     onauxclick(MouseEvent)
@@ -342,18 +370,20 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<Strin
 ...   |
     | |     ontransitionstart(TransitionEvent)
     | | }
-    | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
-    |
-    = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
-    = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
+    | |_^ required by this bound in `yew::html::onclick::Wrapper::__macro_new`
+    = note: this error originates in the macro `impl_action` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>` is not satisfied
    --> tests/html_macro/element-fail.rs:53:29
     |
-53  |       html! { <input onfocus={Some(5)} /> };
-    |                               ^^^^^^^ the trait `IntoEventCallback<FocusEvent>` is not implemented for `Option<{integer}>`
+53  |     html! { <input onfocus={Some(5)} /> };
+    |                             ^^^^^^^ the trait `IntoEventCallback<FocusEvent>` is not implemented for `Option<{integer}>`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
+    = help: the following implementations were found:
+              <Option<T> as IntoEventCallback<EVENT>>
+              <Option<yew::Callback<EVENT>> as IntoEventCallback<EVENT>>
+note: required by a bound in `yew::html::onfocus::Wrapper::__macro_new`
+   --> $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
     | / impl_short! {
     | |     onauxclick(MouseEvent)
@@ -362,11 +392,8 @@ error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>`
 ...   |
     | |     ontransitionstart(TransitionEvent)
     | | }
-    | |_- required by this bound in `yew::html::onfocus::Wrapper::__macro_new`
-    |
-    = help: the following implementations were found:
-              <Option<T> as IntoEventCallback<EVENT>>
-              <Option<yew::Callback<EVENT>> as IntoEventCallback<EVENT>>
+    | |_^ required by this bound in `yew::html::onfocus::Wrapper::__macro_new`
+    = note: this error originates in the macro `impl_action` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
   --> tests/html_macro/element-fail.rs:56:25
@@ -374,7 +401,11 @@ error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
 56 |     html! { <input ref={()} /> };
    |                         ^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
    |
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>` is not satisfied
   --> tests/html_macro/element-fail.rs:57:25
@@ -387,18 +418,25 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
              <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<String> as IntoPropValue<Option<AttrValue>>>
              <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
    --> tests/html_macro/element-fail.rs:58:29
     |
-58  |       html! { <input onclick={Callback::from(|a: String| ())} /> };
-    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                               |
-    |                               expected an implementor of trait `IntoEventCallback<MouseEvent>`
-    |                               help: consider borrowing here: `&Callback::from(|a: String| ())`
+58  |     html! { <input onclick={Callback::from(|a: String| ())} /> };
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                             |
+    |                             expected an implementor of trait `IntoEventCallback<MouseEvent>`
+    |                             help: consider borrowing here: `&Callback::from(|a: String| ())`
     |
-   ::: $WORKSPACE/packages/yew/src/html/listener/events.rs
+    = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
+    = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
+note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
+   --> $WORKSPACE/packages/yew/src/html/listener/events.rs
     |
     | / impl_short! {
     | |     onauxclick(MouseEvent)
@@ -407,10 +445,8 @@ error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<Strin
 ...   |
     | |     ontransitionstart(TransitionEvent)
     | | }
-    | |_- required by this bound in `yew::html::onclick::Wrapper::__macro_new`
-    |
-    = note: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
-    = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
+    | |_^ required by this bound in `yew::html::onclick::Wrapper::__macro_new`
+    = note: this error originates in the macro `impl_action` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is not satisfied
   --> tests/html_macro/element-fail.rs:60:28
@@ -418,7 +454,11 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is
 60 |     html! { <input string={NotToString} /> };
    |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `NotToString`
    |
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
   --> tests/html_macro/element-fail.rs:62:25
@@ -426,19 +466,23 @@ error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
 62 |     html! { <input ref={()} /> };
    |                         ^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
    |
-   = note: required by `into_prop_value`
+note: required by `into_prop_value`
+  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   |
+   |     fn into_prop_value(self) -> T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Cow<'static, str>: From<{integer}>` is not satisfied
-  --> tests/html_macro/element-fail.rs:77:15
-   |
-77 |     html! { <@{55}></@> };
-   |               ^^^^ the trait `From<{integer}>` is not implemented for `Cow<'static, str>`
-   |
-   = help: the following implementations were found:
-             <Cow<'a, CStr> as From<&'a CStr>>
-             <Cow<'a, CStr> as From<&'a CString>>
-             <Cow<'a, CStr> as From<CString>>
-             <Cow<'a, OsStr> as From<&'a OsStr>>
-           and 11 others
-   = note: required because of the requirements on the impl of `Into<Cow<'static, str>>` for `{integer}`
-   = note: required by `into`
+   --> tests/html_macro/element-fail.rs:77:15
+    |
+77  |     html! { <@{55}></@> };
+    |               ^^^^ the trait `From<{integer}>` is not implemented for `Cow<'static, str>`
+    |
+    = help: the following implementations were found:
+              <Cow<'a, CStr> as From<&'a CStr>>
+              <Cow<'a, CStr> as From<&'a CString>>
+              <Cow<'a, CStr> as From<CString>>
+              <Cow<'a, OsStr> as From<&'a OsStr>>
+            and 11 others
+    = note: required because of the requirements on the impl of `Into<Cow<'static, str>>` for `{integer}`
+note: required by `into`

--- a/packages/yew-macro/tests/html_macro/iterable-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/iterable-fail.stderr
@@ -1,31 +1,31 @@
 error: expected an expression after the keyword `for`
- --> $DIR/iterable-fail.rs:4:13
+ --> tests/html_macro/iterable-fail.rs:4:13
   |
 4 |     html! { for };
   |             ^^^
 
 error[E0277]: `()` is not an iterator
- --> $DIR/iterable-fail.rs:5:17
-  |
-5 |     html! { for () };
-  |                 ^^ `()` is not an iterator
-  |
-  = help: the trait `Iterator` is not implemented for `()`
-  = note: required because of the requirements on the impl of `IntoIterator` for `()`
-  = note: required by `into_iter`
+   --> tests/html_macro/iterable-fail.rs:5:17
+    |
+5   |     html! { for () };
+    |                 ^^ `()` is not an iterator
+    |
+    = help: the trait `Iterator` is not implemented for `()`
+    = note: required because of the requirements on the impl of `IntoIterator` for `()`
+note: required by `into_iter`
 
 error[E0277]: `()` is not an iterator
- --> $DIR/iterable-fail.rs:6:17
-  |
-6 |     html! { for {()} };
-  |                 ^^^^ `()` is not an iterator
-  |
-  = help: the trait `Iterator` is not implemented for `()`
-  = note: required because of the requirements on the impl of `IntoIterator` for `()`
-  = note: required by `into_iter`
+   --> tests/html_macro/iterable-fail.rs:6:17
+    |
+6   |     html! { for {()} };
+    |                 ^^^^ `()` is not an iterator
+    |
+    = help: the trait `Iterator` is not implemented for `()`
+    = note: required because of the requirements on the impl of `IntoIterator` for `()`
+note: required by `into_iter`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-    --> $DIR/iterable-fail.rs:7:17
+    --> tests/html_macro/iterable-fail.rs:7:17
      |
 7    |     html! { for Vec::<()>::new().into_iter() };
      |                 ^^^ `()` cannot be formatted with the default formatter
@@ -36,9 +36,10 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
      = note: required because of the requirements on the impl of `From<()>` for `VNode`
      = note: required because of the requirements on the impl of `Into<VNode>` for `()`
      = note: required because of the requirements on the impl of `FromIterator<()>` for `VNode`
+note: required by a bound in `collect`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-    --> $DIR/iterable-fail.rs:10:17
+    --> tests/html_macro/iterable-fail.rs:10:17
      |
 10   |     html! { for empty };
      |                 ^^^^^ `()` cannot be formatted with the default formatter
@@ -49,9 +50,10 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
      = note: required because of the requirements on the impl of `From<()>` for `VNode`
      = note: required because of the requirements on the impl of `Into<VNode>` for `()`
      = note: required because of the requirements on the impl of `FromIterator<()>` for `VNode`
+note: required by a bound in `collect`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-    --> $DIR/iterable-fail.rs:13:17
+    --> tests/html_macro/iterable-fail.rs:13:17
      |
 13   |     html! { for empty.iter() };
      |                 ^^^^^ `()` cannot be formatted with the default formatter
@@ -63,17 +65,18 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
      = note: required because of the requirements on the impl of `From<&()>` for `VNode`
      = note: required because of the requirements on the impl of `Into<VNode>` for `&()`
      = note: required because of the requirements on the impl of `FromIterator<&()>` for `VNode`
+note: required by a bound in `collect`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/iterable-fail.rs:18:19
+  --> tests/html_macro/iterable-fail.rs:18:19
    |
 18 |             { for () }
    |                   ^^ `()` is not an iterator
    |
-  ::: $WORKSPACE/packages/yew/src/utils/mod.rs
-   |
-   |     IT: IntoIterator<Item = T>,
-   |         ---------------------- required by this bound in `into_node_iter`
-   |
    = help: the trait `Iterator` is not implemented for `()`
    = note: required because of the requirements on the impl of `IntoIterator` for `()`
+note: required by a bound in `into_node_iter`
+  --> $WORKSPACE/packages/yew/src/utils/mod.rs
+   |
+   |     IT: IntoIterator<Item = T>,
+   |         ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `into_node_iter`

--- a/packages/yew-macro/tests/html_macro/node-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/node-fail.stderr
@@ -1,65 +1,65 @@
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
- --> $DIR/node-fail.rs:4:21
+ --> tests/html_macro/node-fail.rs:4:21
   |
 4 |     html! { "valid" "invalid" };
   |                     ^^^^^^^^^
 
 error: unexpected token
- --> $DIR/node-fail.rs:5:29
+ --> tests/html_macro/node-fail.rs:5:29
   |
 5 |     html! { <span>{ "valid" "invalid" }</span> };
   |                             ^^^^^^^^^
 
 error: unsupported type
-  --> $DIR/node-fail.rs:10:14
+  --> tests/html_macro/node-fail.rs:10:14
    |
 10 |     html! {  b'a' };
    |              ^^^^
 
 error: unsupported type
-  --> $DIR/node-fail.rs:11:14
+  --> tests/html_macro/node-fail.rs:11:14
    |
 11 |     html! {  b"str" };
    |              ^^^^^^
 
 error: unsupported type
-  --> $DIR/node-fail.rs:12:22
+  --> tests/html_macro/node-fail.rs:12:22
    |
 12 |     html! {  <span>{ b'a' }</span> };
    |                      ^^^^
 
 error: unsupported type
-  --> $DIR/node-fail.rs:13:22
+  --> tests/html_macro/node-fail.rs:13:22
    |
 13 |     html! {  <span>{ b"str" }</span> };
    |                      ^^^^^^
 
 error[E0425]: cannot find value `invalid` in this scope
- --> $DIR/node-fail.rs:7:13
+ --> tests/html_macro/node-fail.rs:7:13
   |
 7 |     html! { invalid };
   |             ^^^^^^^ not found in this scope
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
- --> $DIR/node-fail.rs:6:13
-  |
-6 |     html! { () };
-  |             ^^ `()` cannot be formatted with the default formatter
-  |
-  = help: the trait `std::fmt::Display` is not implemented for `()`
-  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: required because of the requirements on the impl of `ToString` for `()`
-  = note: required because of the requirements on the impl of `From<()>` for `VNode`
-  = note: required by `from`
+   --> tests/html_macro/node-fail.rs:6:13
+    |
+6   |     html! { () };
+    |             ^^ `()` cannot be formatted with the default formatter
+    |
+    = help: the trait `std::fmt::Display` is not implemented for `()`
+    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+    = note: required because of the requirements on the impl of `ToString` for `()`
+    = note: required because of the requirements on the impl of `From<()>` for `VNode`
+note: required by `from`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> $DIR/node-fail.rs:17:9
-   |
-17 |         not_node()
-   |         ^^^^^^^^^^ `()` cannot be formatted with the default formatter
-   |
-   = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `ToString` for `()`
-   = note: required because of the requirements on the impl of `From<()>` for `VNode`
-   = note: required by `from`
+   --> tests/html_macro/node-fail.rs:17:9
+    |
+17  |         not_node()
+    |         ^^^^^^^^^^ `()` cannot be formatted with the default formatter
+    |
+    = help: the trait `std::fmt::Display` is not implemented for `()`
+    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+    = note: required because of the requirements on the impl of `ToString` for `()`
+    = note: required because of the requirements on the impl of `From<()>` for `VNode`
+note: required by `from`

--- a/packages/yew-macro/tests/html_macro_test.rs
+++ b/packages/yew-macro/tests/html_macro_test.rs
@@ -1,7 +1,7 @@
 use yew::{html, html_nested};
 
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.51), test)]
+#[rustversion::attr(stable(1.54), test)]
 fn html_macro() {
     let t = trybuild::TestCases::new();
 

--- a/packages/yew-macro/tests/html_macro_test.rs
+++ b/packages/yew-macro/tests/html_macro_test.rs
@@ -1,7 +1,7 @@
 use yew::{html, html_nested};
 
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.54), test)]
+#[rustversion::attr(stable(1.56), test)]
 fn html_macro() {
     let t = trybuild::TestCases::new();
 

--- a/packages/yew-macro/tests/props_macro/props-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/props-fail.stderr
@@ -1,37 +1,37 @@
 error: special props cannot be specified in the `props!` macro
- --> $DIR/props-fail.rs:9:25
+ --> tests/props_macro/props-fail.rs:9:25
   |
 9 |     yew::props!(Props { ref: NodeRef::default(), key: "key" });
   |                         ^^^
 
 error: special props cannot be specified in the `props!` macro
- --> $DIR/props-fail.rs:9:50
+ --> tests/props_macro/props-fail.rs:9:50
   |
 9 |     yew::props!(Props { ref: NodeRef::default(), key: "key" });
   |                                                  ^^^
 
 error: expected ident
-  --> $DIR/props-fail.rs:13:31
+  --> tests/props_macro/props-fail.rs:13:31
    |
 13 |     yew::props!(Props { a: 1, ..props });
    |                               ^^
 
 error[E0425]: cannot find value `does_not_exist` in this scope
-  --> $DIR/props-fail.rs:15:25
+  --> tests/props_macro/props-fail.rs:15:25
    |
 15 |     yew::props!(Props { does_not_exist });
    |                         ^^^^^^^^^^^^^^ not found in this scope
 
 error[E0609]: no field `fail` on type `Props`
-  --> $DIR/props-fail.rs:10:31
+  --> tests/props_macro/props-fail.rs:10:31
    |
 10 |     yew::props!(Props { a: 5, fail: 10 });
    |                               ^^^^ unknown field
    |
    = note: available fields are: `a`
 
-error[E0599]: no method named `fail` found for struct `PropsBuilder<PropsBuilderStepPropsBuilder>` in the current scope
-  --> $DIR/props-fail.rs:10:31
+error[E0599]: no method named `fail` found for struct `PropsBuilder` in the current scope
+  --> tests/props_macro/props-fail.rs:10:31
    |
 3  | #[derive(Clone, Properties, PartialEq)]
    |                 ---------- method `fail` not found for this
@@ -40,15 +40,15 @@ error[E0599]: no method named `fail` found for struct `PropsBuilder<PropsBuilder
    |                               ^^^^ method not found in `PropsBuilder<PropsBuilderStepPropsBuilder>`
 
 error[E0609]: no field `does_not_exist` on type `Props`
-  --> $DIR/props-fail.rs:15:25
+  --> tests/props_macro/props-fail.rs:15:25
    |
 15 |     yew::props!(Props { does_not_exist });
    |                         ^^^^^^^^^^^^^^ unknown field
    |
    = note: available fields are: `a`
 
-error[E0599]: no method named `does_not_exist` found for struct `PropsBuilder<PropsBuilderStep_missing_required_prop_a>` in the current scope
-  --> $DIR/props-fail.rs:15:25
+error[E0599]: no method named `does_not_exist` found for struct `PropsBuilder` in the current scope
+  --> tests/props_macro/props-fail.rs:15:25
    |
 3  | #[derive(Clone, Properties, PartialEq)]
    |                 ---------- method `does_not_exist` not found for this

--- a/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
@@ -1,5 +1,5 @@
 error[E0277]: can't compare `Props` with `Props`
- --> $DIR/resolve-prop-fail.rs:3:17
+ --> tests/props_macro/resolve-prop-fail.rs:3:17
   |
 3 | #[derive(Clone, Properties)]
   |                 ^^^^^^^^^^ no implementation for `Props == Props`
@@ -10,4 +10,4 @@ error[E0277]: can't compare `Props` with `Props`
   |                       --------- required by this bound in `yew::Properties`
   |
   = help: the trait `PartialEq` is not implemented for `Props`
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
@@ -4,10 +4,10 @@ error[E0277]: can't compare `Props` with `Props`
 3 | #[derive(Clone, Properties)]
   |                 ^^^^^^^^^^ no implementation for `Props == Props`
   |
- ::: $WORKSPACE/packages/yew/src/html/component/properties.rs
+  = help: the trait `PartialEq` is not implemented for `Props`
+note: required by a bound in `yew::Properties`
+ --> $WORKSPACE/packages/yew/src/html/component/properties.rs
   |
   | pub trait Properties: PartialEq {
-  |                       --------- required by this bound in `yew::Properties`
-  |
-  = help: the trait `PartialEq` is not implemented for `Props`
+  |                       ^^^^^^^^^ required by this bound in `yew::Properties`
   = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-macro/tests/props_macro_test.rs
+++ b/packages/yew-macro/tests/props_macro_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.54), test)]
+#[rustversion::attr(stable(1.56), test)]
 fn props_macro() {
     let t = trybuild::TestCases::new();
     t.pass("tests/props_macro/*-pass.rs");

--- a/packages/yew-macro/tests/props_macro_test.rs
+++ b/packages/yew-macro/tests/props_macro_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.51), test)]
+#[rustversion::attr(stable(1.54), test)]
 fn props_macro() {
     let t = trybuild::TestCases::new();
     t.pass("tests/props_macro/*-pass.rs");

--- a/packages/yew-router-macro/Cargo.toml
+++ b/packages/yew-router-macro/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Contains macros used with yew-router"
 repository = "https://github.com/yewstack/yew"
+rust-version = "1.54.0"
 
 [lib]
 proc-macro = true

--- a/packages/yew-router-macro/Cargo.toml
+++ b/packages/yew-router-macro/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Contains macros used with yew-router"
 repository = "https://github.com/yewstack/yew"
-rust-version = "1.54.0"
+rust-version = "1.56.0"
 
 [lib]
 proc-macro = true

--- a/packages/yew-router-macro/Makefile.toml
+++ b/packages/yew-router-macro/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.test]
 clear = true
-toolchain = "1.54"
+toolchain = "1.56"
 command = "cargo"
 args = ["test"]
 

--- a/packages/yew-router-macro/Makefile.toml
+++ b/packages/yew-router-macro/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.test]
 clear = true
-toolchain = "1.51"
+toolchain = "1.54"
 command = "cargo"
 args = ["test"]
 

--- a/packages/yew-router-macro/tests/routable_derive_test.rs
+++ b/packages/yew-router-macro/tests/routable_derive_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.51), test)]
+#[rustversion::attr(stable(1.54), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/routable_derive/*-pass.rs");

--- a/packages/yew-router-macro/tests/routable_derive_test.rs
+++ b/packages/yew-router-macro/tests/routable_derive_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.54), test)]
+#[rustversion::attr(stable(1.56), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/routable_derive/*-pass.rs");

--- a/packages/yew-router/Cargo.toml
+++ b/packages/yew-router/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["web", "yew", "router"]
 categories = ["gui", "web-programming"]
 description = "A router implementation for the Yew framework"
 repository = "https://github.com/yewstack/yew"
-rust-version = "1.54.0"
+rust-version = "1.56.0"
 
 [features]
 wasm_test = []

--- a/packages/yew-router/Cargo.toml
+++ b/packages/yew-router/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["web", "yew", "router"]
 categories = ["gui", "web-programming"]
 description = "A router implementation for the Yew framework"
 repository = "https://github.com/yewstack/yew"
+rust-version = "1.54.0"
 
 [features]
 wasm_test = []

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["web", "webasm", "javascript"]
 categories = ["gui", "wasm", "web-programming"]
 description = "A framework for making client-side single-page apps"
 readme = "../../README.md"
-rust-version = "1.54.0"
+rust-version = "1.56.0"
 
 [dependencies]
 console_error_panic_hook = "0.1"

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["web", "webasm", "javascript"]
 categories = ["gui", "wasm", "web-programming"]
 description = "A framework for making client-side single-page apps"
 readme = "../../README.md"
+rust-version = "1.54.0"
 
 [dependencies]
 console_error_panic_hook = "0.1"

--- a/website/versioned_docs/version-0.19.0/getting-started/introduction.mdx
+++ b/website/versioned_docs/version-0.19.0/getting-started/introduction.mdx
@@ -13,8 +13,9 @@ Your local development environment will need a couple of tools to compile, build
 To install Rust, follow the [official instructions](https://www.rust-lang.org/tools/install).
 
 :::important
-The minimum supported Rust version (MSRV) for Yew is `1.49.0`. Older versions can cause unexpected issues accompanied by incomprehensible error messages.
-You can check your toolchain version using `rustup show` (under "active toolchain") or alternatively `rustc --version`. To update your toolchain, run `rustup update`.
+The minimum supported Rust version (MSRV) for Yew is `1.54.0`. Older versions can cause unexpected issues accompanied
+by incomprehensible error messages or outright fail to compile. You can check your toolchain version using
+`rustup show` (under "active toolchain") or alternatively `rustc --version`. To update your toolchain, run `rustup update`.
 :::
 
 ## Install WebAssembly target

--- a/website/versioned_docs/version-0.19.0/getting-started/introduction.mdx
+++ b/website/versioned_docs/version-0.19.0/getting-started/introduction.mdx
@@ -13,7 +13,7 @@ Your local development environment will need a couple of tools to compile, build
 To install Rust, follow the [official instructions](https://www.rust-lang.org/tools/install).
 
 :::important
-The minimum supported Rust version (MSRV) for Yew is `1.54.0`. Older versions can cause unexpected issues accompanied
+The minimum supported Rust version (MSRV) for Yew is `1.56.0`. Older versions can cause unexpected issues accompanied
 by incomprehensible error messages or outright fail to compile. You can check your toolchain version using
 `rustup show` (under "active toolchain") or alternatively `rustc --version`. To update your toolchain, run `rustup update`.
 :::


### PR DESCRIPTION
#### Description

Bump MSRV to 1.56. A dependency of wasm-bindgen bumped it's MSRV so we need to as well.
Also see https://github.com/yewstack/yew/pull/2330#issuecomment-1006184731

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
