### PR TITLE
Fix #2553 - automatically convert closure to callback for component properties

### DIFF
--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -346,7 +346,7 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
              <&'static str as IntoPropValue<Classes>>
              <&'static str as IntoPropValue<Option<AttrValue>>>
              <&'static str as IntoPropValue<Option<String>>>
-           and 15 others
+           and 18 others
 
 error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfied
   --> tests/html_macro/component-fail.rs:79:34
@@ -359,7 +359,7 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
              <&'static str as IntoPropValue<Classes>>
              <&'static str as IntoPropValue<Option<AttrValue>>>
              <&'static str as IntoPropValue<Option<String>>>
-           and 15 others
+           and 18 others
 
 error[E0308]: mismatched types
   --> tests/html_macro/component-fail.rs:80:31

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -303,6 +303,7 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<AttrVal
    = help: the following implementations were found:
              <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
              <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
              <Option<String> as IntoPropValue<Option<AttrValue>>>
              <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
 note: required by `into_prop_value`
@@ -320,6 +321,7 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<AttrValue
    = help: the following implementations were found:
              <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
              <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
              <Option<String> as IntoPropValue<Option<AttrValue>>>
              <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
 note: required by `into_prop_value`
@@ -416,6 +418,7 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
    = help: the following implementations were found:
              <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
              <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
              <Option<String> as IntoPropValue<Option<AttrValue>>>
              <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
 note: required by `into_prop_value`

--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -1,3 +1,4 @@
+use super::super::callback::Callback;
 use super::{Component, NodeRef, Scope};
 use crate::virtual_dom::AttrValue;
 use std::rc::Rc;
@@ -64,6 +65,24 @@ where
     }
 }
 
+impl<I, O, F> IntoPropValue<Callback<I, O>> for F
+    where
+        F: 'static + Fn(I) -> O,
+{
+    fn into_prop_value(self) -> Callback<I, O> {
+        Callback::from(self)
+    }
+}
+
+impl<I, O, F> IntoPropValue<Option<Callback<I, O>>> for Option<F>
+    where
+        F: 'static + Fn(I) -> O,
+{
+    fn into_prop_value(self) -> Option<Callback<I, O>> {
+        self.map(|f| Callback::from(f))
+    }
+}
+
 macro_rules! impl_into_prop {
     (|$value:ident: $from_ty:ty| -> $to_ty:ty { $conversion:expr }) => {
         // implement V -> T
@@ -110,5 +129,13 @@ mod test {
         let _: AttrValue = "foo".into_prop_value();
         let _: Option<AttrValue> = "foo".into_prop_value();
         let _: Option<AttrValue> = Rc::<str>::from("foo").into_prop_value();
+    }
+
+    #[test]
+    fn test_callback() {
+        let _: Callback<String> = (|_: String| ()).into_prop_value();
+        let _: Option<Callback<String>> = Some(|_: String| ()).into_prop_value();
+        let _: Callback<String, String> = (|s: String| s).into_prop_value();
+        let _: Option<Callback<String, String>> = Some(|s: String| s).into_prop_value();
     }
 }

--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -74,6 +74,15 @@ impl<I, O, F> IntoPropValue<Callback<I, O>> for F
     }
 }
 
+impl<I, O, F> IntoPropValue<Option<Callback<I, O>>> for F
+    where
+        F: 'static + Fn(I) -> O,
+{
+    fn into_prop_value(self) -> Option<Callback<I, O>> {
+        Some(Callback::from(self))
+    }
+}
+
 impl<I, O, F> IntoPropValue<Option<Callback<I, O>>> for Option<F>
     where
         F: 'static + Fn(I) -> O,
@@ -134,8 +143,10 @@ mod test {
     #[test]
     fn test_callback() {
         let _: Callback<String> = (|_: String| ()).into_prop_value();
+        let _: Option<Callback<String>> = (|_: String| ()).into_prop_value();
         let _: Option<Callback<String>> = Some(|_: String| ()).into_prop_value();
         let _: Callback<String, String> = (|s: String| s).into_prop_value();
+        let _: Option<Callback<String, String>> = (|s: String| s).into_prop_value();
         let _: Option<Callback<String, String>> = Some(|s: String| s).into_prop_value();
     }
 }

--- a/packages/yew/src/html/conversion.rs
+++ b/packages/yew/src/html/conversion.rs
@@ -66,8 +66,8 @@ where
 }
 
 impl<I, O, F> IntoPropValue<Callback<I, O>> for F
-    where
-        F: 'static + Fn(I) -> O,
+where
+    F: 'static + Fn(I) -> O,
 {
     fn into_prop_value(self) -> Callback<I, O> {
         Callback::from(self)
@@ -75,8 +75,8 @@ impl<I, O, F> IntoPropValue<Callback<I, O>> for F
 }
 
 impl<I, O, F> IntoPropValue<Option<Callback<I, O>>> for F
-    where
-        F: 'static + Fn(I) -> O,
+where
+    F: 'static + Fn(I) -> O,
 {
     fn into_prop_value(self) -> Option<Callback<I, O>> {
         Some(Callback::from(self))
@@ -84,8 +84,8 @@ impl<I, O, F> IntoPropValue<Option<Callback<I, O>>> for F
 }
 
 impl<I, O, F> IntoPropValue<Option<Callback<I, O>>> for Option<F>
-    where
-        F: 'static + Fn(I) -> O,
+where
+    F: 'static + Fn(I) -> O,
 {
     fn into_prop_value(self) -> Option<Callback<I, O>> {
         self.map(|f| Callback::from(f))


### PR DESCRIPTION
#### Description

I added three functions to facilitate passing closures to component properties of type `Callback`. As noted in #2553, the [documentation](https://yew.rs/docs/concepts/components/callbacks) implies that this functionality already exists.

Fixes #2553

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
