### PR TITLE
Fix some Hook edge cases

### DIFF
--- a/packages/yew-macro/tests/hook_attr/hook-dynamic-dispatch-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-dynamic-dispatch-pass.rs
@@ -1,0 +1,8 @@
+use yew::prelude::*;
+
+#[hook]
+fn use_boxed_fn(_f: Box<dyn Fn(&str) -> &str>) {
+    todo!()
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-dynamic-dispatch-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-dynamic-dispatch-pass.rs
@@ -1,8 +1,8 @@
-use yew::prelude::*;
+#![no_implicit_prelude]
 
-#[hook]
-fn use_boxed_fn(_f: Box<dyn Fn(&str) -> &str>) {
-    todo!()
+#[::yew::prelude::hook]
+fn use_boxed_fn(_f: ::std::boxed::Box<dyn::std::ops::Fn(&str) -> &str>) {
+    ::std::todo!()
 }
 
 fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-return-impl-trait-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-return-impl-trait-pass.rs
@@ -1,0 +1,11 @@
+use std::ops::Deref;
+use std::rc::Rc;
+
+use yew::prelude::*;
+
+#[hook]
+fn use_deref_as_u32() -> impl Deref<Target = u32> {
+    Rc::new(0)
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-return-impl-trait-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-return-impl-trait-pass.rs
@@ -1,11 +1,8 @@
-use std::ops::Deref;
-use std::rc::Rc;
+#![no_implicit_prelude]
 
-use yew::prelude::*;
-
-#[hook]
-fn use_deref_as_u32() -> impl Deref<Target = u32> {
-    Rc::new(0)
+#[::yew::prelude::hook]
+fn use_deref_as_u32() -> impl ::std::ops::Deref<Target = ::std::primitive::u32> {
+    ::std::rc::Rc::new(0)
 }
 
 fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-return-ref-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-return-ref-pass.rs
@@ -1,0 +1,8 @@
+use yew::prelude::*;
+
+#[hook]
+fn use_str_ref(f: &str) -> &str {
+    f
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-return-ref-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-return-ref-pass.rs
@@ -1,7 +1,7 @@
-use yew::prelude::*;
+#![no_implicit_prelude]
 
-#[hook]
-fn use_str_ref(f: &str) -> &str {
+#[::yew::prelude::hook]
+fn use_str_ref(f: &::std::primitive::str) -> &::std::primitive::str {
     f
 }
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This pull request fixes a couple edge cases with the `#[hook]` macro:

1. `impl Trait` in return position is supported.
2.  `Box<dyn Fn(&str) -> &str>` will not have its lifetime rewritten.
3. `&T` in return position will become `'hook` automatically. 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
