### PR TITLE
Fix: boids and password_strength deployment

### DIFF
--- a/ci/build-examples.sh
+++ b/ci/build-examples.sh
@@ -2,8 +2,9 @@
 # yew $ ./ci/build-examples.sh
 
 output="$(pwd)/dist"
-mkdir "$output"
+mkdir -p "$output"
 
+failure=false
 for path in examples/*; do
   if [[ ! -d $path ]]; then
     continue
@@ -16,13 +17,32 @@ for path in examples/*; do
     continue
   fi
 
-  echo "building: $example"
-  (
+  echo "::group::Building $example"
+  if ! (
+    set -e
     # we are sure that $path exists
     # shellcheck disable=SC2164
     cd "$path"
     dist_dir="$output/$example"
+    if [[ "$example" == "boids" || "$example" == "password_strength" ]]; then
+      # works around issue rust-lang/rust#96486
+      # where the compiler forgets to link some symbols connected to const_eval
+      # only an issue on nightly and with build-std enabled which we do for code size
+      # this deoptimizes only the examples that otherwise fail to build
+      export RUSTFLAGS="-Zshare-generics=n -Clto=thin"
+    fi
 
     trunk build --release --dist "$dist_dir" --public-url "$PUBLIC_URL_PREFIX$example"
-  )
+
+    # check that there are no undefined symbols. Those generate an import .. from 'env',
+    # which isn't available in the browser.
+    { cat "$dist_dir"/*.js | grep -q -e "from 'env'" ; } && exit 1 || true
+  ) ; then
+    echo "::error ::$example failed to build"
+    failure=true
+  fi
+  echo "::endgroup::"
 done
+if [ "$failure" = true ] ; then
+    exit 1
+fi

--- a/website/docs/advanced-topics/optimizations.mdx
+++ b/website/docs/advanced-topics/optimizations.mdx
@@ -139,6 +139,11 @@ build-std-features = ["panic_immediate_abort"]
 [`build-std`]: https://doc.rust-lang.org/cargo/reference/unstable.html#build-std
 [`build-std-features`]: https://doc.rust-lang.org/cargo/reference/unstable.html#build-std-features
 
+:::caution
+The nightly rust compiler can contain bugs, such as [this one](https://github.com/yewstack/yew/issues/2696),
+that require occasional attention and tweaking. Use these experimental options with care.
+:::
+
 ### wasm-opt
 
 Further more it is possible to optimize size of `wasm` code.


### PR DESCRIPTION
#### Description

Two examples currently fail to deploy correctly, since they are left with undefined symbols, due to rust-lang/rust#96486.
This contains a workaround for the problem, which slightly increases the wasm size, but at least makes them run.

Fixes [a comment on discord](https://discord.com/channels/701068342760570933/701068343431528490/976368104210845706)
Fixes #2696

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
