### PR TITLE
Make small fix to tutorial to reduce redundancy 

### DIFF
--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -24,13 +24,7 @@ get an overview of the talks and watch them all from one page.
 
 ### Prerequisites
 
-To get started, let's make sure we have an up-to-date development environment.
-We will need the following tools:
-- [Rust](https://www.rust-lang.org/)
-- [`trunk`](https://trunkrs.dev/)
-- `wasm32-unknown-unknown` target, the WASM compiler and build target for Rust.
-
-This tutorial also assumes you're already familiar with Rust. If you're new to Rust,
+This tutorial assumes you're already familiar with Rust. If you're new to Rust,
 the free [Rust Book](https://doc.rust-lang.org/book/ch00-00-introduction.html) offers a great starting point for
 beginners and continues to be an excellent resource even for experienced Rust developers.
 


### PR DESCRIPTION
Remove redundancy in docs. Directions to install each of these prereqs starts 1 paragraph below. 
