### PR TITLE
Fix dead link in tutorial

### DIFF
--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -581,5 +581,5 @@ See [external libraries](more/external-libs) for more details.
 
 ### Learning more about Yew
 
-Read our [official documentation](/docs/getting-started/project-setup/introduction). It explains a lot of concepts in much more details.
+Read our [official documentation](/docs/getting-started/introduction). It explains a lot of concepts in much more details.
 To learn more about our the Yew API, see our [API docs](https://docs.rs/yew).


### PR DESCRIPTION
This commit fixes a dead link in the tutorial:

Old link: https://yew.rs/docs/getting-started/project-setup/introduction
New link: https://yew.rs/docs/getting-started/introduction