### PR TITLE
Incorporate in-code translation in the workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "weekly"
       day: "friday"
     open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "daily"
+    target-branch: "master"

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -23,13 +23,31 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: "14.x"
+          node-version: "16"
 
       - name: Build
         run: |
           cd website
           npm install
           npm run build
+
+      # this won't delete existing translation and will only add new ones
+      - name: Generate Stubs for in-code Localization
+        if: github.event.workflow_run.event == 'pull_request'
+        run: |
+          cd website
+          node ../ci/write-translations.js
+
+      # in order to commit the stubs in case of follow-up commits
+      - run: git pull
+        if: github.event.workflow_run.event == 'pull_request'
+
+      # this will only commit when the generated stubs are different
+      - name: Commit Localization
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "🤖 Append stubs for in-code localization"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v2

--- a/ci/write-translations.js
+++ b/ci/write-translations.js
@@ -1,0 +1,20 @@
+const {i18n: {locales}} = require('../website/docusaurus.config.js');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+/**
+ * @param {string} locale
+ */
+async function writeTranslations(locale) {
+    const {stdout, stderr} = await exec(`npm run docusaurus -- write-translations --locale ${locale}`)
+    console.log(stdout)
+    console.error(stderr)
+}
+
+
+locales
+    .filter(locale => locale !== 'en')
+    .forEach(async locale => await writeTranslations(locale))
+
+
+

--- a/website/i18n/ja/code.json
+++ b/website/i18n/ja/code.json
@@ -1,0 +1,198 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "ページが見つかりません",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "お探しのページが見つかりませんでした。",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "このページにリンクしているサイトの所有者に連絡をしてリンクが壊れていることを伝えてください。",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "閉じる",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Scroll back to top",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archive",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archive",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "ブログ記事一覧のナビゲーション",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "新しい記事",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "過去の記事",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "約{readingTime}分",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.post.readMore": {
+    "message": "もっと見る",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "ブログ記事のナビゲーション",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "新しい記事",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "過去の記事",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count}件",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "「{tagName}」タグの記事が{nPosts}あります",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "全てのタグを見る",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "クリップボードにコードをコピー",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "コピーしました",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "コピー",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "サイドバーを開く",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "サイドバーを開く",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "ドキュメントのナビゲーション",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.next": {
+    "message": "次へ",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "前へ",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "サイドバーを隠す",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "サイドバーを隠す",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "Toggle the collapsible sidebar category '{label}'",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "One doc tagged|{count} docs tagged",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} with \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "これはリリース前の{siteTitle} {versionLabel}のドキュメントです。",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "これは{siteTitle} {versionLabel}のドキュメントで現在はアクティブにメンテナンスされていません。",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "最新のドキュメントは{latestVersionLink} ({versionLabel}) を見てください。",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "最新バージョン",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "このページを編集",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "見出しへの直接リンク",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": "{date}に",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": "{user}が",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "{atDate}{byUser}最終更新",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Back to main menu",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "メインコンテンツまでスキップ",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "タグ:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "On this page",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "タグ",
+    "description": "The title of the tag list page"
+  }
+}

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.sidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts": {
+    "message": "Concepts",
+    "description": "The label for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts.link.generated-index.title": {
+    "message": "Yew concepts",
+    "description": "The generated-index page title for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts.link.generated-index.description": {
+    "message": "Learn about the important Yew concepts!",
+    "description": "The generated-index page description for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Components": {
+    "message": "Components",
+    "description": "The label for category Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.HTML": {
+    "message": "HTML",
+    "description": "The label for category HTML in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Function Components": {
+    "message": "Function Components",
+    "description": "The label for category Function Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen": {
+    "message": "wasm-bindgen",
+    "description": "The label for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen.link.generated-index.title": {
+    "message": "wasm-bindgen",
+    "description": "The generated-index page title for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen.link.generated-index.description": {
+    "message": "Learn about wasm-bindgen",
+    "description": "The generated-index page description for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics": {
+    "message": "Advanced topics",
+    "description": "The label for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics.link.generated-index.title": {
+    "message": "Advanced topics",
+    "description": "The generated-index page title for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics.link.generated-index.description": {
+    "message": "Learn about the advanced topics and inner workings of Yew!",
+    "description": "The generated-index page description for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More": {
+    "message": "More",
+    "description": "The label for category More in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More.link.generated-index.title": {
+    "message": "Miscellaneous",
+    "description": "The generated-index page title for category More in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Migration guides": {
+    "message": "Migration guides",
+    "description": "The label for category Migration guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew": {
+    "message": "yew",
+    "description": "The label for category yew in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-agent": {
+    "message": "yew-agent",
+    "description": "The label for category yew-agent in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-router": {
+    "message": "yew-router",
+    "description": "The label for category yew-router in sidebar sidebar"
+  }
+}

--- a/website/i18n/ja/docusaurus-plugin-content-docs/version-0.18.0.json
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/version-0.18.0.json
@@ -1,0 +1,42 @@
+{
+  "version.label": {
+    "message": "0.18.0",
+    "description": "The label for version 0.18.0"
+  },
+  "sidebar.sidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Project Setup": {
+    "message": "Project Setup",
+    "description": "The label for category Project Setup in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts": {
+    "message": "Concepts",
+    "description": "The label for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Components": {
+    "message": "Components",
+    "description": "The label for category Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen": {
+    "message": "wasm-bindgen",
+    "description": "The label for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.HTML": {
+    "message": "HTML",
+    "description": "The label for category HTML in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Services": {
+    "message": "Services",
+    "description": "The label for category Services in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics": {
+    "message": "Advanced topics",
+    "description": "The label for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More": {
+    "message": "More",
+    "description": "The label for category More in sidebar sidebar"
+  }
+}

--- a/website/i18n/ja/docusaurus-plugin-content-docs/version-0.19.0.json
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/version-0.19.0.json
@@ -1,0 +1,58 @@
+{
+  "version.label": {
+    "message": "0.19.0",
+    "description": "The label for version 0.19.0"
+  },
+  "sidebar.sidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Project Setup": {
+    "message": "Project Setup",
+    "description": "The label for category Project Setup in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts": {
+    "message": "Concepts",
+    "description": "The label for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen": {
+    "message": "wasm-bindgen",
+    "description": "The label for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Components": {
+    "message": "Components",
+    "description": "The label for category Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.HTML": {
+    "message": "HTML",
+    "description": "The label for category HTML in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Function Components": {
+    "message": "Function Components",
+    "description": "The label for category Function Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics": {
+    "message": "Advanced topics",
+    "description": "The label for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More": {
+    "message": "More",
+    "description": "The label for category More in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Migration guides": {
+    "message": "Migration guides",
+    "description": "The label for category Migration guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew": {
+    "message": "yew",
+    "description": "The label for category yew in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-agent": {
+    "message": "yew-agent",
+    "description": "The label for category yew-agent in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-router": {
+    "message": "yew-router",
+    "description": "The label for category yew-router in sidebar sidebar"
+  }
+}

--- a/website/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/website/i18n/ja/docusaurus-theme-classic/footer.json
@@ -1,0 +1,38 @@
+{
+  "link.title.Support": {
+    "message": "Support",
+    "description": "The title of the footer links column with title=Support in the footer"
+  },
+  "link.title.Participate": {
+    "message": "Participate",
+    "description": "The title of the footer links column with title=Participate in the footer"
+  },
+  "link.title.More": {
+    "message": "More",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Fund Issues": {
+    "message": "Fund Issues",
+    "description": "The label of footer link with label=Fund Issues linking to https://issuehunt.io/r/yewstack/yew"
+  },
+  "link.item.label.Sponsor Project": {
+    "message": "Sponsor Project",
+    "description": "The label of footer link with label=Sponsor Project linking to https://opencollective.com/yew"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/yewstack/yew"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/VQck8X4"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/yewstack"
+  },
+  "link.item.label.Yew Awesome": {
+    "message": "Yew Awesome",
+    "description": "The label of footer link with label=Yew Awesome linking to https://github.com/jetli/awesome-yew"
+  }
+}

--- a/website/i18n/ja/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/ja/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,18 @@
+{
+  "title": {
+    "message": "Yew",
+    "description": "The title in the navbar"
+  },
+  "item.label.Docs": {
+    "message": "Docs",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.API": {
+    "message": "API",
+    "description": "Navbar item with label API"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -1,0 +1,198 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "页面找不到啦",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "We could not find what you were looking for.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Close",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Scroll back to top",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archive",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archive",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Blog list page navigation",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Newer Entries",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Older Entries",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "One min read|{readingTime} min read",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Read More",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Blog post page navigation",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Newer Post",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Older Post",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "One post|{count} posts",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} tagged with \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "View All Tags",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copy code to clipboard",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copied",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copy",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Docs pages navigation",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Next",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Previous",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "Toggle the collapsible sidebar category '{label}'",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "One doc tagged|{count} docs tagged",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} with \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "latest version",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Edit this page",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Direct link to heading",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " on {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " by {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Last updated{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Back to main menu",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Skip to main content",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "On this page",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.sidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts": {
+    "message": "Concepts",
+    "description": "The label for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts.link.generated-index.title": {
+    "message": "Yew concepts",
+    "description": "The generated-index page title for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts.link.generated-index.description": {
+    "message": "Learn about the important Yew concepts!",
+    "description": "The generated-index page description for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Components": {
+    "message": "Components",
+    "description": "The label for category Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.HTML": {
+    "message": "HTML",
+    "description": "The label for category HTML in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Function Components": {
+    "message": "Function Components",
+    "description": "The label for category Function Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen": {
+    "message": "wasm-bindgen",
+    "description": "The label for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen.link.generated-index.title": {
+    "message": "wasm-bindgen",
+    "description": "The generated-index page title for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen.link.generated-index.description": {
+    "message": "Learn about wasm-bindgen",
+    "description": "The generated-index page description for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics": {
+    "message": "Advanced topics",
+    "description": "The label for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics.link.generated-index.title": {
+    "message": "Advanced topics",
+    "description": "The generated-index page title for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics.link.generated-index.description": {
+    "message": "Learn about the advanced topics and inner workings of Yew!",
+    "description": "The generated-index page description for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More": {
+    "message": "More",
+    "description": "The label for category More in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More.link.generated-index.title": {
+    "message": "Miscellaneous",
+    "description": "The generated-index page title for category More in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Migration guides": {
+    "message": "Migration guides",
+    "description": "The label for category Migration guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew": {
+    "message": "yew",
+    "description": "The label for category yew in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-agent": {
+    "message": "yew-agent",
+    "description": "The label for category yew-agent in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-router": {
+    "message": "yew-router",
+    "description": "The label for category yew-router in sidebar sidebar"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.18.0.json
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.18.0.json
@@ -1,0 +1,42 @@
+{
+  "version.label": {
+    "message": "0.18.0",
+    "description": "The label for version 0.18.0"
+  },
+  "sidebar.sidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Project Setup": {
+    "message": "Project Setup",
+    "description": "The label for category Project Setup in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts": {
+    "message": "Concepts",
+    "description": "The label for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Components": {
+    "message": "Components",
+    "description": "The label for category Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen": {
+    "message": "wasm-bindgen",
+    "description": "The label for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.HTML": {
+    "message": "HTML",
+    "description": "The label for category HTML in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Services": {
+    "message": "Services",
+    "description": "The label for category Services in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics": {
+    "message": "Advanced topics",
+    "description": "The label for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More": {
+    "message": "More",
+    "description": "The label for category More in sidebar sidebar"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.19.0.json
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.19.0.json
@@ -1,0 +1,58 @@
+{
+  "version.label": {
+    "message": "0.19.0",
+    "description": "The label for version 0.19.0"
+  },
+  "sidebar.sidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Project Setup": {
+    "message": "Project Setup",
+    "description": "The label for category Project Setup in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts": {
+    "message": "Concepts",
+    "description": "The label for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen": {
+    "message": "wasm-bindgen",
+    "description": "The label for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Components": {
+    "message": "Components",
+    "description": "The label for category Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.HTML": {
+    "message": "HTML",
+    "description": "The label for category HTML in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Function Components": {
+    "message": "Function Components",
+    "description": "The label for category Function Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics": {
+    "message": "Advanced topics",
+    "description": "The label for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More": {
+    "message": "More",
+    "description": "The label for category More in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Migration guides": {
+    "message": "Migration guides",
+    "description": "The label for category Migration guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew": {
+    "message": "yew",
+    "description": "The label for category yew in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-agent": {
+    "message": "yew-agent",
+    "description": "The label for category yew-agent in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-router": {
+    "message": "yew-router",
+    "description": "The label for category yew-router in sidebar sidebar"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/website/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -1,0 +1,38 @@
+{
+  "link.title.Support": {
+    "message": "Support",
+    "description": "The title of the footer links column with title=Support in the footer"
+  },
+  "link.title.Participate": {
+    "message": "Participate",
+    "description": "The title of the footer links column with title=Participate in the footer"
+  },
+  "link.title.More": {
+    "message": "More",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Fund Issues": {
+    "message": "Fund Issues",
+    "description": "The label of footer link with label=Fund Issues linking to https://issuehunt.io/r/yewstack/yew"
+  },
+  "link.item.label.Sponsor Project": {
+    "message": "Sponsor Project",
+    "description": "The label of footer link with label=Sponsor Project linking to https://opencollective.com/yew"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/yewstack/yew"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/VQck8X4"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/yewstack"
+  },
+  "link.item.label.Yew Awesome": {
+    "message": "Yew Awesome",
+    "description": "The label of footer link with label=Yew Awesome linking to https://github.com/jetli/awesome-yew"
+  }
+}

--- a/website/i18n/zh-CN/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/zh-CN/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,18 @@
+{
+  "title": {
+    "message": "Yew",
+    "description": "The title in the navbar"
+  },
+  "item.label.Docs": {
+    "message": "Docs",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.API": {
+    "message": "API",
+    "description": "Navbar item with label API"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/website/i18n/zh-TW/code.json
+++ b/website/i18n/zh-TW/code.json
@@ -1,0 +1,198 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "Page Not Found",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "We could not find what you were looking for.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Close",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Scroll back to top",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archive",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archive",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Blog list page navigation",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Newer Entries",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Older Entries",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "One min read|{readingTime} min read",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Read More",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Blog post page navigation",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Newer Post",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Older Post",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "One post|{count} posts",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} tagged with \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "View All Tags",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copy code to clipboard",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copied",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copy",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Docs pages navigation",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Next",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Previous",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "Toggle the collapsible sidebar category '{label}'",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "One doc tagged|{count} docs tagged",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} with \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "latest version",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Edit this page",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Direct link to heading",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " on {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " by {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Last updated{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Back to main menu",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Skip to main content",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "On this page",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
+  }
+}

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.sidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts": {
+    "message": "Concepts",
+    "description": "The label for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts.link.generated-index.title": {
+    "message": "Yew concepts",
+    "description": "The generated-index page title for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts.link.generated-index.description": {
+    "message": "Learn about the important Yew concepts!",
+    "description": "The generated-index page description for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Components": {
+    "message": "Components",
+    "description": "The label for category Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.HTML": {
+    "message": "HTML",
+    "description": "The label for category HTML in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Function Components": {
+    "message": "Function Components",
+    "description": "The label for category Function Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen": {
+    "message": "wasm-bindgen",
+    "description": "The label for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen.link.generated-index.title": {
+    "message": "wasm-bindgen",
+    "description": "The generated-index page title for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen.link.generated-index.description": {
+    "message": "Learn about wasm-bindgen",
+    "description": "The generated-index page description for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics": {
+    "message": "Advanced topics",
+    "description": "The label for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics.link.generated-index.title": {
+    "message": "Advanced topics",
+    "description": "The generated-index page title for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics.link.generated-index.description": {
+    "message": "Learn about the advanced topics and inner workings of Yew!",
+    "description": "The generated-index page description for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More": {
+    "message": "More",
+    "description": "The label for category More in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More.link.generated-index.title": {
+    "message": "Miscellaneous",
+    "description": "The generated-index page title for category More in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Migration guides": {
+    "message": "Migration guides",
+    "description": "The label for category Migration guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew": {
+    "message": "yew",
+    "description": "The label for category yew in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-agent": {
+    "message": "yew-agent",
+    "description": "The label for category yew-agent in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-router": {
+    "message": "yew-router",
+    "description": "The label for category yew-router in sidebar sidebar"
+  }
+}

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.18.0.json
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.18.0.json
@@ -1,0 +1,42 @@
+{
+  "version.label": {
+    "message": "0.18.0",
+    "description": "The label for version 0.18.0"
+  },
+  "sidebar.sidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Project Setup": {
+    "message": "Project Setup",
+    "description": "The label for category Project Setup in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts": {
+    "message": "Concepts",
+    "description": "The label for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Components": {
+    "message": "Components",
+    "description": "The label for category Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen": {
+    "message": "wasm-bindgen",
+    "description": "The label for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.HTML": {
+    "message": "HTML",
+    "description": "The label for category HTML in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Services": {
+    "message": "Services",
+    "description": "The label for category Services in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics": {
+    "message": "Advanced topics",
+    "description": "The label for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More": {
+    "message": "More",
+    "description": "The label for category More in sidebar sidebar"
+  }
+}

--- a/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.19.0.json
+++ b/website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.19.0.json
@@ -1,0 +1,58 @@
+{
+  "version.label": {
+    "message": "0.19.0",
+    "description": "The label for version 0.19.0"
+  },
+  "sidebar.sidebar.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Project Setup": {
+    "message": "Project Setup",
+    "description": "The label for category Project Setup in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Concepts": {
+    "message": "Concepts",
+    "description": "The label for category Concepts in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.wasm-bindgen": {
+    "message": "wasm-bindgen",
+    "description": "The label for category wasm-bindgen in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Components": {
+    "message": "Components",
+    "description": "The label for category Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.HTML": {
+    "message": "HTML",
+    "description": "The label for category HTML in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Function Components": {
+    "message": "Function Components",
+    "description": "The label for category Function Components in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Advanced topics": {
+    "message": "Advanced topics",
+    "description": "The label for category Advanced topics in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.More": {
+    "message": "More",
+    "description": "The label for category More in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.Migration guides": {
+    "message": "Migration guides",
+    "description": "The label for category Migration guides in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew": {
+    "message": "yew",
+    "description": "The label for category yew in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-agent": {
+    "message": "yew-agent",
+    "description": "The label for category yew-agent in sidebar sidebar"
+  },
+  "sidebar.sidebar.category.yew-router": {
+    "message": "yew-router",
+    "description": "The label for category yew-router in sidebar sidebar"
+  }
+}

--- a/website/i18n/zh-TW/docusaurus-theme-classic/footer.json
+++ b/website/i18n/zh-TW/docusaurus-theme-classic/footer.json
@@ -1,0 +1,38 @@
+{
+  "link.title.Support": {
+    "message": "Support",
+    "description": "The title of the footer links column with title=Support in the footer"
+  },
+  "link.title.Participate": {
+    "message": "Participate",
+    "description": "The title of the footer links column with title=Participate in the footer"
+  },
+  "link.title.More": {
+    "message": "More",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Fund Issues": {
+    "message": "Fund Issues",
+    "description": "The label of footer link with label=Fund Issues linking to https://issuehunt.io/r/yewstack/yew"
+  },
+  "link.item.label.Sponsor Project": {
+    "message": "Sponsor Project",
+    "description": "The label of footer link with label=Sponsor Project linking to https://opencollective.com/yew"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/yewstack/yew"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/VQck8X4"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/yewstack"
+  },
+  "link.item.label.Yew Awesome": {
+    "message": "Yew Awesome",
+    "description": "The label of footer link with label=Yew Awesome linking to https://github.com/jetli/awesome-yew"
+  }
+}

--- a/website/i18n/zh-TW/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/zh-TW/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,18 @@
+{
+  "title": {
+    "message": "Yew",
+    "description": "The title in the navbar"
+  },
+  "item.label.Docs": {
+    "message": "Docs",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.API": {
+    "message": "API",
+    "description": "Navbar item with label API"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}


### PR DESCRIPTION
tl;dr:

A lot of displaying strings in docusaurus plugins (like sidebar, footer etc.) are written inside the `<translation>` tags, `docusaurus run write-translations` will grep those tags from the code and add them under `/website/i18n/<locale>/...` as json files. Those are stubs and should be filled out later by translators.

Later maintainers of the website should also remember to use the <translation> tags when they write displaying content in jsx code.

For that reason our GitLocalize project need to add those .json files and I believe @siku2 is the only one capable of doing so atm?


Fixes #2276 

This implements the relevant workflow and generates the stubs for the first time.