### PR TITLE
Change access to VList children to a wrapper

### DIFF
--- a/examples/futures/src/markdown.rs
+++ b/examples/futures/src/markdown.rs
@@ -53,31 +53,34 @@ pub fn render_markdown(src: &str) -> Html {
                     pre.add_child(top.into());
                     top = pre;
                 } else if let Tag::Table(aligns) = tag {
-                    for r in top.children_mut().iter_mut().flat_map(|ch| ch.iter_mut()) {
-                        if let VNode::VTag(ref mut vtag) = r {
-                            for (i, c) in vtag
-                                .children_mut()
-                                .iter_mut()
-                                .flat_map(|ch| ch.iter_mut())
-                                .enumerate()
-                            {
-                                if let VNode::VTag(ref mut vtag) = c {
-                                    match aligns[i] {
-                                        Alignment::None => {}
-                                        Alignment::Left => add_class(vtag, "text-left"),
-                                        Alignment::Center => add_class(vtag, "text-center"),
-                                        Alignment::Right => add_class(vtag, "text-right"),
+                    if let Some(top_children) = top.children_mut() {
+                        for r in top_children.children_mut().iter_mut() {
+                            if let VNode::VTag(ref mut vtag) = r {
+                                if let Some(vtag_children) = vtag.children_mut() {
+                                    for (i, c) in
+                                        vtag_children.children_mut().iter_mut().enumerate()
+                                    {
+                                        if let VNode::VTag(ref mut vtag) = c {
+                                            match aligns[i] {
+                                                Alignment::None => {}
+                                                Alignment::Left => add_class(vtag, "text-left"),
+                                                Alignment::Center => add_class(vtag, "text-center"),
+                                                Alignment::Right => add_class(vtag, "text-right"),
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
                     }
                 } else if let Tag::TableHead = tag {
-                    for c in top.children_mut().iter_mut().flat_map(|ch| ch.iter_mut()) {
-                        if let VNode::VTag(ref mut vtag) = c {
-                            // TODO
-                            //                            vtag.tag = "th".into();
-                            vtag.add_attribute("scope", "col");
+                    if let Some(top_children) = top.children_mut() {
+                        for c in top_children.children_mut().iter_mut() {
+                            if let VNode::VTag(ref mut vtag) = c {
+                                // TODO
+                                //                            vtag.tag = "th".into();
+                                vtag.add_attribute("scope", "col");
+                            }
                         }
                     }
                 }

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -32,6 +32,7 @@ impl Deref for VList {
 /// Mutable children of a [VList].
 ///
 /// This struct has a `DerefMut` implementations into [`Vec<VNode>`](std::vec::Vec).
+/// Prefer to use immutable access, since this re-checks if all nodes have keys when dropped.
 pub struct ChildrenMut<'a> {
     children: &'a mut Vec<VNode>,
     fully_keyed: &'a mut bool,
@@ -110,16 +111,6 @@ impl VList {
             children: &mut self.children,
             fully_keyed: &mut self.fully_keyed,
         }
-    }
-
-    /// Recheck, if the all the children have keys.
-    ///
-    /// Run this, after modifying the child list that contained only keyed children prior to the
-    /// mutable dereference.
-    pub fn recheck_fully_keyed(&mut self) {
-        let mut iter = self.children_mut();
-        let _ = iter.deref_mut(); // pretend we access it
-        drop(iter); // The drop implementation will do the check
     }
 }
 

--- a/tools/changelog/Cargo.toml
+++ b/tools/changelog/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 chrono = "0.4"
-git2 = "0.14"
+git2 = "=0.14.2" # see https://github.com/rust-lang/git2-rs/issues/838 fixed with MSRV 1.60
 regex = "1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
#### Description

Fixes #2654

As a response to the confusion in #2654, restrict mutable access to the children of a `VList` to a wrapper that takes care of recomputing `fully_keyed` automatically.

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
