### PR TITLE
Add `VTag::into_children`

### DIFF
--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -304,6 +304,14 @@ impl VTag {
             _ => None,
         }
     }
+    
+    /// Returns the children of this [VTag]
+    pub fn into_children(self) -> VList {
+        match self.inner {
+            VTagInner::Other { children, .. } => children,
+            _ => VList::new(),
+        }
+    }
 
     /// Returns the `value` of an
     /// [InputElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) or

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -304,7 +304,7 @@ impl VTag {
             _ => None,
         }
     }
-    
+
     /// Returns the children of this [VTag]
     pub fn into_children(self) -> VList {
         match self.inner {

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -297,7 +297,7 @@ impl VTag {
     }
 
     /// Returns a mutable reference to the children of this [VTag], if the node can have
-    // children
+    /// children
     pub fn children_mut(&mut self) -> Option<&mut VList> {
         match &mut self.inner {
             VTagInner::Other { children, .. } => Some(children),


### PR DESCRIPTION
Currently, VTag supports `children` and `children_mut`, but not `into_children` to complete the pattern. This is useful if someone wishes to destructively acquire the children of a VTag to reparent them to a different VTag.

#### Checklist

- [ ] I have run `cargo make pr-flow`
- [x] I have reviewed my own code
- [ ] I have added tests

I've made this edit entirely through github without ever pulling the code, so no `cargo make pr-flow` has been run. I don't see any tests for the original `children` and `children_mut` methods, so they are presumably not considered required?