### PR TITLE
Fixed broken tutorial (#2531)

### DIFF
--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -75,10 +75,10 @@ Update the files as follows:
 [package]
 name = "yew-app"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-+ yew = { git = "https://github.com/yewstack/yew/" }
++ yew = "0.19"
 ```
 
 ```rust ,no_run title="src/main.rs"


### PR DESCRIPTION
* Changed dependency to yew = "0.19"

* Changed edition to "2021"

#### Description

<!-- Please include a summary of the change. -->
The task was to fix the dependency in the tutorial to "0.19" to avoid compilation errors.
I also changed the edition from "2018" to "2021", after checking all toml-files in the whole repo.
There are still a few "2018" left in the tutorials:
```
./website/versioned_docs/version-0.18.0/getting-started/starter-templates.mdx:edition = "2018"
./website/versioned_docs/version-0.18.0/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/versioned_docs/version-0.19.0/getting-started/starter-templates.mdx:edition = "2018"
./website/versioned_docs/version-0.19.0/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/i18n/ja/docusaurus-plugin-content-docs/0.17.3/getting-started/starter-templates.mdx:edition = "2018"
./website/i18n/ja/docusaurus-plugin-content-docs/0.17.3/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/i18n/ja/docusaurus-plugin-content-docs/version-0.18.0/getting-started/starter-templates.mdx:edition = "2018"
./website/i18n/ja/docusaurus-plugin-content-docs/version-0.18.0/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/starter-templates.mdx:edition = "2018"
./website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.17.3/getting-started/starter-templates.mdx:edition = "2018"
./website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.17.3/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.18.0/getting-started/starter-templates.mdx:edition = "2018"
./website/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.18.0/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started/starter-templates.mdx:edition = "2018"
./website/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.17.3/getting-started/starter-templates.mdx:edition = "2018"
./website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.17.3/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.18.0/getting-started/starter-templates.mdx:edition = "2018"
./website/i18n/zh-TW/docusaurus-plugin-content-docs/version-0.18.0/getting-started/build-a-sample-app.mdx:edition = "2018"
./website/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/starter-templates.mdx:edition = "2018"
./website/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/build-a-sample-app.mdx:edition = "2018"
```

Fixes #2531 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [X] I have run `cargo make pr-flow`
One test seem to fail (this should not be related to this PR, and its only difference in white space): 
```
test tests/failed_tests/base_component_impl-fail.rs ... mismatch

EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0277]: the trait bound `Comp: yew::Component` is not satisfied
   --> tests/failed_tests/base_component_impl-fail.rs:6:6
    |
6   | impl BaseComponent for Comp {
    |      ^^^^^^^^^^^^^ the trait `yew::Component` is not implemented for `Comp`
    |
    = note: required because of the requirements on the impl of `html::component::sealed::SealedBaseComponent` for `Comp`
note: required by a bound in `BaseComponent`
   --> src/html/component/mod.rs
    |
    | pub trait BaseComponent: sealed::SealedBaseComponent + Sized + 'static {
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `BaseComponent`
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0277]: the trait bound `Comp: yew::Component` is not satisfied
  --> tests/failed_tests/base_component_impl-fail.rs:6:6
   |
6  | impl BaseComponent for Comp {
   |      ^^^^^^^^^^^^^ the trait `yew::Component` is not implemented for `Comp`
   |
   = note: required because of the requirements on the impl of `html::component::sealed::SealedBaseComponent` for `Comp`
note: required by a bound in `BaseComponent`
  --> src/html/component/mod.rs
   |
   | pub trait BaseComponent: sealed::SealedBaseComponent + Sized + 'static {
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `BaseComponent`
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
note: If the actual output is the correct output you can bless it by rerunning
      your test with the environment variable TRYBUILD=overwrite

test tests/failed_tests/sealed_base_component_impl-fail.rs ... ok


test native_failed_tests ... FAILED
```
- [X] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
