### PR TITLE
Tutorial: Add clarification for html! 'for' syntax

### DIFF
--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -440,7 +440,8 @@ fn app() -> Html {
 
 Don't worry about the `use_state` right now, we will come back to that later.
 Note the trick we pulled with `{ for details }`. `Option<_>` implements `Iterator` so we can use it to display the only
-element returned by the `Iterator` with the `{ for ... }` syntax.
+element returned by the `Iterator` with a special `{ for ... }` syntax
+[supported by the `html!` macro](concepts/html/lists).
 
 ### Handling state
 


### PR DESCRIPTION
#### Description

This PR is based on my personal experience with the docs as a new user. YMMV, so I'm open to modifications. I am the type of person who needs to fully understand the language constructs being presented to me when working through a tutorial. While I was doing the Yew tutorial, I came across the section which used `{ for details }`. I'm still at novice to intermediate level with Rust, so I didn't know _for sure_ that this wasn't native Rust syntax. I googled around, trying to figure out if `for X` was a special Rust language construct that I wasn't aware of. Unfortunately it's much easier to verify language constructs that exist than those that don't. Only after a while doing this did it occur to me that it might be a construct of the `html!` macro instead, and I went hunting in the Yew docs and finally found my answer in the HTML section.

TL;DR - the sentence ending with "using the `{ for ... }` syntax" references a concept that has not been introduced before in the tutorial without any explanation. I think this is has potential to be confusing, so this is my proposed clarification.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow` (N/A - docs only) 
- [x] I have reviewed my own code
- [ ] I have added tests (N/A - docs only)
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
