### PR TITLE
Only approve if PR is not draft

### DIFF
--- a/.github/workflows/auto-approve-maintainer-pr.yml
+++ b/.github/workflows/auto-approve-maintainer-pr.yml
@@ -5,6 +5,7 @@ on: pull_request_target
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Check if organization member
         id: is_organization_member


### PR DESCRIPTION
#### Description

It can get really spam-y when draft PRs get auto approved on every commit. Disable that

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
