### PR TITLE
Add `use_future` hook to make consuming futures as suspense easier

### DIFF
--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -12,9 +12,9 @@ mod feat_futures {
     /// is the output of the suspension.
     #[hook]
     pub fn use_suspending_future<T, F>(f: F) -> SuspensionResult<T>
-        where
-            T: Clone + 'static,
-            F: Future<Output = T> + 'static,
+    where
+        T: Clone + 'static,
+        F: Future<Output = T> + 'static,
     {
         let output = use_state(|| None);
 

--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -1,7 +1,9 @@
 #[cfg_attr(documenting, doc(cfg(any(target_arch = "wasm32", feature = "tokio"))))]
 #[cfg(any(target_arch = "wasm32", feature = "tokio"))]
 mod feat_futures {
+    use std::fmt;
     use std::future::Future;
+    use std::ops::Deref;
 
     use yew::prelude::*;
     use yew::suspense::{Suspension, SuspensionResult};
@@ -10,22 +12,50 @@ mod feat_futures {
     ///
     /// A [Suspension] is created from the passed future and the result of the future
     /// is the output of the suspension.
+    pub struct UseFutureHandle<O> {
+        inner: UseStateHandle<Option<O>>,
+    }
+
+    impl<O> Deref for UseFutureHandle<O> {
+        type Target = O;
+
+        fn deref(&self) -> &Self::Target {
+            &*self.inner.as_ref().unwrap()
+        }
+    }
+
+    impl<T: fmt::Debug> fmt::Debug for UseFutureHandle<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("UseFutureHandle")
+                .field("value", &format!("{:?}", self.inner))
+                .finish()
+        }
+    }
+
     #[hook]
-    pub fn use_future<T, F>(f: F) -> SuspensionResult<T>
+    pub fn use_future<F, T, O>(f: F) -> SuspensionResult<UseFutureHandle<O>>
     where
-        T: Clone + 'static,
-        F: Future<Output = T> + 'static,
+        F: FnOnce() -> T + 'static,
+        T: Future<Output = O> + 'static,
+        O: 'static,
     {
         let output = use_state(|| None);
 
         let suspension = {
             let output = output.clone();
 
-            use_state(move || Suspension::from_future(async move { output.set(Some(f.await)) }))
+            use_memo(
+                move |_| {
+                    Suspension::from_future(async move {
+                        output.set(Some(f().await));
+                    })
+                },
+                (),
+            )
         };
 
         if suspension.resumed() {
-            Ok((*output).clone().unwrap())
+            Ok(UseFutureHandle { inner: output })
         } else {
             Err((*suspension).clone())
         }

--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -1,0 +1,36 @@
+#[cfg_attr(documenting, doc(cfg(any(target_arch = "wasm32", feature = "tokio"))))]
+#[cfg(any(target_arch = "wasm32", feature = "tokio"))]
+mod feat_futures {
+    use std::future::Future;
+
+    use yew::prelude::*;
+    use yew::suspense::{Suspension, SuspensionResult};
+
+    /// This hook is used to await a future in a suspending context.
+    ///
+    /// A [Suspension] is created from the passed future and the result of the future
+    /// is the output of the suspension.
+    #[hook]
+    pub fn use_suspending_future<T, F>(f: F) -> SuspensionResult<T>
+        where
+            T: Clone + 'static,
+            F: Future<Output = T> + 'static,
+    {
+        let output = use_state(|| None);
+
+        let suspension = {
+            let output = output.clone();
+
+            use_state(move || Suspension::from_future(async move { output.set(Some(f.await)) }))
+        };
+
+        if suspension.resumed() {
+            Ok((*output).clone().unwrap())
+        } else {
+            Err((*suspension).clone())
+        }
+    }
+}
+
+#[cfg(any(target_arch = "wasm32", feature = "tokio"))]
+pub use feat_futures::*;

--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -11,7 +11,7 @@ mod feat_futures {
     /// A [Suspension] is created from the passed future and the result of the future
     /// is the output of the suspension.
     #[hook]
-    pub fn use_suspending_future<T, F>(f: F) -> SuspensionResult<T>
+    pub fn use_future<T, F>(f: F) -> SuspensionResult<T>
     where
         T: Clone + 'static,
         F: Future<Output = T> + 'static,

--- a/packages/yew/src/suspense/mod.rs
+++ b/packages/yew/src/suspense/mod.rs
@@ -1,9 +1,11 @@
 //! This module provides suspense support.
 
 mod component;
+mod hooks;
 mod suspension;
 
 #[cfg(any(feature = "csr", feature = "ssr"))]
 pub(crate) use component::BaseSuspense;
 pub use component::Suspense;
+pub use hooks::*;
 pub use suspension::{Suspension, SuspensionHandle, SuspensionResult};

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -598,7 +598,7 @@ async fn effects_not_run_when_suspended() {
 async fn use_suspending_future_works() {
     #[function_component(Content)]
     fn content() -> HtmlResult {
-        let _sleep_handle = use_future(async move {
+        let _sleep_handle = use_future(|| async move {
             TimeoutFuture::new(50).await;
         })?;
 

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -15,7 +15,7 @@ use gloo::timers::future::TimeoutFuture;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{HtmlElement, HtmlTextAreaElement};
-use yew::suspense::{Suspension, SuspensionResult, use_suspending_future};
+use yew::suspense::{use_suspending_future, Suspension, SuspensionResult};
 
 #[wasm_bindgen_test]
 async fn suspense_works() {
@@ -594,10 +594,8 @@ async fn effects_not_run_when_suspended() {
     assert_eq!(*counter.borrow(), 4); // effects ran 4 times.
 }
 
-
 #[wasm_bindgen_test]
 async fn use_suspending_future_works() {
-
     #[function_component(Content)]
     fn content() -> HtmlResult {
         let _sleep_handle = use_suspending_future(async move {
@@ -634,8 +632,5 @@ async fn use_suspending_future_works() {
     TimeoutFuture::new(50).await;
 
     let result = obtain_result();
-    assert_eq!(
-        result.as_str(),
-        r#"<div>Content</div>"#
-    );
+    assert_eq!(result.as_str(), r#"<div>Content</div>"#);
 }

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -15,7 +15,7 @@ use gloo::timers::future::TimeoutFuture;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{HtmlElement, HtmlTextAreaElement};
-use yew::suspense::{use_suspending_future, Suspension, SuspensionResult};
+use yew::suspense::{use_future, Suspension, SuspensionResult};
 
 #[wasm_bindgen_test]
 async fn suspense_works() {
@@ -598,7 +598,7 @@ async fn effects_not_run_when_suspended() {
 async fn use_suspending_future_works() {
     #[function_component(Content)]
     fn content() -> HtmlResult {
-        let _sleep_handle = use_suspending_future(async move {
+        let _sleep_handle = use_future(async move {
             TimeoutFuture::new(50).await;
         })?;
 

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -15,7 +15,7 @@ use gloo::timers::future::TimeoutFuture;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{HtmlElement, HtmlTextAreaElement};
-use yew::suspense::{Suspension, SuspensionResult};
+use yew::suspense::{Suspension, SuspensionResult, use_suspending_future};
 
 #[wasm_bindgen_test]
 async fn suspense_works() {
@@ -592,4 +592,50 @@ async fn effects_not_run_when_suspended() {
         r#"<div class="content-area"><div class="actual-result">2</div><button class="increase">increase</button><div class="action-area"><button class="take-a-break">Take a break!</button></div></div>"#
     );
     assert_eq!(*counter.borrow(), 4); // effects ran 4 times.
+}
+
+
+#[wasm_bindgen_test]
+async fn use_suspending_future_works() {
+
+    #[function_component(Content)]
+    fn content() -> HtmlResult {
+        let _sleep_handle = use_suspending_future(async move {
+            TimeoutFuture::new(50).await;
+        })?;
+
+        Ok(html! {
+            <div>
+                {"Content"}
+            </div>
+        })
+    }
+
+    #[function_component(App)]
+    fn app() -> Html {
+        let fallback = html! {<div>{"wait..."}</div>};
+
+        html! {
+            <div id="result">
+                <Suspense {fallback}>
+                    <Content />
+                </Suspense>
+            </div>
+        }
+    }
+
+    yew::Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+        .render();
+
+    TimeoutFuture::new(10).await;
+    let result = obtain_result();
+    assert_eq!(result.as_str(), "<div>wait...</div>");
+
+    TimeoutFuture::new(50).await;
+
+    let result = obtain_result();
+    assert_eq!(
+        result.as_str(),
+        r#"<div>Content</div>"#
+    );
 }


### PR DESCRIPTION
#### Description

This PR introduced a new hook, `use_future`, to allow suspending a future and resuming with it's response

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
