### PR TITLE
Fix: check examples depending on lipsum for rust 1.56

### DIFF
--- a/examples/function_router/Cargo.toml
+++ b/examples/function_router/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-lipsum = "0.8"
+lipsum = "=0.8.0" # pinned for mgeisler/lipsum#83
 log = "0.4"
 rand = { version = "0.8", features = ["small_rng"] }
 yew = { path = "../../packages/yew" }

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }
-lipsum = "0.8"
+lipsum = "=0.8.0" # pinned for mgeisler/lipsum#83
 log = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
 rand = { version = "0.8", features = ["small_rng"] }


### PR DESCRIPTION
#### Description

Fixes #2710

As a workaround for the lipsum update not working with our current MSRV, pin it to the previous one.
Targets CI working again.

#### Checklist

- [x] I have reviewed my own code
