### PR TITLE
Run doc tests in CI on wasm target

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [target.'cfg(target_arch = "wasm32")']
 runner = 'wasm-bindgen-test-runner'
+
+[unstable]
+doctest-xcompile = true

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -50,18 +50,10 @@ jobs:
           args: --all-targets --release -- -D warnings
 
   spell_tests:
-    name: Documentation Tests
+    name: Spell Test with aspell
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
-          profile: minimal
-
-      - uses: Swatinem/rust-cache@v1
 
       - name: Check spelling
         run: |
@@ -99,6 +91,14 @@ jobs:
         with:
           command: test
           args: --doc --workspace --exclude yew --exclude website-test
+
+      - name: Install wasm-bindgen-cli
+        if: ${{ matrix.toolchain == 'wasm32-unknown-unknown' }}
+        uses: actions-rs/install@v0.1
+        with:
+          crate: wasm-bindgen-cli
+          version: 0.2.78 # update this when changing wasm-bindgen version in yew
+
 
       - name: Run website code snippet tests
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -79,8 +79,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: Swatinem/rust-cache@v1
-
       # we need this target to install wasm-bindgen-cli
       - uses: actions-rs/toolchain@v1
         if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
@@ -99,6 +97,8 @@ jobs:
           target: ${{ matrix.target }}
           override: true
           profile: minimal
+
+      - uses: Swatinem/rust-cache@v1
 
       - name: Run doctest
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           override: true
           profile: minimal
 

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -51,14 +51,26 @@ jobs:
 
 
   doc_tests:
-    name: Documentation Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - toolchain: stable
+            target: "x86_64-unknown-linux-gnu"
+          - toolchain: nightly
+            target: "x86_64-unknown-linux-gnu"
+          - toolchain: nightly
+            target: "wasm32-unknown-unknown"
+
+    name: Documentation Tests on ${{ matrix.toolchain }} with ${{ matrix.target }}
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
+          toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.target }}
           override: true
           profile: minimal
 
@@ -68,7 +80,6 @@ jobs:
         run: |
           sudo apt-get install aspell
           ci/spellcheck.sh list
-
 
       - name: Run doctest
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -87,13 +87,13 @@ jobs:
 
       - name: Run doctest
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.toolchain == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         with:
           command: test
           args: --doc --workspace --exclude yew --exclude website-test
 
       - name: Install wasm-bindgen-cli
-        if: ${{ matrix.toolchain == 'wasm32-unknown-unknown' }}
+        if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
         uses: actions-rs/install@v0.1
         with:
           crate: wasm-bindgen-cli

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -49,10 +49,29 @@ jobs:
           command: clippy
           args: --all-targets --release -- -D warnings
 
+  spell_tests:
+    name: Documentation Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+          profile: minimal
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Check spelling
+        run: |
+          sudo apt-get install aspell
+          ci/spellcheck.sh list
 
   doc_tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - toolchain: stable
@@ -62,7 +81,7 @@ jobs:
           - toolchain: nightly
             target: "wasm32-unknown-unknown"
 
-    name: Documentation Tests on ${{ matrix.toolchain }} with ${{ matrix.target }}
+    name: Test doc code snippets on ${{ matrix.toolchain }} with ${{ matrix.target }}
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
     steps:
@@ -74,18 +93,12 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: Check spelling
-        run: |
-          sudo apt-get install aspell
-          ci/spellcheck.sh list
-
       - name: Run doctest
         uses: actions-rs/cargo@v1
+        if: ${{ matrix.toolchain == 'x86_64-unknown-linux-gnu' }}
         with:
           command: test
-          args: --doc
+          args: --doc --workspace --exclude yew --exclude website-test
 
       - name: Run website code snippet tests
         uses: actions-rs/cargo@v1
@@ -98,8 +111,6 @@ jobs:
         with:
           command: test
           args: --doc --features doc_test --features wasm_test
-
-
 
   integration_tests:
     name: Integration Tests on ${{ matrix.toolchain }}

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -78,6 +78,24 @@ jobs:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v2
+
+      - uses: Swatinem/rust-cache@v1
+
+      # we need this target to install wasm-bindgen-cli
+      - uses: actions-rs/toolchain@v1
+        if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+          profile: minimal
+
+      - name: Install wasm-bindgen-cli
+        if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
+        uses: actions-rs/install@v0.1
+        with:
+          crate: wasm-bindgen-cli
+          version: 0.2.78 # update this when changing wasm-bindgen version in yew
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -91,14 +109,6 @@ jobs:
         with:
           command: test
           args: --doc --workspace --exclude yew --exclude website-test
-
-      - name: Install wasm-bindgen-cli
-        if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
-        uses: actions-rs/install@v0.1
-        with:
-          crate: wasm-bindgen-cli
-          version: 0.2.78 # update this when changing wasm-bindgen version in yew
-
 
       - name: Run website code snippet tests
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -91,10 +91,7 @@ jobs:
 
       - name: Install wasm-bindgen-cli
         if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
-        uses: actions-rs/install@v0.1
-        with:
-          crate: wasm-bindgen-cli
-          version: 0.2.78 # update this when changing wasm-bindgen version in yew
+        run:  cargo install wasm-bindgen-cli --vers "0.2.78"
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -79,18 +79,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # we need this target to install wasm-bindgen-cli
-      - uses: actions-rs/toolchain@v1
-        if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
-
-      - name: Install wasm-bindgen-cli
-        if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
-        run:  cargo install wasm-bindgen-cli --vers "0.2.78"
-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -99,6 +87,11 @@ jobs:
           profile: minimal
 
       - uses: Swatinem/rust-cache@v1
+
+      - name: Install wasm-bindgen-cli
+        run: |
+        wget -qO- https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.69/wasm-bindgen-0.2.78-x86_64-unknown-linux-musl.tar.gz | tar -xzf- && \
+        mv wasm-bindgen-0.2.78-x86_64-unknown-linux-musl/wasm-bindgen ~/.cargo/bin/
 
       - name: Run doctest
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Run website code snippet tests
         uses: actions-rs/cargo@v1
         with:
+          toolchain: ${{ matrix.toolchain }}
           command: test
           args: -p website-test
 

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -90,7 +90,8 @@ jobs:
 
       - name: Install wasm-bindgen-cli
         run: |
-          wget -qO- https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.69/wasm-bindgen-0.2.78-x86_64-unknown-linux-musl.tar.gz | tar -xzf- && \
+          wget https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.78/wasm-bindgen-0.2.78-x86_64-unknown-linux-musl.tar.gz
+          tar -xzf wasm-bindgen-0.2.78-x86_64-unknown-linux-musl.tar.gz
           mv wasm-bindgen-0.2.78-x86_64-unknown-linux-musl/wasm-bindgen ~/.cargo/bin/
 
       - name: Run doctest

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -90,8 +90,8 @@ jobs:
 
       - name: Install wasm-bindgen-cli
         run: |
-        wget -qO- https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.69/wasm-bindgen-0.2.78-x86_64-unknown-linux-musl.tar.gz | tar -xzf- && \
-        mv wasm-bindgen-0.2.78-x86_64-unknown-linux-musl/wasm-bindgen ~/.cargo/bin/
+          wget -qO- https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.69/wasm-bindgen-0.2.78-x86_64-unknown-linux-musl.tar.gz | tar -xzf- && \
+          mv wasm-bindgen-0.2.78-x86_64-unknown-linux-musl/wasm-bindgen ~/.cargo/bin/
 
       - name: Run doctest
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: Swatinem/rust-cache@v1
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -86,13 +88,14 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: Swatinem/rust-cache@v1
-
       - name: Install wasm-bindgen-cli
         run: |
           wget https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.78/wasm-bindgen-0.2.78-x86_64-unknown-linux-musl.tar.gz
           tar -xzf wasm-bindgen-0.2.78-x86_64-unknown-linux-musl.tar.gz
           mv wasm-bindgen-0.2.78-x86_64-unknown-linux-musl/wasm-bindgen ~/.cargo/bin/
+
+      - name: Setup geckodriver
+        uses: browser-actions/setup-geckodriver@latest
 
       - name: Run doctest
         uses: actions-rs/cargo@v1

--- a/tools/website-test/Cargo.toml
+++ b/tools/website-test/Cargo.toml
@@ -18,7 +18,7 @@ wasm-bindgen-futures = "0.4"
 weblog = "0.3.0"
 yew = { path = "../../packages/yew/", features = ["ssr"] }
 yew-router = { path = "../../packages/yew-router/" }
-tokio = { version = "1.15.0", features = ["full"] }
+#tokio = { version = "1.15.0", features = ["full"] }
 
 [dev-dependencies.web-sys]
 version = "0.3"

--- a/website/docs/advanced-topics/server-side-rendering.md
+++ b/website/docs/advanced-topics/server-side-rendering.md
@@ -30,7 +30,7 @@ To render Yew components at the server-side, you can create a renderer
 with `ServerRenderer::<App>::new()` and call `renderer.render().await`
 to render `<App />` into a `String`.
 
-```rust
+```rust ,ignore
 use yew::prelude::*;
 use yew::ServerRenderer;
 


### PR DESCRIPTION
#### Description

Run doc tests in CI on wasm32-unknown-unknown target and on nightly toolchain

Fixes #2503 <!-- replace with issue number or remove if not applicable -->

#### Limitations

- SSR tests can't be run - we need a way to feature gate tokio in website-test