### PR TITLE
Workaround upstream issue for password_strength

### DIFF
--- a/examples/password_strength/Cargo.toml
+++ b/examples/password_strength/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 yew = { path = "../../packages/yew" }
-zxcvbn = "2.1.2"
+zxcvbn = "2.1.2, <2.2.0"
 js-sys = "0.3.46"
 web-sys = { version = "0.3", features = ["Event","EventTarget","InputEvent"] }
 wasm-bindgen = "0.2"


### PR DESCRIPTION
#### Description

The `password_strength` examples fails due to an issue in the upstream `zxcvbn` 2.2.0 release. Workaround for now: force dependency resolution to select the old version.