### PR TITLE
Experiment with monomorph CreateRunner

### DIFF
--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -218,11 +218,7 @@ mod feat_ssr {
 
             scheduler::push_component_create(
                 self.id,
-                Box::new(CreateRunner {
-                    initial_render_state: state,
-                    props,
-                    scope: self.clone(),
-                }),
+                CreateRunner::new_runnable(state, self.clone(), props),
                 Box::new(RenderRunner {
                     state: self.state.clone(),
                 }),
@@ -442,11 +438,7 @@ mod feat_csr {
 
             scheduler::push_component_create(
                 self.id,
-                Box::new(CreateRunner {
-                    initial_render_state: state,
-                    props,
-                    scope: self.clone(),
-                }),
+                CreateRunner::new_runnable(state, self.clone(), props),
                 Box::new(RenderRunner {
                     state: self.state.clone(),
                 }),


### PR DESCRIPTION
#### Description

Get rid of the generic parameter to `CreateRunner`, to unify with the other scheduler runnables, and to target a suggestion in #2485. I want to see if this has any impact on generated code size, first.

#### Checklist

- [x] This is just an experiment for now
