### PR TITLE
Fix bubbling of events originating in user shadow dom

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -54,6 +54,7 @@ features = [
   "NodeList",
   "PointerEvent",
   "ProgressEvent",
+  "ShadowRoot",
   "Text",
   "TouchEvent",
   "TransitionEvent",
@@ -81,7 +82,6 @@ trybuild = "1"
 [dev-dependencies.web-sys]
 version = "0.3"
 features = [
-  "ShadowRoot",
   "ShadowRootInit",
   "ShadowRootMode",
 ]


### PR DESCRIPTION
When there is no explicit portal into the shadow, we should bubble up to the host element of the shadow root and continue. This fixes custom elements internally using open shadow DOM.

#### Description
<!-- Please include a summary of the change. -->

Fixes #2624

#### Checklist

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
