### PR TITLE
stop spamming bench comments on PR's

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request_target:
+      types: [labeled, synchronize, opened, reopened]
 
 permissions:
   # deployments permission to deploy GitHub pages website
@@ -37,7 +38,7 @@ jobs:
           # Push and deploy GitHub pages branch automatically
           alert-threshold: "200%"
           alert-comment-cc-users: "@yewstack/yew"
-          comment-always: true
+          comment-always: ${{ github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'performance') }}
           comment-on-alert: true
           # Don't push to gh-pages if its a pull request
           auto-push: ${{ github.event_name != 'pull_request_target' }}


### PR DESCRIPTION
#### Description

only drop non-alert benchmark comment f performance label is not present

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
