### PR TITLE
docs: fix typo

### DIFF
--- a/website/docs/concepts/html/introduction.mdx
+++ b/website/docs/concepts/html/introduction.mdx
@@ -163,7 +163,7 @@ Currently, there are two such special props: `ref` and `key`.
 Read more at [Lists](./html/lists)
 :::
 
-## Condtional Rendering
+## Conditional Rendering
 
 Markup can be rendered conditonally by using Rust's conditional structures. ' +
     'Currently only `if` and `if let` are supported.


### PR DESCRIPTION
Fixes the typo saw in the documentation https://yew.rs/docs/next/concepts/html