### PR TITLE
Fix typo(s) in use_callback docs

### DIFF
--- a/website/docs/concepts/function-components/hooks/use-callback.mdx
+++ b/website/docs/concepts/function-components/hooks/use-callback.mdx
@@ -58,7 +58,7 @@ fn callback() -> Html {
                 <b>{ "Current value: " }</b>
                 { *counter }
             </p>
-            <MyComponennt {callback} />
+            <MyComponent {callback} />
         </div>
     }
 }

--- a/website/docs/concepts/function-components/hooks/use-callback.mdx
+++ b/website/docs/concepts/function-components/hooks/use-callback.mdx
@@ -17,7 +17,7 @@ pub struct Props {
     pub callback: Callback<String, String>,
 }
 
-#[function_component(MyComponennt)]
+#[function_component(MyComponent)]
 fn my_component(props: &Props) -> Html {
     let greeting = props.callback.emit("Yew".to_string());
 
@@ -34,7 +34,7 @@ fn callback() -> Html {
         Callback::from(move |_| counter.set(*counter + 1))
     };
 
-    // This callback depends on (), so it's created only once, then MyComponennt
+    // This callback depends on (), so it's created only once, then MyComponent
     // will be rendered only once even when you click the button mutiple times.
     let callback = use_callback(
         move |name| format!("Hello, {}!", name),


### PR DESCRIPTION
#### Description
I'm just learning yew, and I stumbled across this typo. I'm assuming this is a typo, even though it was consistent across the file. Feel free to close if I misunderstood this.

#### Checklist
I've only modified the website, so I'm assuming this isn't necessary, I can still do this if that's something you want.

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
