### PR TITLE
Add the ability to use non-literal string as attribute names 

### DIFF
--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -90,8 +90,7 @@ impl Attributes {
         mut new_iter: impl Iterator<Item = (&'a str, &'a str)>,
         new: &IndexMap<AttrValue, AttrValue>,
         old: &IndexMap<AttrValue, AttrValue>,
-    )
-    {
+    ) {
         let mut old_iter = old.iter();
         let new = new
             .iter()

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -84,7 +84,7 @@ impl Apply for InputFields {
 
 impl Attributes {
     #[cold]
-    fn apply_diff_index_maps<'a>(
+    fn apply_diff_index_maps(
         el: &Element,
         new: &IndexMap<AttrValue, AttrValue>,
         old: &IndexMap<AttrValue, AttrValue>,

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -86,27 +86,18 @@ impl Attributes {
     #[cold]
     fn apply_diff_index_maps<'a>(
         el: &Element,
-        // this makes it possible to diff `&'a IndexMap<_, A>` and `IndexMap<_, &'a A>`.
-        mut new_iter: impl Iterator<Item = (&'a str, &'a str)>,
         new: &IndexMap<AttrValue, AttrValue>,
         old: &IndexMap<AttrValue, AttrValue>,
     ) {
         let mut old_iter = old.iter();
-        let new = new
-            .iter()
-            .map(|(k, v)| (k.as_ref(), v))
-            .collect::<IndexMap<_, _>>();
-        let old = old
-            .iter()
-            .map(|(k, v)| (k.as_ref(), v))
-            .collect::<IndexMap<_, _>>();
+        let mut new_iter = new.iter();
         loop {
             match (new_iter.next(), old_iter.next()) {
                 (Some((new_key, new_value)), Some((old_key, old_value))) => {
-                    if new_key != old_key.as_ref() {
+                    if new_key != old_key {
                         break;
                     }
-                    if new_value != old_value.as_ref() {
+                    if new_value != old_value {
                         Self::set_attribute(el, new_key, new_value);
                     }
                 }
@@ -115,7 +106,7 @@ impl Attributes {
                     for (key, value) in iter::once(attr).chain(new_iter) {
                         match old.get(key) {
                             Some(old_value) => {
-                                if value != old_value.as_ref() {
+                                if value != old_value {
                                     Self::set_attribute(el, key, value);
                                 }
                             }
@@ -129,7 +120,7 @@ impl Attributes {
                 // removed attributes
                 (None, Some(attr)) => {
                     for (key, _) in iter::once(attr).chain(old_iter) {
-                        let key = key.as_ref();
+                        let key = key;
                         if !new.contains_key(key) {
                             Self::remove_attribute(el, key);
                         }
@@ -270,8 +261,7 @@ impl Apply for Attributes {
             }
             // For VTag's constructed outside the html! macro
             (Self::IndexMap(new), Self::IndexMap(ref old)) => {
-                let new_iter = new.iter().map(|(k, v)| (k.as_ref(), v.as_ref()));
-                Self::apply_diff_index_maps(el, new_iter, &*new, &*old);
+                Self::apply_diff_index_maps(el, &*new, &*old);
             }
             // Cold path. Happens only with conditional swapping and reordering of `VTag`s with the
             // same tag and no keys.

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::iter;
 use std::ops::Deref;
 use web_sys::{Element, HtmlInputElement as InputElement, HtmlTextAreaElement as TextAreaElement};
+use yew::AttrValue;
 
 impl<T: AccessValue> Apply for Value<T> {
     type Element = T;
@@ -83,15 +84,13 @@ impl Apply for InputFields {
 
 impl Attributes {
     #[cold]
-    fn apply_diff_index_maps<'a, A, B>(
+    fn apply_diff_index_maps<'a>(
         el: &Element,
         // this makes it possible to diff `&'a IndexMap<_, A>` and `IndexMap<_, &'a A>`.
         mut new_iter: impl Iterator<Item = (&'a str, &'a str)>,
-        new: &IndexMap<impl AsRef<str>, A>,
-        old: &IndexMap<impl AsRef<str>, B>,
-    ) where
-        A: AsRef<str>,
-        B: AsRef<str>,
+        new: &IndexMap<AttrValue, AttrValue>,
+        old: &IndexMap<AttrValue, AttrValue>,
+    )
     {
         let mut old_iter = old.iter();
         let new = new
@@ -273,8 +272,7 @@ impl Apply for Attributes {
             // For VTag's constructed outside the html! macro
             (Self::IndexMap(new), Self::IndexMap(ref old)) => {
                 let new_iter = new.iter().map(|(k, v)| (k.as_ref(), v.as_ref()));
-                Self::apply_diff_index_maps(el, new_iter, new, old);
-                todo!();
+                Self::apply_diff_index_maps(el, new_iter, &*new, &*old);
             }
             // Cold path. Happens only with conditional swapping and reordering of `VTag`s with the
             // same tag and no keys.

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -58,6 +58,7 @@ pub enum AttrValue {
 impl Deref for AttrValue {
     type Target = str;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         match self {
             AttrValue::Static(s) => *s,
@@ -67,6 +68,7 @@ impl Deref for AttrValue {
 }
 
 impl Hash for AttrValue {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
             AttrValue::Static(s) => s.hash(&mut *state),
@@ -76,24 +78,28 @@ impl Hash for AttrValue {
 }
 
 impl From<&'static str> for AttrValue {
+    #[inline(always)]
     fn from(s: &'static str) -> Self {
         AttrValue::Static(s)
     }
 }
 
 impl From<String> for AttrValue {
+    #[inline(always)]
     fn from(s: String) -> Self {
         AttrValue::Rc(Rc::from(s))
     }
 }
 
 impl From<Rc<str>> for AttrValue {
+    #[inline(always)]
     fn from(s: Rc<str>) -> Self {
         AttrValue::Rc(s)
     }
 }
 
 impl From<Cow<'static, str>> for AttrValue {
+    #[inline(always)]
     fn from(s: Cow<'static, str>) -> Self {
         match s {
             Cow::Borrowed(s) => s.into(),
@@ -112,6 +118,7 @@ impl Clone for AttrValue {
 }
 
 impl AsRef<str> for AttrValue {
+    #[inline(always)]
     fn as_ref(&self) -> &str {
         &*self
     }
@@ -127,6 +134,7 @@ impl fmt::Display for AttrValue {
 }
 
 impl PartialEq for AttrValue {
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.as_ref() == other.as_ref()
     }

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -39,7 +39,7 @@ pub use self::vtag::VTag;
 pub use self::vtext::VText;
 
 use indexmap::IndexMap;
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 use std::fmt::Formatter;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
@@ -70,10 +70,7 @@ impl Deref for AttrValue {
 impl Hash for AttrValue {
     #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            AttrValue::Static(s) => s.hash(&mut *state),
-            AttrValue::Rc(s) => s.hash(&mut *state),
-        };
+        self.as_ref().hash(state);
     }
 }
 
@@ -120,6 +117,12 @@ impl Clone for AttrValue {
 impl AsRef<str> for AttrValue {
     #[inline(always)]
     fn as_ref(&self) -> &str {
+        &*self
+    }
+}
+
+impl Borrow<str> for AttrValue {
+    fn borrow(&self) -> &str {
         &*self
     }
 }

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -351,7 +351,7 @@ impl VTag {
     pub fn add_attribute(&mut self, key: &'static str, value: impl Into<AttrValue>) {
         self.attributes
             .get_mut_index_map()
-            .insert(key, value.into());
+            .insert(AttrValue::Static(key), value.into());
     }
 
     /// Sets attributes to a virtual node.
@@ -366,7 +366,7 @@ impl VTag {
     pub fn __macro_push_attr(&mut self, key: &'static str, value: impl IntoPropValue<AttrValue>) {
         self.attributes
             .get_mut_index_map()
-            .insert(key, value.into_prop_value());
+            .insert(AttrValue::from(key), value.into_prop_value());
     }
 
     /// Add event listener on the [VTag]'s  [Element](web_sys::Element).


### PR DESCRIPTION
#### Description

Use AttrValue instead of &'static str in Attributes::IndexMap

Fixes #2583 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have updated tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
