### PR TITLE
Ignore website/** changes when benchmarking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,9 +2,13 @@ name: Benchmark
 
 on:
   push:
+    paths-ignore:
+      - 'website/**'
     branches:
       - master
   pull_request_target:
+    paths-ignore:
+      - 'website/**'
     types: [labeled, synchronize, opened, reopened]
 
 permissions:


### PR DESCRIPTION
#### Description
When making my previous PR #2580 I noticed that benchmarks where run. Having a glance at the folder structure it appeared to me that changes in website/** won't ever influence benchmark results, which can easily be implemented using GH actions. If it's desirable to still re-run benchmarks when website/** changes, feel free to just close this.
For reference, the syntax used can be found [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)

#### Checklist
I'm assuming this isn't necessary as this doesn't influence any code, but am of course happy to still do these.

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
