### PR TITLE
Allow to pass Cow<'static, str> as attribute value.

### DIFF
--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -87,6 +87,12 @@ impl_into_prop!(|value: &'static str| -> String { value.to_owned() });
 impl_into_prop!(|value: &'static str| -> AttrValue { AttrValue::Static(value) });
 impl_into_prop!(|value: String| -> AttrValue { AttrValue::Owned(value) });
 impl_into_prop!(|value: Rc<str>| -> AttrValue { AttrValue::Rc(value) });
+impl_into_prop!(|value: Cow<'static, str>| -> AttrValue {
+    match value {
+        Cow::Borrowed(value) => AttrValue::Static(value),
+        Cow::Owned(value) => AttrValue::Owned(value),
+    }
+});
 
 #[cfg(test)]
 mod test {
@@ -99,5 +105,11 @@ mod test {
         let _: AttrValue = "foo".into_prop_value();
         let _: Option<AttrValue> = "foo".into_prop_value();
         let _: Option<AttrValue> = Rc::<str>::from("foo").into_prop_value();
+        let _: Cow<'static, str> = "foo".into_prop_value();
+        let _: Option<Cow<'static, str>> = "foo".into_prop_value();
+        let _: AttrValue = Cow::<'static, str>::Borrowed("foo").into_prop_value();
+        let _: AttrValue = Cow::<'static, str>::Owned("foo".to_owned()).into_prop_value();
+        let _: Option<AttrValue> = Cow::<'static, str>::Borrowed("foo").into_prop_value();
+        let _: Option<AttrValue> = Cow::<'static, str>::Owned("foo".to_owned()).into_prop_value();
     }
 }


### PR DESCRIPTION
#### Description

Allow to pass `Cow<'static, str>` as attribute value.
Example:
```
let my_text: Cow<'static, str> = Cow::Borrowed("foo");
html!{ <input placeholder={ my_text.clone() } /> }
```

#### Checklist

- [ ] I have run `cargo make pr-flow` (I tried but the command seems to fails?)
- [x] I have reviewed my own code
- [x] I have added tests
