### PR TITLE
Span hygene and editor UX

### DIFF
--- a/examples/counter_functional/src/main.rs
+++ b/examples/counter_functional/src/main.rs
@@ -1,7 +1,7 @@
 use yew::prelude::*;
 
-#[function_component(App)]
-fn app() -> Html {
+#[function_component]
+fn App() -> Html {
     let state = use_state(|| 0);
 
     let incr_counter = {

--- a/packages/yew-macro/src/html_tree/html_component.rs
+++ b/packages/yew-macro/src/html_tree/html_component.rs
@@ -18,6 +18,7 @@ pub struct HtmlComponent {
     ty: Type,
     props: ComponentProps,
     children: HtmlChildrenTree,
+    close: Option<HtmlComponentClose>,
 }
 
 impl PeekValue<()> for HtmlComponent {
@@ -47,6 +48,7 @@ impl Parse for HtmlComponent {
                 ty: open.ty,
                 props: open.props,
                 children: HtmlChildrenTree::new(),
+                close: None,
             });
         }
 
@@ -67,7 +69,7 @@ impl Parse for HtmlComponent {
             children.parse_child(input)?;
         }
 
-        input.parse::<HtmlComponentClose>()?;
+        let close = input.parse::<HtmlComponentClose>()?;
 
         if !children.is_empty() {
             if let Some(children_prop) = open.props.children() {
@@ -82,6 +84,7 @@ impl Parse for HtmlComponent {
             ty: open.ty,
             props: open.props,
             children,
+            close: Some(close),
         })
     }
 }
@@ -92,8 +95,10 @@ impl ToTokens for HtmlComponent {
             ty,
             props,
             children,
+            close,
         } = self;
 
+        let ty_span = ty.span().resolved_at(Span::call_site());
         let props_ty = quote_spanned!(ty.span()=> <#ty as ::yew::html::BaseComponent>::Properties);
         let children_renderer = if children.is_empty() {
             None
@@ -119,9 +124,18 @@ impl ToTokens for HtmlComponent {
         } else {
             quote! { ::std::option::Option::None }
         };
+        let use_close_tag = if let Some(close) = close {
+            let close_ty = &close.ty;
+            quote_spanned! {close_ty.span()=>
+                let _ = |_:#close_ty| {};
+            }
+        } else {
+            Default::default()
+        };
 
-        tokens.extend(quote_spanned! {ty.span()=>
+        tokens.extend(quote_spanned! {ty_span=>
             {
+                #use_close_tag
                 let __yew_props = #build_props;
                 ::yew::virtual_dom::VChild::<#ty>::new(__yew_props, #node_ref, #key)
             }
@@ -268,7 +282,7 @@ impl Parse for HtmlComponentOpen {
 
 struct HtmlComponentClose {
     tag: TagTokens,
-    _ty: Type,
+    ty: Type,
 }
 impl HtmlComponentClose {
     fn to_spanned(&self) -> impl ToTokens {
@@ -296,7 +310,7 @@ impl Parse for HtmlComponentClose {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         TagTokens::parse_end_content(input, |input, tag| {
             let ty = input.parse()?;
-            Ok(Self { tag, _ty: ty })
+            Ok(Self { tag, ty })
         })
     }
 }

--- a/packages/yew-macro/src/html_tree/html_component.rs
+++ b/packages/yew-macro/src/html_tree/html_component.rs
@@ -99,7 +99,7 @@ impl ToTokens for HtmlComponent {
         } = self;
 
         let ty_span = ty.span().resolved_at(Span::call_site());
-        let props_ty = quote_spanned!(ty.span()=> <#ty as ::yew::html::BaseComponent>::Properties);
+        let props_ty = quote_spanned!(ty_span=> <#ty as ::yew::html::BaseComponent>::Properties);
         let children_renderer = if children.is_empty() {
             None
         } else {
@@ -110,14 +110,14 @@ impl ToTokens for HtmlComponent {
         let special_props = props.special();
         let node_ref = if let Some(node_ref) = &special_props.node_ref {
             let value = &node_ref.value;
-            quote_spanned! {value.span()=> #value }
+            quote! { #value }
         } else {
             quote! { <::yew::html::NodeRef as ::std::default::Default>::default() }
         };
 
         let key = if let Some(key) = &special_props.key {
             let value = &key.value;
-            quote_spanned! {value.span()=>
+            quote_spanned! {value.span().resolved_at(Span::call_site())=>
                 #[allow(clippy::useless_conversion)]
                 Some(::std::convert::Into::<::yew::virtual_dom::Key>::into(#value))
             }

--- a/packages/yew-macro/src/html_tree/html_node.rs
+++ b/packages/yew-macro/src/html_tree/html_node.rs
@@ -1,5 +1,5 @@
-use proc_macro2::TokenStream;
-use quote::{quote_spanned, ToTokens};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;
@@ -49,7 +49,7 @@ impl ToTokens for HtmlNode {
                 let sr = lit.stringify();
                 quote_spanned! {lit.span()=> ::yew::virtual_dom::VText::new(#sr) }
             }
-            HtmlNode::Expression(expr) => quote_spanned! {expr.span()=> #expr},
+            HtmlNode::Expression(expr) => quote! {#expr},
         });
     }
 }
@@ -60,9 +60,9 @@ impl ToNodeIterator for HtmlNode {
             HtmlNode::Literal(_) => None,
             HtmlNode::Expression(expr) => {
                 // NodeSeq turns both Into<T> and Vec<Into<T>> into IntoIterator<Item = T>
-                Some(
-                    quote_spanned! {expr.span()=> ::std::convert::Into::<::yew::utils::NodeSeq<_, _>>::into(#expr)},
-                )
+                Some(quote_spanned! {expr.span().resolved_at(Span::call_site())=>
+                    ::std::convert::Into::<::yew::utils::NodeSeq<_, _>>::into(#expr)
+                })
             }
         }
     }

--- a/packages/yew-macro/src/html_tree/mod.rs
+++ b/packages/yew-macro/src/html_tree/mod.rs
@@ -181,10 +181,12 @@ impl Parse for HtmlRootVNode {
 impl ToTokens for HtmlRootVNode {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let new_tokens = self.0.to_token_stream();
-        tokens.extend(quote! {{
-            #[allow(clippy::useless_conversion)]
-            <::yew::virtual_dom::VNode as ::std::convert::From<_>>::from(#new_tokens)
-        }});
+        tokens.extend(
+            quote_spanned! {self.0.span().resolved_at(Span::mixed_site())=> {
+                #[allow(clippy::useless_conversion)]
+                <::yew::virtual_dom::VNode as ::std::convert::From<_>>::from(#new_tokens)
+            }},
+        );
     }
 }
 

--- a/packages/yew-macro/src/stringify.rs
+++ b/packages/yew-macro/src/stringify.rs
@@ -1,11 +1,11 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
 use syn::spanned::Spanned;
 use syn::{Expr, Lit, LitStr};
 
 /// Stringify a value at runtime.
 fn stringify_at_runtime(src: impl ToTokens) -> TokenStream {
-    quote_spanned! {src.span()=>
+    quote_spanned! {src.span().resolved_at(Span::call_site())=>
         ::std::convert::Into::<::yew::virtual_dom::AttrValue>::into(#src)
     }
 }

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -18,6 +18,7 @@ error[E0599]: no method named `build` found for struct `PropsBuilder<PropsBuilde
    |
    = note: the method was found for
            - `PropsBuilder<PropsBuilderStepPropsBuilder>`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Comp<MissingTypeBounds>: yew::BaseComponent` is not satisfied
   --> tests/function_component_attr/generic-props-fail.rs:27:14
@@ -27,6 +28,7 @@ error[E0277]: the trait bound `Comp<MissingTypeBounds>: yew::BaseComponent` is n
    |
    = help: the following implementations were found:
              <Comp<P> as yew::BaseComponent>
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `new` exists for struct `VChild<Comp<MissingTypeBounds>>`, but its trait bounds were not satisfied
   --> tests/function_component_attr/generic-props-fail.rs:27:14
@@ -39,6 +41,7 @@ error[E0599]: the function or associated item `new` exists for struct `VChild<Co
    |
    = note: the following trait bounds were not satisfied:
            `Comp<MissingTypeBounds>: yew::BaseComponent`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MissingTypeBounds: yew::Properties` is not satisfied
   --> tests/function_component_attr/generic-props-fail.rs:27:14
@@ -54,6 +57,7 @@ note: required by a bound in `Comp`
 ...
 11 |     P: Properties + PartialEq,
    |        ^^^^^^^^^^ required by this bound in `Comp`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0107]: missing generics for struct `Comp`
   --> tests/function_component_attr/generic-props-fail.rs:30:14

--- a/packages/yew-macro/tests/html_macro/block-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/block-fail.stderr
@@ -12,6 +12,7 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `Into<NodeSeq<(), VNode>>` for `()`
 note: required by `into`
+    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
    --> tests/html_macro/block-fail.rs:12:16
@@ -27,6 +28,7 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `Into<NodeSeq<(), VNode>>` for `()`
 note: required by `into`
+    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> tests/html_macro/block-fail.rs:15:17

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -290,15 +290,6 @@ error[E0308]: mismatched types
    = note: expected struct `ChildProperties`
               found struct `std::ops::Range<_>`
 
-error[E0308]: mismatched types
-  --> tests/html_macro/component-fail.rs:53:14
-   |
-53 |     html! { <Child ..p1 ..p2 /> };
-   |              ^^^^^ expected struct `ChildProperties`, found struct `std::ops::Range`
-   |
-   = note: expected struct `ChildProperties`
-              found struct `std::ops::Range<_>`
-
 error[E0609]: no field `value` on type `ChildProperties`
   --> tests/html_macro/component-fail.rs:69:20
    |
@@ -404,6 +395,7 @@ error[E0609]: no field `children` on type `ChildProperties`
    |              ^^^^^ unknown field
    |
    = note: available fields are: `string`, `int`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:87:14
@@ -413,6 +405,8 @@ error[E0599]: no method named `children` found for struct `ChildPropertiesBuilde
 ...
 87 |     html! { <Child>{ "Not allowed" }</Child> };
    |              ^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
+   |
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `children` on type `ChildProperties`
   --> tests/html_macro/component-fail.rs:94:10
@@ -421,6 +415,7 @@ error[E0609]: no field `children` on type `ChildProperties`
    |          ^^^^^ unknown field
    |
    = note: available fields are: `string`, `int`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `build` found for struct `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
   --> tests/html_macro/component-fail.rs:99:14
@@ -433,6 +428,7 @@ error[E0599]: no method named `build` found for struct `ChildContainerProperties
    |
    = note: the method was found for
            - `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStepPropsBuilder>`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `build` found for struct `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
    --> tests/html_macro/component-fail.rs:100:14
@@ -445,6 +441,7 @@ error[E0599]: no method named `build` found for struct `ChildContainerProperties
     |
     = note: the method was found for
             - `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStepPropsBuilder>`
+    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `VChild<Child>: From<yew::virtual_dom::VText>` is not satisfied
    --> tests/html_macro/component-fail.rs:101:31

--- a/packages/yew-macro/tests/html_macro/component-unimplemented-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-unimplemented-fail.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `Unimplemented: yew::Component` is not satisfied
   |              ^^^^^^^^^^^^^ the trait `yew::Component` is not implemented for `Unimplemented`
   |
   = note: required because of the requirements on the impl of `BaseComponent` for `Unimplemented`
+  = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `new` exists for struct `VChild<Unimplemented>`, but its trait bounds were not satisfied
  --> tests/html_macro/component-unimplemented-fail.rs:6:14
@@ -17,3 +18,4 @@ error[E0599]: the function or associated item `new` exists for struct `VChild<Un
   |
   = note: the following trait bounds were not satisfied:
           `Unimplemented: BaseComponent`
+  = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
#### Description

Fixes #2381

Additionally, *renaming* should now work correctly for usages of component types, properties and in expressions for keys and refs.

To expand on the latter: A quoted TokenStream can have two Spans attached to it: `resolved_at` and `located_at`:
- errors in an expression are reported at `located_at`
- quoted expressions (occurances) have a "usage" attached to the span in `resolved_at`. This not only impacts name resolution, but also renaming and other editor actions analyzing _usage_.

So by decoupling the two and using `Span::call_site()` more often instead of using the same span for both `resolved_at` and `located_at`, editors should be less confused _which_ item should be targeted by a rename or usage lookup. Try it out in your editor. I don't have a good approach to automating these UX tests… Sample manual test code:

```rust
#[derive(
    ::std::clone::Clone, ::yew::Properties, ::std::default::Default, ::std::cmp::PartialEq,
)]
pub struct ContainerProperties {
    pub int: ::std::primitive::i32,
    #[prop_or_default]
    pub children: ::yew::Children,
    #[prop_or_default]
    pub header: ::yew::Html,
}

#[::yew::function_component]
fn Container(_: &ContainerProperties) -> ::yew::Html {
    ::std::unimplemented!()
}

fn compile_pass() {
    // Hover any identifier in here and try to rename it!
    // E.g `the_ref` inside the `<div ref=` or the `Container` in any opening/closing tag
    let the_ref = ::yew::NodeRef::default();
    let an_expression = 34;
    let int = 42;
    ::yew::html! {
        <>
        <div ref={the_ref} hidden={true} />
        <Container {int} key={an_expression} />
        <Container int=1></Container>
        </>
    };
}
```

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests. Indeed... how to test editor UX
