### PR TITLE
Pause simulation, instead of resetting

### DIFF
--- a/examples/boids/src/simulation.rs
+++ b/examples/boids/src/simulation.rs
@@ -24,15 +24,17 @@ pub struct Props {
 pub struct Simulation {
     boids: Vec<Boid>,
     interval: Interval,
+    settings: Settings,
+    generation: usize,
 }
 impl Component for Simulation {
     type Message = Msg;
     type Properties = Props;
 
     fn create(ctx: &Context<Self>) -> Self {
-        let settings = &ctx.props().settings;
+        let settings = ctx.props().settings.clone();
         let boids = (0..settings.boids)
-            .map(|_| Boid::new_random(settings))
+            .map(|_| Boid::new_random(&settings))
             .collect();
 
         let interval = {
@@ -42,7 +44,13 @@ impl Component for Simulation {
             })
         };
 
-        Self { boids, interval }
+        let generation = ctx.props().generation;
+        Self {
+            boids,
+            interval,
+            settings,
+            generation,
+        }
     }
 
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
@@ -65,22 +73,30 @@ impl Component for Simulation {
     }
 
     fn changed(&mut self, ctx: &Context<Self>) -> bool {
-        self.boids.clear();
+        let props = ctx.props();
+        let should_reset = self.settings != props.settings || self.generation != props.generation;
+        self.settings = props.settings.clone();
+        self.generation = props.generation;
+        if should_reset {
+            self.boids.clear();
 
-        let settings = &ctx.props().settings;
-        self.boids
-            .resize_with(settings.boids, || Boid::new_random(settings));
+            let settings = &props.settings;
+            self.boids
+                .resize_with(settings.boids, || Boid::new_random(settings));
 
-        // as soon as the previous task is dropped it is cancelled.
-        // We don't need to worry about manually stopping it.
-        self.interval = {
-            let link = ctx.link().clone();
-            Interval::new(settings.tick_interval_ms as u32, move || {
-                link.send_message(Msg::Tick)
-            })
-        };
+            // as soon as the previous task is dropped it is cancelled.
+            // We don't need to worry about manually stopping it.
+            self.interval = {
+                let link = ctx.link().clone();
+                Interval::new(settings.tick_interval_ms as u32, move || {
+                    link.send_message(Msg::Tick)
+                })
+            };
 
-        true
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {


### PR DESCRIPTION
#### Description

Fix a regression in boids example, where pressing the pause button would actually reset the simulation, instead of only pausing it.

I think this was introduced in #1961 when converting from the old style of storing props inside components to the context API.

I also think that it could aid readability to convert (partially) to function components and use the hook-based `use_memo` to set-up the simulation without obscuring the dependency on the settings and generation, but that's not (yet?) in this PR, I'd like to hear opinions about that first.

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests: n/a hard to automate
