### PR TITLE
Fix Size Comparison

### DIFF
--- a/.github/workflows/post-size-cmp.yml
+++ b/.github/workflows/post-size-cmp.yml
@@ -23,53 +23,11 @@ jobs:
           name: size-cmp-info
           path: "size-cmp-info/"
 
+      - name: Download Repository
+        uses: actions/checkout@v2
+
       - name: Make pull request comment
-        run: |
-          from typing import Dict, List, Optional
-
-          import os
-          import json
-
-          with open("size-cmp-info/.SIZE_CMP_INFO") as f:
-              content = json.loads(f.read())
-
-          joined_sizes = content["sizes"]
-          issue_number = content["issue_number"]
-
-          lines: List[str] = []
-
-          lines.append("### Size Comparison")
-          lines.append("")
-          lines.append("| examples | master (KB) | pull request (KB) | diff |")
-          lines.append("| --- | --- | --- | --- | ")
-
-          for (i, sizes) in joined_sizes:
-              (master_size, pr_size) = sizes
-              diff: Optional[int] = None
-
-              if master_size is not None and pr_size is not None:
-                  diff = pr_size - master_size
-
-              master_size_str = "N/A" if master_size is None else (
-                  f"{master_size / 1024:.3f}" if master_size != 0 else "0"
-              )
-              pr_size_str = "N/A" if pr_size is None else (
-                  f"{pr_size / 1024:.3f}" if pr_size != 0 else "0"
-              )
-              diff_str = "N/A" if diff is None else (
-                  f"{diff / 1024:.3f}" if diff < 0 else (
-                      f"+{diff / 1024:.3f}" if diff > 0 else "0"
-                  )
-              )
-              lines.append(f"| {i} | {master_size_str} | {pr_size_str} | {diff_str} |")
-
-          output = "\n".join(lines)
-
-          with open(os.environ["GITHUB_ENV"], "a+") as f:
-              f.write(f"YEW_EXAMPLE_SIZES={json.dumps(output)}\n")
-              f.write(f"PR_NUMBER={issue_number}\n")
-
-        shell: python3 {0}
+        run: python3 ci/make_example_size_cmt.py
 
       - name: Post Comment
         uses: actions/github-script@v6

--- a/ci/collect_sizes.py
+++ b/ci/collect_sizes.py
@@ -15,13 +15,18 @@ def find_example_sizes(parent_dir: Path) -> Dict[str, int]:
             print(f"{example_dir} is not a directory.")
             continue
 
-        try:
-            wasm_path = next((example_dir / "dist").glob(f"{example_dir.name}*.wasm"))
+        total_size = 0
 
-        except StopIteration:
-            continue
+        # For examples with multiple bundles, we add them together.
+        for bundle in (example_dir / "dist").glob(f"*.wasm"):
+            size = bundle.stat().st_size
 
-        example_sizes[example_dir.name] = wasm_path.stat().st_size
+            print(f"{bundle} has a size of {size}.")
+
+            total_size += size
+
+        if total_size > 0:
+            example_sizes[example_dir.name] = total_size
 
     return example_sizes
 

--- a/ci/collect_sizes.py
+++ b/ci/collect_sizes.py
@@ -16,7 +16,7 @@ def find_example_sizes(parent_dir: Path) -> Dict[str, int]:
             continue
 
         try:
-            wasm_path = next(example_dir.glob("dist/*.wasm"))
+            wasm_path = next((example_dir / "dist").glob(f"{example_dir.name}*.wasm"))
 
         except StopIteration:
             continue

--- a/ci/make_example_size_cmt.py
+++ b/ci/make_example_size_cmt.py
@@ -1,0 +1,88 @@
+from typing import Dict, List, Optional, Tuple
+
+import os
+import json
+
+
+header = "| examples | master (KB) | pull request (KB) | diff |"
+sep = "| --- | --- | --- | --- | "
+
+
+def format_size(size: Optional[int]) -> str:
+    if size is None:
+        return "N/A"
+
+    if size == 0:
+        return "0"
+
+    return f"{size / 1024:.3f}"
+
+
+def format_diff_size(
+    master_size: Optional[int], pr_size: Optional[int]
+) -> Tuple[str, bool]:
+    if master_size is None or pr_size is None:
+        return ("N/A", False)
+
+    diff = pr_size - master_size
+
+    if diff == 0:
+        return ("0", False)
+
+    diff_percent = master_size / diff
+
+    return (f"{diff / 1024:+.3f}({diff_percent:+.3%})", abs(diff_percent) > 0.01)
+
+
+def main() -> None:
+    with open("size-cmp-info/.SIZE_CMP_INFO") as f:
+        content = json.loads(f.read())
+
+    joined_sizes = content["sizes"]
+    issue_number = content["issue_number"]
+
+    lines: List[str] = []
+    significant_lines: List[str] = []
+
+    lines.append("### Size Comparison")
+    lines.append("")
+    lines.append("<details>")
+    lines.append(header)
+    lines.append(sep)
+
+    for (i, sizes) in joined_sizes:
+        (master_size, pr_size) = sizes
+
+        master_size_str = format_size(master_size)
+        pr_size_str = format_size(pr_size)
+
+        (diff_str, diff_significant) = format_diff_size(master_size, pr_size)
+
+        line_str = f"| {i} | {master_size_str} | {pr_size_str} | {diff_str} |"
+
+        lines.append(line_str)
+
+        if diff_significant:
+            significant_lines.append(line_str)
+
+    lines.append("")
+    lines.append("</details>")
+
+    if significant_lines:
+        lines.append("")
+        lines.append("⚠️ The following examples have changed their size significantly:")
+        lines.append("")
+
+        lines.append(header)
+        lines.append(sep)
+        lines.extend(significant_lines)
+
+    output = "\n".join(lines)
+
+    with open(os.environ["GITHUB_ENV"], "a+") as f:
+        f.write(f"YEW_EXAMPLE_SIZES={json.dumps(output)}\n")
+        f.write(f"PR_NUMBER={issue_number}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/make_example_size_cmt.py
+++ b/ci/make_example_size_cmt.py
@@ -29,7 +29,7 @@ def format_diff_size(
     if diff == 0:
         return ("0", False)
 
-    diff_percent = master_size / diff
+    diff_percent = diff / master_size
 
     return (f"{diff / 1024:+.3f}({diff_percent:+.3%})", abs(diff_percent) > 0.01)
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

As of Trunk 0.15, `wasm` bundles now do not have a prefix of `index-` any more.

Also fixes the following from #2541 (may not reflect until this pull request is merged):

- Make the comment collapsable
- Show difference in percentage as well
- Show a summary and warns if any example has received a substantial increase.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
