### PR TITLE
Fix dependencies in tutorial

### DIFF
--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -78,7 +78,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-+ yew = { git = "https://github.com/yewstack/yew/" }
+yew = { git = "https://github.com/yewstack/yew/" }
 ```
 
 ```rust ,no_run title="src/main.rs"


### PR DESCRIPTION
Just a small fix to remove the `+ ` before the yew dependency. Assuming it's a mistake? 
