### PR TITLE
Size Comparison on Pull Requests

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,7 +90,7 @@ jobs:
             ${{ runner.os }}
 
       # Optimisation flags has no effect unless set at workspace level.
-      - name: Write Optimisation Flags
+      - name: Write optimisation flags
         run: |
           cat >> Cargo.toml << EOF
           [profile.release]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: "./yew"
-          repository: ${{ github.event.pull_request.head.repo.full_name }} 
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: "${{ github.head_ref }}"
 
       - uses: actions/checkout@v2
@@ -88,6 +88,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-benchmark-
             ${{ runner.os }}
+
+      # Optimisation flags has no effect unless set at workspace level.
+      - name: Write Optimisation Flags
+        run: |
+          cat >> Cargo.toml << EOF
+          [profile.release]
+          lto = true
+          codegen-units = 1
+          panic = "abort"
+          EOF
+        with:
+          working-directory: yew
 
       - name: save yew-struct setup
         shell: bash

--- a/.github/workflows/post-size-cmp.yml
+++ b/.github/workflows/post-size-cmp.yml
@@ -1,0 +1,115 @@
+---
+name: Post Comment for Size Comparison
+
+on:
+  workflow_run:
+    workflows: ["Size Comparison"]
+    types:
+      - completed
+
+jobs:
+  size-cmp:
+    name: Post Comment on Pull Request
+    runs-on: ubuntu-latest
+
+    steps:
+      - if: github.event.workflow_run.event == 'pull_request'
+        name: Download Artifact
+        uses: Legit-Labs/action-download-artifact@v2
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          workflow: size-cmp.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: size-cmp-info
+          path: "size-cmp-info/"
+
+      - name: Make pull request comment
+        run: |
+          from typing import Dict, List, Optional
+
+          import os
+          import json
+
+          with open("size-cmp-info/.SIZE_CMP_INFO") as f:
+              content = json.loads(f.read())
+
+          joined_sizes = content["sizes"]
+
+          lines: List[str] = []
+
+          lines.append("### Size Comparison")
+          lines.append("")
+          lines.append("| examples | master (KB) | pull request (KB) | diff |")
+          lines.append("| --- | --- | --- | --- | ")
+
+          for (i, sizes) in joined_sizes:
+              (master_size, pr_size) = sizes
+              diff: Optional[int] = None
+
+              if master_size is not None and pr_size is not None:
+                  diff = pr_size - master_size
+
+              master_size_str = "N/A" if master_size is None else (
+                  f"{master_size / 1024:.3f}" if master_size != 0 else "0"
+              )
+              pr_size_str = "N/A" if pr_size is None else (
+                  f"{pr_size / 1024:.3f}" if pr_size != 0 else "0"
+              )
+              diff_str = "N/A" if diff is None else (
+                  f"{diff / 1024:.3f}" if diff < 0 else (
+                      f"+{diff / 1024:.3f}" if diff > 0 else "0"
+                  )
+              )
+              lines.append(f"| {i} | {master_size_str} | {pr_size_str} | {diff_str} |")
+
+          output = "\n".join(lines)
+
+          with open(os.environ["GITHUB_ENV"], "a+") as f:
+              f.write(f"YEW_EXAMPLE_SIZES={json.dumps(output)}\n")
+              f.write(f"PR_NUMBER={content["issue_number"]}\n")
+
+        shell: python3 {0}
+
+      - name: Post Comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const commentInfo = {
+              ...context.repo,
+              issue_number: ${{ env.PR_NUMBER }},
+            };
+
+            const comment = {
+              ...commentInfo,
+              body: JSON.parse(process.env.YEW_EXAMPLE_SIZES),
+            };
+
+            function isCommentByBot(comment) {
+              return comment.user.type === "Bot" && comment.body.includes("### Size Comparison");
+            }
+
+            let commentId = null;
+            const comments = (await github.rest.issues.listComments(commentInfo)).data;
+            for (let i = comments.length; i--; ) {
+              const c = comments[i];
+              if (isCommentByBot(c)) {
+                commentId = c.id;
+                break;
+              }
+            }
+
+            if (commentId) {
+              try {
+                await github.rest.issues.updateComment({
+                  ...context.repo,
+                  comment_id: commentId,
+                  body: comment.body,
+                });
+              } catch (e) {
+                commentId = null;
+              }
+            }
+
+            if (!commentId) {
+              await github.rest.issues.createComment(comment);
+            }

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -86,8 +86,6 @@ jobs:
           import json
 
           def find_example_sizes(parent_dir: str) -> Dict[str, int]:
-              example_dirs_names =
-
               example_sizes: Dict[str, int] = {}
 
               for example_dir in os.listdir(f"{parent_dir}/examples"):
@@ -118,7 +116,7 @@ jobs:
 
           lines.append("### Size Comparison")
           lines.append("")
-          lines.append("| examples | master | pull request | diff |")
+          lines.append("| examples | master (KB) | pull request (KB) | diff |")
           lines.append("| --- | --- | --- | --- | ")
 
           for (i, sizes) in joined_sizes:
@@ -129,18 +127,22 @@ jobs:
                   diff = pr_size - master_size
 
               master_size_str = "N/A" if master_size is None else (
-                  f"{master_size / 1024:.3f}" if master_size != 0 else 0
+                  f"{master_size / 1024:.3f}" if master_size != 0 else "0"
               )
               pr_size_str = "N/A" if pr_size is None else (
-                  f"{pr_size / 1024:.3f}" if pr_size != 0 else 0
+                  f"{pr_size / 1024:.3f}" if pr_size != 0 else "0"
               )
-              diff_str = "N/A" if diff is None else (f"{diff / 1024:.3f}" if diff != 0 else 0)
+              diff_str = "N/A" if diff is None else (
+                  f"{diff / 1024:.3f}" if diff < 0 else (
+                      f"+{diff / 1024:.3f}" if diff > 0 else "0"
+                  )
+              )
               lines.append(f"| {i} | {master_size_str} | {pr_size_str} | {diff_str} |")
 
-          output = lines.join("\n")
+          output = "\n".join(lines)
 
           with open(os.environ["GITHUB_ENV"], "a+") as f:
-              f.write(f"YEW_EXAMPLE_SIZES={json.dumps(output)}")
+              f.write(f"YEW_EXAMPLE_SIZES={json.dumps(output)}\n")
 
         shell: python3 {0}
 

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -70,11 +70,11 @@ jobs:
         working-directory: current-pr
 
       - name: Build master examples
-        run: find examples/*/index.html | xargs -I '{}' trunk build --release '{}'
+        run: find examples/*/index.html | xargs -I '{}' trunk build --release '{}' || exit 0
         working-directory: yew-master
 
       - name: Build pull request examples
-        run: find examples/*/index.html | xargs -I '{}' trunk build --release '{}'
+        run: find examples/*/index.html | xargs -I '{}' trunk build --release '{}' || exit 0
         working-directory: current-pr
 
       - name: Make pull request comment

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -46,24 +46,26 @@ size-cmp:
         with:
           version: 'latest'
 
-      - name: Write Optimisation Flags
+      - name: Write optimisation flags for master
         run: |
           cat >> Cargo.toml << EOF
           [profile.release]
           lto = true
           codegen-units = 1
           panic = "abort"
+          opt-level = "z"
           EOF
         with:
           working-directory: yew-master
 
-      - name: Write Optimisation Flags
+      - name: Write optimisation flags for pull request
         run: |
           cat >> Cargo.toml << EOF
           [profile.release]
           lto = true
           codegen-units = 1
           panic = "abort"
+          opt-level = "z"
           EOF
         with:
           working-directory: current-pr

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -4,8 +4,9 @@ name: Size Comparison
 on:
   pull_request:
 
-size-cmp:
-  publish:
+jobs:
+  size-cmp:
+    name: Compare Size between master and current Pull Request
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -3,6 +3,11 @@ name: Size Comparison
 
 on:
   pull_request:
+    branches: [master]
+    paths:
+      - "packages/**"
+      - "examples/**"
+      - "Cargo.toml"
 
 jobs:
   size-cmp:
@@ -112,80 +117,19 @@ jobs:
 
           joined_sizes = [(i, [master_sizes.get(i), pr_sizes.get(i)]) for i in example_names]
 
-          lines: List[str] = []
+          size_cmp_info = {
+              "sizes": joined_sizes,
+              "issue_number": ${{ github.event.number }},
+          }
 
-          lines.append("### Size Comparison")
-          lines.append("")
-          lines.append("| examples | master (KB) | pull request (KB) | diff |")
-          lines.append("| --- | --- | --- | --- | ")
-
-          for (i, sizes) in joined_sizes:
-              (master_size, pr_size) = sizes
-              diff: Optional[int] = None
-
-              if master_size is not None and pr_size is not None:
-                  diff = pr_size - master_size
-
-              master_size_str = "N/A" if master_size is None else (
-                  f"{master_size / 1024:.3f}" if master_size != 0 else "0"
-              )
-              pr_size_str = "N/A" if pr_size is None else (
-                  f"{pr_size / 1024:.3f}" if pr_size != 0 else "0"
-              )
-              diff_str = "N/A" if diff is None else (
-                  f"{diff / 1024:.3f}" if diff < 0 else (
-                      f"+{diff / 1024:.3f}" if diff > 0 else "0"
-                  )
-              )
-              lines.append(f"| {i} | {master_size_str} | {pr_size_str} | {diff_str} |")
-
-          output = "\n".join(lines)
-
-          with open(os.environ["GITHUB_ENV"], "a+") as f:
-              f.write(f"YEW_EXAMPLE_SIZES={json.dumps(output)}\n")
+          with open(".SIZE_CMP_INFO", "w+") as f:
+              f.write(json.dumps(size_cmp_info))
 
         shell: python3 {0}
 
-      - name: Post Comment
-        uses: actions/github-script@v6
+      - name: Update Artifact
+        uses: actions/upload-artifact@v2
         with:
-          script: |
-            const commentInfo = {
-              ...context.repo,
-              issue_number: context.issue.number,
-            };
-
-            const comment = {
-              ...commentInfo,
-              body: process.env.YEW_EXAMPLE_SIZES,
-            };
-
-            function isCommentByBot(comment) {
-              return comment.user.type === "Bot" && comment.body.includes("### Size Comparison");
-            }
-
-            let commentId = null;
-            const comments = (await github.rest.issues.listComments(commentInfo)).data;
-            for (let i = comments.length; i--; ) {
-              const c = comments[i];
-              if (isCommentByBot(c)) {
-                commentId = c.id;
-                break;
-              }
-            }
-
-            if (commentId) {
-              try {
-                await github.rest.issues.updateComment({
-                  ...context.repo,
-                  comment_id: commentId,
-                  body: comment.body,
-                });
-              } catch (e) {
-                commentId = null;
-              }
-            }
-
-            if (!commentId) {
-              await github.rest.issues.createComment(comment);
-            }
+          name: size-cmp-info
+          path: ".SIZE_CMP_INFO"
+          retention-days: 1

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -56,8 +56,7 @@ jobs:
           panic = "abort"
           opt-level = "z"
           EOF
-        with:
-          working-directory: yew-master
+        working-directory: yew-master
 
       - name: Write optimisation flags for pull request
         run: |
@@ -68,8 +67,7 @@ jobs:
           panic = "abort"
           opt-level = "z"
           EOF
-        with:
-          working-directory: current-pr
+        working-directory: current-pr
 
       - name: Build master examples
         run: find examples/*/index.html | xargs -I '{}' trunk build --release '{}'

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -1,0 +1,188 @@
+---
+name: Size Comparison
+
+on:
+  pull_request:
+
+size-cmp:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v3
+        with:
+          repository: 'yewstack/yew'
+          ref: master
+          path: yew-master
+
+      - name: Checkout pull request
+        uses: actions/checkout@v3
+        with:
+          path: current-pr
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+          profile: minimal
+
+      - name: Restore Rust cache for master
+        uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: yew-master
+          key: master
+
+      - name: Restore Rust cache for current pull request
+        uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: current-pr
+          key: pr
+
+      - name: Setup Trunk
+        uses: jetli/trunk-action@v0.1.0
+        with:
+          version: 'latest'
+
+      - name: Write Optimisation Flags
+        run: |
+          cat >> Cargo.toml << EOF
+          [profile.release]
+          lto = true
+          codegen-units = 1
+          panic = "abort"
+          EOF
+        with:
+          working-directory: yew-master
+
+      - name: Write Optimisation Flags
+        run: |
+          cat >> Cargo.toml << EOF
+          [profile.release]
+          lto = true
+          codegen-units = 1
+          panic = "abort"
+          EOF
+        with:
+          working-directory: current-pr
+
+      - name: Build master examples
+        run: find examples/*/index.html | xargs -I '{}' trunk build --release '{}'
+        working-directory: yew-master
+
+      - name: Build pull request examples
+        run: find examples/*/index.html | xargs -I '{}' trunk build --release '{}'
+        working-directory: current-pr
+
+      - name: Make pull request comment
+        run: |
+          from typing import Dict, List, Optional
+
+          import glob
+          import os
+          import json
+
+          def find_example_sizes(parent_dir: str) -> Dict[str, int]:
+              example_dirs_names =
+
+              example_sizes: Dict[str, int] = {}
+
+              for example_dir in os.listdir(f"{parent_dir}/examples"):
+                  path = f"{parent_dir}/examples/{example_dir}"
+
+                  if not os.path.isdir(path):
+                      continue
+
+                  matches = glob.glob(f"{parent_dir}/examples/{example_dir}/dist/index*.wasm")
+
+                  if not matches:
+                      continue
+
+                  path = matches[0]
+
+                  example_sizes[example_dir] = os.path.getsize(path)
+
+              return example_sizes
+
+          master_sizes = find_example_sizes("yew-master")
+          pr_sizes = find_example_sizes("current-pr")
+
+          example_names = sorted(set([*master_sizes.keys(), *pr_sizes.keys()]))
+
+          joined_sizes = [(i, [master_sizes.get(i), pr_sizes.get(i)]) for i in example_names]
+
+          lines: List[str] = []
+
+          lines.append("### Size Comparison")
+          lines.append("")
+          lines.append("| examples | master | pull request | diff |")
+          lines.append("| --- | --- | --- | --- | ")
+
+          for (i, sizes) in joined_sizes:
+              (master_size, pr_size) = sizes
+              diff: Optional[int] = None
+
+              if master_size is not None and pr_size is not None:
+                  diff = pr_size - master_size
+
+              master_size_str = "N/A" if master_size is None else (
+                  f"{master_size / 1024:.3f}" if master_size != 0 else 0
+              )
+              pr_size_str = "N/A" if pr_size is None else (
+                  f"{pr_size / 1024:.3f}" if pr_size != 0 else 0
+              )
+              diff_str = "N/A" if diff is None else (f"{diff / 1024:.3f}" if diff != 0 else 0)
+              lines.append(f"| {i} | {master_size_str} | {pr_size_str} | {diff_str} |")
+
+          output = lines.join("\n")
+
+          with open(os.environ["GITHUB_ENV"], "a+") as f:
+              f.write(f"YEW_EXAMPLE_SIZES={json.dumps(output)}")
+
+        shell: python3 {0}
+
+      - name: Post Comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const commentInfo = {
+              ...context.repo,
+              issue_number: context.issue.number,
+            };
+
+            const comment = {
+              ...commentInfo,
+              body: process.env.YEW_EXAMPLE_SIZES,
+            };
+
+            function isCommentByBot(comment) {
+              return comment.user.type === "Bot" && comment.body.includes("### Size Comparison");
+            }
+
+            let commentId = null;
+            const comments = (await github.issues.listComments(commentInfo)).data;
+            for (let i = comments.length; i--; ) {
+              const c = comments[i];
+              if (isCommentByBot(c)) {
+                commentId = c.id;
+                break;
+              }
+            }
+
+            if (commentId) {
+              try {
+                await github.issues.updateComment({
+                  ...context.repo,
+                  comment_id: commentId,
+                  body: comment.body,
+                });
+              } catch (e) {
+                commentId = null;
+              }
+            }
+
+            if (!commentId) {
+              await github.issues.createComment(comment);
+            }

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -165,7 +165,7 @@ jobs:
             }
 
             let commentId = null;
-            const comments = (await github.issues.listComments(commentInfo)).data;
+            const comments = (await github.rest.issues.listComments(commentInfo)).data;
             for (let i = comments.length; i--; ) {
               const c = comments[i];
               if (isCommentByBot(c)) {
@@ -176,7 +176,7 @@ jobs:
 
             if (commentId) {
               try {
-                await github.issues.updateComment({
+                await github.rest.issues.updateComment({
                   ...context.repo,
                   comment_id: commentId,
                   body: comment.body,
@@ -187,5 +187,5 @@ jobs:
             }
 
             if (!commentId) {
-              await github.issues.createComment(comment);
+              await github.rest.issues.createComment(comment);
             }

--- a/tools/benchmark-hooks/Cargo.toml
+++ b/tools/benchmark-hooks/Cargo.toml
@@ -14,10 +14,5 @@ wasm-bindgen = "=0.2.78"
 web-sys = { version = "0.3.55", features = ["Window"]}
 yew = "0.19.3"
 
-[profile.release]
-lto = true
-codegen-units = 1
-panic = "abort"
-
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ['-O4']

--- a/tools/benchmark-struct/Cargo.toml
+++ b/tools/benchmark-struct/Cargo.toml
@@ -14,10 +14,5 @@ wasm-bindgen = "=0.2.78"
 web-sys = { version = "0.3.55", features = ["Window"]}
 yew = "0.19.3"
 
-[profile.release]
-lto = true
-codegen-units = 1
-panic = "abort"
-
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ['-O4']


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Fixes #2460

This pull request adds a comment on pull requests that compares the size of examples of master and pull requests.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->

### Preview

For every pull request, a comment like the following will be made on the pull request automatically.

### Size Comparison

| examples | master (KB) | pull request (KB) | diff |
| --- | --- | --- | --- | 
| boids | 420.108 | 413.815 | -6.293 |
| contexts | 311.164 | 312.313 | +1.149 |
| counter | 239.493 | 239.589 | +0.096 |
| dyn_create_destroy_apps | 250.018 | 251.504 | +1.486 |
| file_upload | 271.926 | 270.394 | -1.532 |
| function_memory_game | 458.660 | 452.327 | -6.333 |
| function_router | 657.030 | 4876.129 | +4219.099 |
| function_todomvc | 445.075 | 1937.725 | +1492.649 |
| futures | 485.006 | 484.910 | -0.096 |
| game_of_life | 294.672 | 293.459 | -1.213 |
| inner_html | 226.233 | 226.937 | +0.703 |
| js_callback | 245.771 | 243.983 | -1.788 |
| keyed_list | 440.328 | 437.477 | -2.852 |
| mount_point | 238.485 | 235.455 | -3.030 |
| nested_list | 325.065 | 326.522 | +1.457 |
| node_refs | 248.589 | 249.030 | +0.441 |
| password_strength | 2207.762 | 2173.107 | -34.654 |
| portals | 1405.800 | 258.956 | -1146.844 |
| router | 829.770 | 4074.907 | +3245.138 |
| simple_ssr | 3462.738 | 3462.738 | 0 |
| ssr_router | 5439.181 | 5439.181 | 0 |
| suspense | 305.204 | 300.256 | -4.948 |
| timer | 247.290 | 248.418 | +1.128 |
| todomvc | 371.790 | 368.855 | -2.935 |
| two_apps | 239.160 | 240.350 | +1.189 |
| webgl | 243.624 | 245.023 | +1.399 |