### PR TITLE
Repair document comment on `VTag::children_mut`

### DIFF
--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -297,7 +297,7 @@ impl VTag {
     }
 
     /// Returns a mutable reference to the children of this [VTag], if the node can have
-    // children
+    /// children
     pub fn children_mut(&mut self) -> Option<&mut VList> {
         match &mut self.inner {
             VTagInner::Other { children, .. } => Some(children),


### PR DESCRIPTION
I noticed a missing `/` on this document comment while working on https://github.com/yewstack/yew/pull/2638