### PR TITLE
Improve AnyScope API

### DIFF
--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -141,7 +141,7 @@ impl AnyScope {
     /// Attempts to find a parent scope of a certain type
     ///
     /// Returns [`None`] if no parent scope with the specified type was found.
-    pub(crate) fn find_parent_scope<C: BaseComponent>(&self) -> Option<Scope<C>> {
+    pub fn find_parent_scope<C: BaseComponent>(&self) -> Option<Scope<C>> {
         let expected_type_id = TypeId::of::<C>();
         iter::successors(Some(self), |scope| scope.get_parent())
             .filter(|scope| scope.get_type_id() == &expected_type_id)

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -113,23 +113,34 @@ impl AnyScope {
     }
 
     /// Attempts to downcast into a typed scope
+    ///
+    /// # Panics
+    ///
+    /// If the self value can't be cast into the target type.
     pub fn downcast<COMP: BaseComponent>(self) -> Scope<COMP> {
-        let state = self.state.borrow();
-
-        state
-            .as_ref()
-            .map(|m| {
-                m.inner
-                    .as_any()
-                    .downcast_ref::<CompStateInner<COMP>>()
-                    .unwrap()
-                    .context
-                    .link()
-                    .clone()
-            })
-            .unwrap()
+        self.try_downcast::<COMP>().unwrap()
     }
 
+    /// Attempts to downcast into a typed scope
+    ///
+    /// Returns [`None`] if the self value can't be cast into the target type.
+    pub fn try_downcast<COMP: BaseComponent>(self) -> Option<Scope<COMP>> {
+        let state = self.state.borrow();
+
+        state.as_ref().map(|m| {
+            m.inner
+                .as_any()
+                .downcast_ref::<CompStateInner<COMP>>()
+                .unwrap()
+                .context
+                .link()
+                .clone()
+        })
+    }
+
+    /// Attempts to find a parent scope of a certain type
+    ///
+    /// Returns [`None`] if no parent scope with the specified type was found.
     pub(crate) fn find_parent_scope<C: BaseComponent>(&self) -> Option<Scope<C>> {
         let expected_type_id = TypeId::of::<C>();
         iter::successors(Some(self), |scope| scope.get_parent())


### PR DESCRIPTION
#### Description

+ Improve documentation
+ Add `try_downcast` method to `AnyScope`
+ Make `find_parent_scope` public. It could be used to find a parent component and send a message to it.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
