### PR TITLE
Fix link to "Getting started"

### DIFF
--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -24,7 +24,7 @@ front-end web apps using [WebAssembly](https://webassembly.org/).
 Click the link below to learn how to build your first Yew app and learn from community-built example
 projects
 
-[Getting started](/docs/getting-started/project-setup/introduction)
+[Getting started](/docs/getting-started/introduction)
 
 ## Still not convinced?
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Fixes a link to the "Getting started" documentation page from the index page.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->