### PR TITLE
Prototype `HtmlRef` & `use_imperative_handle`

### DIFF
--- a/examples/dyn_create_destroy_apps/src/main.rs
+++ b/examples/dyn_create_destroy_apps/src/main.rs
@@ -17,7 +17,7 @@ pub enum Msg {
 
 pub struct App {
     apps: Slab<(Element, AppHandle<CounterModel>)>, // Contains the spawned apps and their parent div elements
-    apps_container_ref: NodeRef,
+    apps_container_ref: HtmlRef<Element>,
 }
 
 impl Component for App {
@@ -27,14 +27,14 @@ impl Component for App {
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
             apps: Slab::new(),
-            apps_container_ref: NodeRef::default(),
+            apps_container_ref: Default::default(),
         }
     }
 
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         let app_container = self
             .apps_container_ref
-            .cast::<Element>()
+            .get()
             .expect("Failed to cast app container div to HTMLElement");
 
         match msg {

--- a/examples/keyed_list/src/main.rs
+++ b/examples/keyed_list/src/main.rs
@@ -28,7 +28,7 @@ pub struct App {
     last_id: usize,
     keyed: bool,
     build_component_ratio: f64,
-    delta_ref: NodeRef,
+    delta_ref: HtmlRef<HtmlElement>,
 }
 
 impl Component for App {
@@ -41,7 +41,7 @@ impl Component for App {
             last_id: 0,
             keyed: true,
             build_component_ratio: 0.5,
-            delta_ref: NodeRef::default(),
+            delta_ref: HtmlRef::default(),
         }
     }
 
@@ -126,7 +126,7 @@ impl Component for App {
                 let time_after = Instant::now();
                 let elapsed_max = time_after - time_before;
                 log::info!("Rendering started {} ms ago.", elapsed_max.as_millis());
-                if let Some(input) = self.delta_ref.cast::<HtmlElement>() {
+                if let Some(input) = self.delta_ref.get() {
                     let delta_text =
                         format!("The last rendering took {} ms", elapsed_max.as_millis());
                     input.set_inner_text(&delta_text);

--- a/examples/nested_list/src/list.rs
+++ b/examples/nested_list/src/list.rs
@@ -2,7 +2,7 @@ use crate::header::{ListHeader, Props as HeaderProps};
 use crate::item::{ListItem, Props as ItemProps};
 use crate::{Hovered, WeakComponentLink};
 use std::rc::Rc;
-use yew::html::{ChildrenRenderer, NodeRef};
+use yew::html::ChildrenRenderer;
 use yew::prelude::*;
 use yew::virtual_dom::{VChild, VComp};
 
@@ -44,10 +44,8 @@ where
 impl From<ListVariant> for Html {
     fn from(variant: ListVariant) -> Html {
         match variant.props {
-            Variants::Header(props) => {
-                VComp::new::<ListHeader>(props, NodeRef::default(), None).into()
-            }
-            Variants::Item(props) => VComp::new::<ListItem>(props, NodeRef::default(), None).into(),
+            Variants::Header(props) => VComp::new::<ListHeader>(props, None).into(),
+            Variants::Item(props) => VComp::new::<ListItem>(props, None).into(),
         }
     }
 }

--- a/examples/node_refs/src/input.rs
+++ b/examples/node_refs/src/input.rs
@@ -1,40 +1,25 @@
+use web_sys::HtmlInputElement;
 use yew::prelude::*;
-
-pub enum Msg {
-    Hover,
-}
 
 #[derive(Properties, PartialEq)]
 pub struct Props {
     pub on_hover: Callback<()>,
+    #[prop_or_default]
+    pub ref_: HtmlRef<HtmlInputElement>,
 }
 
-pub struct InputComponent;
+#[function_component]
+pub fn InputComponent(props: &Props) -> Html {
+    let on_mouse_over = {
+        let on_hover = props.on_hover.clone();
+        Callback::from(move |_| on_hover.emit(()))
+    };
 
-impl Component for InputComponent {
-    type Message = Msg;
-    type Properties = Props;
-
-    fn create(_ctx: &Context<Self>) -> Self {
-        Self
-    }
-
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
-        match msg {
-            Msg::Hover => {
-                ctx.props().on_hover.emit(());
-                false
-            }
-        }
-    }
-
-    fn view(&self, ctx: &Context<Self>) -> Html {
-        html! {
-            <input
-                type="text"
-                class="input-component"
-                onmouseover={ctx.link().callback(|_| Msg::Hover)}
-            />
-        }
+    html! {
+        <input
+            type="text"
+            class="input-component"
+            onmouseover={on_mouse_over}
+        />
     }
 }

--- a/examples/node_refs/src/input.rs
+++ b/examples/node_refs/src/input.rs
@@ -20,6 +20,7 @@ pub fn InputComponent(props: &Props) -> Html {
             type="text"
             class="input-component"
             onmouseover={on_mouse_over}
+            ref={props.ref_.clone()}
         />
     }
 }

--- a/examples/node_refs/src/main.rs
+++ b/examples/node_refs/src/main.rs
@@ -9,13 +9,13 @@ pub enum Msg {
 }
 
 pub struct App {
-    input_ref: NodeRef,
+    input_ref: HtmlRef<HtmlInputElement>,
     input_comp_ref: HtmlRef<HtmlInputElement>,
     focus_index: usize,
 }
 impl App {
     fn apply_focus(&self) {
-        if let Some(m) = self.input_ref.cast::<HtmlInputElement>() {
+        if let Some(m) = self.input_ref.get() {
             m.focus().unwrap();
         }
         if let Some(m) = self.input_comp_ref.get() {
@@ -30,7 +30,7 @@ impl Component for App {
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
             focus_index: 0,
-            input_ref: NodeRef::default(),
+            input_ref: HtmlRef::default(),
             input_comp_ref: HtmlRef::default(),
         }
     }

--- a/examples/node_refs/src/main.rs
+++ b/examples/node_refs/src/main.rs
@@ -9,13 +9,17 @@ pub enum Msg {
 }
 
 pub struct App {
-    refs: Vec<NodeRef>,
+    input_ref: NodeRef,
+    input_comp_ref: HtmlRef<HtmlInputElement>,
     focus_index: usize,
 }
 impl App {
     fn apply_focus(&self) {
-        if let Some(input) = self.refs[self.focus_index].cast::<HtmlInputElement>() {
-            input.focus().unwrap();
+        if let Some(m) = self.input_ref.cast::<HtmlInputElement>() {
+            m.focus().unwrap();
+        }
+        if let Some(m) = self.input_comp_ref.get() {
+            m.focus().unwrap();
         }
     }
 }
@@ -26,7 +30,8 @@ impl Component for App {
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
             focus_index: 0,
-            refs: vec![NodeRef::default(), NodeRef::default()],
+            input_ref: NodeRef::default(),
+            input_comp_ref: HtmlRef::default(),
         }
     }
 
@@ -59,7 +64,7 @@ impl Component for App {
                     <label>{ "Using tag ref: " }</label>
                     <input
                         type="text"
-                        ref={self.refs[0].clone()}
+                        ref={self.input_ref.clone()}
                         class="input-element"
                         onmouseover={ctx.link().callback(|_| Msg::HoverIndex(0))}
                     />
@@ -67,7 +72,7 @@ impl Component for App {
                 <div>
                     <label>{ "Using component ref: " }</label>
                     <InputComponent
-                        ref={self.refs[1].clone()}
+                        ref={self.input_comp_ref.clone()}
                         on_hover={ctx.link().callback(|_| Msg::HoverIndex(1))}
                     />
                 </div>

--- a/examples/node_refs/src/main.rs
+++ b/examples/node_refs/src/main.rs
@@ -9,17 +9,13 @@ pub enum Msg {
 }
 
 pub struct App {
-    input_ref: HtmlRef<HtmlInputElement>,
-    input_comp_ref: HtmlRef<HtmlInputElement>,
+    refs: Vec<HtmlRef<HtmlInputElement>>,
     focus_index: usize,
 }
 impl App {
     fn apply_focus(&self) {
-        if let Some(m) = self.input_ref.get() {
-            m.focus().unwrap();
-        }
-        if let Some(m) = self.input_comp_ref.get() {
-            m.focus().unwrap();
+        if let Some(input) = self.refs[self.focus_index].get() {
+            input.focus().unwrap();
         }
     }
 }
@@ -30,8 +26,8 @@ impl Component for App {
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
             focus_index: 0,
-            input_ref: HtmlRef::default(),
-            input_comp_ref: HtmlRef::default(),
+
+            refs: vec![HtmlRef::default(), HtmlRef::default()],
         }
     }
 
@@ -64,7 +60,7 @@ impl Component for App {
                     <label>{ "Using tag ref: " }</label>
                     <input
                         type="text"
-                        ref={self.input_ref.clone()}
+                        ref={self.refs[0].clone()}
                         class="input-element"
                         onmouseover={ctx.link().callback(|_| Msg::HoverIndex(0))}
                     />
@@ -72,7 +68,7 @@ impl Component for App {
                 <div>
                     <label>{ "Using component ref: " }</label>
                     <InputComponent
-                        ref={self.input_comp_ref.clone()}
+                        ref={self.refs[1].clone()}
                         on_hover={ctx.link().callback(|_| Msg::HoverIndex(1))}
                     />
                 </div>

--- a/examples/portals/src/main.rs
+++ b/examples/portals/src/main.rs
@@ -1,6 +1,5 @@
-use wasm_bindgen::JsCast;
 use web_sys::{Element, ShadowRootInit, ShadowRootMode};
-use yew::{create_portal, html, Children, Component, Context, Html, NodeRef, Properties};
+use yew::{create_portal, html, Children, Component, Context, Html, HtmlRef, Properties};
 
 #[derive(Properties, PartialEq)]
 pub struct ShadowDOMProps {
@@ -9,7 +8,7 @@ pub struct ShadowDOMProps {
 }
 
 pub struct ShadowDOMHost {
-    host_ref: NodeRef,
+    host_ref: HtmlRef<Element>,
     inner_host: Option<Element>,
 }
 
@@ -19,7 +18,7 @@ impl Component for ShadowDOMHost {
 
     fn create(_: &Context<Self>) -> Self {
         Self {
-            host_ref: NodeRef::default(),
+            host_ref: HtmlRef::default(),
             inner_host: None,
         }
     }
@@ -30,7 +29,6 @@ impl Component for ShadowDOMHost {
                 .host_ref
                 .get()
                 .expect("rendered host")
-                .unchecked_into::<Element>()
                 .attach_shadow(&ShadowRootInit::new(ShadowRootMode::Open))
                 .expect("installing shadow root succeeds");
             let inner_host = gloo_utils::document()

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -7,7 +7,7 @@ use yew::{
     events::{FocusEvent, KeyboardEvent},
     html,
     html::Scope,
-    Classes, Component, Context, Html, NodeRef, TargetCast,
+    Classes, Component, Context, Html, HtmlRef, TargetCast,
 };
 
 mod state;
@@ -28,7 +28,7 @@ pub enum Msg {
 
 pub struct App {
     state: State,
-    focus_ref: NodeRef,
+    focus_ref: HtmlRef<InputElement>,
 }
 
 impl Component for App {
@@ -42,7 +42,7 @@ impl Component for App {
             filter: Filter::All,
             edit_value: "".into(),
         };
-        let focus_ref = NodeRef::default();
+        let focus_ref = HtmlRef::default();
         Self { state, focus_ref }
     }
 
@@ -84,7 +84,7 @@ impl Component for App {
                 self.state.clear_completed();
             }
             Msg::Focus => {
-                if let Some(input) = self.focus_ref.cast::<InputElement>() {
+                if let Some(input) = self.focus_ref.get() {
                     input.focus().unwrap();
                 }
             }

--- a/examples/web_worker_fib/src/app.rs
+++ b/examples/web_worker_fib/src/app.rs
@@ -7,7 +7,7 @@ use yew_agent::{Bridge, Bridged};
 
 pub struct App {
     clicker_value: u32,
-    input_ref: NodeRef,
+    input_ref: HtmlRef<HtmlInputElement>,
     worker: Box<dyn Bridge<Worker>>,
     fibonacci_output: String,
 }
@@ -31,7 +31,7 @@ impl Component for App {
 
         Self {
             clicker_value: 0,
-            input_ref: NodeRef::default(),
+            input_ref: HtmlRef::default(),
             worker,
             fibonacci_output: String::from("Try out some fibonacci calculations!"),
         }
@@ -43,7 +43,7 @@ impl Component for App {
                 self.clicker_value += 1;
             }
             Self::Message::RunWorker => {
-                if let Some(input) = self.input_ref.cast::<HtmlInputElement>() {
+                if let Some(input) = self.input_ref.get() {
                     // start the worker off!
                     self.worker.send(WorkerInput {
                         n: input.value_as_number() as u32,

--- a/examples/webgl/src/main.rs
+++ b/examples/webgl/src/main.rs
@@ -2,7 +2,7 @@ use gloo_render::{request_animation_frame, AnimationFrame};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlCanvasElement, WebGlRenderingContext as GL};
 use yew::html::Scope;
-use yew::{html, Component, Context, Html, NodeRef};
+use yew::prelude::*;
 
 pub enum Msg {
     Render(f64),
@@ -10,7 +10,7 @@ pub enum Msg {
 
 pub struct App {
     gl: Option<GL>,
-    node_ref: NodeRef,
+    node_ref: HtmlRef<HtmlCanvasElement>,
     _render_loop: Option<AnimationFrame>,
 }
 
@@ -21,7 +21,7 @@ impl Component for App {
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
             gl: None,
-            node_ref: NodeRef::default(),
+            node_ref: HtmlRef::default(),
             _render_loop: None,
         }
     }
@@ -50,7 +50,7 @@ impl Component for App {
         // resizing the rendering area when the window or canvas element are resized, as well as
         // for making GL calls.
 
-        let canvas = self.node_ref.cast::<HtmlCanvasElement>().unwrap();
+        let canvas = self.node_ref.get().unwrap();
 
         let gl: GL = canvas
             .get_context("webgl")

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -104,12 +104,14 @@ impl PropField {
             PropAttr::Option => {
                 quote! {
                     #( #extra_attrs )*
+                    #[allow(non_snake_case)]
                     #wrapped_name: #ty,
                 }
             }
             _ => {
                 quote! {
                     #( #extra_attrs )*
+                    #[allow(non_snake_case)]
                     #wrapped_name: ::std::option::Option<#ty>,
                 }
             }

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -9,7 +9,7 @@ use syn::spanned::Spanned;
 use syn::{Attribute, Error, Expr, Field, Path, Type, TypePath, Visibility};
 
 #[allow(clippy::large_enum_variant)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 enum PropAttr {
     Required { wrapped_name: Ident },
     Option,
@@ -18,15 +18,23 @@ enum PropAttr {
     PropOrDefault,
 }
 
-#[derive(Eq)]
+#[derive(Clone, Eq)]
 pub struct PropField {
     ty: Type,
-    name: Ident,
+    pub(crate) name: Ident,
     attr: PropAttr,
     extra_attrs: Vec<Attribute>,
 }
 
 impl PropField {
+    pub fn name(&self) -> &Ident {
+        &self.name
+    }
+
+    pub fn type_(&self) -> &Type {
+        &self.ty
+    }
+
     /// All required property fields are wrapped in an `Option`
     pub fn is_required(&self) -> bool {
         matches!(self.attr, PropAttr::Required { .. })

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -21,7 +21,7 @@ enum PropAttr {
 #[derive(Clone, Eq)]
 pub struct PropField {
     ty: Type,
-    pub(crate) name: Ident,
+    name: Ident,
     attr: PropAttr,
     extra_attrs: Vec<Attribute>,
 }

--- a/packages/yew-macro/src/html_tree/html_component.rs
+++ b/packages/yew-macro/src/html_tree/html_component.rs
@@ -101,12 +101,6 @@ impl ToTokens for HtmlComponent {
         let build_props = props.build_properties_tokens(&props_ty, children_renderer);
 
         let special_props = props.special();
-        let node_ref = if let Some(node_ref) = &special_props.node_ref {
-            let value = &node_ref.value;
-            quote_spanned! {value.span()=> #value }
-        } else {
-            quote! { <::yew::html::NodeRef as ::std::default::Default>::default() }
-        };
 
         let key = if let Some(key) = &special_props.key {
             let value = &key.value;
@@ -121,7 +115,7 @@ impl ToTokens for HtmlComponent {
         tokens.extend(quote_spanned! {ty.span()=>
             {
                 let __yew_props = #build_props;
-                ::yew::virtual_dom::VChild::<#ty>::new(__yew_props, #node_ref, #key)
+                ::yew::virtual_dom::VChild::<#ty>::new(__yew_props, #key)
             }
         });
     }

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -19,6 +19,14 @@ fn get_element_types() -> HashMap<&'static str, Type> {
         parse_quote!(::yew::__vendored::web_sys::HtmlCanvasElement),
     );
     map.insert("p", parse_quote!(::yew::__vendored::web_sys::HtmlElement));
+    map.insert(
+        "div",
+        parse_quote!(::yew::__vendored::web_sys::HtmlDivElement),
+    );
+    map.insert(
+        "span",
+        parse_quote!(::yew::__vendored::web_sys::HtmlSpanElement),
+    );
 
     map
 }

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -92,6 +92,12 @@ impl ComponentProps {
                     }
                 });
 
+                let set_ref = self.special().node_ref.as_ref().map(|Prop { value, .. }| {
+                    quote_spanned! {value.span()=>
+                        .ref_(#value)
+                    }
+                });
+
                 let set_children = children_renderer.map(|children| {
                     quote_spanned! {props_ty.span()=>
                         .children(#children)
@@ -102,6 +108,7 @@ impl ComponentProps {
                     <#props_ty as ::yew::html::Properties>::builder()
                         #(#set_props)*
                         #set_children
+                        #set_ref
                         .build()
                 }
             }

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -114,6 +114,11 @@ impl ComponentProps {
                         #ident.#label = ::yew::html::IntoPropValue::into_prop_value(#value);
                     }
                 });
+                let set_ref = self.special().node_ref.as_ref().map(|Prop { value, .. }| {
+                    quote_spanned! {value.span()=>
+                        #ident.ref_ = ::yew::html::IntoPropValue::into_prop_value(#value);
+                    }
+                });
                 let set_children = children_renderer.map(|children| {
                     quote_spanned! {props_ty.span()=>
                         #ident.children = #children;
@@ -124,6 +129,7 @@ impl ComponentProps {
                     let mut #ident = #expr;
                     #(#set_props)*
                     #set_children
+                    #set_ref
                     #ident
                 }
             }

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -44,11 +44,11 @@ error[E0599]: no method named `b` found for struct `t4::PropsBuilder<PropsBuilde
 48 |         Props::builder().b(1).a(2).build();
    |                          ^ help: there is an associated function with a similar name: `a`
 
-error[E0277]: the trait bound `Value: Default` is not satisfied
+error[E0277]: the trait bound `Value: std::default::Default` is not satisfied
     --> tests/derive_props/fail.rs:9:21
      |
 9    |     #[derive(Clone, Properties, PartialEq)]
-     |                     ^^^^^^^^^^ the trait `Default` is not implemented for `Value`
+     |                     ^^^^^^^^^^ the trait `std::default::Default` is not implemented for `Value`
      |
 note: required by `Option::<T>::unwrap_or_default`
      = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -361,11 +361,18 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
              <&'static str as IntoPropValue<Option<String>>>
            and 18 others
 
-error[E0308]: mismatched types
+error[E0599]: no method named `ref_` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:80:31
    |
+4  | #[derive(Clone, Properties, PartialEq)]
+   |                 ---------- method `ref_` not found for this
+...
 80 |     html! { <Child int=1 ref={()} /> };
-   |                               ^^ expected struct `NodeRef`, found `()`
+   |                               ^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStepPropsBuilder>`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `ref_`, perhaps you need to implement it:
+           candidate #1: `yew::Properties`
 
 error[E0277]: the trait bound `u32: IntoPropValue<i32>` is not satisfied
   --> tests/html_macro/component-fail.rs:82:24

--- a/packages/yew-macro/tests/html_macro/component-pass.rs
+++ b/packages/yew-macro/tests/html_macro/component-pass.rs
@@ -104,19 +104,13 @@ pub struct ChildProperties {
     pub vec: ::std::vec::Vec<::std::primitive::i32>,
     #[prop_or_default]
     pub optional_callback: ::std::option::Option<::yew::Callback<()>>,
+    #[prop_or_default]
+    pub ref_: ::yew::html::HtmlRef<()>,
 }
 
-pub struct Child;
-impl ::yew::Component for Child {
-    type Message = ();
-    type Properties = ChildProperties;
-
-    fn create(_ctx: &::yew::Context<Self>) -> Self {
-        ::std::unimplemented!()
-    }
-    fn view(&self, _ctx: &::yew::Context<Self>) -> ::yew::Html {
-        ::std::unimplemented!()
-    }
+#[::yew::function_component]
+pub fn Child(_props: &ChildProperties) -> ::yew::html::Html {
+    ::std::unimplemented!()
 }
 
 pub struct AltChild;
@@ -170,16 +164,17 @@ fn compile_pass() {
         </>
     };
 
-    let props = <<Child as ::yew::Component>::Properties as ::std::default::Default>::default();
-    let node_ref = <::yew::NodeRef as ::std::default::Default>::default();
+    let props =
+        <<Child as ::yew::html::IntoComponent>::Properties as ::std::default::Default>::default();
+    let node_ref = ::yew::html::HtmlRef::<()>::new();
     ::yew::html! {
         <>
             <Child ..::std::clone::Clone::clone(&props) />
             <Child int={1} ..props />
-            <Child ref={::std::clone::Clone::clone(&node_ref)} int={2} ..::yew::props!(Child::Properties { int: 5 }) />
-            <Child int=3 ref={::std::clone::Clone::clone(&node_ref)} ..::yew::props!(Child::Properties { int: 5 }) />
-            <Child ref={::std::clone::Clone::clone(&node_ref)} ..::yew::props!(Child::Properties { int: 5 }) />
-            <Child ref={node_ref} ..<<Child as ::yew::Component>::Properties as ::std::default::Default>::default() />
+            <Child ref={::std::clone::Clone::clone(&node_ref)} int={2} ..::yew::props!(<Child as ::yew::html::IntoComponent>::Properties { int: 5 }) />
+            <Child int=3 ref={::std::clone::Clone::clone(&node_ref)} ..::yew::props!(<Child as ::yew::html::IntoComponent>::Properties { int: 5 }) />
+            <Child ref={::std::clone::Clone::clone(&node_ref)} ..::yew::props!(<Child as ::yew::html::IntoComponent>::Properties { int: 5 }) />
+            <Child ref={node_ref} ..<<Child as ::yew::html::IntoComponent>::Properties as ::std::default::Default>::default() />
         </>
     };
 
@@ -218,7 +213,7 @@ fn compile_pass() {
         </>
     };
 
-    let node_ref = <::yew::NodeRef as ::std::default::Default>::default();
+    let node_ref = ::yew::html::HtmlRef::<()>::new();
     ::yew::html! {
         <>
             <Child int=1 ref={node_ref} />
@@ -226,7 +221,7 @@ fn compile_pass() {
     };
 
     let int = 1;
-    let node_ref = <::yew::NodeRef as ::std::default::Default>::default();
+    let node_ref = ::yew::html::HtmlRef::<()>::new();
     ::yew::html! {
         <>
             <Child {int} ref={node_ref} />
@@ -235,7 +230,7 @@ fn compile_pass() {
 
     let props = <<Container as ::yew::Component>::Properties as ::std::default::Default>::default();
     let child_props =
-        <<Child as ::yew::Component>::Properties as ::std::default::Default>::default();
+        <<Child as ::yew::html::IntoComponent>::Properties as ::std::default::Default>::default();
     ::yew::html! {
         <>
             <Container int=1 />
@@ -323,12 +318,10 @@ fn compile_pass() {
         ::std::vec![
             ChildrenVariants::Child(::yew::virtual_dom::VChild::new(
                 <ChildProperties as ::std::default::Default>::default(),
-                <::yew::NodeRef as ::std::default::Default>::default(),
                 ::std::option::Option::None,
             )),
             ChildrenVariants::AltChild(::yew::virtual_dom::VChild::new(
                 (),
-                <::yew::NodeRef as ::std::default::Default>::default(),
                 ::std::option::Option::None
             )),
         ]

--- a/packages/yew-macro/tests/html_macro/element-fail.rs
+++ b/packages/yew-macro/tests/html_macro/element-fail.rs
@@ -1,3 +1,4 @@
+use yew::__vendored::web_sys::{HtmlDivElement, HtmlInputElement};
 use yew::prelude::*;
 
 struct NotToString;
@@ -54,7 +55,8 @@ fn compile_fail() {
 
     // NodeRef type mismatch
     html! { <input ref={()} /> };
-    html! { <input ref={Some(NodeRef::default())} /> };
+    html! { <input ref={Some(HtmlRef::<HtmlInputElement>::default())} /> };
+    html! { <input ref={HtmlRef::<HtmlDivElement>::default()} /> };
     html! { <input onclick={Callback::from(|a: String| ())} /> };
 
     html! { <input string={NotToString} /> };

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -1,255 +1,255 @@
 error: this opening tag has no corresponding closing tag
- --> tests/html_macro/element-fail.rs:7:13
+ --> tests/html_macro/element-fail.rs:8:13
   |
-7 |     html! { <div> };
+8 |     html! { <div> };
   |             ^^^^^
 
 error: this opening tag has no corresponding closing tag
- --> tests/html_macro/element-fail.rs:8:18
+ --> tests/html_macro/element-fail.rs:9:18
   |
-8 |     html! { <div><div> };
+9 |     html! { <div><div> };
   |                  ^^^^^
 
 error: this opening tag has no corresponding closing tag
- --> tests/html_macro/element-fail.rs:9:13
-  |
-9 |     html! { <div><div></div> };
-  |             ^^^^^
+  --> tests/html_macro/element-fail.rs:10:13
+   |
+10 |     html! { <div><div></div> };
+   |             ^^^^^
 
 error: this closing tag has no corresponding opening tag
-  --> tests/html_macro/element-fail.rs:12:13
+  --> tests/html_macro/element-fail.rs:13:13
    |
-12 |     html! { </div> };
+13 |     html! { </div> };
    |             ^^^^^^
 
 error: this closing tag has no corresponding opening tag
-  --> tests/html_macro/element-fail.rs:13:18
+  --> tests/html_macro/element-fail.rs:14:18
    |
-13 |     html! { <div></span></div> };
+14 |     html! { <div></span></div> };
    |                  ^^^^^^^
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
-  --> tests/html_macro/element-fail.rs:14:20
+  --> tests/html_macro/element-fail.rs:15:20
    |
-14 |     html! { <img /></img> };
+15 |     html! { <img /></img> };
    |                    ^^^^^^
 
 error: this closing tag has no corresponding opening tag
-  --> tests/html_macro/element-fail.rs:17:18
+  --> tests/html_macro/element-fail.rs:18:18
    |
-17 |     html! { <div></span> };
+18 |     html! { <div></span> };
    |                  ^^^^^^^
 
 error: this closing tag has no corresponding opening tag
-  --> tests/html_macro/element-fail.rs:18:20
+  --> tests/html_macro/element-fail.rs:19:20
    |
-18 |     html! { <tag-a></tag-b> };
+19 |     html! { <tag-a></tag-b> };
    |                    ^^^^^^^^
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
-  --> tests/html_macro/element-fail.rs:21:24
+  --> tests/html_macro/element-fail.rs:22:24
    |
-21 |     html! { <div></div><div></div> };
+22 |     html! { <div></div><div></div> };
    |                        ^^^^^^^^^^^
 
 error: expected a valid html element
-  --> tests/html_macro/element-fail.rs:23:18
+  --> tests/html_macro/element-fail.rs:24:18
    |
-23 |     html! { <div>Invalid</div> };
+24 |     html! { <div>Invalid</div> };
    |                  ^^^^^^^
 
 error: `attr` can only be specified once but is given here again
-  --> tests/html_macro/element-fail.rs:26:27
+  --> tests/html_macro/element-fail.rs:27:27
    |
-26 |     html! { <input attr=1 attr=2 /> };
+27 |     html! { <input attr=1 attr=2 /> };
    |                           ^^^^
 
 error: `value` can only be specified once but is given here again
-  --> tests/html_macro/element-fail.rs:27:32
+  --> tests/html_macro/element-fail.rs:28:32
    |
-27 |     html! { <input value="123" value="456" /> };
+28 |     html! { <input value="123" value="456" /> };
    |                                ^^^^^
 
 error: `kind` can only be specified once but is given here again
-  --> tests/html_macro/element-fail.rs:28:36
+  --> tests/html_macro/element-fail.rs:29:36
    |
-28 |     html! { <input kind="checkbox" kind="submit" /> };
+29 |     html! { <input kind="checkbox" kind="submit" /> };
    |                                    ^^^^
 
 error: `checked` can only be specified once but is given here again
-  --> tests/html_macro/element-fail.rs:29:33
+  --> tests/html_macro/element-fail.rs:30:33
    |
-29 |     html! { <input checked=true checked=false /> };
+30 |     html! { <input checked=true checked=false /> };
    |                                 ^^^^^^^
 
 error: `disabled` can only be specified once but is given here again
-  --> tests/html_macro/element-fail.rs:30:34
+  --> tests/html_macro/element-fail.rs:31:34
    |
-30 |     html! { <input disabled=true disabled=false /> };
+31 |     html! { <input disabled=true disabled=false /> };
    |                                  ^^^^^^^^
 
 error: `selected` can only be specified once but is given here again
-  --> tests/html_macro/element-fail.rs:31:35
+  --> tests/html_macro/element-fail.rs:32:35
    |
-31 |     html! { <option selected=true selected=false /> };
+32 |     html! { <option selected=true selected=false /> };
    |                                   ^^^^^^^^
 
 error: `class` can only be specified once but is given here again
-  --> tests/html_macro/element-fail.rs:32:32
+  --> tests/html_macro/element-fail.rs:33:32
    |
-32 |     html! { <div class="first" class="second" /> };
+33 |     html! { <div class="first" class="second" /> };
    |                                ^^^^^
 
 error: `ref` can only be specified once
-  --> tests/html_macro/element-fail.rs:33:20
+  --> tests/html_macro/element-fail.rs:34:20
    |
-33 |     html! { <input ref={()} ref={()} /> };
+34 |     html! { <input ref={()} ref={()} /> };
    |                    ^^^
 
 error: `ref` can only be specified once
-  --> tests/html_macro/element-fail.rs:63:20
+  --> tests/html_macro/element-fail.rs:65:20
    |
-63 |     html! { <input ref={()} ref={()} /> };
+65 |     html! { <input ref={()} ref={()} /> };
    |                    ^^^
 
 error: the tag `<input>` is a void element and cannot have children (hint: rewrite this as `<input/>`)
-  --> tests/html_macro/element-fail.rs:66:13
+  --> tests/html_macro/element-fail.rs:68:13
    |
-66 |     html! { <input type="text"></input> };
+68 |     html! { <input type="text"></input> };
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: the tag `<iNpUt>` is a void element and cannot have children (hint: rewrite this as `<iNpUt/>`)
-  --> tests/html_macro/element-fail.rs:68:13
+  --> tests/html_macro/element-fail.rs:70:13
    |
-68 |     html! { <iNpUt type="text"></iNpUt> };
+70 |     html! { <iNpUt type="text"></iNpUt> };
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: this dynamic tag is missing an expression block defining its value
-  --> tests/html_macro/element-fail.rs:71:14
+  --> tests/html_macro/element-fail.rs:73:14
    |
-71 |     html! { <@></@> };
+73 |     html! { <@></@> };
    |              ^
 
 error: this dynamic tag is missing an expression block defining its value
-  --> tests/html_macro/element-fail.rs:72:14
+  --> tests/html_macro/element-fail.rs:74:14
    |
-72 |     html! { <@/> };
+74 |     html! { <@/> };
    |              ^
 
 error: dynamic closing tags must not have a body (hint: replace it with just `</@>`)
-  --> tests/html_macro/element-fail.rs:75:27
+  --> tests/html_macro/element-fail.rs:77:27
    |
-75 |     html! { <@{"test"}></@{"test"}> };
+77 |     html! { <@{"test"}></@{"test"}> };
    |                           ^^^^^^^^
-
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> tests/html_macro/element-fail.rs:83:24
-   |
-83 |     html! { <div class=("deprecated", "warning") /> };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> tests/html_macro/element-fail.rs:84:24
-   |
-84 |     html! { <input ref=() /> };
-   |                        ^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
   --> tests/html_macro/element-fail.rs:85:24
    |
-85 |     html! { <input ref=() ref=() /> };
+85 |     html! { <div class=("deprecated", "warning") /> };
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+  --> tests/html_macro/element-fail.rs:86:24
+   |
+86 |     html! { <input ref=() /> };
    |                        ^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> tests/html_macro/element-fail.rs:86:28
+  --> tests/html_macro/element-fail.rs:87:24
    |
-86 |     html! { <input onfocus=Some(5) /> };
+87 |     html! { <input ref=() ref=() /> };
+   |                        ^^
+
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+  --> tests/html_macro/element-fail.rs:88:28
+   |
+88 |     html! { <input onfocus=Some(5) /> };
    |                            ^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> tests/html_macro/element-fail.rs:87:27
+  --> tests/html_macro/element-fail.rs:89:27
    |
-87 |     html! { <input string=NotToString /> };
+89 |     html! { <input string=NotToString /> };
    |                           ^^^^^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> tests/html_macro/element-fail.rs:88:22
+  --> tests/html_macro/element-fail.rs:90:22
    |
-88 |     html! { <a media=Some(NotToString) /> };
+90 |     html! { <a media=Some(NotToString) /> };
    |                      ^^^^^^^^^^^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> tests/html_macro/element-fail.rs:89:21
+  --> tests/html_macro/element-fail.rs:91:21
    |
-89 |     html! { <a href=Some(5) /> };
+91 |     html! { <a href=Some(5) /> };
    |                     ^^^^^^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> tests/html_macro/element-fail.rs:90:25
+  --> tests/html_macro/element-fail.rs:92:25
    |
-90 |     html! { <input type=() /> };
+92 |     html! { <input type=() /> };
    |                         ^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> tests/html_macro/element-fail.rs:91:26
+  --> tests/html_macro/element-fail.rs:93:26
    |
-91 |     html! { <input value=() /> };
+93 |     html! { <input value=() /> };
    |                          ^^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> tests/html_macro/element-fail.rs:92:27
+  --> tests/html_macro/element-fail.rs:94:27
    |
-92 |     html! { <input string=NotToString /> };
+94 |     html! { <input string=NotToString /> };
    |                           ^^^^^^^^^^^
 
 warning: use of deprecated function `compile_fail::deprecated_use_of_class`: the use of `(...)` with the attribute `class` is deprecated and will be removed in version 0.19. Use the `classes!` macro instead.
-  --> tests/html_macro/element-fail.rs:80:25
+  --> tests/html_macro/element-fail.rs:82:25
    |
-80 |     html! { <div class={("deprecated", "warning")} /> };
+82 |     html! { <div class={("deprecated", "warning")} /> };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default
 
 error[E0308]: mismatched types
-  --> tests/html_macro/element-fail.rs:36:28
+  --> tests/html_macro/element-fail.rs:37:28
    |
-36 |     html! { <input checked=1 /> };
+37 |     html! { <input checked=1 /> };
    |                            ^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> tests/html_macro/element-fail.rs:37:29
+  --> tests/html_macro/element-fail.rs:38:29
    |
-37 |     html! { <input checked={Some(false)} /> };
+38 |     html! { <input checked={Some(false)} /> };
    |                             ^^^^^^^^^^^ expected `bool`, found enum `Option`
    |
    = note: expected type `bool`
               found enum `Option<bool>`
 
 error[E0308]: mismatched types
-  --> tests/html_macro/element-fail.rs:38:29
+  --> tests/html_macro/element-fail.rs:39:29
    |
-38 |     html! { <input disabled=1 /> };
+39 |     html! { <input disabled=1 /> };
    |                             ^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> tests/html_macro/element-fail.rs:39:30
+  --> tests/html_macro/element-fail.rs:40:30
    |
-39 |     html! { <input disabled={Some(true)} /> };
+40 |     html! { <input disabled={Some(true)} /> };
    |                              ^^^^^^^^^^ expected `bool`, found enum `Option`
    |
    = note: expected type `bool`
               found enum `Option<bool>`
 
 error[E0308]: mismatched types
-  --> tests/html_macro/element-fail.rs:40:30
+  --> tests/html_macro/element-fail.rs:41:30
    |
-40 |     html! { <option selected=1 /> };
+41 |     html! { <option selected=1 /> };
    |                              ^ expected `bool`, found integer
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> tests/html_macro/element-fail.rs:43:26
+  --> tests/html_macro/element-fail.rs:44:26
    |
-43 |     html! { <input type={()} /> };
+44 |     html! { <input type={()} /> };
    |                          ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
    |
 note: required by `into_prop_value`
@@ -259,9 +259,9 @@ note: required by `into_prop_value`
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> tests/html_macro/element-fail.rs:44:27
+  --> tests/html_macro/element-fail.rs:45:27
    |
-44 |     html! { <input value={()} /> };
+45 |     html! { <input value={()} /> };
    |                           ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
    |
 note: required by `into_prop_value`
@@ -271,9 +271,9 @@ note: required by `into_prop_value`
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> tests/html_macro/element-fail.rs:45:22
+  --> tests/html_macro/element-fail.rs:46:22
    |
-45 |     html! { <a href={()} /> };
+46 |     html! { <a href={()} /> };
    |                      ^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `()`
    |
 note: required by `into_prop_value`
@@ -283,9 +283,9 @@ note: required by `into_prop_value`
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> tests/html_macro/element-fail.rs:46:28
+  --> tests/html_macro/element-fail.rs:47:28
    |
-46 |     html! { <input string={NotToString} /> };
+47 |     html! { <input string={NotToString} /> };
    |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `NotToString`
    |
 note: required by `into_prop_value`
@@ -295,9 +295,9 @@ note: required by `into_prop_value`
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> tests/html_macro/element-fail.rs:47:23
+  --> tests/html_macro/element-fail.rs:48:23
    |
-47 |     html! { <a media={Some(NotToString)} /> };
+48 |     html! { <a media={Some(NotToString)} /> };
    |                       ^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `Option<NotToString>`
    |
    = help: the following implementations were found:
@@ -313,9 +313,9 @@ note: required by `into_prop_value`
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> tests/html_macro/element-fail.rs:48:22
+  --> tests/html_macro/element-fail.rs:49:22
    |
-48 |     html! { <a href={Some(5)} /> };
+49 |     html! { <a href={Some(5)} /> };
    |                      ^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `Option<{integer}>`
    |
    = help: the following implementations were found:
@@ -331,9 +331,9 @@ note: required by `into_prop_value`
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
-   --> tests/html_macro/element-fail.rs:51:28
+   --> tests/html_macro/element-fail.rs:52:28
     |
-51  |     html! { <input onclick=1 /> };
+52  |     html! { <input onclick=1 /> };
     |                            ^ expected an `Fn<(MouseEvent,)>` closure, found `{integer}`
     |
     = help: the trait `Fn<(MouseEvent,)>` is not implemented for `{integer}`
@@ -352,9 +352,9 @@ note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
     = note: this error originates in the macro `impl_action` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
-   --> tests/html_macro/element-fail.rs:52:29
+   --> tests/html_macro/element-fail.rs:53:29
     |
-52  |     html! { <input onclick={Callback::from(|a: String| ())} /> };
+53  |     html! { <input onclick={Callback::from(|a: String| ())} /> };
     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |                             |
     |                             expected an implementor of trait `IntoEventCallback<MouseEvent>`
@@ -376,9 +376,9 @@ note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
     = note: this error originates in the macro `impl_action` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>` is not satisfied
-   --> tests/html_macro/element-fail.rs:53:29
+   --> tests/html_macro/element-fail.rs:54:29
     |
-53  |     html! { <input onfocus={Some(5)} /> };
+54  |     html! { <input onfocus={Some(5)} /> };
     |                             ^^^^^^^ the trait `IntoEventCallback<FocusEvent>` is not implemented for `Option<{integer}>`
     |
     = help: the following implementations were found:
@@ -397,40 +397,46 @@ note: required by a bound in `yew::html::onfocus::Wrapper::__macro_new`
     | |_^ required by this bound in `yew::html::onfocus::Wrapper::__macro_new`
     = note: this error originates in the macro `impl_action` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
-  --> tests/html_macro/element-fail.rs:56:25
-   |
-56 |     html! { <input ref={()} /> };
-   |                         ^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
-   |
-note: required by `into_prop_value`
-  --> $WORKSPACE/packages/yew/src/html/conversion.rs
-   |
-   |     fn into_prop_value(self) -> T;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>` is not satisfied
+error[E0308]: mismatched types
   --> tests/html_macro/element-fail.rs:57:25
    |
-57 |     html! { <input ref={Some(NodeRef::default())} /> };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `Option<yew::NodeRef>`
+57 |     html! { <input ref={()} /> };
+   |                         ^^ expected struct `yew::HtmlRef`, found `()`
    |
-   = help: the following implementations were found:
-             <Option<&'static str> as IntoPropValue<Option<AttrValue>>>
-             <Option<&'static str> as IntoPropValue<Option<String>>>
-             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-             <Option<String> as IntoPropValue<Option<AttrValue>>>
-             <Option<std::rc::Rc<str>> as IntoPropValue<Option<AttrValue>>>
-note: required by `into_prop_value`
-  --> $WORKSPACE/packages/yew/src/html/conversion.rs
+   = note: expected struct `yew::HtmlRef<_>`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> tests/html_macro/element-fail.rs:58:25
    |
-   |     fn into_prop_value(self) -> T;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+58 |     html! { <input ref={Some(HtmlRef::<HtmlInputElement>::default())} /> };
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `yew::HtmlRef`, found enum `Option`
+   |
+   = note: expected struct `yew::HtmlRef<_>`
+                found enum `Option<yew::HtmlRef<HtmlInputElement>>`
+
+error[E0277]: the trait bound `HtmlDivElement: From<HtmlInputElement>` is not satisfied
+   --> tests/html_macro/element-fail.rs:59:25
+    |
+59  |     html! { <input ref={HtmlRef::<HtmlDivElement>::default()} /> };
+    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                         |
+    |                         expected an implementor of trait `From<HtmlInputElement>`
+    |                         help: consider borrowing here: `&HtmlRef::<HtmlDivElement>::default()`
+    |
+note: required by `yew::HtmlRef::<T>::into_node_setter`
+   --> $WORKSPACE/packages/yew/src/html/mod.rs
+    |
+    | /     pub unsafe fn into_node_setter<I>(self) -> Callback<Option<Node>>
+    | |     where
+    | |         I: JsCast,
+    | |         T: From<I>,
+    | |___________________^
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
-   --> tests/html_macro/element-fail.rs:58:29
+   --> tests/html_macro/element-fail.rs:60:29
     |
-58  |     html! { <input onclick={Callback::from(|a: String| ())} /> };
+60  |     html! { <input onclick={Callback::from(|a: String| ())} /> };
     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |                             |
     |                             expected an implementor of trait `IntoEventCallback<MouseEvent>`
@@ -452,9 +458,9 @@ note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
     = note: this error originates in the macro `impl_action` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<AttrValue>>` is not satisfied
-  --> tests/html_macro/element-fail.rs:60:28
+  --> tests/html_macro/element-fail.rs:62:28
    |
-60 |     html! { <input string={NotToString} /> };
+62 |     html! { <input string={NotToString} /> };
    |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<AttrValue>>` is not implemented for `NotToString`
    |
 note: required by `into_prop_value`
@@ -463,22 +469,19 @@ note: required by `into_prop_value`
    |     fn into_prop_value(self) -> T;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
-  --> tests/html_macro/element-fail.rs:62:25
+error[E0308]: mismatched types
+  --> tests/html_macro/element-fail.rs:64:25
    |
-62 |     html! { <input ref={()} /> };
-   |                         ^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
+64 |     html! { <input ref={()} /> };
+   |                         ^^ expected struct `yew::HtmlRef`, found `()`
    |
-note: required by `into_prop_value`
-  --> $WORKSPACE/packages/yew/src/html/conversion.rs
-   |
-   |     fn into_prop_value(self) -> T;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected struct `yew::HtmlRef<_>`
+           found unit type `()`
 
 error[E0277]: the trait bound `Cow<'static, str>: From<{integer}>` is not satisfied
-   --> tests/html_macro/element-fail.rs:77:15
+   --> tests/html_macro/element-fail.rs:79:15
     |
-77  |     html! { <@{55}></@> };
+79  |     html! { <@{55}></@> };
     |               ^^^^ the trait `From<{integer}>` is not implemented for `Cow<'static, str>`
     |
     = help: the following implementations were found:

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -40,13 +40,14 @@ fn compile_pass() {
     let onclick = <::yew::Callback<::yew::events::MouseEvent> as ::std::convert::From<_>>::from(
         |_: ::yew::events::MouseEvent| (),
     );
-    let parent_ref = <::yew::NodeRef as ::std::default::Default>::default();
+    let parent_ref = ::yew::html::HtmlRef::<::yew::__vendored::web_sys::Node>::new();
 
     let dyn_tag =
         || <::std::string::String as ::std::convert::From<&::std::primitive::str>>::from("test");
     let mut extra_tags_iter = ::std::iter::IntoIterator::into_iter(::std::vec!["a", "b"]);
 
-    let attr_val_none: ::std::option::Option<::yew::virtual_dom::AttrValue> = ::std::option::Option::None;
+    let attr_val_none: ::std::option::Option<::yew::virtual_dom::AttrValue> =
+        ::std::option::Option::None;
 
     ::yew::html! {
         <div>

--- a/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
@@ -1,13 +1,13 @@
 error[E0277]: can't compare `Props` with `Props`
- --> tests/props_macro/resolve-prop-fail.rs:3:17
-  |
-3 | #[derive(Clone, Properties)]
-  |                 ^^^^^^^^^^ no implementation for `Props == Props`
-  |
-  = help: the trait `PartialEq` is not implemented for `Props`
+  --> tests/props_macro/resolve-prop-fail.rs:3:17
+   |
+3  | #[derive(Clone, Properties)]
+   |                 ^^^^^^^^^^ no implementation for `Props == Props`
+   |
+   = help: the trait `PartialEq` is not implemented for `Props`
 note: required by a bound in `yew::Properties`
- --> $WORKSPACE/packages/yew/src/html/component/properties.rs
-  |
-  | pub trait Properties: PartialEq {
-  |                       ^^^^^^^^^ required by this bound in `yew::Properties`
-  = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
+   |
+   | pub trait Properties: PartialEq {
+   |                       ^^^^^^^^^ required by this bound in `yew::Properties`
+   = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -45,6 +45,7 @@ features = [
   "HtmlElement",
   "HtmlInputElement",
   "HtmlTextAreaElement",
+  "HtmlCanvasElement",
   "InputEvent",
   "InputEventInit",
   "KeyboardEvent",

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -46,6 +46,8 @@ features = [
   "HtmlInputElement",
   "HtmlTextAreaElement",
   "HtmlCanvasElement",
+  "HtmlDivElement",
+  "HtmlSpanElement",
   "InputEvent",
   "InputEventInit",
   "KeyboardEvent",

--- a/packages/yew/src/dom_bundle/bcomp.rs
+++ b/packages/yew/src/dom_bundle/bcomp.rs
@@ -1,9 +1,8 @@
 //! This module contains the bundle implementation of a virtual component [BComp].
 
 use super::{BNode, BSubtree, Reconcilable, ReconcileTarget};
-use crate::html::{AnyScope, Scoped};
+use crate::html::{AnyScope, NodeRef, Scoped};
 use crate::virtual_dom::{Key, VComp};
-use crate::NodeRef;
 use std::fmt;
 use std::{any::TypeId, borrow::Borrow};
 use web_sys::Element;
@@ -244,7 +243,7 @@ mod tests {
             Props {
                 field_1: 2,
                 field_2: 2,
-                ref_: ref_.clone(),
+                ref_,
             },
             None,
         );

--- a/packages/yew/src/dom_bundle/bcomp.rs
+++ b/packages/yew/src/dom_bundle/bcomp.rs
@@ -111,7 +111,7 @@ impl Reconcilable for VComp {
         } = self;
 
         bcomp.key = key;
-        mountable.reuse(bcomp.node_ref.clone(), bcomp.scope.borrow(), next_sibling);
+        mountable.reuse(bcomp.scope.borrow(), next_sibling);
         bcomp.node_ref.clone()
     }
 }

--- a/packages/yew/src/dom_bundle/bcomp.rs
+++ b/packages/yew/src/dom_bundle/bcomp.rs
@@ -121,12 +121,12 @@ impl Reconcilable for VComp {
 mod tests {
     use super::*;
     use crate::dom_bundle::{Reconcilable, ReconcileTarget};
-    use crate::html::HtmlRef;
+    use crate::html::{HtmlRef, NodeRef};
     use crate::scheduler;
     use crate::{
         function_component, html,
         virtual_dom::{Key, VChild, VNode},
-        Children, Component, Context, Html, NodeRef, Properties,
+        Children, Component, Context, Html, Properties,
     };
     use gloo_utils::document;
     use std::ops::Deref;

--- a/packages/yew/src/dom_bundle/bcomp.rs
+++ b/packages/yew/src/dom_bundle/bcomp.rs
@@ -54,9 +54,10 @@ impl Reconcilable for VComp {
         let VComp {
             type_id,
             mountable,
-            node_ref,
             key,
         } = self;
+
+        let node_ref = NodeRef::default();
 
         let scope = mountable.mount(
             root,
@@ -106,16 +107,13 @@ impl Reconcilable for VComp {
     ) -> NodeRef {
         let VComp {
             mountable,
-            node_ref,
             key,
             type_id: _,
         } = self;
 
         bcomp.key = key;
-        let old_ref = std::mem::replace(&mut bcomp.node_ref, node_ref.clone());
-        bcomp.node_ref.reuse(old_ref);
-        mountable.reuse(node_ref.clone(), bcomp.scope.borrow(), next_sibling);
-        node_ref
+        mountable.reuse(bcomp.node_ref.clone(), bcomp.scope.borrow(), next_sibling);
+        bcomp.node_ref.clone()
     }
 }
 

--- a/packages/yew/src/dom_bundle/bcomp.rs
+++ b/packages/yew/src/dom_bundle/bcomp.rs
@@ -105,12 +105,7 @@ impl Reconcilable for VComp {
         next_sibling: NodeRef,
         bcomp: &mut Self::Bundle,
     ) -> NodeRef {
-        let VComp {
-            mountable,
-            key,
-            type_id: _,
-            ..
-        } = self;
+        let VComp { mountable, key, .. } = self;
 
         bcomp.key = key;
         mountable.reuse(bcomp.scope.borrow(), next_sibling);

--- a/packages/yew/src/dom_bundle/bcomp.rs
+++ b/packages/yew/src/dom_bundle/bcomp.rs
@@ -220,11 +220,13 @@ mod tests {
 
     #[test]
     fn vchild_partialeq() {
+        let ref_ = HtmlRef::default();
+
         let vchild1: VChild<FunctionComponent<Comp>> = VChild::new(
             Props {
                 field_1: 1,
                 field_2: 1,
-                ref_: Default::default(),
+                ref_: ref_.clone(),
             },
             None,
         );
@@ -233,7 +235,7 @@ mod tests {
             Props {
                 field_1: 1,
                 field_2: 1,
-                ref_: Default::default(),
+                ref_: ref_.clone(),
             },
             None,
         );
@@ -242,7 +244,7 @@ mod tests {
             Props {
                 field_1: 2,
                 field_2: 2,
-                ref_: Default::default(),
+                ref_: ref_.clone(),
             },
             None,
         );

--- a/packages/yew/src/dom_bundle/bcomp.rs
+++ b/packages/yew/src/dom_bundle/bcomp.rs
@@ -54,6 +54,7 @@ impl Reconcilable for VComp {
             type_id,
             mountable,
             key,
+            ..
         } = self;
 
         let node_ref = NodeRef::default();
@@ -108,6 +109,7 @@ impl Reconcilable for VComp {
             mountable,
             key,
             type_id: _,
+            ..
         } = self;
 
         bcomp.key = key;

--- a/packages/yew/src/dom_bundle/bportal.rs
+++ b/packages/yew/src/dom_bundle/bportal.rs
@@ -47,6 +47,7 @@ impl Reconcilable for VPortal {
             node,
         } = self;
         let inner_root = root.create_subroot(parent.clone(), &host);
+        let inner_sibling = inner_sibling.map(NodeRef::new).unwrap_or_default();
         let (_, inner) = node.attach(&inner_root, parent_scope, &host, inner_sibling.clone());
         (
             host_next_sibling,
@@ -90,6 +91,7 @@ impl Reconcilable for VPortal {
         } = self;
 
         let old_host = std::mem::replace(&mut portal.host, host);
+        let inner_sibling = inner_sibling.map(NodeRef::new).unwrap_or_default();
         let old_inner_sibling = std::mem::replace(&mut portal.inner_sibling, inner_sibling);
 
         if old_host != portal.host || old_inner_sibling != portal.inner_sibling {

--- a/packages/yew/src/dom_bundle/bsuspense.rs
+++ b/packages/yew/src/dom_bundle/bsuspense.rs
@@ -1,9 +1,8 @@
 //! This module contains the bundle version of a supsense [BSuspense]
 
 use super::{BNode, BSubtree, Reconcilable, ReconcileTarget};
-use crate::html::AnyScope;
+use crate::html::{AnyScope, NodeRef};
 use crate::virtual_dom::{Key, VSuspense};
-use crate::NodeRef;
 use gloo::utils::document;
 use web_sys::Element;
 

--- a/packages/yew/src/dom_bundle/btag/listeners.rs
+++ b/packages/yew/src/dom_bundle/btag/listeners.rs
@@ -199,12 +199,12 @@ mod tests {
     use std::marker::PhantomData;
 
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
-    use web_sys::{Event, EventInit, HtmlElement, MouseEvent};
+    use web_sys::{Event, EventInit, HtmlElement, MouseEvent, Node};
     wasm_bindgen_test_configure!(run_in_browser);
 
     use crate::{
         create_portal, html, html::TargetCast, scheduler, virtual_dom::VNode, AppHandle, Component,
-        Context, Html, NodeRef, Properties,
+        Context, Html, HtmlRef, Properties,
     };
     use gloo_utils::document;
     use wasm_bindgen::JsCast;
@@ -226,7 +226,7 @@ mod tests {
 
     #[derive(Default, PartialEq, Properties)]
     struct MixinProps<M: Properties> {
-        state_ref: NodeRef,
+        state_ref: HtmlRef<Node>,
         wrapped: M,
     }
 
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_count(el: &NodeRef, count: isize) {
+    fn assert_count(el: &HtmlRef<Node>, count: isize) {
         let text = el
             .get()
             .expect("State ref not bound in the test case?")
@@ -288,7 +288,7 @@ mod tests {
     }
 
     #[track_caller]
-    fn click(el: &NodeRef) {
+    fn click(el: &HtmlRef<Node>) {
         el.get().unwrap().dyn_into::<HtmlElement>().unwrap().click();
         scheduler::start_now();
     }
@@ -302,7 +302,7 @@ mod tests {
             .unwrap()
     }
 
-    fn init<M>() -> (AppHandle<Comp<M>>, NodeRef)
+    fn init<M>() -> (AppHandle<Comp<M>>, HtmlRef<Node>)
     where
         M: Mixin + Properties + Default,
     {
@@ -337,11 +337,11 @@ mod tests {
 
                 if state.stop_listening {
                     html! {
-                        <a ref={&ctx.props().state_ref}>{state.action}</a>
+                        <a ref={ctx.props().state_ref.clone()}>{state.action}</a>
                     }
                 } else {
                     html! {
-                        <a {onclick} ref={&ctx.props().state_ref}>
+                        <a {onclick} ref={ctx.props().state_ref.clone()}>
                             {state.action}
                         </a>
                     }
@@ -383,7 +383,7 @@ mod tests {
                 });
                 html! {
                     <div>
-                        <a ref={&ctx.props().state_ref}>
+                        <a ref={ctx.props().state_ref.clone()}>
                             <input id="input" {onblur} type="text" />
                             {state.action}
                         </a>
@@ -425,7 +425,7 @@ mod tests {
                 if state.stop_listening {
                     html! {
                         <div>
-                            <a ref={&ctx.props().state_ref}>
+                            <a ref={ctx.props().state_ref.clone()}>
                                 {state.action}
                             </a>
                         </div>
@@ -434,7 +434,7 @@ mod tests {
                     let cb = ctx.link().callback(|_| Message::Action);
                     html! {
                         <div onclick={cb.clone()}>
-                            <a onclick={cb} ref={&ctx.props().state_ref}>
+                            <a onclick={cb} ref={ctx.props().state_ref.clone()}>
                                 {state.action}
                             </a>
                         </div>
@@ -475,7 +475,7 @@ mod tests {
 
                 html! {
                     <div onclick={onclick}>
-                        <a onclick={onclick2} ref={&ctx.props().state_ref}>
+                        <a onclick={onclick2} ref={ctx.props().state_ref.clone()}>
                             {state.action}
                         </a>
                     </div>
@@ -513,7 +513,7 @@ mod tests {
                 html! {
                     <div onclick={onclick}>
                         <div onclick={onclick2}>
-                            <a ref={&ctx.props().state_ref}>
+                            <a ref={ctx.props().state_ref.clone()}>
                                 {state.action}
                             </a>
                         </div>
@@ -558,7 +558,7 @@ mod tests {
                     <>
                         <div onclick={onclick}>
                             {create_portal(html! {
-                                <a ref={&ctx.props().state_ref}>
+                                <a ref={ctx.props().state_ref.clone()}>
                                     {state.action}
                                 </a>
                             }, portal_target.clone())}
@@ -607,7 +607,7 @@ mod tests {
                     <div onclick={onclick.clone()}>
                         <div {onclick}>
                             {create_portal(html! {
-                                <a ref={&ctx.props().state_ref}>
+                                <a ref={ctx.props().state_ref.clone()}>
                                     {state.action}
                                 </a>
                             }, mixin.inner_root.clone())}
@@ -640,7 +640,7 @@ mod tests {
                     html! {
                         <div>
                             <input type="text" />
-                            <p ref={&ctx.props().state_ref}>{state.text.clone()}</p>
+                            <p ref={ctx.props().state_ref.clone()}>{state.text.clone()}</p>
                         </div>
                     }
                 } else {
@@ -656,7 +656,7 @@ mod tests {
                     html! {
                         <div>
                             <input type="text" {onchange} {oninput} />
-                            <p ref={&ctx.props().state_ref}>{state.text.clone()}</p>
+                            <p ref={ctx.props().state_ref.clone()}>{state.text.clone()}</p>
                         </div>
                     }
                 }

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -319,6 +319,7 @@ mod tests {
     use gloo_utils::document;
     use wasm_bindgen::JsCast;
     use web_sys::HtmlInputElement as InputElement;
+    use yew::html::HtmlRef;
 
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
@@ -779,7 +780,7 @@ mod tests {
     fn reset_node_ref() {
         let (root, scope, parent) = setup_parent();
 
-        let node_ref = NodeRef::default();
+        let node_ref = HtmlRef::<Node>::default();
         let elem: VNode = html! { <div ref={node_ref.clone()}></div> };
         assert_vtag_ref(&elem);
         let (_, elem) = elem.attach(&root, &scope, &parent, NodeRef::default());
@@ -792,14 +793,14 @@ mod tests {
     fn vtag_reuse_should_reset_ancestors_node_ref() {
         let (root, scope, parent) = setup_parent();
 
-        let node_ref_a = NodeRef::default();
+        let node_ref_a = HtmlRef::<Node>::default();
         let elem_a = html! { <div id="a" ref={node_ref_a.clone()} /> };
         let (_, mut elem) = elem_a.attach(&root, &scope, &parent, NodeRef::default());
 
         // save the Node to check later that it has been reused.
         let node_a = node_ref_a.get().unwrap();
 
-        let node_ref_b = NodeRef::default();
+        let node_ref_b = HtmlRef::<Node>::default();
         let elem_b = html! { <div id="b" ref={node_ref_b.clone()} /> };
         elem_b.reconcile_node(&root, &scope, &parent, NodeRef::default(), &mut elem);
 
@@ -816,16 +817,16 @@ mod tests {
     fn vtag_should_not_touch_newly_bound_refs() {
         let (root, scope, parent) = setup_parent();
 
-        let test_ref = NodeRef::default();
+        let test_ref = HtmlRef::<Node>::default();
         let before = html! {
             <>
-                <div ref={&test_ref} id="before" />
+                <div ref={test_ref.clone()} id="before" />
             </>
         };
         let after = html! {
             <>
                 <h6 />
-                <div ref={&test_ref} id="after" />
+                <div ref={test_ref.clone()} id="after" />
             </>
         };
         // The point of this diff is to first render the "after" div and then detach the "before" div,

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -6,10 +6,9 @@ mod listeners;
 pub use listeners::Registry;
 
 use super::{insert_node, BList, BNode, BSubtree, Reconcilable, ReconcileTarget};
-use crate::html::AnyScope;
+use crate::html::{AnyScope, NodeRef};
 use crate::virtual_dom::vtag::{InputFields, VTagInner, Value, SVG_NAMESPACE};
 use crate::virtual_dom::{Attributes, Key, VTag};
-use crate::NodeRef;
 use gloo::console;
 use gloo_utils::document;
 use listeners::ListenerRegistration;

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -155,6 +155,9 @@ impl Reconcilable for VTag {
             }
         };
         node_ref.set(Some(el.clone().into()));
+        if let Some(m) = set_node.as_ref() {
+            m(Some(el.clone().into()));
+        }
         (
             node_ref.clone(),
             BTag {

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -13,7 +13,6 @@ use crate::virtual_dom::{Attributes, Key, VTag};
 use gloo::console;
 use gloo_utils::document;
 use listeners::ListenerRegistration;
-use std::fmt;
 use std::ops::DerefMut;
 use std::{borrow::Cow, hint::unreachable_unchecked};
 use wasm_bindgen::JsCast;
@@ -56,6 +55,7 @@ enum BTagInner {
 }
 
 /// The bundle implementation to [VTag]
+#[derive(Debug)]
 pub(super) struct BTag {
     /// [BTag] fields that are specific to different [BTag] kinds.
     inner: BTagInner,
@@ -102,19 +102,6 @@ impl ReconcileTarget for BTag {
         next_parent
             .insert_before(&self.reference, next_sibling.get().as_ref())
             .unwrap();
-    }
-}
-
-impl fmt::Debug for BTag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VTag")
-            .field("inner", &self.inner)
-            .field("listeners", &self.listeners)
-            .field("set_node", &"Option<Rc<dyn Fn(Option<Node>)>>")
-            .field("node_ref", &self.node_ref)
-            .field("reference", &self.reference)
-            .field("key", &self.key)
-            .finish()
     }
 }
 

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -93,6 +93,10 @@ impl ReconcileTarget for BTag {
         if self.node_ref.get().as_ref() == Some(&node) {
             self.node_ref.set(None);
         }
+
+        if let Some(m) = self.set_node.as_ref() {
+            m(None);
+        }
     }
 
     fn shift(&self, next_parent: &Element, next_sibling: NodeRef) {

--- a/packages/yew/src/dom_bundle/btext.rs
+++ b/packages/yew/src/dom_bundle/btext.rs
@@ -1,9 +1,8 @@
 //! This module contains the bundle implementation of text [BText].
 
 use super::{insert_node, BNode, BSubtree, Reconcilable, ReconcileTarget};
-use crate::html::AnyScope;
+use crate::html::{AnyScope, NodeRef};
 use crate::virtual_dom::{AttrValue, VText};
-use crate::NodeRef;
 use gloo::console;
 use gloo_utils::document;
 use web_sys::{Element, Text as TextNode};

--- a/packages/yew/src/functional/hooks/mod.rs
+++ b/packages/yew/src/functional/hooks/mod.rs
@@ -1,5 +1,6 @@
 mod use_context;
 mod use_effect;
+mod use_imperative_handle;
 mod use_memo;
 mod use_reducer;
 mod use_ref;

--- a/packages/yew/src/functional/hooks/use_imperative_handle.rs
+++ b/packages/yew/src/functional/hooks/use_imperative_handle.rs
@@ -1,0 +1,19 @@
+use super::use_effect;
+use crate::functional::hook;
+use crate::html::HtmlRef;
+
+/// A hook to register an imperative handle.
+#[hook]
+pub fn use_imperative_handle<T, F>(ref_: HtmlRef<T>, f: F)
+where
+    T: Clone + 'static,
+    F: 'static + FnOnce() -> T,
+{
+    use_effect(move || {
+        ref_.set(Some(f()));
+
+        move || {
+            ref_.set::<T>(None);
+        }
+    });
+}

--- a/packages/yew/src/functional/hooks/use_ref.rs
+++ b/packages/yew/src/functional/hooks/use_ref.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::functional::{hook, use_memo, use_state};
-use crate::NodeRef;
+use crate::html::HtmlRef;
 
 /// This hook is used for obtaining a mutable reference to a stateful value.
 /// Its state persists across renders.
@@ -58,7 +58,7 @@ where
     use_memo(|_| RefCell::new(init_fn()), ())
 }
 
-/// This hook is used for obtaining a [`NodeRef`].
+/// This hook is used for obtaining an [`HtmlRef`].
 /// It persists across renders.
 ///
 /// It is important to note that you do not get notified of state changes.
@@ -67,14 +67,14 @@ where
 /// ```rust
 /// # use wasm_bindgen::{prelude::Closure, JsCast};
 /// # use yew::{
-/// #    function_component, html, use_effect_with_deps, use_node_ref,
+/// #    function_component, html, use_effect_with_deps, use_html_ref,
 /// #    Html,
 /// # };
 /// # use web_sys::{Event, HtmlElement};
 ///
-/// #[function_component(UseNodeRef)]
-/// pub fn node_ref_hook() -> Html {
-///     let div_ref = use_node_ref();
+/// #[function_component(UseHtmlRef)]
+/// pub fn html_ref_hook() -> Html {
+///     let div_ref = use_html_ref::<HtmlElement>();
 ///
 ///     {
 ///         let div_ref = div_ref.clone();
@@ -82,7 +82,7 @@ where
 ///         use_effect_with_deps(
 ///             |div_ref| {
 ///                 let div = div_ref
-///                     .cast::<HtmlElement>()
+///                     .get()
 ///                     .expect("div_ref not attached to div element");
 ///
 ///                 let listener = Closure::<dyn Fn(Event)>::wrap(Box::new(|_| {
@@ -116,6 +116,9 @@ where
 ///
 /// ```
 #[hook]
-pub fn use_node_ref() -> NodeRef {
-    (*use_state(NodeRef::default)).clone()
+pub fn use_html_ref<T>() -> HtmlRef<T>
+where
+    T: 'static + Clone,
+{
+    (*use_state(HtmlRef::<T>::default)).clone()
 }

--- a/packages/yew/src/functional/mod.rs
+++ b/packages/yew/src/functional/mod.rs
@@ -29,7 +29,7 @@ use std::rc::Rc;
 mod hooks;
 pub use hooks::*;
 
-use crate::html::Context;
+use crate::html::{Context, RefProp};
 
 use crate::html::sealed::SealedBaseComponent;
 
@@ -229,12 +229,15 @@ where
         result
     }
 
-    fn rendered(&mut self, _ctx: &Context<Self>, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
         let hook_ctx = self.hook_ctx.borrow();
 
         for effect in hook_ctx.effects.iter() {
             effect.rendered();
         }
+
+        #[cfg(debug_assertions)]
+        ctx.props().ref_().assert_ref_set();
     }
 
     fn destroy(&mut self, _ctx: &Context<Self>) {

--- a/packages/yew/src/functional/mod.rs
+++ b/packages/yew/src/functional/mod.rs
@@ -29,7 +29,9 @@ use std::rc::Rc;
 mod hooks;
 pub use hooks::*;
 
-use crate::html::{Context, RefProp};
+use crate::html::Context;
+#[cfg(debug_assertions)]
+use crate::html::RefProp;
 
 use crate::html::sealed::SealedBaseComponent;
 
@@ -229,7 +231,7 @@ where
         result
     }
 
-    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+    fn rendered(&mut self, _ctx: &Context<Self>, _first_render: bool) {
         let hook_ctx = self.hook_ctx.borrow();
 
         for effect in hook_ctx.effects.iter() {
@@ -237,7 +239,7 @@ where
         }
 
         #[cfg(debug_assertions)]
-        ctx.props().ref_().assert_ref_set();
+        _ctx.props().ref_().assert_ref_set();
     }
 
     fn destroy(&mut self, _ctx: &Context<Self>) {

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -249,7 +249,7 @@ pub(crate) enum UpdateEvent {
     Message,
     /// Wraps properties, node ref, and next sibling for a component
     #[cfg(feature = "csr")]
-    Properties(Rc<dyn Any>, NodeRef, NodeRef),
+    Properties(Rc<dyn Any>, NodeRef),
 }
 
 pub(crate) struct UpdateRunner {
@@ -264,16 +264,13 @@ impl Runnable for UpdateRunner {
                 UpdateEvent::Message => state.inner.flush_messages(),
 
                 #[cfg(feature = "csr")]
-                UpdateEvent::Properties(props, next_node_ref, next_sibling) => {
+                UpdateEvent::Properties(props, next_sibling) => {
                     match state.render_state {
                         #[cfg(feature = "csr")]
                         ComponentRenderState::Render {
-                            ref mut node_ref,
                             next_sibling: ref mut current_next_sibling,
                             ..
                         } => {
-                            // When components are updated, a new node ref could have been passed in
-                            *node_ref = next_node_ref;
                             // When components are updated, their siblings were likely also updated
                             *current_next_sibling = next_sibling;
                             // Only trigger changed if props were changed

--- a/packages/yew/src/html/component/mod.rs
+++ b/packages/yew/src/html/component/mod.rs
@@ -123,7 +123,7 @@ pub trait Component: Sized + 'static {
     ///
     /// When the parent of a Component is re-rendered, it will either be re-created or
     /// receive new properties in the context passed to the `changed` lifecycle method.
-    type Properties: Properties;
+    type Properties: Properties<Ref = ()>;
 
     /// Called when component is created.
     fn create(ctx: &Context<Self>) -> Self;

--- a/packages/yew/src/html/component/properties.rs
+++ b/packages/yew/src/html/component/properties.rs
@@ -1,14 +1,32 @@
 //! Component properties module
 
+use crate::html::HtmlRef;
 pub use yew_macro::Properties;
+
+mod sealed {
+    use super::*;
+
+    /// Trait to limit `ref_` to `HtmlRef<_>`.
+    pub trait RefProp {}
+
+    impl<T> RefProp for HtmlRef<T> {}
+    impl RefProp for () {}
+}
+
+use sealed::RefProp;
 
 /// Trait for building properties for a component
 pub trait Properties: PartialEq {
     /// Builder that will be used to construct properties
     type Builder;
+    /// The component reference type.
+    type Ref: RefProp;
 
     /// Entrypoint for building properties
     fn builder() -> Self::Builder;
+
+    /// Returns ref type.
+    fn ref_(&self) -> &Self::Ref;
 }
 
 /// Builder for when a component has no properties
@@ -18,9 +36,14 @@ pub struct EmptyBuilder;
 
 impl Properties for () {
     type Builder = EmptyBuilder;
+    type Ref = ();
 
     fn builder() -> Self::Builder {
         EmptyBuilder
+    }
+
+    fn ref_(&self) -> &Self::Ref {
+        &()
     }
 }
 

--- a/packages/yew/src/html/component/properties.rs
+++ b/packages/yew/src/html/component/properties.rs
@@ -7,13 +7,27 @@ mod sealed {
     use super::*;
 
     /// Trait to limit `ref_` to `HtmlRef<_>`.
-    pub trait RefProp {}
+    pub trait RefProp {
+        #[cfg(debug_assertions)]
+        fn assert_ref_set(&self);
+    }
 
-    impl<T> RefProp for HtmlRef<T> {}
-    impl RefProp for () {}
+    impl<T> RefProp for HtmlRef<T>
+    where
+        T: Clone + 'static,
+    {
+        #[cfg(debug_assertions)]
+        fn assert_ref_set(&self) {
+            assert!(self.get().is_some(), "HtmlRef must be set!");
+        }
+    }
+    impl RefProp for () {
+        #[cfg(debug_assertions)]
+        fn assert_ref_set(&self) {}
+    }
 }
 
-use sealed::RefProp;
+pub(crate) use sealed::RefProp;
 
 /// Trait for building properties for a component
 pub trait Properties: PartialEq {

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -455,16 +455,11 @@ mod feat_csr {
             scheduler::start();
         }
 
-        pub(crate) fn reuse(
-            &self,
-            props: Rc<COMP::Properties>,
-            node_ref: NodeRef,
-            next_sibling: NodeRef,
-        ) {
+        pub(crate) fn reuse(&self, props: Rc<COMP::Properties>, next_sibling: NodeRef) {
             #[cfg(debug_assertions)]
             super::super::log_event(self.id, "reuse");
 
-            self.push_update(UpdateEvent::Properties(props, node_ref, next_sibling));
+            self.push_update(UpdateEvent::Properties(props, next_sibling));
         }
     }
 

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -110,14 +110,13 @@ where
     ///
     /// This method converts node into the target element type via unchecked_into.
     /// You should only use this method if you are certain that it would cast into the target type.
-    pub unsafe fn create_node_setter<I>(&self) -> Rc<dyn Fn(Option<Node>)>
+    pub unsafe fn into_node_setter<I>(self) -> Rc<dyn Fn(Option<Node>)>
     where
         I: JsCast,
         T: From<I>,
     {
-        let this = self.clone();
         Rc::new(move |node: Option<Node>| {
-            this.set_node_unchecked(node);
+            self.set_node_unchecked(node);
         }) as Rc<dyn Fn(Option<Node>)>
     }
 }

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -62,6 +62,12 @@ impl<T> Default for HtmlRef<T> {
     }
 }
 
+impl<T> PartialEq for HtmlRef<T> {
+    fn eq(&self, rhs: &Self) -> bool {
+        Rc::ptr_eq(&self.inner, &rhs.inner)
+    }
+}
+
 impl<T> HtmlRef<T>
 where
     T: Clone + 'static,
@@ -193,19 +199,6 @@ mod feat_csr {
     use super::*;
 
     impl NodeRef {
-        // /// Reuse an existing `NodeRef`
-        // pub(crate) fn reuse(&self, node_ref: Self) {
-        //     // Avoid circular references
-        //     if self == &node_ref {
-        //         return;
-        //     }
-
-        //     let mut this = self.0.borrow_mut();
-        //     let existing = node_ref.0.borrow();
-        //     this.node = existing.node.clone();
-        //     this.link = existing.link.clone();
-        // }
-
         /// Link a downstream `NodeRef`
         pub(crate) fn link(&self, node_ref: Self) {
             // Avoid circular references

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -193,18 +193,18 @@ mod feat_csr {
     use super::*;
 
     impl NodeRef {
-        /// Reuse an existing `NodeRef`
-        pub(crate) fn reuse(&self, node_ref: Self) {
-            // Avoid circular references
-            if self == &node_ref {
-                return;
-            }
+        // /// Reuse an existing `NodeRef`
+        // pub(crate) fn reuse(&self, node_ref: Self) {
+        //     // Avoid circular references
+        //     if self == &node_ref {
+        //         return;
+        //     }
 
-            let mut this = self.0.borrow_mut();
-            let existing = node_ref.0.borrow();
-            this.node = existing.node.clone();
-            this.link = existing.link.clone();
-        }
+        //     let mut this = self.0.borrow_mut();
+        //     let existing = node_ref.0.borrow();
+        //     this.node = existing.node.clone();
+        //     this.link = existing.link.clone();
+        // }
 
         /// Link a downstream `NodeRef`
         pub(crate) fn link(&self, node_ref: Self) {

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -132,7 +132,6 @@ where
     T: Clone + 'static + JsCast,
 {
     /// Set by value via `JsCast::unchecked_into`.
-    #[inline]
     unsafe fn set_node_unchecked<I>(&self, val: Option<Node>)
     where
         I: JsCast,
@@ -191,13 +190,6 @@ impl NodeRef {
         let inner = self.0.borrow();
         inner.node.clone().or_else(|| inner.link.as_ref()?.get())
     }
-
-    /// Place a Node in a reference for later use
-    pub(crate) fn set(&self, node: Option<Node>) {
-        let mut this = self.0.borrow_mut();
-        this.node = node;
-        this.link = None;
-    }
 }
 
 #[cfg(feature = "csr")]
@@ -222,6 +214,13 @@ mod feat_csr {
             let node_ref = NodeRef::default();
             node_ref.set(Some(node));
             node_ref
+        }
+
+        /// Place a Node in a reference for later use
+        pub(crate) fn set(&self, node: Option<Node>) {
+            let mut this = self.0.borrow_mut();
+            this.node = node;
+            this.link = None;
         }
     }
 }

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -13,6 +13,7 @@ pub use conversion::*;
 pub use error::*;
 pub use listener::*;
 
+use crate::callback::Callback;
 use crate::sealed::Sealed;
 use crate::virtual_dom::{VNode, VPortal};
 use std::cell::RefCell;
@@ -147,14 +148,14 @@ where
     ///
     /// This method converts node into the target element type via unchecked_into.
     /// You should only use this method if you are certain that it would cast into the target type.
-    pub unsafe fn into_node_setter<I>(self) -> Rc<dyn Fn(Option<Node>)>
+    pub unsafe fn into_node_setter<I>(self) -> Callback<Option<Node>>
     where
         I: JsCast,
         T: From<I>,
     {
-        Rc::new(move |node: Option<Node>| {
+        Callback::from(move |node: Option<Node>| {
             self.set_node_unchecked(node);
-        }) as Rc<dyn Fn(Option<Node>)>
+        })
     }
 }
 

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -17,7 +17,7 @@ use crate::sealed::Sealed;
 use crate::virtual_dom::{VNode, VPortal};
 use std::cell::RefCell;
 use std::rc::Rc;
-use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen::JsCast;
 use web_sys::{Element, Node};
 
 /// A type which expected as a result of `view` function implementation.
@@ -121,7 +121,7 @@ where
     }
 
     /// Sets an [`HtmlRef`].
-    pub fn set<F: Into<T>>(&self, val: Option<F>) {
+    pub(crate) fn set<F: Into<T>>(&self, val: Option<F>) {
         let mut inner = self.inner.borrow_mut();
         *inner = val.map(Into::into);
     }
@@ -160,46 +160,8 @@ where
 }
 
 /// Wrapped Node reference for later use in Component lifecycle methods.
-// ///
-// /// # Example
-// /// Focus an `<input>` element on mount.
-// /// ```
-// /// use web_sys::HtmlInputElement;
-// ///# use yew::prelude::*;
-// ///
-// /// pub struct Input {
-// ///     node_ref: HtmlRef<HtmlInputElement>,
-// /// }
-// ///
-// /// impl Component for Input {
-// ///     type Message = ();
-// ///     type Properties = ();
-// ///
-// ///     fn create(_ctx: &Context<Self>) -> Self {
-// ///         Input {
-// ///             node_ref: HtmlRef::default(),
-// ///         }
-// ///     }
-// ///
-// ///     fn rendered(&mut self, _ctx: &Context<Self>, first_render: bool) {
-// ///         if first_render {
-// ///             if let Some(input) = self.node_ref.cast::<HtmlInputElement>() {
-// ///                 input.focus();
-// ///             }
-// ///         }
-// ///     }
-// ///
-// ///     fn view(&self, _ctx: &Context<Self>) -> Html {
-// ///         html! {
-// ///             <input ref={self.node_ref.clone()} type="text" />
-// ///         }
-// ///     }
-// /// }
-// /// ```
-// /// ## Relevant examples
-// /// - [Node Refs](https://github.com/yewstack/yew/tree/master/examples/node_refs)
 #[derive(Default, Clone)]
-pub struct NodeRef(Rc<RefCell<NodeRefInner>>);
+pub(crate) struct NodeRef(Rc<RefCell<NodeRefInner>>);
 
 impl PartialEq for NodeRef {
     fn eq(&self, other: &Self) -> bool {
@@ -228,12 +190,6 @@ impl NodeRef {
     pub fn get(&self) -> Option<Node> {
         let inner = self.0.borrow();
         inner.node.clone().or_else(|| inner.link.as_ref()?.get())
-    }
-
-    /// Try converting the node reference into another form
-    pub fn cast<INTO: AsRef<Node> + From<JsValue>>(&self) -> Option<INTO> {
-        let node = self.get();
-        node.map(Into::into).map(INTO::from)
     }
 
     /// Place a Node in a reference for later use

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -94,18 +94,31 @@ where
     T: Clone + 'static + JsCast,
 {
     /// Set by value via `JsCast::unchecked_into`.
-    ///
-    /// # Safety
-    ///
-    /// This method converts node into the target element type via unchecked_into.
-    /// You should only use this method if you are certain that it would cast into the target type.
-    pub unsafe fn set_node_unchecked<I>(&self, val: Option<Node>)
+    #[inline]
+    unsafe fn set_node_unchecked<I>(&self, val: Option<Node>)
     where
         I: JsCast,
         T: From<I>,
     {
         let val = val.map(|m| m.unchecked_into::<I>());
         self.set(val);
+    }
+
+    /// Creates a setter for Node.
+    ///
+    /// # Safety
+    ///
+    /// This method converts node into the target element type via unchecked_into.
+    /// You should only use this method if you are certain that it would cast into the target type.
+    pub unsafe fn create_node_setter<I>(&self) -> Rc<dyn Fn(Option<Node>)>
+    where
+        I: JsCast,
+        T: From<I>,
+    {
+        let this = self.clone();
+        Rc::new(move |node: Option<Node>| {
+            this.set_node_unchecked(node);
+        }) as Rc<dyn Fn(Option<Node>)>
     }
 }
 

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -49,6 +49,44 @@ impl IntoHtmlResult for Html {
 }
 
 /// Wrapped a reference for later use in component effects.
+///
+/// # Example
+/// Focus an `<input>` element on mount.
+/// ```
+/// use web_sys::HtmlInputElement;
+///# use yew::prelude::*;
+///
+/// pub struct Input {
+///     node_ref: HtmlRef<HtmlInputElement>,
+/// }
+///
+/// impl Component for Input {
+///     type Message = ();
+///     type Properties = ();
+///
+///     fn create(_ctx: &Context<Self>) -> Self {
+///         Input {
+///             node_ref: HtmlRef::default(),
+///         }
+///     }
+///
+///     fn rendered(&mut self, _ctx: &Context<Self>, first_render: bool) {
+///         if first_render {
+///             if let Some(input) = self.node_ref.get() {
+///                 input.focus();
+///             }
+///         }
+///     }
+///
+///     fn view(&self, _ctx: &Context<Self>) -> Html {
+///         html! {
+///             <input ref={self.node_ref.clone()} type="text" />
+///         }
+///     }
+/// }
+/// ```
+/// ## Relevant examples
+/// - [Node Refs](https://github.com/yewstack/yew/tree/master/examples/node_refs)
 #[derive(Debug, Clone)]
 pub struct HtmlRef<T> {
     inner: Rc<RefCell<Option<T>>>,
@@ -122,44 +160,44 @@ where
 }
 
 /// Wrapped Node reference for later use in Component lifecycle methods.
-///
-/// # Example
-/// Focus an `<input>` element on mount.
-/// ```
-/// use web_sys::HtmlInputElement;
-///# use yew::prelude::*;
-///
-/// pub struct Input {
-///     node_ref: NodeRef,
-/// }
-///
-/// impl Component for Input {
-///     type Message = ();
-///     type Properties = ();
-///
-///     fn create(_ctx: &Context<Self>) -> Self {
-///         Input {
-///             node_ref: NodeRef::default(),
-///         }
-///     }
-///
-///     fn rendered(&mut self, _ctx: &Context<Self>, first_render: bool) {
-///         if first_render {
-///             if let Some(input) = self.node_ref.cast::<HtmlInputElement>() {
-///                 input.focus();
-///             }
-///         }
-///     }
-///
-///     fn view(&self, _ctx: &Context<Self>) -> Html {
-///         html! {
-///             <input ref={self.node_ref.clone()} type="text" />
-///         }
-///     }
-/// }
-/// ```
-/// ## Relevant examples
-/// - [Node Refs](https://github.com/yewstack/yew/tree/master/examples/node_refs)
+// ///
+// /// # Example
+// /// Focus an `<input>` element on mount.
+// /// ```
+// /// use web_sys::HtmlInputElement;
+// ///# use yew::prelude::*;
+// ///
+// /// pub struct Input {
+// ///     node_ref: HtmlRef<HtmlInputElement>,
+// /// }
+// ///
+// /// impl Component for Input {
+// ///     type Message = ();
+// ///     type Properties = ();
+// ///
+// ///     fn create(_ctx: &Context<Self>) -> Self {
+// ///         Input {
+// ///             node_ref: HtmlRef::default(),
+// ///         }
+// ///     }
+// ///
+// ///     fn rendered(&mut self, _ctx: &Context<Self>, first_render: bool) {
+// ///         if first_render {
+// ///             if let Some(input) = self.node_ref.cast::<HtmlInputElement>() {
+// ///                 input.focus();
+// ///             }
+// ///         }
+// ///     }
+// ///
+// ///     fn view(&self, _ctx: &Context<Self>) -> Html {
+// ///         html! {
+// ///             <input ref={self.node_ref.clone()} type="text" />
+// ///         }
+// ///     }
+// /// }
+// /// ```
+// /// ## Relevant examples
+// /// - [Node Refs](https://github.com/yewstack/yew/tree/master/examples/node_refs)
 #[derive(Default, Clone)]
 pub struct NodeRef(Rc<RefCell<NodeRefInner>>);
 

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -324,7 +324,7 @@ pub mod prelude {
     pub use crate::events::*;
     pub use crate::html::{
         create_portal, BaseComponent, Children, ChildrenWithProps, Classes, Component, Context,
-        Html, HtmlRef, HtmlResult, IntoComponent, NodeRef, Properties,
+        Html, HtmlRef, HtmlResult, IntoComponent, Properties,
     };
     pub use crate::macros::{classes, html, html_nested};
     pub use crate::suspense::Suspense;

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -334,3 +334,9 @@ pub mod prelude {
 }
 
 pub use self::prelude::*;
+
+#[doc(hidden)]
+pub mod __vendored {
+    //! Vendored exports.
+    pub use web_sys;
+}

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -324,7 +324,7 @@ pub mod prelude {
     pub use crate::events::*;
     pub use crate::html::{
         create_portal, BaseComponent, Children, ChildrenWithProps, Classes, Component, Context,
-        Html, HtmlResult, IntoComponent, NodeRef, Properties,
+        Html, HtmlRef, HtmlResult, IntoComponent, NodeRef, Properties,
     };
     pub use crate::macros::{classes, html, html_nested};
     pub use crate::suspense::Suspense;

--- a/packages/yew/src/tests/layout_tests.rs
+++ b/packages/yew/src/tests/layout_tests.rs
@@ -1,10 +1,9 @@
 use crate::dom_bundle::{BSubtree, Bundle};
-use crate::html::AnyScope;
+use crate::html::{AnyScope, NodeRef};
 use crate::scheduler;
 use crate::virtual_dom::VNode;
 use crate::{Component, Context, Html};
 use gloo::console::log;
-use yew::NodeRef;
 
 struct Comp;
 impl Component for Comp {

--- a/packages/yew/src/virtual_dom/vcomp.rs
+++ b/packages/yew/src/virtual_dom/vcomp.rs
@@ -1,7 +1,7 @@
 //! This module contains the implementation of a virtual component (`VComp`).
 
 use super::Key;
-use crate::html::{BaseComponent, IntoComponent, NodeRef};
+use crate::html::{BaseComponent, IntoComponent};
 use std::any::TypeId;
 use std::fmt;
 use std::rc::Rc;
@@ -12,7 +12,7 @@ use crate::html::{AnyScope, Scope};
 #[cfg(feature = "csr")]
 use crate::dom_bundle::BSubtree;
 #[cfg(feature = "csr")]
-use crate::html::Scoped;
+use crate::html::{NodeRef, Scoped};
 #[cfg(feature = "csr")]
 use web_sys::Element;
 

--- a/packages/yew/src/virtual_dom/vcomp.rs
+++ b/packages/yew/src/virtual_dom/vcomp.rs
@@ -60,7 +60,7 @@ pub(crate) trait Mountable {
     ) -> Box<dyn Scoped>;
 
     #[cfg(feature = "csr")]
-    fn reuse(self: Box<Self>, node_ref: NodeRef, scope: &dyn Scoped, next_sibling: NodeRef);
+    fn reuse(self: Box<Self>, scope: &dyn Scoped, next_sibling: NodeRef);
 
     #[cfg(feature = "ssr")]
     fn render_to_string<'a>(
@@ -105,9 +105,9 @@ impl<COMP: BaseComponent> Mountable for PropsWrapper<COMP> {
     }
 
     #[cfg(feature = "csr")]
-    fn reuse(self: Box<Self>, node_ref: NodeRef, scope: &dyn Scoped, next_sibling: NodeRef) {
+    fn reuse(self: Box<Self>, scope: &dyn Scoped, next_sibling: NodeRef) {
         let scope: Scope<COMP> = scope.to_any().downcast::<COMP>();
-        scope.reuse(self.props, node_ref, next_sibling);
+        scope.reuse(self.props, next_sibling);
     }
 
     #[cfg(feature = "ssr")]

--- a/packages/yew/src/virtual_dom/vportal.rs
+++ b/packages/yew/src/virtual_dom/vportal.rs
@@ -1,6 +1,7 @@
 //! This module contains the implementation of a portal `VPortal`.
 
 use super::VNode;
+#[cfg(feature = "csr")]
 use crate::html::NodeRef;
 use web_sys::{Element, Node};
 
@@ -9,7 +10,8 @@ pub struct VPortal {
     /// The element under which the content is inserted.
     pub host: Element,
     /// The next sibling after the inserted content. Most be a child of `host`.
-    pub inner_sibling: NodeRef,
+    #[cfg(feature = "csr")]
+    pub(crate) inner_sibling: NodeRef,
     /// The inserted node
     pub node: Box<VNode>,
 }
@@ -19,6 +21,7 @@ impl VPortal {
     pub fn new(content: VNode, host: Element) -> Self {
         Self {
             host,
+            #[cfg(feature = "csr")]
             inner_sibling: NodeRef::default(),
             node: Box::new(content),
         }
@@ -27,8 +30,12 @@ impl VPortal {
     /// If `next_sibling` is given, the content is inserted before that [Node].
     /// The parent of `next_sibling`, if given, must be `host`.
     pub fn new_before(content: VNode, host: Element, inner_sibling: Option<Node>) -> Self {
+        #[cfg(not(feature = "csr"))]
+        drop(inner_sibling);
+
         Self {
             host,
+            #[cfg(feature = "csr")]
             inner_sibling: {
                 let sib_ref = NodeRef::default();
                 sib_ref.set(inner_sibling);

--- a/packages/yew/src/virtual_dom/vportal.rs
+++ b/packages/yew/src/virtual_dom/vportal.rs
@@ -1,8 +1,6 @@
 //! This module contains the implementation of a portal `VPortal`.
 
 use super::VNode;
-#[cfg(feature = "csr")]
-use crate::html::NodeRef;
 use web_sys::{Element, Node};
 
 #[derive(Debug, Clone)]
@@ -10,8 +8,7 @@ pub struct VPortal {
     /// The element under which the content is inserted.
     pub host: Element,
     /// The next sibling after the inserted content. Most be a child of `host`.
-    #[cfg(feature = "csr")]
-    pub(crate) inner_sibling: NodeRef,
+    pub inner_sibling: Option<Node>,
     /// The inserted node
     pub node: Box<VNode>,
 }
@@ -21,8 +18,7 @@ impl VPortal {
     pub fn new(content: VNode, host: Element) -> Self {
         Self {
             host,
-            #[cfg(feature = "csr")]
-            inner_sibling: NodeRef::default(),
+            inner_sibling: None,
             node: Box::new(content),
         }
     }
@@ -30,17 +26,9 @@ impl VPortal {
     /// If `next_sibling` is given, the content is inserted before that [Node].
     /// The parent of `next_sibling`, if given, must be `host`.
     pub fn new_before(content: VNode, host: Element, inner_sibling: Option<Node>) -> Self {
-        #[cfg(not(feature = "csr"))]
-        drop(inner_sibling);
-
         Self {
             host,
-            #[cfg(feature = "csr")]
-            inner_sibling: {
-                let sib_ref = NodeRef::default();
-                sib_ref.set(inner_sibling);
-                sib_ref
-            },
+            inner_sibling,
             node: Box::new(content),
         }
     }

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -1,14 +1,14 @@
 //! This module contains the implementation of a virtual element node [VTag].
 
 use super::{AttrValue, Attributes, Key, Listener, Listeners, VList, VNode};
-use crate::html::{IntoPropValue, NodeRef};
+use crate::html::IntoPropValue;
 use std::cmp::PartialEq;
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::{borrow::Cow, ops::DerefMut};
-use web_sys::{HtmlInputElement as InputElement, HtmlTextAreaElement as TextAreaElement};
+use web_sys::{HtmlInputElement as InputElement, HtmlTextAreaElement as TextAreaElement, Node};
 
 /// SVG namespace string used for creating svg elements
 pub const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
@@ -111,17 +111,40 @@ pub(crate) enum VTagInner {
 /// A type for a virtual
 /// [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element)
 /// representation.
-#[derive(Debug, Clone)]
 pub struct VTag {
     /// [VTag] fields that are specific to different [VTag] kinds.
     pub(crate) inner: VTagInner,
     /// List of attached listeners.
     pub(crate) listeners: Listeners,
     /// A node reference used for DOM access in Component lifecycle methods
-    pub node_ref: NodeRef,
+    pub set_node: Option<Rc<dyn Fn(Option<Node>)>>,
     /// List of attributes.
     pub attributes: Attributes,
     pub key: Option<Key>,
+}
+
+impl std::fmt::Debug for VTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VTag")
+            .field("inner", &self.inner)
+            .field("listeners", &self.listeners)
+            .field("set_node", &"Option<Rc<dyn Fn(Option<Node>)>>")
+            .field("attributes", &self.attributes)
+            .field("key", &self.key)
+            .finish()
+    }
+}
+
+impl Clone for VTag {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            listeners: self.listeners.clone(),
+            set_node: self.set_node.clone(),
+            attributes: self.attributes.clone(),
+            key: self.key.clone(),
+        }
+    }
 }
 
 impl VTag {
@@ -159,7 +182,7 @@ impl VTag {
     pub fn __new_input(
         value: Option<AttrValue>,
         checked: bool,
-        node_ref: NodeRef,
+        set_node: Option<Rc<dyn Fn(Option<Node>)>>,
         key: Option<Key>,
         // at bottom for more readable macro-expanded coded
         attributes: Attributes,
@@ -172,7 +195,7 @@ impl VTag {
                 // but we use own field to control real `checked` parameter
                 checked,
             )),
-            node_ref,
+            set_node,
             key,
             attributes,
             listeners,
@@ -191,7 +214,7 @@ impl VTag {
     #[allow(clippy::too_many_arguments)]
     pub fn __new_textarea(
         value: Option<AttrValue>,
-        node_ref: NodeRef,
+        set_node: Option<Rc<dyn Fn(Option<Node>)>>,
         key: Option<Key>,
         // at bottom for more readable macro-expanded coded
         attributes: Attributes,
@@ -201,7 +224,7 @@ impl VTag {
             VTagInner::Textarea {
                 value: Value::new(value),
             },
-            node_ref,
+            set_node,
             key,
             attributes,
             listeners,
@@ -218,7 +241,7 @@ impl VTag {
     #[allow(clippy::too_many_arguments)]
     pub fn __new_other(
         tag: Cow<'static, str>,
-        node_ref: NodeRef,
+        set_node: Option<Rc<dyn Fn(Option<Node>)>>,
         key: Option<Key>,
         // at bottom for more readable macro-expanded coded
         attributes: Attributes,
@@ -227,7 +250,7 @@ impl VTag {
     ) -> Self {
         VTag::new_base(
             VTagInner::Other { tag, children },
-            node_ref,
+            set_node,
             key,
             attributes,
             listeners,
@@ -239,7 +262,7 @@ impl VTag {
     #[allow(clippy::too_many_arguments)]
     fn new_base(
         inner: VTagInner,
-        node_ref: NodeRef,
+        set_node: Option<Rc<dyn Fn(Option<Node>)>>,
         key: Option<Key>,
         attributes: Attributes,
         listeners: Listeners,
@@ -248,7 +271,7 @@ impl VTag {
             inner,
             attributes,
             listeners,
-            node_ref,
+            set_node,
             key,
         }
     }

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -1,6 +1,7 @@
 //! This module contains the implementation of a virtual element node [VTag].
 
 use super::{AttrValue, Attributes, Key, Listener, Listeners, VList, VNode};
+use crate::callback::Callback;
 use crate::html::IntoPropValue;
 use std::cmp::PartialEq;
 use std::marker::PhantomData;
@@ -111,40 +112,17 @@ pub(crate) enum VTagInner {
 /// A type for a virtual
 /// [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element)
 /// representation.
+#[derive(Debug, Clone)]
 pub struct VTag {
     /// [VTag] fields that are specific to different [VTag] kinds.
     pub(crate) inner: VTagInner,
     /// List of attached listeners.
     pub(crate) listeners: Listeners,
     /// A node reference used for DOM access in Component lifecycle methods
-    pub set_node: Option<Rc<dyn Fn(Option<Node>)>>,
+    pub set_node: Option<Callback<Option<Node>>>,
     /// List of attributes.
     pub attributes: Attributes,
     pub key: Option<Key>,
-}
-
-impl std::fmt::Debug for VTag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VTag")
-            .field("inner", &self.inner)
-            .field("listeners", &self.listeners)
-            .field("set_node", &"Option<Rc<dyn Fn(Option<Node>)>>")
-            .field("attributes", &self.attributes)
-            .field("key", &self.key)
-            .finish()
-    }
-}
-
-impl Clone for VTag {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            listeners: self.listeners.clone(),
-            set_node: self.set_node.clone(),
-            attributes: self.attributes.clone(),
-            key: self.key.clone(),
-        }
-    }
 }
 
 impl VTag {
@@ -182,7 +160,7 @@ impl VTag {
     pub fn __new_input(
         value: Option<AttrValue>,
         checked: bool,
-        set_node: Option<Rc<dyn Fn(Option<Node>)>>,
+        set_node: Option<Callback<Option<Node>>>,
         key: Option<Key>,
         // at bottom for more readable macro-expanded coded
         attributes: Attributes,
@@ -214,7 +192,7 @@ impl VTag {
     #[allow(clippy::too_many_arguments)]
     pub fn __new_textarea(
         value: Option<AttrValue>,
-        set_node: Option<Rc<dyn Fn(Option<Node>)>>,
+        set_node: Option<Callback<Option<Node>>>,
         key: Option<Key>,
         // at bottom for more readable macro-expanded coded
         attributes: Attributes,
@@ -241,7 +219,7 @@ impl VTag {
     #[allow(clippy::too_many_arguments)]
     pub fn __new_other(
         tag: Cow<'static, str>,
-        set_node: Option<Rc<dyn Fn(Option<Node>)>>,
+        set_node: Option<Callback<Option<Node>>>,
         key: Option<Key>,
         // at bottom for more readable macro-expanded coded
         attributes: Attributes,
@@ -262,7 +240,7 @@ impl VTag {
     #[allow(clippy::too_many_arguments)]
     fn new_base(
         inner: VTagInner,
-        set_node: Option<Rc<dyn Fn(Option<Node>)>>,
+        set_node: Option<Callback<Option<Node>>>,
         key: Option<Key>,
         attributes: Attributes,
         listeners: Listeners,

--- a/website/docs/advanced-topics/struct-components/lifecycle.mdx
+++ b/website/docs/advanced-topics/struct-components/lifecycle.mdx
@@ -101,11 +101,12 @@ being called on the first render, or instead a subsequent one.
 ```rust
 use web_sys::HtmlInputElement;
 use yew::{
-    Component, Context, html, Html, NodeRef,
+    Component, Context, html, Html,
+    html::HtmlRef,
 };
 
 pub struct MyComponent {
-    node_ref: NodeRef,
+    node_ref: HtmlRef<HtmlInputElement>,
 }
 
 impl Component for MyComponent {
@@ -114,7 +115,7 @@ impl Component for MyComponent {
 
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
-            node_ref: NodeRef::default(),
+            node_ref: HtmlRef::default(),
         }
     }
 
@@ -127,7 +128,7 @@ impl Component for MyComponent {
     // highlight-start
     fn rendered(&mut self, _ctx: &Context<Self>, first_render: bool) {
         if first_render {
-            if let Some(input) = self.node_ref.cast::<HtmlInputElement>() {
+            if let Some(input) = self.node_ref.get() {
                 input.focus();
             }
         }

--- a/website/docs/advanced-topics/struct-components/refs.mdx
+++ b/website/docs/advanced-topics/struct-components/refs.mdx
@@ -3,12 +3,12 @@ title: "Refs"
 description: "Out-of-band DOM access"
 ---
 
-The `ref` keyword can be used inside of any HTML element or component to get the DOM `Element` that 
+The `ref` keyword can be used inside of any HTML element or component to get the DOM `Element` that
 the item is attached to. This can be used to make changes to the DOM outside of the `view` lifecycle
-method. 
+method.
 
-This is useful for getting ahold of canvas elements, or scrolling to different sections of a page. 
-For example, using a `NodeRef` in a component's `rendered` method allows you to make draw calls to 
+This is useful for getting ahold of canvas elements, or scrolling to different sections of a page.
+For example, using a `NodeRef` in a component's `rendered` method allows you to make draw calls to
 a canvas element after it has been rendered from `view`.
 
 The syntax is:
@@ -16,9 +16,10 @@ The syntax is:
 ```rust
 use web_sys::Element;
 use yew::{html, Component, Context, Html, NodeRef};
+use yew::html::HtmlRef;
 
 struct Comp {
-    node_ref: NodeRef,
+    node_ref: HtmlRef<Element>,
 }
 
 impl Component for Comp {
@@ -28,7 +29,7 @@ impl Component for Comp {
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
             // highlight-next-line
-            node_ref: NodeRef::default(),
+            node_ref: HtmlRef::default(),
         }
     }
 
@@ -42,7 +43,7 @@ impl Component for Comp {
     fn rendered(&mut self, _ctx: &Context<Self>, _first_render: bool) {
         // highlight-start
         let has_attributes = self.node_ref
-            .cast::<Element>()
+            .get()
             .unwrap()
             .has_attributes();
         // highlight-end

--- a/website/docs/advanced-topics/struct-components/refs.mdx
+++ b/website/docs/advanced-topics/struct-components/refs.mdx
@@ -8,14 +8,14 @@ the item is attached to. This can be used to make changes to the DOM outside of 
 method.
 
 This is useful for getting ahold of canvas elements, or scrolling to different sections of a page.
-For example, using a `NodeRef` in a component's `rendered` method allows you to make draw calls to
+For example, using a `HtmlRef` in a component's `rendered` method allows you to make draw calls to
 a canvas element after it has been rendered from `view`.
 
 The syntax is:
 
 ```rust
 use web_sys::Element;
-use yew::{html, Component, Context, Html, NodeRef};
+use yew::{html, Component, Context, Html};
 use yew::html::HtmlRef;
 
 struct Comp {

--- a/website/docs/concepts/function-components/hooks/introduction.mdx
+++ b/website/docs/concepts/function-components/hooks/introduction.mdx
@@ -29,7 +29,7 @@ Yew comes with the following predefined Hooks:
 - [`use_state_eq`](./use-state.mdx#use_state_eq)
 - [`use_memo`](./use-memo.mdx)
 - [`use_mut_ref`](./use-mut-ref.mdx)
-- [`use_node_ref`](./use-node-ref.mdx)
+- [`use_html_ref`](./use-html-ref.mdx)
 - [`use_reducer`](./use-reducer.mdx)
 - [`use_reducer_eq`](./use-reducer.mdx#use_reducer_eq)
 - [`use_effect`](./use-effect.mdx)

--- a/website/docs/concepts/function-components/hooks/use-effect.mdx
+++ b/website/docs/concepts/function-components/hooks/use-effect.mdx
@@ -136,17 +136,18 @@ But for cases when you need to do it manually always re-apply and destroy old ev
 Same tip applies to intervals and timeouts.
 
 ```rust
-use yew::{function_component, html, Html, use_effect_with_deps, use_node_ref};
+use yew::{function_component, html, Html, use_effect_with_deps, use_html_ref};
+use web_sys::HtmlElement;
 
 #[function_component]
 fn HelloWorld() -> Html {
-    let span_ref = use_node_ref();
+    let span_ref = use_html_ref::<HtmlElement>();
 
     {
         let span_ref = span_ref.clone();
         use_effect_with_deps(
             move |_| {
-                let listener = gloo::events::EventListener::new(&span_ref.cast::<web_sys::HtmlElement>().unwrap(), "click", move |event| {
+                let listener = gloo::events::EventListener::new(&span_ref.get().unwrap(), "click", move |event| {
                     web_sys::console::log_1(&"I got clicked".into());
                 });
                 move || drop(listener)

--- a/website/docs/concepts/function-components/hooks/use-html-ref.mdx
+++ b/website/docs/concepts/function-components/hooks/use-html-ref.mdx
@@ -1,8 +1,8 @@
 ---
-title: "use_node_ref"
+title: "use_html_ref"
 ---
 
-`use_node_ref` is used for maintaining an easy reference to the DOM element represented as a `NodeRef`. It also persists across renders.
+`use_html_ref` is used for maintaining an easy reference to the DOM element represented as an `HtmlRef`. It also persists across renders.
 
 ## Example
 
@@ -10,13 +10,13 @@ title: "use_node_ref"
 use web_sys::HtmlInputElement;
 use yew::{
     function_component, functional::*, html,
-    NodeRef, Html
+    Html
 };
 
 #[function_component(UseRef)]
 pub fn ref_hook() -> Html {
     // highlight-next-line
-    let input_ref = use_node_ref();
+    let input_ref = use_html_ref::<HtmlInputElement>();
     let value = use_state(|| 25_f64);
 
     let onclick = {
@@ -24,7 +24,7 @@ pub fn ref_hook() -> Html {
         let value = value.clone();
         move |_| {
             // highlight-start
-            if let Some(input) = input_ref.cast::<HtmlInputElement>() {
+            if let Some(input) = input_ref.get() {
                 value.set(*value + input.value_as_number());
             }
             // highlight-end
@@ -43,7 +43,7 @@ pub fn ref_hook() -> Html {
 
 :::tip Advanced tip
 
-When conditionally rendering elements you can use `NodeRef` in conjunction with `use_effect_with_deps`
+When conditionally rendering elements you can use `HtmlRef` in conjunction with `use_effect_with_deps`
 to perform actions each time an element is rendered and just before its going to be removed from the
 DOM.
 

--- a/website/docs/concepts/function-components/node-refs.mdx
+++ b/website/docs/concepts/function-components/node-refs.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Node Refs"
+title: "Html Refs"
 description: "Out-of-band DOM access"
 ---
 
@@ -11,4 +11,4 @@ This is useful for getting ahold of canvas elements, or scrolling to different s
 
 ## Example
 
-See [use_node_ref hook](./hooks/use-node-ref)
+See [use_html_ref hook](./hooks/use-html-ref)

--- a/website/docs/concepts/html/events.mdx
+++ b/website/docs/concepts/html/events.mdx
@@ -353,9 +353,9 @@ see that `TargetCast::target_dyn_into` feels similar to `JsCast::dyn_into` but s
 does the cast on the target of the event. `TargetCast::target_unchecked_into` is similar to
 `JsCast::unchecked_into`, and as such all the same warnings above `JsCast` apply to `TargetCast`.
 
-### Using `NodeRef`
+### Using `HtmlRef`
 
-[`NodeRef`](../components/refs) can be used instead of querying the event given to a `Callback`.
+[`HtmlRef`](../components/refs) can be used instead of querying the event given to a `Callback`.
 
 ```rust
 use web_sys::HtmlInputElement;
@@ -364,17 +364,17 @@ use yew::prelude::*;
 #[function_component]
 fn MyComponent() -> Html {
     //highlight-next-line
-    let input_node_ref = use_node_ref();
+    let input_html_ref = use_html_ref::<HtmlInputElement>();
 
     let input_value_handle = use_state(String::default);
     let input_value = (*input_value_handle).clone();
 
     let onchange = {
-        let input_node_ref = input_node_ref.clone();
+        let input_html_ref = input_html_ref.clone();
 
         Callback::from(move |_| {
             //highlight-next-line
-            let input = input_node_ref.cast::<HtmlInputElement>();
+            let input = input_html_ref.get();
 
             if let Some(input) = input {
                 input_value_handle.set(input.value());
@@ -387,7 +387,7 @@ fn MyComponent() -> Html {
             <label for="my-input">
                 { "My input:" }
                 //highlight-next-line
-                <input ref={input_node_ref}
+                <input ref={input_html_ref}
                     {onchange}
                     id="my-input"
                     type="text"
@@ -399,11 +399,8 @@ fn MyComponent() -> Html {
 }
 ```
 
-Using `NodeRef`, you can ignore the event and use the `NodeRef::cast` method to get an
-`Option<HtmlInputElement>` - this is optional as calling `cast` before the `NodeRef` has been
-set, or when the type doesn't match will return `None`.
-
-You might also see by using `NodeRef` we don't have to send the `String` back into state as we always access to `input_node_ref` - so we could do the following:
+Using `HtmlRef::get()`, you can get an`Option<HtmlInputElement>` which is type checked at compile time.
+You might also see by using `HtmlRef` we don't have to send the `String` back into state as we always access to `use_html_ref` - so we could do the following:
 
 ```rust
 use web_sys::HtmlInputElement;
@@ -411,14 +408,14 @@ use yew::prelude::*;
 
 #[function_component]
 fn MyComponent() -> Html {
-    let input_node_ref = use_node_ref();
+    let input_html_ref = use_html_ref::<HtmlInputElement>();
 
     //highlight-start
     let onchange = {
-        let input_node_ref = input_node_ref.clone();
+        let input_html_ref = input_html_ref.clone();
 
         Callback::from(move |_| {
-            if let Some(input) = input_node_ref.cast::<HtmlInputElement>() {
+            if let Some(input) = input_html_ref.get() {
                 let value = input.value();
                 // do something with value
             }
@@ -430,7 +427,7 @@ fn MyComponent() -> Html {
         <>
             <label for="my-input">
                 { "My input:" }
-                <input ref={input_node_ref}
+                <input ref={input_html_ref}
                     {onchange}
                     id="my-input"
                     type="text"
@@ -450,7 +447,7 @@ You may want to listen to an event that is not supported by Yew's `html` macro, 
 [supported events listed here](#event-types).
 
 In order to add an event listener to one of elements manually we need the help of
-[`NodeRef`](../components/refs) so that in `use_effect_with_deps` we can add a listener using the
+[`HtmlRef`](../components/refs) so that in `use_effect_with_deps` we can add a listener using the
 [`web-sys`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/index.html) and
 [wasm-bindgen](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/index.html) API.
 
@@ -473,16 +470,16 @@ use yew::prelude::*;
 
 #[function_component]
 fn MyComponent() -> Html {
-    let div_node_ref = use_node_ref();
+    let div_html_ref = use_html_ref::<HtmlElement>();
 
     use_effect_with_deps(
         {
-            let div_node_ref = div_node_ref.clone();
+            let div_html_ref = div_html_ref.clone();
 
             move |_| {
                 let mut custard_listener = None;
 
-                if let Some(element) = div_node_ref.cast::<HtmlElement>() {
+                if let Some(element) = div_html_ref.get() {
                     // Create your Callback as you normally would
                     let oncustard = Callback::from(move |_: Event| {
                         // do something about custard..
@@ -507,11 +504,11 @@ fn MyComponent() -> Html {
                 move || drop(custard_listener)
             }
         },
-        div_node_ref.clone()
+        div_html_ref.clone()
     );
 
     html! {
-        <div ref={div_node_ref} id="my-div"></div>
+        <div ref={div_html_ref} id="my-div"></div>
     }
 }
 ```
@@ -540,16 +537,16 @@ use gloo::events::EventListener;
 
 #[function_component]
 fn MyComponent() -> Html {
-    let div_node_ref = use_node_ref();
+    let div_html_ref = use_html_ref::<HtmlElement>();
 
     use_effect_with_deps(
         {
-            let div_node_ref = div_node_ref.clone();
+            let div_html_ref = div_html_ref.clone();
 
             move |_| {
                 let mut custard_listener = None;
 
-                if let Some(element) = div_node_ref.cast::<HtmlElement>() {
+                if let Some(element) = div_html_ref.get() {
                     // Create your Callback as you normally would
                     let oncustard = Callback::from(move |_: Event| {
                         // do something about custard..
@@ -568,11 +565,11 @@ fn MyComponent() -> Html {
                 move || drop(custard_listener)
             }
         },
-        div_node_ref.clone()
+        div_html_ref.clone()
     );
 
     html! {
-        <div ref={div_node_ref} id="my-div"></div>
+        <div ref={div_html_ref} id="my-div"></div>
     }
 }
 ```

--- a/website/docs/concepts/wasm-bindgen/web-sys.mdx
+++ b/website/docs/concepts/wasm-bindgen/web-sys.mdx
@@ -77,55 +77,29 @@ fn inheritance_of_text_area(text_area: HtmlTextAreaElement) {
 
 _[Inheritance in `web-sys` in The `wasm-bindgen` Guide](https://rustwasm.github.io/wasm-bindgen/web-sys/inheritance.html)._
 
-## The `Node` in `NodeRef`
+## The `Node` in `HtmlRef`
 
-Yew uses a [`NodeRef`](../components/refs) in order to provide a way for keeping a reference to
-a `Node` made by the [`html!`](../html/introduction.mdx) macro. The `Node` part of `NodeRef` is referring to
-[`web_sys::Node`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Node.html). The
-`NodeRef::get` method will return a `Option<Node>` value, however, most of the time in Yew you want
-to cast this value to a specific element so you can use it's specific methods. This casting
-can be done using [`JsCast`](../wasm-bindgen#JsCast) on the `Node` value, if present, but Yew
-provides the `NodeRef::cast` method to perform this casting for convenience and so that you don't
-necessarily have to include the `wasm-bindgen` dependency for the `JsCast` trait.
-
-The two code blocks below do essentially the same thing, the first is using `NodeRef::cast` and
-the second is using [`JsCast::dyn_into`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html#method.dyn_into)
-on the `web_sys::Node` returned from `NodeRef::get`.
-
-<Tabs>
-  <TabItem value="Using NodeRef::cast" label="Using NodeRef::cast">
+Yew uses a [`HtmlRef`](../components/refs) in order to provide a way for keeping a reference to
+a `Node` made by the [`html!`](../html/introduction.mdx) macro. The
+`HtmlRef<T>::get` method will return a `Option<T>` value, correctly typed by procedural macro.
+If you wish to cast `T` into another type [`JsCast`](../wasm-bindgen#JsCast) on the value,
+if present. You may specify `T` as any type that implements `From<ElementType>`.
 
 ```rust
-use web_sys::HtmlInputElement;
-use yew::NodeRef;
+use web_sys::{HtmlElement, HtmlInputElement};
+use yew::{html, HtmlRef};
 
-fn with_node_ref_cast(node_ref: NodeRef) {
-    if let Some(input) = node_ref.cast::<HtmlInputElement>() {
-        // do something with HtmlInputElement
-    }
-}
+// You can specify HtmlInputElement as type for HtmlRef.
+let html_ref = HtmlRef::<HtmlInputElement>::new();
+
+let rendered = html! { <input ref={html_ref} /> };
+
+// You can also specify HtmlElement which implements From<HtmlInputElement>.
+let html_ref = HtmlRef::<HtmlElement>::new();
+
+let rendered = html! { <input ref={html_ref} /> };
+
 ```
-
-  </TabItem>
-  <TabItem value="Using NodeRef::get" label="Using NodeRef::get">
-
-```rust
-use wasm_bindgen::JsCast;
-use web_sys::HtmlInputElement;
-use yew::NodeRef;
-
-fn with_jscast(node_ref: NodeRef) {
-    if let Some(input) = node_ref
-        .get()
-        .and_then(|node| node.dyn_into::<HtmlInputElement>().ok()) {
-        // do something with HtmlInputElement
-    }
-}
-```
-
-  </TabItem>
-</Tabs>
-
 
 ## JavaScript example to Rust
 

--- a/website/sidebars/docs.js
+++ b/website/sidebars/docs.js
@@ -34,7 +34,8 @@ module.exports = {
           link: {
             type: "generated-index",
             title: "Yew Take on Basic Web Technologies",
-            description: "Yew mostly operates on the idea of keeping everything that a reusable piece of UI may need, in one place - rust files. But also seeks to stay close to the original look of the technology. Explore further to fully grasp what we mean by these statements:",
+            description:
+              "Yew mostly operates on the idea of keeping everything that a reusable piece of UI may need, in one place - rust files. But also seeks to stay close to the original look of the technology. Explore further to fully grasp what we mean by these statements:",
           },
           items: [
             "concepts/basic-web-technologies/html",
@@ -45,7 +46,10 @@ module.exports = {
         {
           type: "category",
           label: "Function Components",
-          link: { type: "doc", id: "concepts/function-components/introduction" },
+          link: {
+            type: "doc",
+            id: "concepts/function-components/introduction",
+          },
           items: [
             "concepts/function-components/properties",
             "concepts/function-components/callbacks",
@@ -54,12 +58,15 @@ module.exports = {
             {
               type: "category",
               label: "Hooks",
-              link: { type: "doc", id: "concepts/function-components/hooks/introduction" },
+              link: {
+                type: "doc",
+                id: "concepts/function-components/hooks/introduction",
+              },
               items: [
                 "concepts/function-components/hooks/use-state",
                 "concepts/function-components/hooks/use-reducer",
                 "concepts/function-components/hooks/use-mut-ref",
-                "concepts/function-components/hooks/use-node-ref",
+                "concepts/function-components/hooks/use-html-ref",
                 "concepts/function-components/hooks/use-effect",
                 "concepts/function-components/hooks/use-memo",
                 "concepts/function-components/hooks/use-context",
@@ -121,7 +128,10 @@ module.exports = {
         {
           type: "category",
           label: "Struct Components",
-          link: { type: "doc", id: "advanced-topics/struct-components/introduction" },
+          link: {
+            type: "doc",
+            id: "advanced-topics/struct-components/introduction",
+          },
           items: [
             "advanced-topics/struct-components/hoc",
             "advanced-topics/struct-components/introduction",


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This pull request draft primarily serves a purpose to facilitate discussion mentioned in #2505 and contains a superset of changes in #2551 with an intention to evaluate designs and work towards a minimal changeset that fulfils a typed `HtmlRef` and ref forwarding.

### Rationale

This implementation is a balance between proposals that:

1. `HtmlRef<T>` is only available to function components and elements. 
  You need to switch to function components before start using `ref`.
  So it does not break anything if you are using struct components.
  This also makes it possible to avoid any downcasting based behaviour.
2. `ref` is passed as normal props (automatically renamed to `ref_` to avoid `r#ref`).
3. `ref` is type checked.
4. An `ref` must be set if it presents on ref (or `panic!`).
5. `ref` can be any type for components.

### Missing Items

As this is not meant to be a complete pull request so it's still missing a couple items:
1. tests & docs
2. a complete map of html element types in procedural macro.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
