### PR TITLE
Fix macro hygine issues

### DIFF
--- a/packages/yew-macro/src/derive_props/builder.rs
+++ b/packages/yew-macro/src/derive_props/builder.rs
@@ -48,7 +48,7 @@ impl ToTokens for PropsBuilder<'_> {
 
         // Each builder step implements the `BuilderStep` trait and `step_generics` is used to
         // enforce that.
-        let step_generic_param = Ident::new("YEW_PROPS_BUILDER_STEP", Span::call_site());
+        let step_generic_param = Ident::new("YEW_PROPS_BUILDER_STEP", Span::mixed_site());
         let step_generics =
             with_param_bounds(generics, step_generic_param.clone(), (*step_trait).clone());
 

--- a/packages/yew-macro/src/derive_props/builder.rs
+++ b/packages/yew-macro/src/derive_props/builder.rs
@@ -62,7 +62,10 @@ impl ToTokens for PropsBuilder<'_> {
             #[doc(hidden)]
             #vis trait #step_trait {}
 
-            #(impl #step_trait for #step_names {})*
+            #(
+                #[automatically_derived]
+                impl #step_trait for #step_names {}
+            )*
 
             #[doc(hidden)]
             #vis struct #builder_name #step_generics
@@ -74,6 +77,7 @@ impl ToTokens for PropsBuilder<'_> {
 
             #impl_steps
 
+            #[automatically_derived]
             impl #impl_generics #builder_name<#generic_args> #where_clause {
                 #[doc(hidden)]
                 #vis fn build(self) -> #props_name #ty_generics {
@@ -189,6 +193,7 @@ impl PropsBuilder<'_> {
             });
 
             token_stream.extend(quote! {
+                #[automatically_derived]
                 #( #extra_attrs )*
                 impl #impl_generics #builder_name<#current_step_arguments> #where_clause {
                     #(#optional_prop_fn)*

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -191,7 +191,7 @@ impl PropField {
             Ok(PropAttr::Option)
         } else {
             let ident = named_field.ident.as_ref().unwrap();
-            let wrapped_name = format_ident!("{}_wrapper", ident, span = Span::call_site());
+            let wrapped_name = format_ident!("{}_wrapper", ident, span = Span::mixed_site());
             Ok(PropAttr::Required { wrapped_name })
         }
     }

--- a/packages/yew-macro/src/derive_props/generics.rs
+++ b/packages/yew-macro/src/derive_props/generics.rs
@@ -84,7 +84,7 @@ fn new_param_bounds(param_ident: Ident, param_bounds: Ident) -> GenericParam {
     GenericParam::Type(TypeParam {
         attrs: Vec::new(),
         ident: param_ident,
-        colon_token: Some(Token![:](Span::call_site())),
+        colon_token: Some(Token![:](Span::mixed_site())),
         bounds: param_bounds,
         eq_token: None,
         default: None,

--- a/packages/yew-macro/src/derive_props/mod.rs
+++ b/packages/yew-macro/src/derive_props/mod.rs
@@ -80,7 +80,7 @@ impl ToTokens for DerivePropsInput {
         } = self;
 
         // The wrapper is a new struct which wraps required props in `Option`
-        let wrapper_name = format_ident!("{}Wrapper", props_name, span = Span::call_site());
+        let wrapper_name = format_ident!("{}Wrapper", props_name, span = Span::mixed_site());
         let wrapper = PropsWrapper::new(
             &wrapper_name,
             generics,
@@ -90,8 +90,8 @@ impl ToTokens for DerivePropsInput {
         tokens.extend(wrapper.into_token_stream());
 
         // The builder will only build if all required props have been set
-        let builder_name = format_ident!("{}Builder", props_name, span = Span::call_site());
-        let builder_step = format_ident!("{}BuilderStep", props_name, span = Span::call_site());
+        let builder_name = format_ident!("{}Builder", props_name, span = Span::mixed_site());
+        let builder_step = format_ident!("{}BuilderStep", props_name, span = Span::mixed_site());
         let builder = PropsBuilder::new(
             &builder_name,
             &builder_step,

--- a/packages/yew-macro/src/derive_props/wrapper.rs
+++ b/packages/yew-macro/src/derive_props/wrapper.rs
@@ -26,6 +26,7 @@ impl ToTokens for PropsWrapper<'_> {
         let wrapper_default_setters = self.default_setters();
 
         let wrapper = quote! {
+            #[doc(hidden)]
             #(#extra_attrs)*
             struct #wrapper_name #generics
                 #where_clause
@@ -33,6 +34,7 @@ impl ToTokens for PropsWrapper<'_> {
                 #(#wrapper_field_defs)*
             }
 
+            #[automatically_derived]
             impl #impl_generics ::std::default::Default for #wrapper_name #ty_generics #where_clause {
                 fn default() -> Self {
                     #wrapper_name #turbofish_generics {

--- a/packages/yew-macro/src/hook/mod.rs
+++ b/packages/yew-macro/src/hook/mod.rs
@@ -162,6 +162,7 @@ pub fn hook_impl(hook: HookFn) -> syn::Result<TokenStream> {
                 #args_ident: (#(#input_types,)*),
             }
 
+            #[automatically_derived]
             impl #impl_generics ::yew::functional::Hook for #hook_struct_name #ty_generics #where_clause {
                 type Output = #output_type;
 
@@ -172,6 +173,7 @@ pub fn hook_impl(hook: HookFn) -> syn::Result<TokenStream> {
                 }
             }
 
+            #[automatically_derived]
             impl #impl_generics #hook_struct_name #ty_generics #where_clause {
                 fn new(#inputs) -> Self {
                    #hook_struct_name {

--- a/packages/yew-macro/src/html_tree/html_component.rs
+++ b/packages/yew-macro/src/html_tree/html_component.rs
@@ -166,7 +166,7 @@ impl HtmlComponent {
                 if punct.as_char() == '>' {
                     break;
                 } else if punct.as_char() == ',' {
-                    args.push_punct(Token![,](Span::call_site()))
+                    args.push_punct(Token![,](Span::mixed_site()))
                 }
             }
         }
@@ -174,9 +174,9 @@ impl HtmlComponent {
         Some((
             PathArguments::AngleBracketed(AngleBracketedGenericArguments {
                 colon2_token: None,
-                lt_token: Token![<](Span::call_site()),
+                lt_token: Token![<](Span::mixed_site()),
                 args,
-                gt_token: Token![>](Span::call_site()),
+                gt_token: Token![>](Span::mixed_site()),
             }),
             cursor,
         ))
@@ -191,7 +191,7 @@ impl HtmlComponent {
             let mut post_colons_cursor = cursor;
             if let Some(c) = Self::double_colon(post_colons_cursor) {
                 if colons_optional {
-                    leading_colon = Some(Token![::](Span::call_site()));
+                    leading_colon = Some(Token![::](Span::mixed_site()));
                 }
                 post_colons_cursor = c;
             } else if !colons_optional {

--- a/packages/yew-macro/src/html_tree/html_dashed_name.rs
+++ b/packages/yew-macro/src/html_tree/html_dashed_name.rs
@@ -60,7 +60,7 @@ impl Peek<'_, Self> for HtmlDashedName {
                 if punct.as_char() == '-' {
                     let (ident, i_cursor) = p_cursor.ident()?;
                     cursor = i_cursor;
-                    extended.push((Token![-](Span::call_site()), ident));
+                    extended.push((Token![-](Span::mixed_site()), ident));
                     continue;
                 }
             }

--- a/packages/yew-macro/src/html_tree/mod.rs
+++ b/packages/yew-macro/src/html_tree/mod.rs
@@ -243,7 +243,7 @@ impl HtmlChildrenTree {
             };
         }
 
-        let vec_ident = Ident::new("__yew_v", Span::call_site());
+        let vec_ident = Ident::new("__yew_v", Span::mixed_site());
         let add_children_streams = children.iter().map(|child| {
             if let Some(node_iterator_stream) = child.to_node_iterator_stream() {
                 quote! {

--- a/packages/yew-macro/tests/function_component_attr/no-name-default-pass.rs
+++ b/packages/yew-macro/tests/function_component_attr/no-name-default-pass.rs
@@ -1,13 +1,13 @@
-use yew::prelude::*;
+#![no_implicit_prelude]
 
-#[derive(Clone, Properties, PartialEq)]
+#[derive(::yew::prelude::Properties, ::std::prelude::rust_2021::PartialEq,)]
 struct Props {
     a: usize,
 }
 
-#[function_component]
-fn Comp(props: &Props) -> Html {
-    html! {
+#[::yew::prelude::function_component]
+fn Comp(props: &Props) -> ::yew::prelude::Html {
+    ::yew::prelude::html! {
         <p>
             { props.a }
         </p>
@@ -15,7 +15,7 @@ fn Comp(props: &Props) -> Html {
 }
 
 fn main() {
-    let _ = html! {
+    let _ = ::yew::prelude::html! {
         <Comp a={0} />
     };
 }

--- a/packages/yew-macro/tests/function_component_attr/with-defaulted-type-param-pass.rs
+++ b/packages/yew-macro/tests/function_component_attr/with-defaulted-type-param-pass.rs
@@ -1,25 +1,25 @@
-use yew::prelude::*;
+#![no_implicit_prelude]
 
-#[derive(Properties, Debug)]
+#[derive(::yew::prelude::Properties, ::std::fmt::Debug)]
 pub struct CompProps<A> {
     #[prop_or_default]
-    _phantom: std::marker::PhantomData<A>,
+    _phantom: ::std::marker::PhantomData<A>,
 }
 
-impl<A> PartialEq for CompProps<A> {
+impl<A> ::std::cmp::PartialEq for CompProps<A> {
     fn eq(&self, _rhs: &Self) -> bool {
         true
     }
 }
 
-#[function_component(Comp)]
-pub fn comp<A = ()>(_props: &CompProps<A>) -> Html {
-    todo!()
+#[::yew::prelude::function_component(Comp)]
+pub fn comp<A = ()>(_props: &CompProps<A>) -> ::yew::prelude::Html {
+    ::std::todo!()
 }
 
-#[function_component(App)]
-pub fn app() -> Html {
-    html! { <Comp /> } // No generics here.
+#[::yew::prelude::function_component(App)]
+pub fn app() -> ::yew::prelude::Html {
+    ::yew::prelude::html! { <Comp /> } // No generics here.
 }
 
 fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-lifetime-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-lifetime-pass.rs
@@ -1,6 +1,6 @@
-use yew::prelude::*;
+#![no_implicit_prelude]
 
-#[hook]
+#[::yew::functional::hook]
 fn use_as_is<'a>(input: &'a ()) -> &'a () {
     input
 }

--- a/packages/yew-macro/tests/hook_attr/hook_macro-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook_macro-pass.rs
@@ -1,8 +1,9 @@
-use yew::prelude::*;
+#![no_implicit_prelude]
 
-#[hook]
-pub fn use_some_macro_inner(val: &str) -> String {
-    use_state(|| val.to_owned()).to_string()
+#[::yew::functional::hook]
+pub fn use_some_macro_inner(val: &str) -> ::std::string::String {
+    let state = ::yew::functional::use_state(|| ::std::borrow::ToOwned::to_owned(val));
+    ::std::string::ToString::to_string(&*state)
 }
 
 macro_rules! use_some_macro {
@@ -14,12 +15,12 @@ macro_rules! use_some_macro {
     };
 }
 
-#[function_component]
-fn Comp() -> Html {
+#[::yew::functional::function_component]
+fn Comp() -> ::yew::Html {
     let a = use_some_macro!();
     let b = use_some_macro!("b");
 
-    html! {
+    ::yew::html! {
         <div>{a}{b}</div>
     }
 }

--- a/packages/yew-macro/tests/html_macro/html-if-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-if-pass.rs
@@ -1,35 +1,35 @@
-use yew::prelude::*;
+#![no_implicit_prelude]
 
 fn compile_pass_lit() {
-    html! { if true {} };
-    html! { if true { <div/> } };
-    html! { if true { <div/><div/> } };
-    html! { if true { <><div/><div/></> } };
-    html! { if true { { html! {} } } };
-    html! { if true { { { let _x = 42; html! {} } } } };
-    html! { if true {} else {} };
-    html! { if true {} else if true {} };
-    html! { if true {} else if true {} else {} };
-    html! { if let Some(text) = Some("text") { <span>{ text }</span> } };
-    html! { <><div/>if true {}<div/></> };
-    html! { <div>if true {}</div> };
+    ::yew::html! { if true {} };
+    ::yew::html! { if true { <div/> } };
+    ::yew::html! { if true { <div/><div/> } };
+    ::yew::html! { if true { <><div/><div/></> } };
+    ::yew::html! { if true { { ::yew::html! {} } } };
+    ::yew::html! { if true { { { let _x = 42; ::yew::html! {} } } } };
+    ::yew::html! { if true {} else {} };
+    ::yew::html! { if true {} else if true {} };
+    ::yew::html! { if true {} else if true {} else {} };
+    ::yew::html! { if let ::std::option::Option::Some(text) = ::std::option::Option::Some("text") { <span>{ text }</span> } };
+    ::yew::html! { <><div/>if true {}<div/></> };
+    ::yew::html! { <div>if true {}</div> };
 }
 
 fn compile_pass_expr() {
     let condition = true;
 
-    html! { if condition {} };
-    html! { if condition { <div/> } };
-    html! { if condition { <div/><div/> } };
-    html! { if condition { <><div/><div/></> } };
-    html! { if condition { { html! {} } } };
-    html! { if condition { { { let _x = 42; html! {} } } } };
-    html! { if condition {} else {} };
-    html! { if condition {} else if condition {} };
-    html! { if condition {} else if condition {} else {} };
-    html! { if let Some(text) = Some("text") { <span>{ text }</span> } };
-    html! { <><div/>if condition {}<div/></> };
-    html! { <div>if condition {}</div> };
+    ::yew::html! { if condition {} };
+    ::yew::html! { if condition { <div/> } };
+    ::yew::html! { if condition { <div/><div/> } };
+    ::yew::html! { if condition { <><div/><div/></> } };
+    ::yew::html! { if condition { { ::yew::html! {} } } };
+    ::yew::html! { if condition { { { let _x = 42; ::yew::html! {} } } } };
+    ::yew::html! { if condition {} else {} };
+    ::yew::html! { if condition {} else if condition {} };
+    ::yew::html! { if condition {} else if condition {} else {} };
+    ::yew::html! { if let ::std::option::Option::Some(text) = ::std::option::Option::Some("text") { <span>{ text }</span> } };
+    ::yew::html! { <><div/>if condition {}<div/></> };
+    ::yew::html! { <div>if condition {}</div> };
 }
 
 fn main() {}


### PR DESCRIPTION
#### Description
This PR:

- Adds `#![no_implicit_prelude]` in macro tests. This ensures that:
  - We don't use anything we are not supposed to use
  - Traits are called unambiguously
- Adds `#[automatically_derived]` and `#[doc(hidden)]` where missing
- Replace `Span::call_site()` with `Span::mixed_site()`

Fixes #1633

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
