### PR TITLE
Add Other variant to the ListenerKind

### DIFF
--- a/packages/yew/src/virtual_dom/listeners.rs
+++ b/packages/yew/src/virtual_dom/listeners.rs
@@ -358,12 +358,10 @@ impl GlobalHandlers {
     fn ensure_handled(&mut self, desc: EventDescriptor) {
         if !self.handling.contains(&desc) {
             let cl = BODY.with(|body| {
-                let cl = Closure::wrap(
-                    Box::new({
-                        let desc = desc.clone();
-                        move |e: Event| Registry::handle(desc.clone(), e)
-                    }) as Box<dyn Fn(Event)>
-                );
+                let cl = Closure::wrap(Box::new({
+                    let desc = desc.clone();
+                    move |e: Event| Registry::handle(desc.clone(), e)
+                }) as Box<dyn Fn(Event)>);
                 AsRef::<web_sys::EventTarget>::as_ref(body)
                     .add_event_listener_with_callback_and_add_event_listener_options(
                         desc.kind.type_name(),


### PR DESCRIPTION
#### Description

This pull request provides a new listener kind variant so that user-defined listeners can be added to the `VTag`. The new `ListenerKind::other(Cow<'static, str>)` variant makes possible to implement the `Listener` trait for a user-defined listener type with a custom event name.

This option is very useful for the custom `Html` builders. These are temporary and only used in `view` so they can't use the `gloo::events::EventListener`. For example, have the following custom event listener:

```rust
pub struct EventListener<E> {
    event_type: &'static str,
    callback: Callback<E>,
}

impl<E> Listener for EventListener<E>
where
    E: From<JsValue> + Clone,
{
    fn kind(&self) -> ListenerKind {
        ListenerKind::other(Cow::Borrowed(self.event_type))
    }

    fn handle(&self, event: Event) {
        let event: E = JsValue::from(event).into();
        self.callback.emit(event);
    }

    fn passive(&self) -> bool {
        false
    }
}
```

And the MDC widget `TopAppBar` builder using it:

```rust
pub struct TopAppBar {
    html: Html,
}

impl TopAppBar {
    pub fn new() -> Self {
        Self {
            html: html! {
                <header class = "mdc-top-app-bar" data-mdc-auto-init = "MDCTopAppBar">
                    <div class = "mdc-top-app-bar__row">
                        <section class = "mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
                            <span class = "mdc-top-app-bar__title"></span>
                        </section>
                        <section class = "mdc-top-app-bar__section mdc-top-app-bar__section--align-end"
                                role = "toolbar">
                        </section>
                    </div>
                </header>
            },
        }
    }
    
    ...
    
    pub fn on_navigation(self, callback: impl Into<Callback<Event>>) -> Self {
        self.listener(Rc::new(EventListener::new("MDCTopAppBar:nav", callback.into())))
    }
}
```
It sets the listener for the event with name `"MDCTopAppBar:nav"` inside `view`:

```rust
fn view(&self, _ctx: &Context<Self>) -> Html {
    let drawer = self.create_drawer("app-drawer");

    let top_app_bar = TopAppBar::new()
        .id("top-app-bar")
        .title("App title")
        .navigation_item(IconButton::new().icon("menu"))
        .enable_shadow_when_scroll_window()
        .on_navigation(|_| {
            let drawer = dom::existing::get_element_by_id::<Element>("app-drawer")
                .get(drawer::mdc::TYPE_NAME);
            let opened = drawer.get("open").as_bool().unwrap_or(false);
            drawer.set("open", !opened);
        });

    html! {
        <>
            { drawer }
            <div class = "mdc-drawer-scrim"></div>

            <div class = { classes!("app-content", Drawer::APP_CONTENT_CLASS) }>
                { top_app_bar }

                <div class = { TopAppBar::FIXED_ADJUST_CLASS }>
                   ...
                </div>
            </div>
        </>
    }
}
```

The full working example: https://github.com/noogen-projects/yew-mdc-widgets/blob/master/examples/client/src/main.rs

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
