### PR TITLE
Allow to consume deps in use_callback hook

### DIFF
--- a/packages/yew/tests/use_callback.rs
+++ b/packages/yew/tests/use_callback.rs
@@ -42,7 +42,7 @@ async fn use_callback_works() {
     fn use_callback_comp() -> Html {
         let state = use_state(|| 0);
 
-        let callback = use_callback(move |name| format!("Hello, {}!", name), ());
+        let callback = use_callback(move |name, _| format!("Hello, {}!", name), ());
 
         use_effect(move || {
             if *state < 5 {

--- a/website/docs/concepts/function-components/hooks/use-callback.mdx
+++ b/website/docs/concepts/function-components/hooks/use-callback.mdx
@@ -37,15 +37,17 @@ fn callback() -> Html {
     // This callback depends on (), so it's created only once, then MyComponent
     // will be rendered only once even when you click the button mutiple times.
     let callback = use_callback(
-        move |name| format!("Hello, {}!", name),
+        move |name, _| format!("Hello, {}!", name),
         ()
     );
 
-    // It can also be used for events.
+    // It can also be used for events, this callback depends on `counter`.
     let oncallback = {
         let counter = counter.clone();
         use_callback(
-            move |_e| (),
+            move |_e, counter| {
+                let _ = **counter;
+            },
             counter
         )
     };


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This pr refactors  `use_callback` hook to allows to consume deps, e.g.
```rust
    let onclick = {
        let counter = counter.clone();
        use_callback(
            move |_e, counter| {
                // Consume the deps `counter` here.
                let _ = **counter;
            },
            counter
        )
    };
```
This is a break change of previous design, the signature of `use_callback` changes from `use_callback(|in_type| {}, deps);` to `use_callback(|in_type, deps| {}, deps);`.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
