### PR TITLE
Fix cargo fmt from merge changes

### DIFF
--- a/packages/yew/src/functional/hooks/use_effect.rs
+++ b/packages/yew/src/functional/hooks/use_effect.rs
@@ -161,7 +161,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// use yew::{function_component, html, Html, Properties, use_effect_with_deps};
+/// use yew::{function_component, html, use_effect_with_deps, Html, Properties};
 /// # use gloo::console::log;
 ///
 /// #[derive(Properties, PartialEq)]
@@ -189,16 +189,15 @@ where
 ///
 /// ## Only on first render
 ///
-/// Provide a empty tuple `()` as dependencies when you need to do something only on the first render
-/// of a component.
+/// Provide a empty tuple `()` as dependencies when you need to do something only on the first
+/// render of a component.
 ///
 /// ```rust
-/// use yew::{function_component, html, Html, use_effect_with_deps};
+/// use yew::{function_component, html, use_effect_with_deps, Html};
 /// # use gloo::console::log;
 ///
 /// #[function_component]
 /// fn HelloWorld() -> Html {
-///
 ///     use_effect_with_deps(
 ///         move |_| {
 ///             log!("I got rendered, yay!");
@@ -217,7 +216,7 @@ where
 /// It will only get called when the component is removed from view / gets destroyed.
 ///
 /// ```rust
-/// use yew::{function_component, html, Html, use_effect_with_deps};
+/// use yew::{function_component, html, use_effect_with_deps, Html};
 /// # use gloo::console::log;
 ///
 /// #[function_component]

--- a/packages/yew/src/functional/hooks/use_force_update.rs
+++ b/packages/yew/src/functional/hooks/use_force_update.rs
@@ -42,10 +42,10 @@ impl UseForceUpdate {
 ///
 /// # Use-case
 ///
-/// Use this hook when wrapping an API that doesn't expose precise subscription events for fetched data.
-/// You could then, at some point, invalidate your local cache of the fetched data and trigger a re-render
-/// to let the normal render flow of components tell you again which data to fetch, and repopulate the
-/// cache accordingly.
+/// Use this hook when wrapping an API that doesn't expose precise subscription events for fetched
+/// data. You could then, at some point, invalidate your local cache of the fetched data and trigger
+/// a re-render to let the normal render flow of components tell you again which data to fetch, and
+/// repopulate the cache accordingly.
 ///
 /// A large externally managed cache, such as a app-wide cache for GraphQL data
 /// should not rerender every component whenever new data arrives, but only those where a query
@@ -56,8 +56,8 @@ impl UseForceUpdate {
 /// # Example
 ///
 /// This example implements a silly, manually updated display of the current time. The component
-/// is re-rendered every time the button is clicked. You should usually use a timeout and `use_state`
-/// to automatically trigger a re-render every second without having to use this hook.
+/// is re-rendered every time the button is clicked. You should usually use a timeout and
+/// `use_state` to automatically trigger a re-render every second without having to use this hook.
 ///
 /// ```rust
 /// use yew::prelude::*;

--- a/packages/yew/src/functional/hooks/use_ref.rs
+++ b/packages/yew/src/functional/hooks/use_ref.rs
@@ -25,11 +25,12 @@ impl<T: 'static, F: FnOnce() -> T> Hook for UseMutRef<F> {
 ///
 /// # Example
 /// ```rust
-/// use yew::prelude::*;
-/// use web_sys::HtmlInputElement;
-/// use std::rc::Rc;
 /// use std::cell::RefCell;
 /// use std::ops::{Deref, DerefMut};
+/// use std::rc::Rc;
+///
+/// use web_sys::HtmlInputElement;
+/// use yew::prelude::*;
 ///
 /// #[function_component(UseRef)]
 /// fn ref_hook() -> Html {
@@ -79,9 +80,10 @@ where
 /// # Example
 ///
 /// ```rust
-/// use wasm_bindgen::{prelude::Closure, JsCast};
-/// use yew::{function_component, html, use_effect_with_deps, use_node_ref, Html};
+/// use wasm_bindgen::prelude::Closure;
+/// use wasm_bindgen::JsCast;
 /// use web_sys::{Event, HtmlElement};
+/// use yew::{function_component, html, use_effect_with_deps, use_node_ref, Html};
 ///
 /// #[function_component(UseNodeRef)]
 /// pub fn node_ref_hook() -> Html {
@@ -128,9 +130,9 @@ where
 ///
 /// # Tip
 ///
-/// When conditionally rendering elements you can use `NodeRef` in conjunction with `use_effect_with_deps`
-/// to perform actions each time an element is rendered and just before the component where the hook is used in is going to be removed from the
-/// DOM.
+/// When conditionally rendering elements you can use `NodeRef` in conjunction with
+/// `use_effect_with_deps` to perform actions each time an element is rendered and just before the
+/// component where the hook is used in is going to be removed from the DOM.
 #[hook]
 pub fn use_node_ref() -> NodeRef {
     (*use_state(NodeRef::default)).clone()


### PR DESCRIPTION
#### Description

#2630 introduced fmt checking. But the CI checks ran before 12c9ebb0eaa2bcacb4c29b3bc9d3c4ac153fae73 was pushed to master, so didn't pick up the misformatted docs in there. The [CI on master did](https://github.com/yewstack/yew/runs/6117381279?check_suite_focus=true), and failed. This formats also the missed parts of the code base.

#### Checklist

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
