### PR TITLE
Reduce size of examples

### DIFF
--- a/examples/boids/index.html
+++ b/examples/boids/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Yew • Boids</title>
 
+    <link data-trunk rel="rust" />
     <link data-trunk rel="sass" href="index.scss" />
   </head>
 

--- a/examples/contexts/index.html
+++ b/examples/contexts/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Yew • Context</title>
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Yew • Counter</title>
 
+    <link data-trunk rel="rust" />
     <link data-trunk rel="sass" href="index.scss" />
   </head>
 

--- a/examples/dyn_create_destroy_apps/index.html
+++ b/examples/dyn_create_destroy_apps/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Yew • Create and destroy apps</title>
 
+    <link data-trunk rel="rust" />
     <link data-trunk rel="sass" href="index.scss" />
   </head>
 

--- a/examples/file_upload/index.html
+++ b/examples/file_upload/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Yew • File Upload</title>
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/function_memory_game/index.html
+++ b/examples/function_memory_game/index.html
@@ -7,6 +7,7 @@
     <title>Yew • Function Memory Game</title>
     <base data-trunk-public-url />
 
+    <link data-trunk rel="rust" />
     <link data-trunk rel="sass" href="scss/index.scss" />
     <link data-trunk rel="copy-dir" href="public/" />
     

--- a/examples/function_router/index.html
+++ b/examples/function_router/index.html
@@ -10,7 +10,6 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css"
     />
-    <link data-trunk rel="rust" />
     <link data-trunk rel="sass" href="index.scss" />
     <link data-trunk rel="rust" data-cargo-features="csr" data-bin="function_router" />
   </head>

--- a/examples/function_router/index.html
+++ b/examples/function_router/index.html
@@ -10,6 +10,7 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css"
     />
+    <link data-trunk rel="rust" />
     <link data-trunk rel="sass" href="index.scss" />
     <link data-trunk rel="rust" data-cargo-features="csr" data-bin="function_router" />
   </head>

--- a/examples/function_todomvc/index.html
+++ b/examples/function_todomvc/index.html
@@ -12,6 +12,8 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/todomvc-app-css@2.3.0/index.css"
     />
+
+    <link data-trunk rel="rust" />
   </head>
   <body></body>
 </html>

--- a/examples/futures/index.html
+++ b/examples/futures/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Yew • Futures</title>
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/game_of_life/index.html
+++ b/examples/game_of_life/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Yew • Game of Life</title>
 
+    <link data-trunk rel="rust" />
     <link data-trunk rel="css" href="styles.css" />
     <link data-trunk rel="copy-file" href="assets/favicon.ico" />
   </head>

--- a/examples/inner_html/index.html
+++ b/examples/inner_html/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Yew • Inner HTML</title>
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/js_callback/index.html
+++ b/examples/js_callback/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Yew • Js Callback</title>
 
+    <link data-trunk rel="rust" />
     <link data-trunk rel="sass" href="index.scss" />
   </head>
 

--- a/examples/keyed_list/index.html
+++ b/examples/keyed_list/index.html
@@ -5,6 +5,8 @@
     <title>Yew • Keyed list</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link data-trunk rel="css" href="styles.css" />
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/mount_point/index.html
+++ b/examples/mount_point/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Yew • Mount Point</title>
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/nested_list/index.html
+++ b/examples/nested_list/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Yew • Nested List</title>
 
+    <link data-trunk rel="rust" />
     <link data-trunk rel="sass" href="styles.scss" />
   </head>
 

--- a/examples/node_refs/index.html
+++ b/examples/node_refs/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Yew • Node Refs</title>
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/password_strength/index.html
+++ b/examples/password_strength/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Yew • Password Strength Estimator</title>
 
+    <link data-trunk rel="rust" />
     <link data-trunk rel="sass" href="index.scss" />
   </head>
 

--- a/examples/portals/index.html
+++ b/examples/portals/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Yew • Portals</title>
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/router/index.html
+++ b/examples/router/index.html
@@ -11,6 +11,8 @@
       href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css"
     />
     <link data-trunk rel="sass" href="index.scss" />
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/suspense/index.html
+++ b/examples/suspense/index.html
@@ -5,6 +5,7 @@
     <title>Yew Suspense Demo</title>
 
     <link data-trunk rel="sass" href="index.scss" />
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>

--- a/examples/timer/index.html
+++ b/examples/timer/index.html
@@ -6,6 +6,7 @@
   <title>Yew • Timer</title>
   <link data-trunk rel="scss" href="index.scss"/>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@900&display=swap" rel="stylesheet">
+  <link data-trunk rel="rust" />
 </head>
 
 <body></body>

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -12,6 +12,8 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/todomvc-app-css@2.3.0/index.css"
     />
+
+    <link data-trunk rel="rust" />
   </head>
   <body></body>
 </html>

--- a/examples/two_apps/index.html
+++ b/examples/two_apps/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Yew • Two Apps</title>
+
+    <link data-trunk rel="rust" />
   </head>
   <body>
     <div class="first-app"></div>

--- a/examples/webgl/index.html
+++ b/examples/webgl/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Yew • WebGL</title>
+
+    <link data-trunk rel="rust" />
   </head>
 
   <body></body>


### PR DESCRIPTION
#### Description

Explicitly mentioning `<link rel="rust">` apparently has different wasm-opt defaults than not having the link.

This explains a lot... turns out actually turning on `wasm-opt` with default parameters is a bargain not to miss.

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
