### PR TITLE
[POC] Redo properties

### DIFF
--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 
 [dependencies]
 boolinator = "2"
+convert_case = "0.5"
 lazy_static = "1"
 proc-macro-error = "1"
 proc-macro2 = "1"

--- a/packages/yew-macro/src/lib.rs
+++ b/packages/yew-macro/src/lib.rs
@@ -50,6 +50,7 @@ mod classes;
 mod derive_props;
 mod function_component;
 mod html_tree;
+mod properties_attr;
 mod props;
 mod stringify;
 
@@ -132,5 +133,15 @@ pub fn function_component(
 
     function_component_impl(attr, item)
         .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
+#[proc_macro_attribute]
+pub fn properties(
+    attrs: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    properties_attr::parse_properties(attrs.into(), item.into())
+        .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }

--- a/packages/yew-macro/src/lib.rs
+++ b/packages/yew-macro/src/lib.rs
@@ -53,6 +53,7 @@ mod html_tree;
 mod properties_attr;
 mod props;
 mod stringify;
+pub(crate) mod typed_vdom;
 
 use derive_props::DerivePropsInput;
 use function_component::{function_component_impl, FunctionComponent, FunctionComponentName};
@@ -136,6 +137,7 @@ pub fn function_component(
         .into()
 }
 
+/// Marks a struct as Properties
 #[proc_macro_attribute]
 pub fn properties(
     attrs: proc_macro::TokenStream,
@@ -144,4 +146,23 @@ pub fn properties(
     properties_attr::parse_properties(attrs.into(), item.into())
         .unwrap_or_else(|e| e.to_compile_error())
         .into()
+}
+
+/// Declares HTML element
+///
+/// Every HTML element is a component, which returns a manually constructed `VTag`.
+/// This macro is used to generate this component.
+#[proc_macro]
+pub fn generate_element(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as typed_vdom::generate_element::GenerateElement);
+
+    input.to_token_stream().into()
+}
+
+/// Declares all the global elements
+#[proc_macro]
+pub fn global(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as typed_vdom::global::GlobalAttributes);
+
+    input.to_token_stream().into()
 }

--- a/packages/yew-macro/src/properties_attr.rs
+++ b/packages/yew-macro/src/properties_attr.rs
@@ -1,4 +1,4 @@
-use crate::{build_fields, build_setters, kw};
+use crate::typed_vdom::{build_fields, build_setters, kw};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, ToTokens};
 use syn::parse::{Parse, ParseStream};

--- a/packages/yew-macro/src/properties_attr.rs
+++ b/packages/yew-macro/src/properties_attr.rs
@@ -1,0 +1,189 @@
+use crate::{build_fields, build_setters, kw};
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Iter;
+use syn::spanned::Spanned;
+use syn::{Field, Fields, FieldsNamed, ItemStruct, Token, Type};
+
+struct Properties {
+    extends_ty: Option<Type>,
+    item: ItemStruct,
+}
+
+impl ToTokens for Properties {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(match self.extends_ty {
+            Some(_) => self.build_extended_props(),
+            None => self.build_non_extended_props(),
+        });
+    }
+}
+
+impl Properties {
+    fn builder_ident(&self) -> Ident {
+        let ident = &self.item.ident;
+        format_ident!("{}Builder", ident, span = ident.span())
+    }
+
+    fn build_extended_props(&self) -> TokenStream {
+        let ItemStruct {
+            attrs,
+            vis,
+            struct_token,
+            ident,
+            generics,
+            ..
+        } = &self.item;
+        let fields = self.fields();
+        let setters = self
+            .fields()
+            .map(|field| build_setters(field.ident.as_ref().unwrap(), &field.ty, false));
+        let extends_ty = &self.extends_ty.as_ref().unwrap();
+        let builder_ident = self.builder_ident();
+
+        quote! {
+            #(#attrs)*
+            #vis #struct_token #ident #generics {
+                #(#fields)*,
+                __parent: #extends_ty
+            }
+
+            impl #ident {
+                #(#setters)*
+            }
+
+            impl ::std::ops::Deref for #ident {
+                type Target = #extends_ty;
+
+                fn deref(&self) -> &Self::Target {
+                    &self.__parent
+                }
+            }
+
+            impl ::std::ops::DerefMut for #ident {
+                fn deref_mut(&mut self) -> &mut Self::Target {
+                    &mut self.__parent
+                }
+            }
+
+            struct #builder_ident { props: #ident }
+
+            impl #builder_ident {
+                fn build(self) -> #ident {
+                    self.props
+                }
+            }
+
+            impl ::yew::Properties for #ident {
+                type Builder = #builder_ident;
+
+                fn builder() -> Self::Builder {
+                    #builder_ident { props: Self::default() }
+                }
+            }
+
+
+            impl ::std::ops::Deref for #builder_ident {
+                type Target = #ident;
+
+                fn deref(&self) -> &Self::Target {
+                    &self.props
+                }
+            }
+
+            impl ::std::ops::DerefMut for #builder_ident {
+                fn deref_mut(&mut self) -> &mut Self::Target {
+                    &mut self.props
+                }
+            }
+        }
+    }
+
+    fn build_non_extended_props(&self) -> TokenStream {
+        let item = &self.item;
+        let ident = &item.ident;
+        let builder_ident = self.builder_ident();
+        let fields = self
+            .fields()
+            .map(|it| build_fields(it.ident.as_ref().unwrap(), &it.ty, true));
+        let setters = self
+            .fields()
+            .map(|it| build_setters(it.ident.as_ref().unwrap(), &it.ty, true));
+        let built_fields = self.fields().map(|field| {
+            let ident = field.ident.as_ref().unwrap();
+            quote! {
+                // todo support unwrap_or{_else}
+                #ident: ::std::option::Option::unwrap(self.#ident)
+            }
+        });
+
+        quote! {
+            #item
+
+            impl ::yew::Properties for #ident {
+                type Builder = #builder_ident;
+
+                fn builder() -> Self::Builder {
+                    ::std::default::Default::default()
+                }
+            }
+
+            #[derive(::std::default::Default)]
+            struct #builder_ident {
+                #(#fields)*
+            }
+
+            impl #builder_ident {
+                #(#setters)*
+
+                fn build(self) -> #ident {
+                    #ident {
+                        #(#built_fields)*
+                    }
+                }
+            }
+        }
+    }
+
+    fn fields(&self) -> Iter<Field> {
+        match &self.item.fields {
+            Fields::Unit | Fields::Unnamed(_) => unreachable!(),
+            Fields::Named(FieldsNamed { named, .. }) => named.iter(),
+        }
+    }
+}
+
+struct PropertiesAttrs {
+    extend_ty: Option<Type>,
+}
+
+impl Parse for PropertiesAttrs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let extend_ty = if input.parse::<kw::extends>().is_ok() {
+            let _separator = input.parse::<Token![=]>()?;
+            Some(input.parse::<Type>()?)
+        } else {
+            None
+        };
+        Ok(Self { extend_ty })
+    }
+}
+
+pub fn parse_properties(attrs: TokenStream, item: TokenStream) -> syn::Result<TokenStream> {
+    let item: ItemStruct = syn::parse2(item)?;
+    if matches!(item.fields, Fields::Unit | Fields::Unnamed(_)) {
+        return Err(syn::Error::new(
+            item.fields.span(),
+            "only structs with named fields may be used for props",
+        ));
+    };
+
+    let attrs = syn::parse2::<PropertiesAttrs>(attrs)?;
+
+    let properties = Properties {
+        extends_ty: attrs.extend_ty,
+        item,
+    };
+    Ok(properties.to_token_stream())
+}

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -59,7 +59,9 @@ impl ComponentProps {
         let check_props: TokenStream = self
             .props
             .iter()
-            .map(|Prop { label, .. }| quote_spanned! ( label.span()=> let _ = &__yew_props.#label; ))
+            .map(
+                |Prop { label, .. }| quote_spanned! ( label.span()=> let _ = &__yew_props.#label; ),
+            )
             .chain(self.base_expr.iter().map(|expr| {
                 quote_spanned! {props_ty.span()=>
                     let _: #props_ty = #expr;

--- a/packages/yew-macro/src/typed_vdom/generate_element.rs
+++ b/packages/yew-macro/src/typed_vdom/generate_element.rs
@@ -1,0 +1,162 @@
+use convert_case::{Case, Casing};
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote, ToTokens};
+use syn::{braced, Token};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use crate::typed_vdom::{AttributePropDefinition, kw};
+
+pub struct GenerateElement {
+    element_name: Ident,
+    props: Punctuated<AttributePropDefinition, Token![,]>,
+    extends: Option<Ident>,
+}
+
+impl Parse for GenerateElement {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name = input.parse()?;
+        let _separator = input.parse::<Token![;]>()?;
+
+        let extends = {
+            if input.parse::<kw::extends>().is_err() {
+                None
+            } else {
+                let _separator = input.parse::<Token![:]>()?;
+                let extends = input.parse()?;
+                let _separator = input.parse::<Token![;]>()?;
+                Some(extends)
+            }
+        };
+
+
+        let props = {
+            let _props_kw = input.parse::<kw::props>()?;
+            let _separator = input.parse::<Token![:]>()?;
+
+            let buf;
+            let _brace_token = braced!(buf in input);
+            buf
+        };
+        let props = Punctuated::parse_terminated(&props)?;
+
+
+        Ok(Self {
+            element_name: name,
+            props,
+            extends,
+        })
+    }
+}
+
+impl ToTokens for GenerateElement {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let GenerateElement { element_name, props: prop_definitions, extends } = self;
+
+        let props_ident = format_ident!("{}Props", element_name.to_string().to_case(Case::Pascal), span = element_name.span());
+        let props_len = prop_definitions.len();
+        let props = prop_definitions.iter().map(|it| it.build_fields());
+        let setters = prop_definitions.iter().map(|it| it.build_setter());
+        let attribute_if_lets = prop_definitions.iter().map(|it| it.build_if_lets());
+
+        let (extends_field, extends_impls, extend_element) = extends.as_ref().map(|e| impl_extends_deref(e, &props_ident)).unwrap_or_default();
+        let (extend_var, extend_attributes) = if extend_element.is_empty() {
+            (quote! {}, quote! {})
+        } else {
+            (
+                quote! {
+                    let parent = #extend_element;
+                },
+                quote! {
+                    attrs.extend(parent.attributes)
+                }
+            )
+        };
+
+        let out = quote! {
+            #[allow(non_camel_case_types)]
+            struct #element_name;
+
+            #[derive(::std::default::Default, ::std::clone::Clone, ::std::fmt::Debug, ::yew::html::Properties, ::std::cmp::PartialEq)]
+            struct #props_ident {
+                #(#props)*
+                #extends_field
+            }
+
+            impl #props_ident {
+                #(#setters)*
+            }
+
+            // todo qualified path
+            impl PropsExtend for #props_ident{
+                fn into_data(self) -> ElementData {
+                    #extend_var;
+
+                    ElementData {
+                        node_ref: self.node_ref.unwrap_or_default(),
+                        attributes: {
+                            let mut attrs = ::std::collections::HashMap::with_capacity(#props_len);
+                            #(#attribute_if_lets)*
+                            #extend_attributes;
+                            attrs
+                        },
+                        listeners: ::std::default::Default::default(),
+                        key: self.key,
+                        children: self.children.map(|it| it.into_iter().collect()).unwrap_or_default()
+                    }
+                }
+            }
+
+            impl ::yew::Component for #element_name {
+                type Message = ();
+                type Properties = #props_ident;
+
+                fn create(_ctx: &Context<Self>) -> Self {
+                    Self
+                }
+
+                fn view(&self, ctx: &Context<Self>) -> Html {
+                    let element: ElementData = ctx.props().clone().into_data();
+                    // todo use __new_{other, textarea, input} depending upon the element
+                    VTag::__new_other(
+                        ::std::stringify!(#element_name).into(),
+                        element.node_ref,
+                        element.key,
+                        ::yew::virtual_dom::Attributes::IndexMap(element.attributes.into_iter().collect()),
+                        ::yew::virtual_dom::Listeners::Pending(element.listeners.into_boxed_slice()),
+                        ::yew::virtual_dom::VList::with_children(element.children, ::std::option::Option::None),
+                    ).into()
+                }
+            }
+
+
+            #extends_impls
+        };
+
+        tokens.extend(out);
+    }
+}
+
+fn impl_extends_deref(extends: &Ident, props_ident: &Ident) -> (TokenStream, TokenStream, TokenStream) {
+    let field = quote! { __parent: #extends };
+
+    let impls = quote! {
+        impl ::std::ops::Deref for #props_ident {
+            type Target = #extends;
+
+            fn deref(&self) -> &Self::Target {
+                &self.__parent
+            }
+        }
+
+        impl ::std::ops::DerefMut for #props_ident {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.__parent
+            }
+        }
+    };
+    let attributes = quote! {
+        self.__parent.into_data()
+    };
+
+    (field, impls, attributes)
+}

--- a/packages/yew-macro/src/typed_vdom/global.rs
+++ b/packages/yew-macro/src/typed_vdom/global.rs
@@ -1,0 +1,134 @@
+use proc_macro2::Ident;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::{braced, parse_quote, Token};
+use syn::punctuated::Punctuated;
+use crate::typed_vdom::{AttributePropDefinition, kw};
+
+pub struct ListenerPropDefinition {
+    name: Ident,
+    ty: Ident,
+    ident: Ident,
+}
+
+impl Parse for ListenerPropDefinition {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name = input.parse()?;
+        let _separator = input.parse::<Token![:]>();
+        let ty = input.parse().unwrap_or_else(|_| parse_quote!(::web_sys::Event));
+        let ident = format_ident!("on_{}", name);
+        Ok(Self { name, ty, ident })
+    }
+}
+
+impl ListenerPropDefinition {
+    fn build_fields(&self) -> TokenStream {
+        let ListenerPropDefinition { ident, ty, .. } = self;
+
+        quote! {
+            pub #ident: ::std::option::Option::<::yew::Callback::<#ty>>,
+        }
+    }
+
+    fn build_setter(&self) -> TokenStream {
+        let ListenerPropDefinition { ty, ident, .. } = self;
+
+        quote! {
+            pub fn #ident(&mut self, val: ::yew::Callback::<#ty>) {
+                self.#ident = ::std::option::Option::Some(val);
+            }
+        }
+    }
+
+    fn build_if_lets(&self) -> TokenStream {
+        let ListenerPropDefinition { name, ident, .. } = self;
+
+        let listener_path: Ident = syn::parse_str(&format!("on{}", name)).unwrap();
+        quote! {
+            if let Some(callback) = self.#ident {
+                let cb: ::std::rc::Rc::<dyn ::yew::virtual_dom::Listener> = ::std::rc::Rc::new(::yew::html::#listener_path::Wrapper::new(callback));
+                listeners.push(::std::option::Option::Some(cb));
+            }
+        }
+    }
+}
+
+pub struct GlobalAttributes {
+    attrs: Punctuated<AttributePropDefinition, Token![,]>,
+    listeners: Punctuated<ListenerPropDefinition, Token![,]>,
+}
+
+impl Parse for GlobalAttributes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let attrs = {
+            let _props_kw = input.parse::<kw::attrs>()?;
+
+            let buf;
+            let _brace_token = braced!(buf in input);
+            buf
+        };
+        let attrs = Punctuated::parse_terminated(&attrs)?;
+
+        let listeners = {
+            let _props_kw = input.parse::<kw::listeners>()?;
+
+            let buf;
+            let _brace_token = braced!(buf in input);
+            buf
+        };
+        let listeners = Punctuated::parse_terminated(&listeners)?;
+
+        Ok(Self { attrs, listeners })
+    }
+}
+
+impl ToTokens for GlobalAttributes {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let GlobalAttributes { attrs, listeners } = self;
+
+        let attributes = attrs.iter().map(|it| it.build_fields());
+        let setters = attrs.iter().map(|it| it.build_setter());
+        let attribute_if_lets = attrs.iter().map(|it| it.build_if_lets());
+
+        let listeners_fields = listeners.iter().map(|it| it.build_fields());
+        let listeners_setters = listeners.iter().map(|it| it.build_setter());
+        let listeners_if_lets = listeners.iter().map(|it| it.build_if_lets());
+
+
+        let output = quote! {
+            #[derive(::std::default::Default, ::std::clone::Clone, ::std::fmt::Debug, ::yew::html::Properties, ::std::cmp::PartialEq)]
+            struct GlobalAttributes {
+                #(#attributes)*
+                #(#listeners_fields)*
+            }
+
+            impl GlobalAttributes {
+                #(#setters)*
+                #(#listeners_setters)*
+            }
+
+            impl PropsExtend for GlobalAttributes {
+                fn into_data(self) -> ElementData {
+                    ElementData {
+                        node_ref: ::std::default::Default::default(),
+                        attributes: {
+                            let mut attrs = ::std::collections::HashMap::new();
+                            #(#attribute_if_lets)*
+                            attrs
+                        },
+                        listeners: {
+                            let mut listeners = ::std::vec::Vec::new();
+                            #(#listeners_if_lets)*
+                            listeners
+                        },
+                        key: None,
+                        children: ::std::default::Default::default(),
+                    }
+                }
+            }
+        };
+
+        tokens.extend(output)
+    }
+}

--- a/packages/yew-macro/src/typed_vdom/mod.rs
+++ b/packages/yew-macro/src/typed_vdom/mod.rs
@@ -1,0 +1,70 @@
+pub mod global;
+pub mod generate_element;
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote};
+use syn::{ Token, Type};
+use syn::parse::{Parse, ParseStream};
+
+pub(crate) fn build_setters(name: &Ident, ty: &Type, wrap_option: bool) -> TokenStream {
+    let value = if wrap_option { quote! { ::std::option::Option::Some(val) } } else { quote! { val } };
+    quote! {
+        pub fn #name(&mut self, val: #ty) {
+            self.#name = #value;
+        }
+    }
+}
+
+pub(crate) fn build_fields(name: &Ident, ty: &Type, wrap_option: bool) -> TokenStream {
+    let ty = if wrap_option { quote! { ::std::option::Option::<#ty> } } else { quote! { #ty }};
+    quote! {
+        pub #name: #ty,
+    }
+}
+
+struct AttributePropDefinition {
+    name: Ident,
+    ty: Type,
+}
+
+impl Parse for AttributePropDefinition {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name = input.parse()?;
+        let _separator = input.parse::<Token![:]>();
+        let ty = input.parse()?;
+        Ok(Self { name, ty })
+    }
+}
+
+impl AttributePropDefinition {
+    fn build_fields(&self) -> TokenStream {
+        let AttributePropDefinition { name, ty } = self;
+        build_fields(name, ty, true)
+    }
+
+    fn build_setter(&self) -> TokenStream {
+        let AttributePropDefinition { name, ty } = self;
+        build_setters(name, ty, true)
+    }
+
+    fn build_if_lets(&self) -> TokenStream {
+        let AttributePropDefinition { name, .. } = self;
+        if name == "children" || name == "key" || name == "node_ref" {
+            quote! {}
+        } else {
+            quote! {
+                if let Some(val) = self.#name {
+                    attrs.insert(::std::stringify!(#name), val);
+                }
+            }
+        }
+    }
+}
+
+pub(crate) mod kw {
+    syn::custom_keyword!(extends);
+    syn::custom_keyword!(props);
+
+    syn::custom_keyword!(attrs);
+    syn::custom_keyword!(listeners);
+}

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -324,7 +324,7 @@ mod tests {
 
     use crate::html;
     use crate::html::*;
-    use crate::Properties;
+    use crate::properties;
     use std::ops::Deref;
     #[cfg(feature = "wasm_test")]
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
@@ -332,7 +332,8 @@ mod tests {
     #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
 
-    #[derive(Clone, Properties, Default, PartialEq)]
+    #[derive(Clone, Default, PartialEq)]
+    #[properties]
     struct ChildProps {
         lifecycle: Rc<RefCell<Vec<String>>>,
     }

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -255,6 +255,8 @@ pub use yew_macro::html_nested;
 /// [Yew Docs]: https://yew.rs/concepts/components/properties
 pub use yew_macro::props;
 
+pub use yew_macro::properties;
+
 /// This module contains macros which implements html! macro and JSX-like templates
 pub mod macros {
     pub use crate::classes;

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -4,6 +4,7 @@
 pub mod key;
 #[doc(hidden)]
 pub mod listeners;
+pub mod typings;
 #[doc(hidden)]
 pub mod vcomp;
 #[doc(hidden)]

--- a/packages/yew/src/virtual_dom/typings.rs
+++ b/packages/yew/src/virtual_dom/typings.rs
@@ -1,0 +1,78 @@
+//! This module contains the items required for a statically typed VDOM
+
+use crate::events::*;
+use crate::html::*;
+use crate::virtual_dom::*;
+use std::collections::HashMap;
+use std::rc::Rc;
+use yew_macro::{generate_element, global};
+
+global! {
+    attrs {
+        autocapitalize: AttrValue,
+        contextmenu: AttrValue,
+        contenteditable: AttrValue,
+        slot: AttrValue,
+        spellcheck: AttrValue,
+        class: AttrValue,
+        title: AttrValue,
+        itemprop: AttrValue,
+        accesskey: AttrValue,
+        lang: AttrValue,
+        id: AttrValue,
+        translate: AttrValue,
+        draggable: AttrValue,
+        style: AttrValue,
+        dir: AttrValue,
+        tabindex: AttrValue,
+        hidden: AttrValue,
+    }
+    listeners {
+        click: MouseEvent
+    }
+}
+
+generate_element! {
+    button;
+    extends: GlobalAttributes;
+    props: {
+        autofocus: AttrValue,
+        disabled: AttrValue,
+        form: AttrValue,
+        formaction: AttrValue,
+        formenctype: AttrValue,
+        formmethod: AttrValue,
+        formnovalidate: AttrValue,
+        formtarget: AttrValue,
+        name: AttrValue,
+        type_: AttrValue,
+        value: AttrValue,
+        node_ref: NodeRef,
+        key: Key,
+        children: Children,
+    }
+}
+
+// I can't fucking come up with a better name.
+/// Props which are extended
+pub trait PropsExtend {
+    /// Provides [`ElementData`] of extender
+    fn into_data(self) -> ElementData;
+}
+
+/// Metadata of an HTML element
+///
+/// A [Component](crate::html::Component) is generated using this data for every element.
+///
+/// # Note
+///
+/// While it says "Element" in the name, usage with an element necessarily required.
+/// `#[properties(extends = Type)]` uses this type to provide information about the extended type.
+#[derive(Debug)]
+pub struct ElementData {
+    node_ref: NodeRef,
+    attributes: HashMap<&'static str, AttrValue>,
+    listeners: Vec<Option<Rc<dyn Listener>>>,
+    key: Option<Key>,
+    children: Vec<VNode>,
+}

--- a/packages/yew/src/virtual_dom/vcomp.rs
+++ b/packages/yew/src/virtual_dom/vcomp.rs
@@ -327,7 +327,7 @@ mod feat_ssr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{html, Children, Component, Context, Html, NodeRef, Properties};
+    use crate::{html, Children, Component, Context, Html, NodeRef, properties};
     use gloo_utils::document;
     use web_sys::Node;
 
@@ -339,7 +339,8 @@ mod tests {
 
     struct Comp;
 
-    #[derive(Clone, PartialEq, Properties)]
+    #[derive(Clone, PartialEq)]
+    #[properties]
     struct Props {
         #[prop_or_default]
         field_1: u32,
@@ -488,7 +489,8 @@ mod tests {
         assert_ne!(vchild2, vchild3);
     }
 
-    #[derive(Clone, Properties, PartialEq)]
+    #[derive(Clone, PartialEq)]
+    #[properties]
     pub struct ListProps {
         pub children: Children,
     }
@@ -606,7 +608,7 @@ mod layout_tests {
 
     use crate::html;
     use crate::tests::layout_tests::{diff_layouts, TestLayout};
-    use crate::{Children, Component, Context, Html, Properties};
+    use crate::{Children, Component, Context, Html, properties};
     use std::marker::PhantomData;
 
     #[cfg(feature = "wasm_test")]
@@ -619,7 +621,8 @@ mod layout_tests {
         _marker: PhantomData<T>,
     }
 
-    #[derive(Properties, Clone, PartialEq)]
+    #[derive(Clone, PartialEq)]
+    #[properties]
     struct CompProps {
         #[prop_or_default]
         children: Children,
@@ -865,7 +868,8 @@ mod layout_tests {
 
     #[test]
     fn component_with_children() {
-        #[derive(Properties, PartialEq)]
+        #[derive(PartialEq)]
+        #[properties]
         struct Props {
             children: Children,
         }
@@ -918,7 +922,8 @@ mod ssr_tests {
 
     #[test]
     async fn test_props() {
-        #[derive(PartialEq, Properties, Debug)]
+        #[derive(PartialEq, Debug)]
+        #[properties]
         struct ChildProps {
             name: String,
         }

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -460,7 +460,7 @@ mod layout_tests_keys {
     use crate::html;
     use crate::tests::layout_tests::{diff_layouts, TestLayout};
     use crate::virtual_dom::VNode;
-    use crate::{Children, Component, Context, Html, Properties};
+    use crate::{Children, Component, Context, Html, properties};
     use web_sys::Node;
 
     #[cfg(feature = "wasm_test")]
@@ -471,11 +471,12 @@ mod layout_tests_keys {
 
     struct Comp {}
 
-    #[derive(Properties, Clone, PartialEq)]
+    #[derive(Clone, PartialEq)]
+    #[properties]
     struct CountingCompProps {
         id: usize,
         #[prop_or(false)]
-        can_change: bool,
+        can_change: bool
     }
 
     impl Component for Comp {
@@ -495,7 +496,8 @@ mod layout_tests_keys {
         }
     }
 
-    #[derive(Clone, Properties, PartialEq)]
+    #[derive(Clone, PartialEq)]
+    #[properties]
     pub struct ListProps {
         pub children: Children,
     }
@@ -1315,7 +1317,8 @@ mod ssr_tests {
 
     #[test]
     async fn test_fragment() {
-        #[derive(PartialEq, Properties, Debug)]
+        #[derive(PartialEq, Debug)]
+        #[properties]
         struct ChildProps {
             name: String,
         }

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -3,6 +3,7 @@ mod common;
 use common::obtain_result;
 use wasm_bindgen_test::*;
 use yew::prelude::*;
+use yew::properties;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -440,7 +441,8 @@ async fn effects_not_run_when_suspended() {
         }
     }
 
-    #[derive(Properties, Clone)]
+    #[derive(Clone)]
+    #[properties]
     struct Props {
         counter: Rc<RefCell<u64>>,
     }

--- a/packages/yew/tests/use_context.rs
+++ b/packages/yew/tests/use_context.rs
@@ -6,7 +6,7 @@ use wasm_bindgen_test::*;
 use yew::functional::{
     use_context, use_effect, use_mut_ref, use_state, FunctionComponent, FunctionProvider,
 };
-use yew::{html, Children, ContextProvider, HtmlResult, Properties};
+use yew::{html, Children, ContextProvider, HtmlResult, properties};
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -174,7 +174,8 @@ fn use_context_update_works() {
     #[derive(Clone, Debug, PartialEq)]
     struct MyContext(String);
 
-    #[derive(Clone, Debug, PartialEq, Properties)]
+    #[derive(Clone, Debug, PartialEq)]
+    #[properties]
     struct RenderCounterProps {
         id: String,
         children: Children,
@@ -199,7 +200,8 @@ fn use_context_update_works() {
     }
     type RenderCounter = FunctionComponent<RenderCounterFunction>;
 
-    #[derive(Clone, Debug, PartialEq, Properties)]
+    #[derive(Clone, Debug, PartialEq)]
+    #[properties]
     struct ContextOutletProps {
         id: String,
         #[prop_or_default]

--- a/packages/yew/tests/use_effect.rs
+++ b/packages/yew/tests/use_effect.rs
@@ -7,7 +7,7 @@ use wasm_bindgen_test::*;
 use yew::functional::{
     use_effect_with_deps, use_mut_ref, use_state, FunctionComponent, FunctionProvider,
 };
-use yew::{html, HtmlResult, Properties};
+use yew::{html, HtmlResult, properties};
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -15,7 +15,8 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 fn use_effect_destroys_on_component_drop() {
     struct UseEffectFunction {}
     struct UseEffectWrapper {}
-    #[derive(Properties, Clone)]
+    #[derive(Clone)]
+    #[properties]
     struct WrapperProps {
         destroy_called: Rc<dyn Fn()>,
     }
@@ -24,7 +25,8 @@ fn use_effect_destroys_on_component_drop() {
             false
         }
     }
-    #[derive(Properties, Clone)]
+    #[derive(Clone)]
+    #[properties]
     struct FunctionProps {
         effect_called: Rc<dyn Fn()>,
         destroy_called: Rc<dyn Fn()>,


### PR DESCRIPTION
This PR is a proof-of-concept which redoes properties. Right now, the new properties attribute macro is not feature complete and thus the code does not compile. However, this implementation demonstrates inheritance for props (see #1533)

It is possible to build upon on this implementation. While implementing this, I ran into some roadblocks that may or may not be possible to overcome while keeping certain API in mind.

## My Observations 
- If we want properties to be extendable, they **must** be `Default`
- Because of the nature of Rust type system, we must use `Deref`/`DerefMut` to "emulate" inheritance for properties. This results in function signature of setters similar to: `fn class(&mut self, value: AttrValue)`. These are called on the builder struct one-by-one and **cannot** be chained.
- Regular properties (ones that do not extend other properties, and are not `Default`) are checked at compile time. This is possible by following "typestate pattern". The function signature of the setter is used to ensure all required props are set and handle the default cases.
- The function signature required for compile time verification does **not** match with the one required to "emulate" inheritance.
- Because of the above point, we cannot construct the properties from the `html!` macro
  - A workaround would be to `panic!` at runtime for missing props. This would ensure the function signature is the same.

## TL;DR

Having _both_, compile time verification of validity of passed props and a fix for #1533 (props inheritance) is impossible. We need to pick a poison and go with it.

---

We should explore more ways to solving the issue at hand: being able to pass props which are not explicitly defined in the Properties struct (may be defined else where)