### PR TITLE
Fix Call Generics & FnOnce macro hygiene

### DIFF
--- a/packages/yew-macro/tests/hook_attr/hook-call-generics-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-call-generics-pass.rs
@@ -1,0 +1,12 @@
+use yew::prelude::*;
+
+#[hook]
+fn use_reducer_default_action<T>() -> T::Action
+where
+    T: Reducible + 'static,
+    T::Action: Default + 'static,
+{
+    T::Action::default()
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-const-generic-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-const-generic-pass.rs
@@ -1,0 +1,8 @@
+use yew::prelude::*;
+
+#[hook]
+fn use_a_const<const N: u32>() -> u32 {
+    N
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-const-generic-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-const-generic-pass.rs
@@ -1,6 +1,6 @@
-use yew::prelude::*;
+#![no_implicit_prelude]
 
-#[hook]
+#[::yew::prelude::hook]
 fn use_a_const<const N: u32>() -> u32 {
     N
 }

--- a/packages/yew-macro/tests/hook_attr/hook-impl-trait-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-impl-trait-pass.rs
@@ -1,13 +1,6 @@
 // we need to re-test the macro hygiene here as it uses a different implementation for impl traits.
 #![no_implicit_prelude]
 
-#[derive(
-    ::std::prelude::rust_2021::Debug,
-    ::std::prelude::rust_2021::PartialEq,
-    ::std::prelude::rust_2021::Clone,
-)]
-struct Ctx;
-
 #[::yew::prelude::hook]
 fn use_some_string(a: impl ::std::convert::Into<::std::string::String>) -> ::std::string::String {
     a.into()

--- a/packages/yew-macro/tests/hook_attr/hook-impl-trait-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-impl-trait-pass.rs
@@ -1,0 +1,16 @@
+// we need to re-test the macro hygiene here as it uses a different implementation for impl traits.
+#![no_implicit_prelude]
+
+#[derive(
+    ::std::prelude::rust_2021::Debug,
+    ::std::prelude::rust_2021::PartialEq,
+    ::std::prelude::rust_2021::Clone,
+)]
+struct Ctx;
+
+#[::yew::prelude::hook]
+fn use_some_string(a: impl ::std::convert::Into<::std::string::String>) -> ::std::string::String {
+    a.into()
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-lifetime-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-lifetime-pass.rs
@@ -1,0 +1,8 @@
+use yew::prelude::*;
+
+#[hook]
+fn use_as_is<'a>(input: &'a ()) -> &'a () {
+    input
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook_location-fail.rs
+++ b/packages/yew-macro/tests/hook_attr/hook_location-fail.rs
@@ -1,0 +1,39 @@
+use yew::prelude::*;
+
+#[derive(Debug, PartialEq, Clone)]
+struct Ctx;
+
+#[hook]
+fn use_some_html() -> Html {
+    if let Some(_m) = use_context::<Ctx>() {
+        use_context::<Ctx>().unwrap();
+        todo!()
+    }
+
+    let _ = || {
+        use_context::<Ctx>().unwrap();
+        todo!()
+    };
+
+    for _ in 0..10 {
+        use_context::<Ctx>().unwrap();
+    }
+
+    while let Some(_m) = use_context::<Ctx>() {
+        use_context::<Ctx>().unwrap();
+    }
+
+    match use_context::<Ctx>() {
+        Some(_) => use_context::<Ctx>(),
+        None => {
+            todo!()
+        }
+    }
+
+    loop {
+        use_context::<Ctx>().unwrap();
+        todo!()
+    }
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook_location-fail.stderr
+++ b/packages/yew-macro/tests/hook_attr/hook_location-fail.stderr
@@ -1,0 +1,69 @@
+error: hooks cannot be called at this position.
+
+  = help: move hooks to the top-level of your function.
+  = note: see: https://yew.rs/docs/next/concepts/function-components/introduction#hooks
+
+ --> tests/hook_attr/hook_location-fail.rs:9:9
+  |
+9 |         use_context::<Ctx>().unwrap();
+  |         ^^^^^^^^^^^
+
+error: hooks cannot be called at this position.
+
+  = help: move hooks to the top-level of your function.
+  = note: see: https://yew.rs/docs/next/concepts/function-components/introduction#hooks
+
+  --> tests/hook_attr/hook_location-fail.rs:14:9
+   |
+14 |         use_context::<Ctx>().unwrap();
+   |         ^^^^^^^^^^^
+
+error: hooks cannot be called at this position.
+
+  = help: move hooks to the top-level of your function.
+  = note: see: https://yew.rs/docs/next/concepts/function-components/introduction#hooks
+
+  --> tests/hook_attr/hook_location-fail.rs:19:9
+   |
+19 |         use_context::<Ctx>().unwrap();
+   |         ^^^^^^^^^^^
+
+error: hooks cannot be called at this position.
+
+  = help: move hooks to the top-level of your function.
+  = note: see: https://yew.rs/docs/next/concepts/function-components/introduction#hooks
+
+  --> tests/hook_attr/hook_location-fail.rs:22:26
+   |
+22 |     while let Some(_m) = use_context::<Ctx>() {
+   |                          ^^^^^^^^^^^
+
+error: hooks cannot be called at this position.
+
+  = help: move hooks to the top-level of your function.
+  = note: see: https://yew.rs/docs/next/concepts/function-components/introduction#hooks
+
+  --> tests/hook_attr/hook_location-fail.rs:23:9
+   |
+23 |         use_context::<Ctx>().unwrap();
+   |         ^^^^^^^^^^^
+
+error: hooks cannot be called at this position.
+
+  = help: move hooks to the top-level of your function.
+  = note: see: https://yew.rs/docs/next/concepts/function-components/introduction#hooks
+
+  --> tests/hook_attr/hook_location-fail.rs:27:20
+   |
+27 |         Some(_) => use_context::<Ctx>(),
+   |                    ^^^^^^^^^^^
+
+error: hooks cannot be called at this position.
+
+  = help: move hooks to the top-level of your function.
+  = note: see: https://yew.rs/docs/next/concepts/function-components/introduction#hooks
+
+  --> tests/hook_attr/hook_location-fail.rs:34:9
+   |
+34 |         use_context::<Ctx>().unwrap();
+   |         ^^^^^^^^^^^

--- a/packages/yew-macro/tests/hook_attr/hook_location-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook_location-pass.rs
@@ -1,0 +1,30 @@
+#![no_implicit_prelude]
+
+#[derive(
+    ::std::prelude::rust_2021::Debug,
+    ::std::prelude::rust_2021::PartialEq,
+    ::std::prelude::rust_2021::Clone,
+)]
+struct Ctx;
+
+#[::yew::prelude::hook]
+fn use_some_html() -> ::yew::prelude::Html {
+    ::yew::prelude::use_context::<Ctx>().unwrap();
+
+    if let ::std::prelude::rust_2021::Some(_m) = ::yew::prelude::use_context::<Ctx>() {
+        ::std::todo!()
+    }
+
+    let _ctx = { ::yew::prelude::use_context::<Ctx>() };
+
+    match ::yew::prelude::use_context::<Ctx>() {
+        ::std::prelude::rust_2021::Some(_) => {
+            ::std::todo!()
+        }
+        ::std::prelude::rust_2021::None => {
+            ::std::todo!()
+        }
+    }
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr_test.rs
+++ b/packages/yew-macro/tests/hook_attr_test.rs
@@ -1,0 +1,7 @@
+#[allow(dead_code)]
+#[rustversion::attr(stable(1.56), test)]
+fn tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/hook_attr/*-pass.rs");
+    t.compile_fail("tests/hook_attr/*-fail.rs");
+}


### PR DESCRIPTION
#### Description

This pull request consists of the following:
- Fixes a call generics issue where the generics are not passed to the function call in `#[hook]`.
- Fixes a `FnOnce` usage in the macro that is not using a fully qualified path name.
- Added test cases to the `#[hook]` macro attribute.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow` (#2403)
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
