### PR TITLE
Fixed broken link to getting-started/introduction

### DIFF
--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -24,7 +24,7 @@ front-end web apps using [WebAssembly](https://webassembly.org/).
 Click the link below to learn how to build your first Yew app and learn from community-built example
 projects
 
-[Getting started](/docs/getting-started/project-setup/introduction)
+[Getting started](/docs/getting-started/introduction)
 
 ## Still not convinced?
 


### PR DESCRIPTION
#### Description

Typo fix. Broken link on home page. Single line changed.

```
-[Getting started](/docs/getting-started/project-setup/introduction)
+[Getting started](/docs/getting-started/introduction)
```



