### PR TITLE
Automatic Message Batching

### DIFF
--- a/packages/yew-router/tests/basename.rs
+++ b/packages/yew-router/tests/basename.rs
@@ -1,4 +1,6 @@
+use gloo::timers::future::sleep;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::functional::function_component;
 use yew::prelude::*;
@@ -112,19 +114,29 @@ fn root() -> Html {
 // - query parameters
 // - 404 redirects
 #[test]
-fn router_works() {
+async fn router_works() {
     yew::start_app_in_element::<Root>(gloo::utils::document().get_element_by_id("output").unwrap());
+
+    sleep(Duration::ZERO).await;
 
     assert_eq!("Home", obtain_result_by_id("result"));
 
+    sleep(Duration::ZERO).await;
+
     let initial_length = history_length();
 
+    sleep(Duration::ZERO).await;
+
     click("button"); // replacing the current route
+
+    sleep(Duration::ZERO).await;
     assert_eq!("2", obtain_result_by_id("result-params"));
     assert_eq!("bar", obtain_result_by_id("result-query"));
     assert_eq!(initial_length, history_length());
 
     click("button"); // pushing a new route
+
+    sleep(Duration::ZERO).await;
     assert_eq!("3", obtain_result_by_id("result-params"));
     assert_eq!("baz", obtain_result_by_id("result-query"));
     assert_eq!(initial_length + 1, history_length());

--- a/packages/yew-router/tests/browser_router.rs
+++ b/packages/yew-router/tests/browser_router.rs
@@ -1,4 +1,6 @@
+use gloo::timers::future::sleep;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::functional::function_component;
 use yew::prelude::*;
@@ -112,19 +114,29 @@ fn root() -> Html {
 // - query parameters
 // - 404 redirects
 #[test]
-fn router_works() {
+async fn router_works() {
     yew::start_app_in_element::<Root>(gloo::utils::document().get_element_by_id("output").unwrap());
+
+    sleep(Duration::ZERO).await;
 
     assert_eq!("Home", obtain_result_by_id("result"));
 
+    sleep(Duration::ZERO).await;
+
     let initial_length = history_length();
 
+    sleep(Duration::ZERO).await;
+
     click("button"); // replacing the current route
+
+    sleep(Duration::ZERO).await;
     assert_eq!("2", obtain_result_by_id("result-params"));
     assert_eq!("bar", obtain_result_by_id("result-query"));
     assert_eq!(initial_length, history_length());
 
     click("button"); // pushing a new route
+
+    sleep(Duration::ZERO).await;
     assert_eq!("3", obtain_result_by_id("result-params"));
     assert_eq!("baz", obtain_result_by_id("result-query"));
     assert_eq!(initial_length + 1, history_length());

--- a/packages/yew-router/tests/hash_router.rs
+++ b/packages/yew-router/tests/hash_router.rs
@@ -1,4 +1,6 @@
+use gloo::timers::future::sleep;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::functional::function_component;
 use yew::prelude::*;
@@ -112,19 +114,29 @@ fn root() -> Html {
 // - query parameters
 // - 404 redirects
 #[test]
-fn router_works() {
+async fn router_works() {
     yew::start_app_in_element::<Root>(gloo::utils::document().get_element_by_id("output").unwrap());
+
+    sleep(Duration::ZERO).await;
 
     assert_eq!("Home", obtain_result_by_id("result"));
 
+    sleep(Duration::ZERO).await;
+
     let initial_length = history_length();
 
+    sleep(Duration::ZERO).await;
+
     click("button"); // replacing the current route
+
+    sleep(Duration::ZERO).await;
     assert_eq!("2", obtain_result_by_id("result-params"));
     assert_eq!("bar", obtain_result_by_id("result-query"));
     assert_eq!(initial_length, history_length());
 
     click("button"); // pushing a new route
+
+    sleep(Duration::ZERO).await;
     assert_eq!("3", obtain_result_by_id("result-params"));
     assert_eq!("baz", obtain_result_by_id("result-query"));
     assert_eq!(initial_length + 1, history_length());

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -21,6 +21,11 @@ where
     pub(crate) context: Context<COMP>,
 }
 
+/// A trait to provide common,
+/// generic free behaviour across all components to reduce code size.
+///
+/// Mostly a thin wrapper that passes the context to a component's lifecycle
+/// methods.
 pub(crate) trait Stateful {
     fn view(&self) -> RenderResult<VNode>;
     fn rendered(&mut self, first_render: bool);

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -54,6 +54,7 @@ pub struct AnyScope {
     parent: Option<Rc<AnyScope>>,
     state: Shared<Option<ComponentState>>,
 
+    #[cfg(debug_assertions)]
     pub(crate) vcomp_id: usize,
 }
 
@@ -70,6 +71,7 @@ impl<COMP: BaseComponent> From<Scope<COMP>> for AnyScope {
             parent: scope.parent,
             state: scope.state,
 
+            #[cfg(debug_assertions)]
             vcomp_id: scope.vcomp_id,
         }
     }
@@ -83,6 +85,7 @@ impl AnyScope {
             parent: None,
             state: Rc::new(RefCell::new(None)),
 
+            #[cfg(debug_assertions)]
             vcomp_id: 0,
         }
     }
@@ -185,6 +188,7 @@ pub struct Scope<COMP: BaseComponent> {
     pub(crate) pending_messages: MsgQueue<COMP::Message>,
     pub(crate) state: Shared<Option<ComponentState>>,
 
+    #[cfg(debug_assertions)]
     pub(crate) vcomp_id: usize,
 }
 
@@ -202,6 +206,7 @@ impl<COMP: BaseComponent> Clone for Scope<COMP> {
             parent: self.parent.clone(),
             state: self.state.clone(),
 
+            #[cfg(debug_assertions)]
             vcomp_id: self.vcomp_id,
         }
     }
@@ -235,6 +240,7 @@ impl<COMP: BaseComponent> Scope<COMP> {
         let state = Rc::new(RefCell::new(None));
         let pending_messages = MsgQueue::new();
 
+        #[cfg(debug_assertions)]
         let vcomp_id = parent.as_ref().map(|p| p.vcomp_id).unwrap_or_default();
 
         Scope {
@@ -243,6 +249,7 @@ impl<COMP: BaseComponent> Scope<COMP> {
             state,
             parent,
 
+            #[cfg(debug_assertions)]
             vcomp_id,
         }
     }

--- a/packages/yew/src/scheduler.rs
+++ b/packages/yew/src/scheduler.rs
@@ -127,7 +127,7 @@ mod target_wasm {
     use super::*;
     use crate::io_coop::spawn_local;
 
-    /// We delay the start of the scheduler to the end of the browser event loop.
+    /// We delay the start of the scheduler to the end of the micro task queue.
     /// So any messages that needs to be queued can be queued.
     pub(crate) fn start() {
         spawn_local(async {
@@ -143,10 +143,10 @@ pub(crate) use target_wasm::*;
 mod target_native {
     use super::*;
 
-    // Delayed rendering is not very useful on server-side rendering.
-    // There is not event listener or other high priority events that needs to be
+    // Delayed rendering is not very useful in the context of server-side rendering.
+    // There are no event listeners or other high priority events that need to be
     // processed and we risk of having a future un-finished.
-    // Until scheduler is future-capable which we means can join inside a future,
+    // Until scheduler is future-capable which means we can join inside a future,
     // it can remain synchronous.
     pub(crate) fn start() {
         start_now();

--- a/packages/yew/src/tests/layout_tests.rs
+++ b/packages/yew/src/tests/layout_tests.rs
@@ -1,4 +1,5 @@
 use crate::html::{AnyScope, Scope};
+use crate::scheduler;
 use crate::virtual_dom::{VDiff, VNode, VText};
 use crate::{Component, Context, Html};
 use gloo::console::log;
@@ -51,6 +52,7 @@ pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
         log!("Independently apply layout '{}'", layout.name);
 
         node.apply(&parent_scope, &parent_element, next_sibling.clone(), None);
+        scheduler::start_now();
         assert_eq!(
             parent_element.inner_html(),
             format!("{}END", layout.expected),
@@ -69,6 +71,7 @@ pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
             next_sibling.clone(),
             Some(node),
         );
+        scheduler::start_now();
         assert_eq!(
             parent_element.inner_html(),
             format!("{}END", layout.expected),
@@ -83,6 +86,7 @@ pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
             next_sibling.clone(),
             Some(node_clone),
         );
+        scheduler::start_now();
         assert_eq!(
             parent_element.inner_html(),
             "END",
@@ -103,6 +107,7 @@ pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
             next_sibling.clone(),
             ancestor,
         );
+        scheduler::start_now();
         assert_eq!(
             parent_element.inner_html(),
             format!("{}END", layout.expected),
@@ -123,6 +128,7 @@ pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
             next_sibling.clone(),
             ancestor,
         );
+        scheduler::start_now();
         assert_eq!(
             parent_element.inner_html(),
             format!("{}END", layout.expected),
@@ -134,6 +140,7 @@ pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
 
     // Detach last layout
     empty_node.apply(&parent_scope, &parent_element, next_sibling, ancestor);
+    scheduler::start_now();
     assert_eq!(
         parent_element.inner_html(),
         "END",

--- a/packages/yew/src/virtual_dom/vcomp.rs
+++ b/packages/yew/src/virtual_dom/vcomp.rs
@@ -9,11 +9,12 @@ use std::borrow::Borrow;
 use std::fmt;
 use std::ops::Deref;
 use std::rc::Rc;
+#[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use web_sys::Element;
 
+#[cfg(debug_assertions)]
 thread_local! {
-    #[cfg(debug_assertions)]
      static EVENT_HISTORY: std::cell::RefCell<std::collections::HashMap<usize, Vec<String>>>
         = Default::default();
      static COMP_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -49,6 +50,7 @@ pub struct VComp {
     pub(crate) node_ref: NodeRef,
     pub(crate) key: Option<Key>,
 
+    #[cfg(debug_assertions)]
     pub(crate) id: usize,
 }
 
@@ -68,6 +70,7 @@ impl Clone for VComp {
             node_ref: self.node_ref.clone(),
             key: self.key.clone(),
 
+            #[cfg(debug_assertions)]
             id: self.id,
         }
     }
@@ -137,6 +140,7 @@ impl VComp {
             scope: None,
             key,
 
+            #[cfg(debug_assertions)]
             id: Self::next_id(),
         }
     }
@@ -160,6 +164,7 @@ impl VComp {
         })
     }
 
+    #[cfg(debug_assertions)]
     pub(crate) fn next_id() -> usize {
         COMP_ID_COUNTER.with(|m| m.fetch_add(1, Ordering::Relaxed))
     }

--- a/packages/yew/tests/mod.rs
+++ b/packages/yew/tests/mod.rs
@@ -1,13 +1,15 @@
 mod common;
 
 use common::obtain_result;
+use gloo::timers::future::sleep;
+use std::time::Duration;
 use wasm_bindgen_test::*;
 use yew::prelude::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-fn props_are_passed() {
+async fn props_are_passed() {
     #[derive(Properties, Clone, PartialEq)]
     struct PropsPassedFunctionProps {
         value: String,
@@ -29,6 +31,8 @@ fn props_are_passed() {
             value: "props".to_string(),
         },
     );
+
+    sleep(Duration::ZERO).await;
     let result = obtain_result();
     assert_eq!(result.as_str(), "done");
 }

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -119,6 +119,8 @@ async fn suspense_works() {
         .unwrap()
         .click();
 
+    TimeoutFuture::new(0).await;
+
     gloo_utils::document()
         .query_selector(".increase")
         .unwrap()
@@ -126,6 +128,8 @@ async fn suspense_works() {
         .dyn_into::<HtmlElement>()
         .unwrap()
         .click();
+
+    TimeoutFuture::new(1).await;
 
     let result = obtain_result();
     assert_eq!(
@@ -542,6 +546,8 @@ async fn effects_not_run_when_suspended() {
         .unwrap()
         .click();
 
+    TimeoutFuture::new(0).await;
+
     gloo_utils::document()
         .query_selector(".increase")
         .unwrap()
@@ -549,6 +555,8 @@ async fn effects_not_run_when_suspended() {
         .dyn_into::<HtmlElement>()
         .unwrap()
         .click();
+
+    TimeoutFuture::new(0).await;
 
     let result = obtain_result();
     assert_eq!(

--- a/packages/yew/tests/use_context.rs
+++ b/packages/yew/tests/use_context.rs
@@ -1,14 +1,16 @@
 mod common;
 
 use common::obtain_result_by_id;
+use gloo::timers::future::sleep;
 use std::rc::Rc;
+use std::time::Duration;
 use wasm_bindgen_test::*;
 use yew::prelude::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-fn use_context_scoping_works() {
+async fn use_context_scoping_works() {
     #[derive(Clone, Debug, PartialEq)]
     struct ExampleContext(String);
 
@@ -62,12 +64,15 @@ fn use_context_scoping_works() {
     yew::start_app_in_element::<UseContextComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+
+    sleep(Duration::ZERO).await;
+
     let result: String = obtain_result_by_id("result");
     assert_eq!("correct", result);
 }
 
 #[wasm_bindgen_test]
-fn use_context_works_with_multiple_types() {
+async fn use_context_works_with_multiple_types() {
     #[derive(Clone, Debug, PartialEq)]
     struct ContextA(u32);
     #[derive(Clone, Debug, PartialEq)]
@@ -141,10 +146,12 @@ fn use_context_works_with_multiple_types() {
     yew::start_app_in_element::<TestComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+
+    sleep(Duration::ZERO).await;
 }
 
 #[wasm_bindgen_test]
-fn use_context_update_works() {
+async fn use_context_update_works() {
     #[derive(Clone, Debug, PartialEq)]
     struct MyContext(String);
 
@@ -238,6 +245,8 @@ fn use_context_update_works() {
     yew::start_app_in_element::<TestComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+
+    sleep(Duration::ZERO).await;
 
     // 1 initial render + 3 update steps
     assert_eq!(obtain_result_by_id("test-0"), "total: 4");

--- a/packages/yew/tests/use_effect.rs
+++ b/packages/yew/tests/use_effect.rs
@@ -1,15 +1,17 @@
 mod common;
 
 use common::obtain_result;
+use gloo::timers::future::sleep;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
+use std::time::Duration;
 use wasm_bindgen_test::*;
 use yew::prelude::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-fn use_effect_destroys_on_component_drop() {
+async fn use_effect_destroys_on_component_drop() {
     #[derive(Properties, Clone)]
     struct WrapperProps {
         destroy_called: Rc<dyn Fn()>,
@@ -68,11 +70,14 @@ fn use_effect_destroys_on_component_drop() {
             destroy_called: Rc::new(move || *destroy_counter_c.borrow_mut().deref_mut() += 1),
         },
     );
+
+    sleep(Duration::ZERO).await;
+
     assert_eq!(1, *destroy_counter.borrow().deref());
 }
 
 #[wasm_bindgen_test]
-fn use_effect_works_many_times() {
+async fn use_effect_works_many_times() {
     #[function_component(UseEffectComponent)]
     fn use_effect_comp() -> Html {
         let counter = use_state(|| 0);
@@ -100,12 +105,14 @@ fn use_effect_works_many_times() {
     yew::start_app_in_element::<UseEffectComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+
+    sleep(Duration::ZERO).await;
     let result = obtain_result();
     assert_eq!(result.as_str(), "4");
 }
 
 #[wasm_bindgen_test]
-fn use_effect_works_once() {
+async fn use_effect_works_once() {
     #[function_component(UseEffectComponent)]
     fn use_effect_comp() -> Html {
         let counter = use_state(|| 0);
@@ -131,12 +138,15 @@ fn use_effect_works_once() {
     yew::start_app_in_element::<UseEffectComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+    sleep(Duration::ZERO).await;
+
     let result = obtain_result();
+
     assert_eq!(result.as_str(), "1");
 }
 
 #[wasm_bindgen_test]
-fn use_effect_refires_on_dependency_change() {
+async fn use_effect_refires_on_dependency_change() {
     #[function_component(UseEffectComponent)]
     fn use_effect_comp() -> Html {
         let number_ref = use_mut_ref(|| 0);
@@ -175,6 +185,8 @@ fn use_effect_refires_on_dependency_change() {
     yew::start_app_in_element::<UseEffectComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+
+    sleep(Duration::ZERO).await;
     let result: String = obtain_result();
 
     assert_eq!(result.as_str(), "11");

--- a/packages/yew/tests/use_memo.rs
+++ b/packages/yew/tests/use_memo.rs
@@ -3,13 +3,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 mod common;
 
 use common::obtain_result;
+use gloo::timers::future::sleep;
+use std::time::Duration;
 use wasm_bindgen_test::*;
 use yew::prelude::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-fn use_memo_works() {
+async fn use_memo_works() {
     #[function_component(UseMemoComponent)]
     fn use_memo_comp() -> Html {
         let state = use_state(|| 0);
@@ -47,6 +49,8 @@ fn use_memo_works() {
     yew::start_app_in_element::<UseMemoComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+
+    sleep(Duration::ZERO).await;
 
     let result = obtain_result();
     assert_eq!(result.as_str(), "true");

--- a/packages/yew/tests/use_reducer.rs
+++ b/packages/yew/tests/use_reducer.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use gloo::timers::future::sleep;
 use gloo_utils::document;
+use std::time::Duration;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 use web_sys::HtmlElement;
@@ -30,7 +32,7 @@ impl Reducible for CounterState {
 }
 
 #[wasm_bindgen_test]
-fn use_reducer_works() {
+async fn use_reducer_works() {
     #[function_component(UseReducerComponent)]
     fn use_reducer_comp() -> Html {
         let counter = use_reducer(|| CounterState { counter: 10 });
@@ -55,6 +57,7 @@ fn use_reducer_works() {
     yew::start_app_in_element::<UseReducerComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+    sleep(Duration::ZERO).await;
     let result = obtain_result();
 
     assert_eq!(result.as_str(), "11");
@@ -76,7 +79,7 @@ impl Reducible for ContentState {
 }
 
 #[wasm_bindgen_test]
-fn use_reducer_eq_works() {
+async fn use_reducer_eq_works() {
     #[function_component(UseReducerComponent)]
     fn use_reducer_comp() -> Html {
         let content = use_reducer_eq(|| ContentState {
@@ -113,6 +116,7 @@ fn use_reducer_eq_works() {
     yew::start_app_in_element::<UseReducerComponent>(
         document().get_element_by_id("output").unwrap(),
     );
+    sleep(Duration::ZERO).await;
 
     let result = obtain_result();
     assert_eq!(result.as_str(), "1");
@@ -122,6 +126,7 @@ fn use_reducer_eq_works() {
         .unwrap()
         .unchecked_into::<HtmlElement>()
         .click();
+    sleep(Duration::ZERO).await;
 
     let result = obtain_result();
     assert_eq!(result.as_str(), "2");
@@ -131,6 +136,7 @@ fn use_reducer_eq_works() {
         .unwrap()
         .unchecked_into::<HtmlElement>()
         .click();
+    sleep(Duration::ZERO).await;
 
     let result = obtain_result();
     assert_eq!(result.as_str(), "2");
@@ -140,6 +146,7 @@ fn use_reducer_eq_works() {
         .unwrap()
         .unchecked_into::<HtmlElement>()
         .click();
+    sleep(Duration::ZERO).await;
 
     let result = obtain_result();
     assert_eq!(result.as_str(), "3");
@@ -149,6 +156,7 @@ fn use_reducer_eq_works() {
         .unwrap()
         .unchecked_into::<HtmlElement>()
         .click();
+    sleep(Duration::ZERO).await;
 
     let result = obtain_result();
     assert_eq!(result.as_str(), "3");

--- a/packages/yew/tests/use_ref.rs
+++ b/packages/yew/tests/use_ref.rs
@@ -1,14 +1,16 @@
 mod common;
 
 use common::obtain_result;
+use gloo::timers::future::sleep;
 use std::ops::DerefMut;
+use std::time::Duration;
 use wasm_bindgen_test::*;
 use yew::prelude::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-fn use_ref_works() {
+async fn use_ref_works() {
     #[function_component(UseRefComponent)]
     fn use_ref_comp() -> Html {
         let ref_example = use_mut_ref(|| 0);
@@ -29,6 +31,7 @@ fn use_ref_works() {
     yew::start_app_in_element::<UseRefComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+    sleep(Duration::ZERO).await;
 
     let result = obtain_result();
     assert_eq!(result.as_str(), "true");

--- a/packages/yew/tests/use_state.rs
+++ b/packages/yew/tests/use_state.rs
@@ -1,13 +1,15 @@
 mod common;
 
 use common::obtain_result;
+use gloo::timers::future::sleep;
+use std::time::Duration;
 use wasm_bindgen_test::*;
 use yew::prelude::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-fn use_state_works() {
+async fn use_state_works() {
     #[function_component(UseComponent)]
     fn use_state_comp() -> Html {
         let counter = use_state(|| 0);
@@ -26,12 +28,13 @@ fn use_state_works() {
     yew::start_app_in_element::<UseComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+    sleep(Duration::ZERO).await;
     let result = obtain_result();
     assert_eq!(result.as_str(), "5");
 }
 
 #[wasm_bindgen_test]
-fn multiple_use_state_setters() {
+async fn multiple_use_state_setters() {
     #[function_component(UseComponent)]
     fn use_state_comp() -> Html {
         let counter = use_state(|| 0);
@@ -67,12 +70,13 @@ fn multiple_use_state_setters() {
     yew::start_app_in_element::<UseComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+    sleep(Duration::ZERO).await;
     let result = obtain_result();
     assert_eq!(result.as_str(), "11");
 }
 
 #[wasm_bindgen_test]
-fn use_state_eq_works() {
+async fn use_state_eq_works() {
     use std::sync::atomic::{AtomicUsize, Ordering};
     static RENDER_COUNT: AtomicUsize = AtomicUsize::new(0);
 
@@ -94,6 +98,7 @@ fn use_state_eq_works() {
     yew::start_app_in_element::<UseComponent>(
         gloo_utils::document().get_element_by_id("output").unwrap(),
     );
+    sleep(Duration::ZERO).await;
     let result = obtain_result();
     assert_eq!(result.as_str(), "1");
     assert_eq!(RENDER_COUNT.load(Ordering::Relaxed), 2);

--- a/website/docs/advanced-topics/server-side-rendering.md
+++ b/website/docs/advanced-topics/server-side-rendering.md
@@ -33,8 +33,6 @@ to render `<App />` into a `String`.
 ```rust
 use yew::prelude::*;
 use yew::ServerRenderer;
-use tokio::task::LocalSet;
-use tokio::task::spawn_blocking;
 
 #[function_component]
 fn App() -> Html {
@@ -43,21 +41,9 @@ fn App() -> Html {
 
 #[tokio::main]
 async fn main() {
-    // Yew is not thread-safe so we need to spawn it onto a single thread.
-    let rendered = spawn_blocking(move || {
-        use tokio::runtime::Builder;
-        let set = LocalSet::new();
+    let renderer = ServerRenderer::<App>::new();
 
-        let rt = Builder::new_current_thread().enable_all().build().unwrap();
-
-        set.block_on(&rt, async {
-            let renderer = yew::ServerRenderer::<App>::new();
-
-            renderer.render().await
-        })
-    })
-    .await
-    .expect("rendering has failed.");
+    let rendered = renderer.render().await;
 
     // Prints: <div>Hello, World!</div>
     println!("{}", rendered);

--- a/website/docs/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
+++ b/website/docs/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
@@ -15,3 +15,31 @@ The Function Components and Hooks API are re-implemented with a different mechan
 - Hooks will now report compile errors if they are not called from the top level of a function component
   or a user defined hook. The limitation existed in the previous version of Yew as well. In this version,
   It is reported as a compile time error.
+
+## Automatic Message Batching
+
+The scheduler now shedules its start to the end of the browser event loop.
+All messages queued during in the meantime will be run in batch.
+The running order of messages between components are no longer guaranteed, but
+messages sent to the same component is still acknowledged in an FIFO order.
+If multiple updates will result in a render, the component will be rendered
+once.
+
+:::info What this means to developers?
+
+For struct components, this means that if you send 2 messages to 2 different
+components, they will not be guaranteed to be seen in the same order they are
+sent. If you send 2 messages to the same component, they will still be passed
+to the component in the order they are sent. The messages are not sent to the
+component immediately so you should not assume that when the component receives
+a message it still has the same state at the time the message is created.
+
+For function components, if you store states with `use_state(_eq)`
+and the new value of that state depends on the previous value,
+you may want to switch to `use_reducer(_eq)`. The new value of the state will
+not be visible / acknowledged until the next time the component is rendered.
+The reducer action works similar to messages for struct components and
+will be sent to the reducer function in the same order as they are dispatched.
+The reducer function can see all previous changes at the time they are run.
+
+:::


### PR DESCRIPTION
#### Description

This is the first step towards concurrent mode.

When working on Bounce, a Yew state management library, I find that when a message is sent outside of a scheduled runner (e.g.: event handlers), it triggers a render immediately. Which can be inefficient when a component subscribes to many states.

Example:

https://user-images.githubusercontent.com/11693215/151647250-73f31027-e057-4784-8e8d-0217c56091dd.mov

In the example, the components on the first row subscribe to 1 state,
the components on the second row subscribe to 2 states
and the component on the third row subscribes to 3 states.

As the video above demonstrated, currently, even if the updates are dispatched back-to-back, this still results in multiple renders for components with multiple states.

This can be solved by running updates in a `Runnable` but I think the better way to solve this issue is to give Yew (part of) concurrent mode so any messages that are sent in a blocking task can be batched automatically.

This pull request makes Yew to automatically batch the messages for components and no longer triggers a render immediately.
The scheduler now runs at the next browser tick (or at the end of current tick if it is spawned by another future).

https://user-images.githubusercontent.com/11693215/151647360-993df5c6-1307-4094-8401-63ea5573e56d.mov

As a side effect, this allows most generics to be removed from the runners and hence all examples received a 10%~20% size reduction. (Some examples are now smaller than 0.19.3)

```
PR      master  example
416K	444K	examples/boids
312K	360K	examples/contexts
236K	252K	examples/counter
256K	280K	examples/dyn_create_destroy_apps
268K	288K	examples/file_upload
436K	552K	examples/function_memory_game
456K	512K	examples/function_todomvc
488K	504K	examples/futures
296K	312K	examples/game_of_life
224K	240K	examples/inner_html
240K	256K	examples/js_callback
432K	456K	examples/keyed_list
240K	256K	examples/mount_point
332K	348K	examples/nested_list
248K	268K	examples/node_refs
2.1M	2.1M	examples/password_strength
264K	276K	examples/portals
828K	996K	examples/router
308K	340K	examples/suspense
252K	268K	examples/timer
368K	384K	examples/todomvc
240K	252K	examples/two_apps
248K	264K	examples/webgl
```

Requires #2420 (due to messing up git history)

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow` (#2403)
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
