### PR TITLE
add documentation for function component type alias

### DIFF
--- a/packages/yew-macro/src/function_component.rs
+++ b/packages/yew-macro/src/function_component.rs
@@ -272,7 +272,6 @@ pub fn function_component_impl(
             }
         }
 
-
         #[doc = #component_type_doc]
         #[allow(type_alias_bounds)]
         #vis type #component_name #generics = ::yew::functional::FunctionComponent<#provider_name #ty_generics>;

--- a/packages/yew-macro/src/function_component.rs
+++ b/packages/yew-macro/src/function_component.rs
@@ -252,6 +252,7 @@ pub fn function_component_impl(
 
     let ctx_ident = Ident::new("ctx", Span::mixed_site());
 
+    let component_type_doc = format!("{} Component", component_name);
     let quoted = quote! {
         #[doc(hidden)]
         #[allow(non_camel_case_types)]
@@ -271,6 +272,8 @@ pub fn function_component_impl(
             }
         }
 
+
+        #[doc = #component_type_doc]
         #[allow(type_alias_bounds)]
         #vis type #component_name #generics = ::yew::functional::FunctionComponent<#provider_name #ty_generics>;
     };


### PR DESCRIPTION
#### Description

The `#[function_component]` proc macro currently generates the type alias without any documentation. This causes issues when using the `missing_docs` lint, especially when using `#![deny(missing_docs)]`.

This PR adds a simple one-line doc tag to the function component's type alias, ending clippy's ceaseless harassment.

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests – _no, doesn't seem relevant_