### PR TITLE
Fix cargo make config and tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,6 @@ Fixes #0000 <!-- replace with issue number or remove if not applicable -->
 
 <!-- For further details, please read CONTRIBUTING.md -->
 
-- [ ] I have run `cargo make pr-flow`
 - [ ] I have reviewed my own code
 - [ ] I have added tests
   <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -176,6 +176,12 @@ jobs:
           command: test
           args: --all-targets --workspace --exclude yew --exclude website-test
 
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-targets --workspace --exclude yew --exclude website-test
+
 
 
   test-lints:

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -87,7 +87,6 @@ jobs:
           sudo apt-get install aspell
           ci/spellcheck.sh list
 
-
       - name: Run doctest
         uses: actions-rs/cargo@v1
         with:
@@ -105,8 +104,6 @@ jobs:
         with:
           command: test
           args: --doc --features doc_test --features wasm_test
-
-
 
   integration_tests:
     name: Integration Tests on ${{ matrix.toolchain }}
@@ -133,7 +130,6 @@ jobs:
           version: "latest"
 
       - uses: Swatinem/rust-cache@v1
-
 
       - name: Run tests - yew
         run: |
@@ -170,19 +166,17 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - name: Run tests
+      - name: Run native tests
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-targets --workspace --exclude yew --exclude website-test
 
-      - name: Run tests
+      - name: Run native tests for yew
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-targets --workspace --exclude yew --exclude website-test
-
-
+          args: -p yew --features "csr,ssr,hydration"
 
   test-lints:
     name: Test lints on nightly
@@ -197,7 +191,6 @@ jobs:
           profile: minimal
 
       - uses: Swatinem/rust-cache@v1
-
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,80 +1,90 @@
 ######################
 #
 # public tasks:
-# * lint
-# * lint-release
-# * tests
+# * checks-flow
+#   * lint
+#   * lint-release
+#   * format
+# * test-flow
+#   * test
+#   * doc-test
+#   * website-test
 #
+# packages/yew also contains `clippy-feature-soundness` to ensure everything is fine
 # Run `cargo make --list-all-steps` for more details.
 #
 ######################
 [config]
 min_version = "0.32.4"
+skip_core_tasks = true
 default_to_workspace = false
 
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 CARGO_MAKE_CLIPPY_ARGS = "-- --deny=warnings"
+CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = [
+    "examples/*",
+    "tools/*",
+]
 
 [config.modify_core_tasks]
 private = true
 namespace = "core"
 
+# checks
+
 [tasks.lint]
 category = "Checks"
-description = "Check formatting and run Clippy"
-toolchain = "nightly"
-run_task = { name = ["lint-flow"], fork = true }
-
-[tasks.tests]
-category = "Testing"
-description = "Run all tests"
-env = { CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["**/examples/*", "**/packages/changelog"] }
-run_task = { name = ["test-flow", "doc-test-flow", "ssr-test", "website-test"], fork = true }
-
-[tasks.lint-flow]
-private = true
-workspace = true
-dependencies = ["core::check-format-flow", "core::clippy-flow"]
+description = "Runs clippy"
+command = "cargo"
+args = ["clippy", "--", "--deny=warnings"]
 
 # Needed, because we have some code differences between debug and release builds
 [tasks.lint-release]
 category = "Checks"
-workspace = true
 command = "cargo"
 args = ["clippy", "--all-targets", "--release", "--", "--deny=warnings"]
 
-[tasks.test-flow]
-private = true
-workspace = true
-dependencies = ["test"]
+[tasks.format]
+category = "Checks"
+toolchain = "nightly"
+env = { CARGO_MAKE_RUST_CHANNEL = "nightly" }
+
+
+[tasks.checks-flow]
+category = "Checks"
+description = "Runs clippy in debug and release mode and format all the code"
+run_task = { name = ["lint", "lint-release", "format"], fork = true }
+
+# Tests
 
 [tasks.test]
-private = true
 command = "cargo"
 args = ["test", "--all-targets"]
-
-[tasks.doc-test-flow]
-private = true
 workspace = true
-dependencies = ["doc-test"]
 
 [tasks.doc-test]
-private = true
 command = "cargo"
-args = ["test", "--doc"]
+args = ["test", "--doc", "--all-features"]
+workspace = true
 
 [tasks.website-test]
 command = "cargo"
 args = ["test", "-p", "website-test"]
 
+[tasks.test-flow]
+category = "Testing"
+description = "Run all tests"
+run_task = { name = ["test", "doc-test", "website-test"], fork = true, parallel = true }
+
+# misc
+
 [tasks.generate-change-log]
 category = "Maintainer processes"
 toolchain = "stable"
 command = "cargo"
-args = ["run","-p","changelog", "--release", "${@}"]
+args = ["run", "-p", "changelog", "--release", "${@}"]
 
-[tasks.ssr-test]
-env = { CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS = ["**/packages/yew"] }
-private = true
-workspace = true
+[tasks.default]
+#run_task = { name = ["checks-flow", "test-flow"], fork = true }
+dependencies = ["checks-flow", "test-flow"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,7 +1,6 @@
 ######################
 #
 # public tasks:
-# * pr-flow
 # * lint
 # * lint-release
 # * tests
@@ -20,12 +19,6 @@ CARGO_MAKE_CLIPPY_ARGS = "-- --deny=warnings"
 [config.modify_core_tasks]
 private = true
 namespace = "core"
-
-[tasks.pr-flow]
-toolchain = "stable"
-category = "Checks"
-description = "Lint and test"
-run_task = { name = ["lint", "lint-release", "tests"], fork = true }
 
 [tasks.lint]
 category = "Checks"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -29,7 +29,6 @@ run_task = { name = ["lint-flow"], fork = true }
 [tasks.tests]
 category = "Testing"
 description = "Run all tests"
-dependencies = ["tests-setup"]
 env = { CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["**/examples/*", "**/packages/changelog"] }
 run_task = { name = ["test-flow", "doc-test-flow", "ssr-test", "website-test"], fork = true }
 
@@ -44,22 +43,6 @@ category = "Checks"
 workspace = true
 command = "cargo"
 args = ["clippy", "--all-targets", "--release", "--", "--deny=warnings"]
-
-[tasks.tests-setup]
-private = true
-script_runner = "@duckscript"
-script = [
-    """
-    test_flags = array --headless --firefox
-    yew_test_features = set wasm_test
-
-    yew_test_flags = array_join ${test_flags} " "
-    echo "running tests with flags: ${yew_test_flags} and features: ${yew_test_features}"
-
-    set_env YEW_TEST_FLAGS ${yew_test_flags}
-    set_env YEW_TEST_FEATURES ${yew_test_features}
-    """,
-]
 
 [tasks.test-flow]
 private = true

--- a/packages/yew-macro/Makefile.toml
+++ b/packages/yew-macro/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.test]
 clear = true
-toolchain = ""
+toolchain = "1.56.0"
 command = "cargo"
 # test target can be optionally specified like `cargo make test html_macro`,
 args = ["test", "${@}"]
@@ -9,7 +9,7 @@ args = ["test", "${@}"]
 clear = true
 toolchain = "nightly"
 command = "cargo"
-args = ["test test_html_lints --features lints"]
+args = ["test", "test_html_lints", "--features", "lints"]
 
 [tasks.test-overwrite]
 extend = "test"

--- a/packages/yew-router-macro/Makefile.toml
+++ b/packages/yew-router-macro/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.test]
 clear = true
-toolchain = "1.56"
+toolchain = "1.56.0"
 command = "cargo"
 args = ["test"]
 

--- a/packages/yew-router/Makefile.toml
+++ b/packages/yew-router/Makefile.toml
@@ -1,5 +1,4 @@
 [tasks.test]
-extend = "wasm-pack-base"
 command = "wasm-pack"
 args = [
     "test",

--- a/packages/yew-router/Makefile.toml
+++ b/packages/yew-router/Makefile.toml
@@ -1,10 +1,8 @@
 [tasks.test]
-extend = "core::wasm-pack-base"
+# if wasm-pack is not installed, install it from https://rustwasm.github.io/wasm-pack/
 command = "wasm-pack"
 args = [
     "test",
-    "@@split(YEW_TEST_FLAGS, )",
-    "--",
-    "--features",
-    "${YEW_TEST_FEATURES}",
+    "--firefox",
+    "--headless",
 ]

--- a/packages/yew-router/Makefile.toml
+++ b/packages/yew-router/Makefile.toml
@@ -1,5 +1,5 @@
 [tasks.test]
-# if wasm-pack is not installed, install it from https://rustwasm.github.io/wasm-pack/
+extend = "wasm-pack-base"
 command = "wasm-pack"
 args = [
     "test",

--- a/packages/yew/Makefile.toml
+++ b/packages/yew/Makefile.toml
@@ -1,11 +1,10 @@
 [tasks.native-test]
 command = "cargo"
-toolchain = "1.56"
-args = ["test", "native_"]
+args = ["test", "--features", "csr,ssr,hydration"]
 
 [tasks.test]
 dependencies = ["native-test"]
-extend = "core::wasm-pack-base"
+# if wasm-pack is not installed, install it from https://rustwasm.github.io/wasm-pack/
 command = "wasm-pack"
 args = [
     "test",

--- a/packages/yew/Makefile.toml
+++ b/packages/yew/Makefile.toml
@@ -2,9 +2,8 @@
 command = "cargo"
 args = ["test", "--features", "csr,ssr,hydration"]
 
-[tasks.test]
-dependencies = ["native-test"]
-# if wasm-pack is not installed, install it from https://rustwasm.github.io/wasm-pack/
+[tasks.wasm-test]
+extend = "wasm-pack-base"
 command = "wasm-pack"
 args = [
     "test",
@@ -14,6 +13,9 @@ args = [
     "--features",
     "wasm_test"
 ]
+
+[tasks.test]
+dependencies = ["native-test", "wasm-test"]
 
 [tasks.doc-test]
 clear = true

--- a/packages/yew/Makefile.toml
+++ b/packages/yew/Makefile.toml
@@ -8,10 +8,11 @@ dependencies = ["native-test"]
 command = "wasm-pack"
 args = [
     "test",
-    "@@split(YEW_TEST_FLAGS, )",
+    "--firefox",
+    "--headless",
     "--",
     "--features",
-    "${YEW_TEST_FEATURES}",
+    "wasm_test"
 ]
 
 [tasks.doc-test]

--- a/packages/yew/Makefile.toml
+++ b/packages/yew/Makefile.toml
@@ -3,7 +3,6 @@ command = "cargo"
 args = ["test", "--features", "csr,ssr,hydration"]
 
 [tasks.wasm-test]
-extend = "wasm-pack-base"
 command = "wasm-pack"
 args = [
     "test",
@@ -14,25 +13,12 @@ args = [
     "wasm_test"
 ]
 
-[tasks.test]
-dependencies = ["native-test", "wasm-test"]
-
-[tasks.doc-test]
-clear = true
-run_task = { name = ["doc-test-normal"], fork = true }
-
-[tasks.doc-test-normal]
-command = "cargo"
-args = [
-    "test",
-    "--doc",
-    "--features",
-    "tokio,doc_test,wasm_test",
-]
-
 [tasks.ssr-test]
 command = "cargo"
 args = ["test", "ssr_tests", "--features", "ssr"]
+
+[tasks.test]
+dependencies = ["native-test", "wasm-test"]
 
 [tasks.clippy-feature-soundness]
 script = '''
@@ -50,6 +36,3 @@ cargo clippy --release --features=csr -- --deny=warnings
 cargo clippy --release --features=hydration -- --deny=warnings
 cargo clippy --release --all-features --all-targets -- --deny=warnings
 '''
-
-[tasks.lint-flow]
-dependencies = ["clippy-feature-soundness"]

--- a/packages/yew/src/dom_bundle/blist.rs
+++ b/packages/yew/src/dom_bundle/blist.rs
@@ -500,7 +500,7 @@ mod feat_hydration {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "wasm_test"))]
 mod layout_tests {
     extern crate self as yew;
 
@@ -510,7 +510,6 @@ mod layout_tests {
     use crate::html;
     use crate::tests::layout_tests::{diff_layouts, TestLayout};
 
-    #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[test]
@@ -578,7 +577,7 @@ mod layout_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "wasm_test"))]
 mod layout_tests_keys {
     extern crate self as yew;
 
@@ -590,7 +589,6 @@ mod layout_tests_keys {
     use crate::virtual_dom::VNode;
     use crate::{html, Children, Component, Context, Html, Properties};
 
-    #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
 
     struct Comp {}

--- a/packages/yew/src/dom_bundle/bnode.rs
+++ b/packages/yew/src/dom_bundle/bnode.rs
@@ -289,7 +289,7 @@ mod feat_hydration {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "wasm_test"))]
 mod layout_tests {
     #[cfg(feature = "wasm_test")]
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
@@ -297,7 +297,6 @@ mod layout_tests {
     use super::*;
     use crate::tests::layout_tests::{diff_layouts, TestLayout};
 
-    #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[test]

--- a/packages/yew/src/dom_bundle/bportal.rs
+++ b/packages/yew/src/dom_bundle/bportal.rs
@@ -116,7 +116,7 @@ impl BPortal {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "wasm_test"))]
 mod layout_tests {
     extern crate self as yew;
 
@@ -128,7 +128,6 @@ mod layout_tests {
     use crate::tests::layout_tests::{diff_layouts, TestLayout};
     use crate::virtual_dom::VNode;
 
-    #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[test]

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -1038,7 +1038,11 @@ mod tests_without_browser {
                     <div class="foo" />
                 }
             },
-            html! { <div class="foo" /> },
+            html! {
+                <>
+                    <div class="foo" />
+                </>
+            },
         );
         assert_eq!(
             html! {
@@ -1049,7 +1053,7 @@ mod tests_without_browser {
                 }
             },
             html! {
-                <div class="bar" />
+                <><div class="bar" /></>
             },
         );
         assert_eq!(
@@ -1058,7 +1062,9 @@ mod tests_without_browser {
                     <div class="foo" />
                 }
             },
-            html! {},
+            html! {
+                <></>
+            },
         );
 
         // non-root tests
@@ -1072,7 +1078,7 @@ mod tests_without_browser {
             },
             html! {
                 <div>
-                    <div class="foo" />
+                    <><div class="foo" /></>
                 </div>
             },
         );
@@ -1088,7 +1094,7 @@ mod tests_without_browser {
             },
             html! {
                 <div>
-                    <div class="bar" />
+                    <><div class="bar" /></>
                 </div>
             },
         );
@@ -1118,7 +1124,11 @@ mod tests_without_browser {
                     <div class={class} />
                 }
             },
-            html! { <div class="foo" /> },
+            html! {
+                <>
+                    <div class={Some("foo")} />
+                </>
+            },
         );
         assert_eq!(
             html! {
@@ -1128,7 +1138,11 @@ mod tests_without_browser {
                     <div class="bar" />
                 }
             },
-            html! { <div class="bar" /> },
+            html! {
+                <>
+                    <div class="bar" />
+                </>
+            },
         );
         assert_eq!(
             html! {
@@ -1136,7 +1150,9 @@ mod tests_without_browser {
                     <div class={class} />
                 }
             },
-            html! {},
+            html! {
+                <></>
+            },
         );
 
         // non-root tests
@@ -1148,7 +1164,13 @@ mod tests_without_browser {
                     }
                 </div>
             },
-            html! { <div><div class="foo" /></div> },
+            html! {
+                <div>
+                    <>
+                        <div class={Some("foo")} />
+                    </>
+                </div>
+            },
         );
         assert_eq!(
             html! {
@@ -1160,7 +1182,13 @@ mod tests_without_browser {
                     }
                 </div>
             },
-            html! { <div><div class="bar" /></div> },
+            html! {
+                <div>
+                    <>
+                        <div class="bar" />
+                    </>
+                </div>
+            },
         );
         assert_eq!(
             html! {

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -931,7 +931,7 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "wasm_test"))]
 mod layout_tests {
     extern crate self as yew;
 
@@ -941,7 +941,6 @@ mod layout_tests {
     use crate::html;
     use crate::tests::layout_tests::{diff_layouts, TestLayout};
 
-    #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[test]

--- a/packages/yew/src/dom_bundle/btext.rs
+++ b/packages/yew/src/dom_bundle/btext.rs
@@ -175,7 +175,7 @@ mod test {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "wasm_test"))]
 mod layout_tests {
     extern crate self as yew;
 
@@ -185,7 +185,6 @@ mod layout_tests {
     use crate::html;
     use crate::tests::layout_tests::{diff_layouts, TestLayout};
 
-    #[cfg(feature = "wasm_test")]
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[test]

--- a/packages/yew/src/tests/layout_tests.rs
+++ b/packages/yew/src/tests/layout_tests.rs
@@ -1,3 +1,6 @@
+//! Snapshot testing of Yew components
+//!
+//! This tests must be run in browser and thus require the `csr` feature to be enabled
 use gloo::console::log;
 use yew::NodeRef;
 

--- a/packages/yew/src/tests/mod.rs
+++ b/packages/yew/src/tests/mod.rs
@@ -1,1 +1,3 @@
+#[cfg(feature = "csr")]
+#[cfg_attr(documenting, doc(cfg(feature = "csr")))]
 pub mod layout_tests;


### PR DESCRIPTION
## Description

This PR:
- Removes `cargo make pr-flow`
- Updates cargo make config to be more user-friendly
- Runs test that were never, ever run

Fixes #2637
Fixes #2403 

## cargo-make config

 * `checks-flow`
   * `lint`
   * `lint-release`
   * `format`
 * `test-flow`
   * `test`
   * `doc-test`
   * `website-test`

 `packages/yew` also contains `clippy-feature-soundness` to ensure features are used properly