### PR TITLE
Code Size: Document and use additional nightly features

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,7 @@ on:
   pull_request_target:
     paths-ignore:
       - 'website/**'
+    types: [labeled, synchronize, opened, reopened]
 
 permissions:
   # deployments permission to deploy GitHub pages website

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,6 @@ on:
   pull_request_target:
     paths-ignore:
       - 'website/**'
-    types: [labeled, synchronize, opened, reopened]
 
 permissions:
   # deployments permission to deploy GitHub pages website

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches: [master]
     paths:
+      - .github/workflows/size-cmp.yml
+      - ci/collect_sizes.py
       - "packages/**"
       - "examples/**"
       - "Cargo.toml"

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -30,8 +30,9 @@ jobs:
       - name: Setup toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           target: wasm32-unknown-unknown
+          components: rust-src
           override: true
           profile: minimal
 
@@ -54,6 +55,11 @@ jobs:
 
       - name: Write optimisation flags for master
         run: |
+          cat >> .cargo/config << EOF
+          [unstable]
+          build-std = ["std", "panic_abort"]
+          build-std-features = ["panic_immediate_abort"]
+          EOF
           cat >> Cargo.toml << EOF
           [profile.release]
           lto = true
@@ -65,6 +71,11 @@ jobs:
 
       - name: Write optimisation flags for pull request
         run: |
+          cat >> .cargo/config << EOF
+          [unstable]
+          build-std = ["std", "panic_abort"]
+          build-std-features = ["panic_immediate_abort"]
+          EOF
           cat >> Cargo.toml << EOF
           [profile.release]
           lto = true
@@ -77,55 +88,19 @@ jobs:
       - name: Build master examples
         run: find examples/*/index.html | xargs -I '{}' trunk build --release '{}' || exit 0
         working-directory: yew-master
+        env:
+          RUSTUP_TOOLCHAIN: nightly
 
       - name: Build pull request examples
         run: find examples/*/index.html | xargs -I '{}' trunk build --release '{}' || exit 0
         working-directory: current-pr
+        env:
+          RUSTUP_TOOLCHAIN: nightly
 
       - name: Collect size information
-        run: |
-          from typing import Dict, List, Optional
-
-          import glob
-          import os
-          import json
-
-          def find_example_sizes(parent_dir: str) -> Dict[str, int]:
-              example_sizes: Dict[str, int] = {}
-
-              for example_dir in os.listdir(f"{parent_dir}/examples"):
-                  path = f"{parent_dir}/examples/{example_dir}"
-
-                  if not os.path.isdir(path):
-                      continue
-
-                  matches = glob.glob(f"{parent_dir}/examples/{example_dir}/dist/index*.wasm")
-
-                  if not matches:
-                      continue
-
-                  path = matches[0]
-
-                  example_sizes[example_dir] = os.path.getsize(path)
-
-              return example_sizes
-
-          master_sizes = find_example_sizes("yew-master")
-          pr_sizes = find_example_sizes("current-pr")
-
-          example_names = sorted(set([*master_sizes.keys(), *pr_sizes.keys()]))
-
-          joined_sizes = [(i, [master_sizes.get(i), pr_sizes.get(i)]) for i in example_names]
-
-          size_cmp_info = {
-              "sizes": joined_sizes,
-              "issue_number": ${{ github.event.number }},
-          }
-
-          with open(".SIZE_CMP_INFO", "w+") as f:
-              f.write(json.dumps(size_cmp_info))
-
-        shell: python3 {0}
+        run: python3 current-pr/ci/collect_sizes.py
+        env:
+          ISSUE_NUMBER: ${{ github.event.number }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/ci/collect_sizes.py
+++ b/ci/collect_sizes.py
@@ -1,0 +1,40 @@
+from typing import Dict, List, Optional
+
+import glob
+import os
+import json
+
+def find_example_sizes(parent_dir: str) -> Dict[str, int]:
+    example_sizes: Dict[str, int] = {}
+
+    for example_dir in os.listdir(f"{parent_dir}/examples"):
+        path = f"{parent_dir}/examples/{example_dir}"
+
+        if not os.path.isdir(path):
+            continue
+
+        matches = glob.glob(f"{parent_dir}/examples/{example_dir}/dist/index*.wasm")
+
+        if not matches:
+            continue
+
+        path = matches[0]
+
+        example_sizes[example_dir] = os.path.getsize(path)
+
+    return example_sizes
+
+master_sizes = find_example_sizes("yew-master")
+pr_sizes = find_example_sizes("current-pr")
+
+example_names = sorted(set([*master_sizes.keys(), *pr_sizes.keys()]))
+
+joined_sizes = [(i, [master_sizes.get(i), pr_sizes.get(i)]) for i in example_names]
+
+size_cmp_info = {
+    "sizes": joined_sizes,
+    "issue_number": os.environ["ISSUE_NUMBER"],
+}
+
+with open(".SIZE_CMP_INFO", "w+") as f:
+    f.write(json.dumps(size_cmp_info))

--- a/website/docs/advanced-topics/optimizations.mdx
+++ b/website/docs/advanced-topics/optimizations.mdx
@@ -120,6 +120,17 @@ opt-level = 'z'
 lto = true
 ```
 
+You can also gain additional benefits from experimental nightly features, avilable with nightly
+rust. To use the nightly toolchain with `trunk`, set the `RUSTUP_TOOLCHAIN="nightly"` environment
+variable. Then, you can toggle unstable rustc features in your `.cargo/config.toml`.
+
+```toml, title=".cargo/config.toml"
+[unstable]
+# Requires the rust-src component. `rustup +nightly component add rust-src`
+build-std = ["std", "panic_abort"]
+build-std-features = ["panic_immediate_abort"]
+```
+
 ### wasm-opt
 
 Further more it is possible to optimize size of `wasm` code.

--- a/website/docs/advanced-topics/optimizations.mdx
+++ b/website/docs/advanced-topics/optimizations.mdx
@@ -120,9 +120,13 @@ opt-level = 'z'
 lto = true
 ```
 
-You can also gain additional benefits from experimental nightly features, avilable with nightly
-rust. To use the nightly toolchain with `trunk`, set the `RUSTUP_TOOLCHAIN="nightly"` environment
-variable. Then, you can toggle unstable rustc features in your `.cargo/config.toml`.
+### Nightly Cargo configuration
+
+You can also gain additional benefits from experimental nightly features of rust and
+cargo. To use the nightly toolchain with `trunk`, set the `RUSTUP_TOOLCHAIN="nightly"` environment
+variable. Then, you can configure unstable rustc features in your `.cargo/config.toml`.
+Refer to the doc of [unstable features], specifically the section about [`build-std`] and
+[`build-std-features`], to understand the configuration.
 
 ```toml, title=".cargo/config.toml"
 [unstable]
@@ -130,6 +134,10 @@ variable. Then, you can toggle unstable rustc features in your `.cargo/config.to
 build-std = ["std", "panic_abort"]
 build-std-features = ["panic_immediate_abort"]
 ```
+
+[unstable features]: https://doc.rust-lang.org/cargo/reference/unstable.html
+[`build-std`]: https://doc.rust-lang.org/cargo/reference/unstable.html#build-std
+[`build-std-features`]: https://doc.rust-lang.org/cargo/reference/unstable.html#build-std-features
 
 ### wasm-opt
 


### PR DESCRIPTION
#### Description

Using the additional unstable nightly features of `build-std` and `build-std-features` can further reduce the size of the wasm.

Document this and use it to compile the example during size comparison.

#### Checklist

- [x] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
