### PR TITLE
Separate scheduler rendered call from create and render

### DIFF
--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -170,9 +170,6 @@ impl<COMP: BaseComponent> Runnable for UpdateRunner<COMP> {
                     RenderRunner {
                         state: self.state.clone(),
                     },
-                    RenderedRunner {
-                        state: self.state.clone(),
-                    },
                 );
                 // Only run from the scheduler, so no need to call `scheduler::start()`
             }
@@ -236,6 +233,14 @@ impl<COMP: BaseComponent> Runnable for RenderRunner<COMP> {
 
                         let node = new_root.apply(&scope, m, next_sibling, ancestor);
                         state.node_ref.link(node);
+
+                        scheduler::push_component_rendered(
+                            self.state.as_ptr() as usize,
+                            RenderedRunner {
+                                state: self.state.clone(),
+                            },
+                            !state.has_rendered,
+                        );
                     } else {
                         #[cfg(feature = "ssr")]
                         if let Some(tx) = state.html_sender.take() {
@@ -257,9 +262,6 @@ impl<COMP: BaseComponent> Runnable for RenderRunner<COMP> {
                             RenderRunner {
                                 state: shared_state.clone(),
                             },
-                            RenderedRunner {
-                                state: shared_state,
-                            },
                         );
                     } else {
                         // We schedule a render after current suspension is resumed.
@@ -275,9 +277,6 @@ impl<COMP: BaseComponent> Runnable for RenderRunner<COMP> {
                             scheduler::push_component_render(
                                 shared_state.as_ptr() as usize,
                                 RenderRunner {
-                                    state: shared_state.clone(),
-                                },
-                                RenderedRunner {
                                     state: shared_state.clone(),
                                 },
                             );

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -2,8 +2,7 @@
 
 use super::{
     lifecycle::{
-        ComponentState, CreateRunner, DestroyRunner, RenderRunner, RenderedRunner, UpdateEvent,
-        UpdateRunner,
+        ComponentState, CreateRunner, DestroyRunner, RenderRunner, UpdateEvent, UpdateRunner,
     },
     BaseComponent,
 };
@@ -244,9 +243,6 @@ impl<COMP: BaseComponent> Scope<COMP> {
             RenderRunner {
                 state: self.state.clone(),
             },
-            RenderedRunner {
-                state: self.state.clone(),
-            },
         );
         // Not guaranteed to already have the scheduler started
         scheduler::start();
@@ -379,9 +375,6 @@ mod feat_ssr {
                     html_sender: Some(tx),
                 },
                 RenderRunner {
-                    state: self.state.clone(),
-                },
-                RenderedRunner {
                     state: self.state.clone(),
                 },
             );

--- a/packages/yew/src/scheduler.rs
+++ b/packages/yew/src/scheduler.rs
@@ -58,12 +58,10 @@ pub fn push(runnable: Box<dyn Runnable>) {
 pub(crate) fn push_component_create(
     create: impl Runnable + 'static,
     first_render: impl Runnable + 'static,
-    first_rendered: impl Runnable + 'static,
 ) {
     with(|s| {
         s.create.push(Box::new(create));
         s.render_first.push_back(Box::new(first_render));
-        s.rendered_first.push(Box::new(first_rendered));
     });
 }
 
@@ -73,14 +71,25 @@ pub(crate) fn push_component_destroy(runnable: impl Runnable + 'static) {
 }
 
 /// Push a component render and rendered [Runnable]s to be executed
-pub(crate) fn push_component_render(
-    component_id: usize,
-    render: impl Runnable + 'static,
-    rendered: impl Runnable + 'static,
-) {
+pub(crate) fn push_component_render(component_id: usize, render: impl Runnable + 'static) {
     with(|s| {
         s.render.schedule(component_id, Box::new(render));
-        s.rendered.schedule(component_id, Box::new(rendered));
+    });
+}
+
+pub(crate) fn push_component_rendered(
+    component_id: usize,
+    rendered: impl Runnable + 'static,
+    first_render: bool,
+) {
+    with(|s| {
+        let rendered = Box::new(rendered);
+
+        if first_render {
+            s.rendered_first.push(rendered);
+        } else {
+            s.rendered.schedule(component_id, rendered);
+        }
     });
 }
 

--- a/tools/changelog/src/write_version_changelog.rs
+++ b/tools/changelog/src/write_version_changelog.rs
@@ -19,7 +19,7 @@ pub fn write_changelog_file(
         version_only_changelog,
         "## ✨ {package} **{next_version}** *({release_date})* Changelog",
         next_version = next_version,
-        package = package.to_string(),
+        package = package,
         release_date = chrono::Utc::now().format("%Y-%m-%d")
     )?;
     writeln!(version_only_changelog)?;


### PR DESCRIPTION
#### Description

This pull request separates rendered runner into `push_component_rendered` from `push_component_create` and `push_component_render`.

Rationale:
1. With Suspense, every render is no longer guaranteed to be rendered (can be suspended instead and rendered will not be called).
2. SSR hydration needs a way to defer rendered call until the entire dom tree under a `<Suspense />` is hydrated and needs a separate way to trigger `rendered()` after a component is hydrated.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
