### PR TITLE
yew.rs/api redirect for api.yew.rs and use website the in the website navbar api.yew.rs

### DIFF
--- a/website/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/website/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -18,7 +18,7 @@ export default function DefaultNavbarItem(props) {
     if (props.label === API_BUTTON) {
         const href =
             version === 'next'
-                ? 'https://yew-rs-api.web.app/next/yew'
+                ? 'https://api.yew.rs/next/yew'
                 : `https://docs.rs/yew/${version}`
         return <OriginalNavbarItem {...props} href={href} />
     }


### PR DESCRIPTION
#### Description

This PR:
- Adds a `yew.rs/api` redirect for `api.yew.rs` using [dynamic-links](https://firebase.google.com/docs/dynamic-links/custom-domains)
- Uses website the in the website navbar `api.yew.rs`

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
