### PR TITLE
Actually add a yew.rs/api redirect for api.yew.rs

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -4,7 +4,13 @@
       "target": "website",
       "public": "website/build/",
       "cleanUrls": true,
-      "redirects": []
+      "redirects": [],
+      "rewrites": [
+        {
+          "source": "/api/**",
+          "dynamicLinks": true
+        }
+      ]
     },
     {
       "target": "api",


### PR DESCRIPTION
#### Description

This PR: Adds a yew.rs/api redirect for api.yew.rs that was supposed to be in https://github.com/yewstack/yew/pull/2676

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
