### PR TITLE
Redo properties, take 2

### DIFF
--- a/packages/yew-macro/src/derive_props/builder.rs
+++ b/packages/yew-macro/src/derive_props/builder.rs
@@ -106,7 +106,7 @@ impl PropsBuilder<'_> {
         let assert_impl_generics = assert_impl_generics;
         let (impl_generics, _, where_clause) = assert_impl_generics.split_for_impl();
 
-        let props_mod_name = format_ident!("{}_props", props_name, span = Span::mixed_site());
+        let props_mod_name = format_ident!("_{}", props_name, span = Span::mixed_site());
         let mut check_impl_generics = assert_impl_generics.clone();
         let mut check_args = vec![];
         let mut check_props = proc_macro2::TokenStream::new();

--- a/packages/yew-macro/src/derive_props/builder.rs
+++ b/packages/yew-macro/src/derive_props/builder.rs
@@ -61,9 +61,9 @@ impl ToTokens for PropsBuilder<'_> {
             #impl_steps
 
             #[automatically_derived]
-            impl #impl_generics #builder_name<#generic_args> #where_clause {
-                #[doc(hidden)]
-                #vis fn build(self) -> #props_name #ty_generics {
+            impl #impl_generics ::yew::html::Buildable for #builder_name<#generic_args> #where_clause {
+                type Output = #props_name #ty_generics;
+                fn build(this: Self) -> Self::Output {
                     #props_name #turbofish_generics {
                         #(#set_fields)*
                     }

--- a/packages/yew-macro/src/derive_props/builder.rs
+++ b/packages/yew-macro/src/derive_props/builder.rs
@@ -5,18 +5,19 @@
 //! properties have been set, the builder moves to the final build step which implements the
 //! `build()` method.
 
-use proc_macro2::Ident;
+use proc_macro2::{Ident, Span};
 use quote::{format_ident, quote, ToTokens};
-use syn::Attribute;
+use syn::{parse_quote_spanned, Attribute, GenericParam};
 
-use super::generics::{to_arguments, GenericArguments};
-use super::{DerivePropsInput, PropField};
+use super::generics::to_arguments;
+use super::DerivePropsInput;
+use crate::derive_props::generics::push_type_param;
 
 pub struct PropsBuilder<'a> {
     builder_name: &'a Ident,
-    step_names: Vec<Ident>,
     props: &'a DerivePropsInput,
     wrapper_name: &'a Ident,
+    check_all_props_name: &'a Ident,
     extra_attrs: &'a [Attribute],
 }
 
@@ -24,33 +25,18 @@ impl ToTokens for PropsBuilder<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let Self {
             builder_name,
-            step_names,
             props,
             wrapper_name,
             ..
         } = self;
 
-        let DerivePropsInput {
-            vis,
-            generics,
-            props_name,
-            ..
-        } = props;
+        let DerivePropsInput { vis, generics, .. } = props;
 
-        let impl_steps = self.impl_steps();
-        let set_fields = self.set_fields();
+        let assert_all_props = self.impl_assert_props();
 
-        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-        let turbofish_generics = ty_generics.as_turbofish();
-        let generic_args = to_arguments(generics);
+        let (_, ty_generics, where_clause) = generics.split_for_impl();
 
         let builder = quote! {
-            #(
-                #[doc(hidden)]
-                #[allow(non_camel_case_types)]
-                #vis struct #step_names;
-            )*
-
             #[doc(hidden)]
             #vis struct #builder_name #generics
                 #where_clause
@@ -58,17 +44,7 @@ impl ToTokens for PropsBuilder<'_> {
                 wrapped: ::std::boxed::Box<#wrapper_name #ty_generics>,
             }
 
-            #impl_steps
-
-            #[automatically_derived]
-            impl #impl_generics ::yew::html::Buildable for #builder_name<#generic_args> #where_clause {
-                type Output = #props_name #ty_generics;
-                fn build(this: Self) -> Self::Output {
-                    #props_name #turbofish_generics {
-                        #(#set_fields)*
-                    }
-                }
-            }
+            #assert_all_props
         };
 
         tokens.extend(builder);
@@ -78,73 +54,115 @@ impl ToTokens for PropsBuilder<'_> {
 impl<'a> PropsBuilder<'_> {
     pub fn new(
         name: &'a Ident,
-        prefix: &'a Ident,
         props: &'a DerivePropsInput,
         wrapper_name: &'a Ident,
+        check_all_props_name: &'a Ident,
         extra_attrs: &'a [Attribute],
     ) -> PropsBuilder<'a> {
         PropsBuilder {
             builder_name: name,
-            step_names: Self::build_step_names(prefix, &props.prop_fields),
             props,
             wrapper_name,
+            check_all_props_name,
             extra_attrs,
         }
     }
 }
 
 impl PropsBuilder<'_> {
-    pub fn first_step_generic_args(&self) -> GenericArguments {
-        to_arguments(&self.props.generics)
-    }
-
-    fn build_step_names(prefix: &Ident, prop_fields: &[PropField]) -> Vec<Ident> {
-        let mut step_names: Vec<Ident> = prop_fields
-            .iter()
-            .filter(|pf| pf.is_required())
-            .map(|pf| pf.to_step_name(prefix))
-            .collect();
-        step_names.push(format_ident!(
-            "{}PropsBuilder",
-            prefix,
-            span = prefix.span(),
-        ));
-        step_names
-    }
-
     fn set_fields(&self) -> impl Iterator<Item = impl ToTokens + '_> {
         self.props.prop_fields.iter().map(|pf| pf.to_field_setter())
     }
 
-    fn impl_steps(&self) -> proc_macro2::TokenStream {
+    fn impl_assert_props(&self) -> proc_macro2::TokenStream {
         let Self {
             builder_name,
-            props,
+            check_all_props_name,
             extra_attrs,
             ..
         } = self;
         let DerivePropsInput {
             vis,
             generics,
+            props_name,
             prop_fields,
             ..
-        } = props;
+        } = self.props;
 
-        let (impl_generics, _, where_clause) = generics.split_for_impl();
-        let mut token_stream = proc_macro2::TokenStream::new();
+        let set_fields = self.set_fields();
+        let prop_fns = prop_fields
+            .iter()
+            .map(|pf| pf.to_build_step_fn(vis, props_name));
 
-        {
-            let generic_args = to_arguments(generics);
-            let prop_fns = prop_fields.iter().map(|pf| pf.to_build_step_fn(vis));
-            token_stream.extend(quote! {
-                #[automatically_derived]
-                #( #extra_attrs )*
-                impl #impl_generics #builder_name<#generic_args> #where_clause {
-                    #( #prop_fns )*
-                }
-            });
+        let (builder_impl_generics, ty_generics, builder_where_clause) = generics.split_for_impl();
+        let turbofish_generics = ty_generics.as_turbofish();
+        let generic_args = to_arguments(generics);
+
+        let mut assert_impl_generics = generics.clone();
+        let token_arg: GenericParam = parse_quote_spanned! {Span::mixed_site()=>
+            __YewToken
+        };
+        push_type_param(&mut assert_impl_generics, token_arg.clone());
+        let assert_impl_generics = assert_impl_generics;
+        let (impl_generics, _, where_clause) = assert_impl_generics.split_for_impl();
+
+        let props_mod_name = format_ident!("{}_props", props_name, span = Span::mixed_site());
+        let mut check_impl_generics = assert_impl_generics.clone();
+        let mut check_args = vec![];
+        let mut check_props = proc_macro2::TokenStream::new();
+        let prop_field_decls = prop_fields
+            .iter()
+            .map(|pf| pf.to_field_check(props_name, vis, &token_arg))
+            .collect::<Vec<_>>();
+        let prop_name_decls = prop_field_decls.iter().map(|pf| pf.to_fake_prop_decl());
+        for pf in prop_field_decls.iter() {
+            check_props.extend(pf.to_stream(
+                &mut check_impl_generics,
+                &mut check_args,
+                &props_mod_name,
+            ));
         }
-        // FIXME: steps and required prop validation
-        token_stream
+        let (check_impl_generics, _, check_where_clause) = check_impl_generics.split_for_impl();
+
+        quote! {
+            #[automatically_derived]
+            #( #extra_attrs )*
+            impl #builder_impl_generics #builder_name<#generic_args> #builder_where_clause {
+                #( #prop_fns )*
+            }
+
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            #vis mod #props_mod_name {
+                #( #prop_name_decls )*
+            }
+            #check_props
+
+            #[doc(hidden)]
+            #vis struct #check_all_props_name<How>(::std::marker::PhantomData<How>);
+
+            #[automatically_derived]
+            impl<B, P, How> ::yew::html::HasProp<P, &dyn ::yew::html::HasProp<P, How>>
+                for #check_all_props_name<B>
+                where B: ::yew::html::HasProp<P, How> {}
+
+            #[automatically_derived]
+            impl #check_impl_generics ::yew::html::HasAllProps<
+                #props_name #ty_generics ,
+                ( #( #check_args , )* ),
+            > for #check_all_props_name< #token_arg > #check_where_clause {
+            }
+
+            #[automatically_derived]
+            impl #impl_generics ::yew::html::Buildable< #token_arg > for #builder_name<#generic_args> #where_clause {
+                type Output = #props_name #ty_generics;
+                type WrappedTok = #check_all_props_name< #token_arg >;
+                fn build(this: Self) -> Self::Output {
+                    #props_name #turbofish_generics {
+                        #(#set_fields)*
+                    }
+                }
+            }
+        }
     }
 }

--- a/packages/yew-macro/src/derive_props/builder.rs
+++ b/packages/yew-macro/src/derive_props/builder.rs
@@ -156,7 +156,7 @@ impl PropsBuilder<'_> {
             #[automatically_derived]
             impl #impl_generics ::yew::html::Buildable< #token_arg > for #builder_name<#generic_args> #where_clause {
                 type Output = #props_name #ty_generics;
-                type WrappedTok = #check_all_props_name< #token_arg >;
+                type WrappedToken = #check_all_props_name< #token_arg >;
                 fn build(this: Self) -> Self::Output {
                     #props_name #turbofish_generics {
                         #(#set_fields)*

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -122,28 +122,44 @@ impl PropField {
     /// Each field is set using a builder method
     pub fn to_build_step_fn(&self, vis: &Visibility) -> proc_macro2::TokenStream {
         let Self { name, ty, attr, .. } = self;
+        let token_ty = Ident::new("__YewTokenTy", Span::mixed_site());
         let build_fn = match attr {
             PropAttr::Required { wrapped_name } => {
                 quote! {
                     #[doc(hidden)]
-                    #vis fn #name(&mut self, value: impl ::yew::html::IntoPropValue<#ty>) {
+                    #vis fn #name<#token_ty>(
+                        &mut self,
+                        token: #token_ty,
+                        value: impl ::yew::html::IntoPropValue<#ty>,
+                    ) -> #token_ty {
                         self.wrapped.#wrapped_name = ::std::option::Option::Some(value.into_prop_value());
+                        token
                     }
                 }
             }
             PropAttr::Option => {
                 quote! {
                     #[doc(hidden)]
-                    #vis fn #name(&mut self, value: impl ::yew::html::IntoPropValue<#ty>) {
+                    #vis fn #name<#token_ty>(
+                        &mut self,
+                        token: #token_ty,
+                        value: impl ::yew::html::IntoPropValue<#ty>,
+                    ) -> #token_ty {
                         self.wrapped.#name = value.into_prop_value();
+                        token
                     }
                 }
             }
             _ => {
                 quote! {
                     #[doc(hidden)]
-                    #vis fn #name(&mut self, value: impl ::yew::html::IntoPropValue<#ty>) {
+                    #vis fn #name<#token_ty>(
+                        &mut self,
+                        token: #token_ty,
+                        value: impl ::yew::html::IntoPropValue<#ty>,
+                    ) -> #token_ty {
                         self.wrapped.#name = ::std::option::Option::Some(value.into_prop_value());
+                        token
                     }
                 }
             }

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -5,9 +5,13 @@ use proc_macro2::{Ident, Span};
 use quote::{format_ident, quote, quote_spanned};
 use syn::parse::Result;
 use syn::spanned::Spanned;
-use syn::{Attribute, Error, Expr, Field, Path, Type, TypePath, Visibility};
+use syn::{
+    parse_quote, Attribute, Error, Expr, Field, GenericParam, Generics, Path, Type, TypePath,
+    Visibility,
+};
 
 use super::should_preserve_attr;
+use crate::derive_props::generics::push_type_param;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(PartialEq, Eq)]
@@ -33,14 +37,15 @@ impl PropField {
         matches!(self.attr, PropAttr::Required { .. })
     }
 
-    /// This step name is descriptive to help a developer realize they missed a required prop
-    pub fn to_step_name(&self, props_name: &Ident) -> Ident {
-        format_ident!(
-            "{}_missing_required_prop_{}",
-            props_name,
-            self.name,
-            span = Span::call_site(),
-        )
+    /// This check name is descriptive to help a developer realize they missed a required prop
+    fn to_check_name(&self, props_name: &Ident) -> Ident {
+        format_ident!("Has{}{}", props_name, self.name, span = Span::mixed_site(),)
+    }
+
+    /// This check name is descriptive to help a developer realize they missed a required prop
+    fn to_check_arg_name(&self, props_name: &Ident) -> GenericParam {
+        let ident = format_ident!("How{}{}", props_name, self.name, span = Span::mixed_site(),);
+        GenericParam::Type(ident.into())
     }
 
     /// Ident of the wrapped field name
@@ -48,6 +53,23 @@ impl PropField {
         match &self.attr {
             PropAttr::Required { wrapped_name } => wrapped_name,
             _ => &self.name,
+        }
+    }
+
+    pub fn to_field_check<'a>(
+        &'a self,
+        props_name: &'a Ident,
+        vis: &'a Visibility,
+        token: &'a GenericParam,
+    ) -> PropFieldCheck<'_> {
+        let check_struct = self.to_check_name(props_name);
+        let check_arg = self.to_check_arg_name(props_name);
+        PropFieldCheck {
+            this: self,
+            vis,
+            token,
+            check_struct,
+            check_arg,
         }
     }
 
@@ -120,20 +142,25 @@ impl PropField {
     }
 
     /// Each field is set using a builder method
-    pub fn to_build_step_fn(&self, vis: &Visibility) -> proc_macro2::TokenStream {
+    pub fn to_build_step_fn(
+        &self,
+        vis: &Visibility,
+        props_name: &Ident,
+    ) -> proc_macro2::TokenStream {
         let Self { name, ty, attr, .. } = self;
         let token_ty = Ident::new("__YewTokenTy", Span::mixed_site());
         let build_fn = match attr {
             PropAttr::Required { wrapped_name } => {
+                let check_struct = self.to_check_name(props_name);
                 quote! {
                     #[doc(hidden)]
                     #vis fn #name<#token_ty>(
                         &mut self,
                         token: #token_ty,
                         value: impl ::yew::html::IntoPropValue<#ty>,
-                    ) -> #token_ty {
+                    ) -> #check_struct< #token_ty > {
                         self.wrapped.#wrapped_name = ::std::option::Option::Some(value.into_prop_value());
-                        token
+                        #check_struct ( ::std::marker::PhantomData )
                     }
                 }
             }
@@ -199,6 +226,69 @@ impl PropField {
             let ident = named_field.ident.as_ref().unwrap();
             let wrapped_name = format_ident!("{}_wrapper", ident, span = Span::mixed_site());
             Ok(PropAttr::Required { wrapped_name })
+        }
+    }
+}
+
+pub struct PropFieldCheck<'a> {
+    this: &'a PropField,
+    vis: &'a Visibility,
+    token: &'a GenericParam,
+    check_struct: Ident,
+    check_arg: GenericParam,
+}
+
+impl<'a> PropFieldCheck<'a> {
+    pub fn to_fake_prop_decl(&self) -> proc_macro2::TokenStream {
+        let Self { this, .. } = self;
+        if !this.is_required() {
+            return Default::default();
+        }
+        let mut prop_check_name = this.name.clone();
+        prop_check_name.set_span(Span::mixed_site());
+        quote! {
+            #[allow(non_camel_case_types)]
+            pub struct #prop_check_name;
+        }
+    }
+
+    pub fn to_stream(
+        &self,
+        type_generics: &mut Generics,
+        check_args: &mut Vec<GenericParam>,
+        prop_name_mod: &Ident,
+    ) -> proc_macro2::TokenStream {
+        let Self {
+            this,
+            vis,
+            token,
+            check_struct,
+            check_arg,
+        } = self;
+        if !this.is_required() {
+            return Default::default();
+        }
+        let mut prop_check_name = this.name.clone();
+        prop_check_name.set_span(Span::mixed_site());
+        check_args.push(check_arg.clone());
+        push_type_param(type_generics, check_arg.clone());
+        let where_clause = type_generics.make_where_clause();
+        where_clause.predicates.push(parse_quote! {
+            #token: ::yew::html::HasProp< #prop_name_mod :: #prop_check_name, #check_arg >
+        });
+
+        quote! {
+            #[doc(hidden)]
+            #vis struct #check_struct<How>(::std::marker::PhantomData<How>);
+
+            #[automatically_derived]
+            impl<B> ::yew::html::HasProp<#prop_name_mod :: #prop_check_name, #check_struct<B>>
+                for #check_struct<B> {}
+            #[automatically_derived]
+            impl<B, P, How> ::yew::html::HasProp<P, &dyn ::yew::html::HasProp<P, How>>
+                for #check_struct<B>
+                where B: ::yew::html::HasProp<P, How> {}
+
         }
     }
 }

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -282,7 +282,7 @@ impl<'a> PropFieldCheck<'a> {
             #vis struct #check_struct<How>(::std::marker::PhantomData<How>);
 
             #[automatically_derived]
-            impl<B> ::yew::html::HasProp<#prop_name_mod :: #prop_check_name, #check_struct<B>>
+            impl<B> ::yew::html::HasProp< #prop_name_mod :: #prop_check_name, #check_struct<B>>
                 for #check_struct<B> {}
             #[automatically_derived]
             impl<B, P, How> ::yew::html::HasProp<P, &dyn ::yew::html::HasProp<P, How>>

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -39,12 +39,12 @@ impl PropField {
 
     /// This check name is descriptive to help a developer realize they missed a required prop
     fn to_check_name(&self, props_name: &Ident) -> Ident {
-        format_ident!("Has{}{}", props_name, self.name, span = Span::mixed_site(),)
+        format_ident!("Has{}{}", props_name, self.name, span = Span::mixed_site())
     }
 
     /// This check name is descriptive to help a developer realize they missed a required prop
     fn to_check_arg_name(&self, props_name: &Ident) -> GenericParam {
-        let ident = format_ident!("How{}{}", props_name, self.name, span = Span::mixed_site(),);
+        let ident = format_ident!("How{}{}", props_name, self.name, span = Span::mixed_site());
         GenericParam::Type(ident.into())
     }
 

--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -57,27 +57,27 @@ impl PropField {
         let setter = match &self.attr {
             PropAttr::Required { wrapped_name } => {
                 quote! {
-                    #name: ::std::option::Option::unwrap(self.wrapped.#wrapped_name),
+                    #name: ::std::option::Option::unwrap(this.wrapped.#wrapped_name),
                 }
             }
             PropAttr::Option => {
                 quote! {
-                    #name: self.wrapped.#name,
+                    #name: this.wrapped.#name,
                 }
             }
             PropAttr::PropOr(value) => {
                 quote_spanned! {value.span()=>
-                    #name: ::std::option::Option::unwrap_or(self.wrapped.#name, #value),
+                    #name: ::std::option::Option::unwrap_or(this.wrapped.#name, #value),
                 }
             }
             PropAttr::PropOrElse(func) => {
                 quote_spanned! {func.span()=>
-                    #name: ::std::option::Option::unwrap_or_else(self.wrapped.#name, #func),
+                    #name: ::std::option::Option::unwrap_or_else(this.wrapped.#name, #func),
                 }
             }
             PropAttr::PropOrDefault => {
                 quote! {
-                    #name: ::std::option::Option::unwrap_or_default(self.wrapped.#name),
+                    #name: ::std::option::Option::unwrap_or_default(this.wrapped.#name),
                 }
             }
         };

--- a/packages/yew-macro/src/derive_props/generics.rs
+++ b/packages/yew-macro/src/derive_props/generics.rs
@@ -5,6 +5,24 @@ use syn::{GenericArgument, GenericParam, Generics, Path, Token, Type, TypePath};
 /// Alias for a comma-separated list of `GenericArgument`
 pub type GenericArguments = Punctuated<GenericArgument, Token![,]>;
 
+/// Finds the index of the first generic param with a default value or a const generic.
+fn first_default_or_const_param_position(generics: &Generics) -> Option<usize> {
+    generics.params.iter().position(|param| match param {
+        GenericParam::Type(param) => param.default.is_some(),
+        GenericParam::Const(_) => true,
+        _ => false,
+    })
+}
+
+/// Push a type GenericParam into a Generics
+pub fn push_type_param(generics: &mut Generics, type_param: GenericParam) {
+    if let Some(idx) = first_default_or_const_param_position(generics) {
+        generics.params.insert(idx, type_param)
+    } else {
+        generics.params.push(type_param)
+    }
+}
+
 /// Converts `GenericParams` into `GenericArguments`.
 pub fn to_arguments(generics: &Generics) -> GenericArguments {
     let mut args: GenericArguments = Punctuated::new();

--- a/packages/yew-macro/src/derive_props/generics.rs
+++ b/packages/yew-macro/src/derive_props/generics.rs
@@ -1,27 +1,12 @@
-use proc_macro2::{Ident, Span};
+use proc_macro2::Ident;
 use syn::punctuated::Punctuated;
-use syn::token::Colon2;
-use syn::{
-    GenericArgument, GenericParam, Generics, Path, PathArguments, PathSegment, Token, TraitBound,
-    TraitBoundModifier, Type, TypeParam, TypeParamBound, TypePath,
-};
+use syn::{GenericArgument, GenericParam, Generics, Path, Token, Type, TypePath};
 
 /// Alias for a comma-separated list of `GenericArgument`
 pub type GenericArguments = Punctuated<GenericArgument, Token![,]>;
 
-/// Finds the index of the first generic param with a default value or a const generic.
-fn first_default_or_const_param_position(generics: &Generics) -> Option<usize> {
-    generics.params.iter().position(|param| match param {
-        GenericParam::Type(param) => param.default.is_some(),
-        GenericParam::Const(_) => true,
-        _ => false,
-    })
-}
-
-/// Converts `GenericParams` into `GenericArguments` and adds `type_ident` as a type arg.
-/// `type_ident` is added at the end of the existing type arguments which don't have a default
-/// value.
-pub fn to_arguments(generics: &Generics, type_ident: Ident) -> GenericArguments {
+/// Converts `GenericParams` into `GenericArguments`.
+pub fn to_arguments(generics: &Generics) -> GenericArguments {
     let mut args: GenericArguments = Punctuated::new();
     args.extend(generics.params.iter().map(|param| match param {
         GenericParam::Type(type_param) => new_generic_type_arg(type_param.ident.clone()),
@@ -30,30 +15,7 @@ pub fn to_arguments(generics: &Generics, type_ident: Ident) -> GenericArguments 
         }
         GenericParam::Const(const_param) => new_generic_type_arg(const_param.ident.clone()),
     }));
-
-    let new_arg = new_generic_type_arg(type_ident);
-    if let Some(index) = first_default_or_const_param_position(generics) {
-        args.insert(index, new_arg);
-    } else {
-        args.push(new_arg);
-    }
-
     args
-}
-
-/// Adds a new bounded `GenericParam` to a `Generics`
-/// The new param is added after the existing ones without a default value.
-pub fn with_param_bounds(generics: &Generics, param_ident: Ident, param_bounds: Ident) -> Generics {
-    let mut new_generics = generics.clone();
-    let params = &mut new_generics.params;
-    let new_param = new_param_bounds(param_ident, param_bounds);
-    if let Some(index) = first_default_or_const_param_position(generics) {
-        params.insert(index, new_param);
-    } else {
-        params.push(new_param);
-    }
-
-    new_generics
 }
 
 // Creates a `GenericArgument` from an `Ident`
@@ -62,33 +24,4 @@ fn new_generic_type_arg(ident: Ident) -> GenericArgument {
         path: Path::from(ident),
         qself: None,
     }))
-}
-
-// Creates a bounded `GenericParam` from two `Ident`
-fn new_param_bounds(param_ident: Ident, param_bounds: Ident) -> GenericParam {
-    let mut path_segments: Punctuated<PathSegment, Colon2> = Punctuated::new();
-    path_segments.push(PathSegment {
-        ident: param_bounds,
-        arguments: PathArguments::None,
-    });
-
-    let mut param_bounds: Punctuated<TypeParamBound, Token![+]> = Punctuated::new();
-    param_bounds.push(TypeParamBound::Trait(TraitBound {
-        paren_token: None,
-        modifier: TraitBoundModifier::None,
-        lifetimes: None,
-        path: Path {
-            leading_colon: None,
-            segments: path_segments,
-        },
-    }));
-
-    GenericParam::Type(TypeParam {
-        attrs: Vec::new(),
-        ident: param_ident,
-        colon_token: Some(Token![:](Span::mixed_site())),
-        bounds: param_bounds,
-        eq_token: None,
-        default: None,
-    })
 }

--- a/packages/yew-macro/src/derive_props/mod.rs
+++ b/packages/yew-macro/src/derive_props/mod.rs
@@ -92,10 +92,10 @@ impl ToTokens for DerivePropsInput {
 
         // The builder will only build if all required props have been set
         let builder_name = format_ident!("{}Builder", props_name, span = Span::mixed_site());
-        let builder_step = format_ident!("{}BuilderStep", props_name, span = Span::mixed_site());
+        let prefix = format_ident!("{}BuilderStep", props_name, span = Span::mixed_site());
         let builder = PropsBuilder::new(
             &builder_name,
-            &builder_step,
+            &prefix,
             self,
             &wrapper_name,
             &self.preserved_attrs,
@@ -112,7 +112,6 @@ impl ToTokens for DerivePropsInput {
                 fn builder() -> Self::Builder {
                     #builder_name {
                         wrapped: ::std::boxed::Box::new(::std::default::Default::default()),
-                        _marker: ::std::marker::PhantomData,
                     }
                 }
             }

--- a/packages/yew-macro/src/derive_props/mod.rs
+++ b/packages/yew-macro/src/derive_props/mod.rs
@@ -13,6 +13,8 @@ use syn::parse::{Parse, ParseStream, Result};
 use syn::{Attribute, DeriveInput, Generics, Visibility};
 use wrapper::PropsWrapper;
 
+use self::generics::to_arguments;
+
 pub struct DerivePropsInput {
     vis: Visibility,
     generics: Generics,
@@ -92,22 +94,23 @@ impl ToTokens for DerivePropsInput {
 
         // The builder will only build if all required props have been set
         let builder_name = format_ident!("{}Builder", props_name, span = Span::mixed_site());
-        let prefix = format_ident!("{}BuilderStep", props_name, span = Span::mixed_site());
+        let check_all_props_name =
+            format_ident!("Check{}All", props_name, span = Span::mixed_site());
         let builder = PropsBuilder::new(
             &builder_name,
-            &prefix,
             self,
             &wrapper_name,
+            &check_all_props_name,
             &self.preserved_attrs,
         );
-        let builder_generic_args = builder.first_step_generic_args();
+        let generic_args = to_arguments(generics);
         tokens.extend(builder.into_token_stream());
 
         // The properties trait has a `builder` method which creates the props builder
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let properties = quote! {
             impl #impl_generics ::yew::html::Properties for #props_name #ty_generics #where_clause {
-                type Builder = #builder_name<#builder_generic_args>;
+                type Builder = #builder_name<#generic_args>;
 
                 fn builder() -> Self::Builder {
                     #builder_name {

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -109,7 +109,7 @@ impl ComponentProps {
                     }
                 });
                 let build_builder = quote_spanned! {props_ty.span()=>
-                    ::yew::html::Buildable::pre_build(#builder_ident, &#token_ident).build()
+                    ::yew::html::Buildable::prepare_build(#builder_ident, &#token_ident).build()
                 };
 
                 quote! {

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -105,8 +105,9 @@ impl ComponentProps {
                         let #token_ident = #ident.children(#token_ident, #children);
                     }
                 });
-                let build_builder = quote_spanned! {props_ty.span()=>
-                    ::yew::html::Buildable::build(#ident)
+                // let finished_build = Ident::new("finish_build", Span::mixed_site());
+                let build_builder = quote_spanned! {props_ty.span().resolved_at(Span::mixed_site())=>
+                    ::yew::html::finish_build(#ident, #token_ident)
                 };
 
                 quote! {

--- a/packages/yew-macro/tests/derive_props/fail.rs
+++ b/packages/yew-macro/tests/derive_props/fail.rs
@@ -32,20 +32,7 @@ mod t3 {
     }
 
     fn required_props_should_be_set() {
-        Props::builder().build();
-    }
-}
-
-mod t4 {
-    use super::*;
-    #[derive(Clone, Properties, PartialEq)]
-    pub struct Props {
-        b: i32,
-        a: i32,
-    }
-
-    fn enforce_ordering() {
-        Props::builder().b(1).a(2).build();
+        ::yew::props!{ Props { } };
     }
 }
 

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -34,7 +34,7 @@ note: required because of the requirements on the impl of `HasAllProps<t3::Props
    |
 29 |     #[derive(Clone, Properties, PartialEq)]
    |                     ^^^^^^^^^^
-   = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, t3::PropsBuilder, (_,)>` for `AssertAllProps`
+   = note: required because of the requirements on the impl of `AllPropsFor<t3::PropsBuilder, (_,)>` for `AssertAllProps`
    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Value: Default` is not satisfied

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -1,7 +1,7 @@
 error: unexpected end of input, expected expression
-  --> tests/derive_props/fail.rs:57:19
+  --> tests/derive_props/fail.rs:44:19
    |
-57 |         #[prop_or()]
+44 |         #[prop_or()]
    |                   ^
 
 error: cannot find attribute `props` in this scope
@@ -11,38 +11,35 @@ error: cannot find attribute `props` in this scope
    |           ^^^^^
 
 error[E0425]: cannot find value `foo` in this scope
-  --> tests/derive_props/fail.rs:87:24
+  --> tests/derive_props/fail.rs:74:24
    |
-87 |         #[prop_or_else(foo)]
+74 |         #[prop_or_else(foo)]
    |                        ^^^ not found in this scope
    |
 help: consider importing one of these items
    |
-83 |     use crate::t10::foo;
+70 |     use crate::t10::foo;
    |
-83 |     use crate::t9::foo;
+70 |     use crate::t9::foo;
    |
 
-error[E0599]: no method named `build` found for struct `t3::PropsBuilder<t3::PropsBuilderStep_missing_required_prop_value>` in the current scope
-  --> tests/derive_props/fail.rs:35:26
+error[E0277]: the trait bound `AssertAllProps: HasAllProps<t3::Props, _>` is not satisfied
+  --> tests/derive_props/fail.rs:35:9
+   |
+35 |         ::yew::props!{ Props { } };
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<t3::Props, _>`
+   |
+note: required because of the requirements on the impl of `HasAllProps<t3::Props, (_,)>` for `t3::CheckPropsAll<AssertAllProps>`
+  --> tests/derive_props/fail.rs:29:21
    |
 29 |     #[derive(Clone, Properties, PartialEq)]
-   |                     ---------- method `build` not found for this
-...
-35 |         Props::builder().build();
-   |                          ^^^^^ method not found in `t3::PropsBuilder<t3::PropsBuilderStep_missing_required_prop_value>`
+   |                     ^^^^^^^^^^
+note: required by a bound in `finish_build`
+  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
    |
-   = note: the method was found for
-           - `t3::PropsBuilder<t3::PropsBuilderStepPropsBuilder>`
-
-error[E0599]: no method named `b` found for struct `t4::PropsBuilder<PropsBuilderStep_missing_required_prop_a>` in the current scope
-  --> tests/derive_props/fail.rs:48:26
-   |
-41 |     #[derive(Clone, Properties, PartialEq)]
-   |                     ---------- method `b` not found for this
-...
-48 |         Props::builder().b(1).a(2).build();
-   |                          ^ help: there is an associated function with a similar name: `a`
+   |     B::WrappedTok: HasAllProps<B::Output, How>,
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
+   = note: this error originates in the macro `::yew::props` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Value: Default` is not satisfied
     --> tests/derive_props/fail.rs:9:21
@@ -78,22 +75,22 @@ error[E0369]: binary operation `!=` cannot be applied to type `Value`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/derive_props/fail.rs:67:19
+  --> tests/derive_props/fail.rs:54:19
    |
-67 |         #[prop_or(123)]
+54 |         #[prop_or(123)]
    |                   ^^^ expected struct `String`, found integer
    |
 help: try using a conversion method
    |
-67 |         #[prop_or(123.to_string())]
+54 |         #[prop_or(123.to_string())]
    |                      ++++++++++++
-67 |         #[prop_or(123.to_string())]
+54 |         #[prop_or(123.to_string())]
    |                      ++++++++++++
 
 error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
-   --> tests/derive_props/fail.rs:77:24
+   --> tests/derive_props/fail.rs:64:24
     |
-77  |         #[prop_or_else(123)]
+64  |         #[prop_or_else(123)]
     |                        ^^^ expected an `FnOnce<()>` closure, found `{integer}`
     |
     = help: the trait `FnOnce<()>` is not implemented for `{integer}`
@@ -101,20 +98,20 @@ error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
 note: required by a bound in `Option::<T>::unwrap_or_else`
 
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
-   --> tests/derive_props/fail.rs:97:24
+   --> tests/derive_props/fail.rs:84:24
     |
-97  |         #[prop_or_else(foo)]
+84  |         #[prop_or_else(foo)]
     |                        ^^^ expected function that takes 0 arguments
 ...
-101 |     fn foo(bar: i32) -> String {
+88  |     fn foo(bar: i32) -> String {
     |     -------------------------- takes 1 argument
     |
 note: required by a bound in `Option::<T>::unwrap_or_else`
 
 error[E0271]: type mismatch resolving `<fn() -> i32 {t10::foo} as FnOnce<()>>::Output == String`
-   --> tests/derive_props/fail.rs:111:24
+   --> tests/derive_props/fail.rs:98:24
     |
-111 |         #[prop_or_else(foo)]
+98  |         #[prop_or_else(foo)]
     |                        ^^^ expected struct `String`, found `i32`
     |
 note: required by `Option::<T>::unwrap_or_else`

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -23,23 +23,19 @@ help: consider importing one of these items
 70 |     use crate::t9::foo;
    |
 
-error[E0277]: the trait bound `AssertAllProps: HasAllProps<t3::Props, _>` is not satisfied
-  --> tests/derive_props/fail.rs:35:9
+error[E0277]: the trait bound `AssertAllProps: HasProp<t3::_Props::value, _>` is not satisfied
+  --> tests/derive_props/fail.rs:35:24
    |
 35 |         ::yew::props!{ Props { } };
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<t3::Props, _>`
+   |                        ^^^^^ the trait `HasProp<t3::_Props::value, _>` is not implemented for `AssertAllProps`
    |
 note: required because of the requirements on the impl of `HasAllProps<t3::Props, (_,)>` for `t3::CheckPropsAll<AssertAllProps>`
   --> tests/derive_props/fail.rs:29:21
    |
 29 |     #[derive(Clone, Properties, PartialEq)]
    |                     ^^^^^^^^^^
-note: required by a bound in `finish_build`
-  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
-   |
-   |     B::WrappedTok: HasAllProps<B::Output, How>,
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
-   = note: this error originates in the macro `::yew::props` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, t3::PropsBuilder, (_,)>` for `AssertAllProps`
+   = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Value: Default` is not satisfied
     --> tests/derive_props/fail.rs:9:21

--- a/packages/yew-macro/tests/derive_props/pass.rs
+++ b/packages/yew-macro/tests/derive_props/pass.rs
@@ -45,10 +45,8 @@ mod t1 {
     }
 
     fn optional_prop_generics_should_work() {
-        use ::yew::Properties;
-
-        Props::<::std::primitive::bool>::builder().build();
-        Props::<::std::primitive::bool>::builder().value(true).build();
+        ::yew::props! { Props::<::std::primitive::bool> { } };
+        ::yew::props! { Props::<::std::primitive::bool> { value: true } };
     }
 }
 
@@ -61,9 +59,7 @@ mod t2 {
     }
 
     fn required_prop_generics_should_work() {
-        use ::yew::Properties;
-
-        Props::<Value>::builder().value(Value).build();
+        ::yew::props! { Props::<Value> { value: Value } };
     }
 }
 
@@ -76,10 +72,8 @@ mod t3 {
     }
 
     fn order_is_alphabetized() {
-        use ::yew::Properties;
-
-        Props::builder().b(1).build();
-        Props::builder().a(1).b(2).build();
+        ::yew::props! { Props { b: 1 } };
+        ::yew::props! { Props { a: 1, b: 2 } };
     }
 }
 
@@ -94,10 +88,8 @@ mod t4 {
     }
 
     fn optional_prop_generics_should_work() {
-        use ::yew::Properties;
-
-        Props::<::std::primitive::bool>::builder().build();
-        Props::<::std::primitive::bool>::builder().value(true).build();
+        ::yew::props! { Props::<::std::primitive::bool> { } };
+        ::yew::props! { Props::<::std::primitive::bool> { value: true } };
     }
 }
 
@@ -114,13 +106,10 @@ mod t5 {
 
     fn optional_prop_generics_with_lifetime_should_work() {
         use ::std::{convert::From, string::String};
-        use ::yew::Properties;
 
-        Props::<String>::builder().value(&String::from("")).build();
-        Props::<String>::builder()
-            .static_value("")
-            .value(&String::from(""))
-            .build();
+        let borrowed_value = &String::from("");
+        ::yew::props! { Props::<String> { value: borrowed_value, } };
+        ::yew::props! { Props::<String> { static_value: "", value: borrowed_value, } };
     }
 }
 
@@ -135,11 +124,8 @@ mod t6 {
 
     fn required_prop_generics_with_where_clause_should_work() {
         use ::std::{convert::From, result::Result::Ok, string::String};
-        use ::yew::Properties;
 
-        Props::<String>::builder()
-            .value(Ok(String::from("")))
-            .build();
+        ::yew::props! { Props::<String> { value: Ok(String::from("")) } };
     }
 }
 
@@ -158,11 +144,10 @@ mod t7 {
 
     fn prop_or_value_should_work() {
         use ::std::assert_eq;
-        use ::yew::Properties;
 
-        let props = Props::builder().build();
+        let props = ::yew::props! { Props { } };
         assert_eq!(props.value, Foo::One);
-        Props::builder().value(Foo::Two).build();
+        ::yew::props! { Props { value: Foo::Two } };
     }
 }
 
@@ -175,11 +160,10 @@ mod t8 {
 
     fn prop_or_else_closure_should_work() {
         use ::std::assert_eq;
-        use ::yew::Properties;
 
-        let props = Props::builder().build();
+        let props = ::yew::props! { Props { } };
         assert_eq!(props.value, 123);
-        Props::builder().value(123).build();
+        ::yew::props! { Props { value: 123 } };
     }
 }
 
@@ -203,11 +187,10 @@ mod t9 {
 
     fn prop_or_else_function_with_generics_should_work() {
         use ::std::{assert_eq, result::Result::Ok};
-        use ::yew::Properties;
 
-        let props = Props::<::std::primitive::i32>::builder().build();
+        let props = ::yew::props! { Props::<::std::primitive::i32> { } };
         assert_eq!(props.value, Ok(123));
-        Props::<i32>::builder().value(Ok(456)).build();
+        ::yew::props! { Props::<::std::primitive::i32> { value: Ok(456) } };
     }
 }
 
@@ -244,10 +227,8 @@ mod t12 {
     }
 
     fn optional_prop_generics_should_work() {
-        use ::yew::Properties;
-
-        Props::<::std::primitive::bool>::builder().build();
-        Props::<::std::primitive::bool>::builder().value(true).build();
+        ::yew::props! { Props::<::std::primitive::bool> { } };
+        ::yew::props! { Props::<::std::primitive::bool> { value: true } };
     }
 }
 

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -41,22 +41,18 @@ help: add missing generic argument
 30 |     html! { <Comp<P> /> };
    |              ~~~~~~~
 
-error[E0277]: the trait bound `AssertAllProps: HasAllProps<Props, _>` is not satisfied
-  --> tests/function_component_attr/generic-props-fail.rs:22:5
+error[E0277]: the trait bound `AssertAllProps: HasProp<a, _>` is not satisfied
+  --> tests/function_component_attr/generic-props-fail.rs:22:14
    |
 22 |     html! { <Comp<Props> /> };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<Props, _>`
+   |              ^^^^ the trait `HasProp<a, _>` is not implemented for `AssertAllProps`
    |
 note: required because of the requirements on the impl of `HasAllProps<Props, (_,)>` for `CheckPropsAll<AssertAllProps>`
   --> tests/function_component_attr/generic-props-fail.rs:3:17
    |
 3  | #[derive(Clone, Properties, PartialEq)]
    |                 ^^^^^^^^^^
-note: required by a bound in `finish_build`
-  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
-   |
-   |     B::WrappedTok: HasAllProps<B::Output, How>,
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
+   = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, PropsBuilder, (_,)>` for `AssertAllProps`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `new` exists for struct `VChild<Comp<MissingTypeBounds>>`, but its trait bounds were not satisfied

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -41,17 +41,22 @@ help: add missing generic argument
 30 |     html! { <Comp<P> /> };
    |              ~~~~~~~
 
-error[E0599]: no method named `build` found for struct `PropsBuilder<PropsBuilderStep_missing_required_prop_a>` in the current scope
-  --> tests/function_component_attr/generic-props-fail.rs:22:14
+error[E0277]: the trait bound `AssertAllProps: HasAllProps<Props, _>` is not satisfied
+  --> tests/function_component_attr/generic-props-fail.rs:22:5
+   |
+22 |     html! { <Comp<Props> /> };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<Props, _>`
+   |
+note: required because of the requirements on the impl of `HasAllProps<Props, (_,)>` for `CheckPropsAll<AssertAllProps>`
+  --> tests/function_component_attr/generic-props-fail.rs:3:17
    |
 3  | #[derive(Clone, Properties, PartialEq)]
-   |                 ---------- method `build` not found for this
-...
-22 |     html! { <Comp<Props> /> };
-   |              ^^^^ method not found in `PropsBuilder<PropsBuilderStep_missing_required_prop_a>`
+   |                 ^^^^^^^^^^
+note: required by a bound in `finish_build`
+  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
    |
-   = note: the method was found for
-           - `PropsBuilder<PropsBuilderStepPropsBuilder>`
+   |     B::WrappedTok: HasAllProps<B::Output, How>,
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `new` exists for struct `VChild<Comp<MissingTypeBounds>>`, but its trait bounds were not satisfied

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -1,11 +1,45 @@
 error[E0412]: cannot find type `INVALID` in this scope
   --> tests/function_component_attr/generic-props-fail.rs:25:19
    |
+25 |     html! { <Comp<INVALID> /> };
+   |                   ^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `INVALID` in this scope
+  --> tests/function_component_attr/generic-props-fail.rs:25:19
+   |
 20 | fn compile_fail() {
    |                - help: you might be missing a type parameter: `<INVALID>`
 ...
 25 |     html! { <Comp<INVALID> /> };
    |                   ^^^^^^^ not found in this scope
+
+error[E0277]: the trait bound `Comp<MissingTypeBounds>: yew::BaseComponent` is not satisfied
+  --> tests/function_component_attr/generic-props-fail.rs:27:14
+   |
+27 |     html! { <Comp<MissingTypeBounds> /> };
+   |              ^^^^ the trait `yew::BaseComponent` is not implemented for `Comp<MissingTypeBounds>`
+   |
+   = help: the following implementations were found:
+             <Comp<P> as yew::BaseComponent>
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0107]: missing generics for struct `Comp`
+  --> tests/function_component_attr/generic-props-fail.rs:30:14
+   |
+30 |     html! { <Comp /> };
+   |              ^^^^ expected 1 generic argument
+   |
+note: struct defined here, with 1 generic parameter: `P`
+  --> tests/function_component_attr/generic-props-fail.rs:8:22
+   |
+8  | #[function_component(Comp)]
+   |                      ^^^^
+9  | fn comp<P>(_props: &P) -> Html
+   |         -
+help: add missing generic argument
+   |
+30 |     html! { <Comp<P> /> };
+   |              ~~~~~~~
 
 error[E0599]: no method named `build` found for struct `PropsBuilder<PropsBuilderStep_missing_required_prop_a>` in the current scope
   --> tests/function_component_attr/generic-props-fail.rs:22:14
@@ -18,16 +52,6 @@ error[E0599]: no method named `build` found for struct `PropsBuilder<PropsBuilde
    |
    = note: the method was found for
            - `PropsBuilder<PropsBuilderStepPropsBuilder>`
-   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `Comp<MissingTypeBounds>: yew::BaseComponent` is not satisfied
-  --> tests/function_component_attr/generic-props-fail.rs:27:14
-   |
-27 |     html! { <Comp<MissingTypeBounds> /> };
-   |              ^^^^ the trait `yew::BaseComponent` is not implemented for `Comp<MissingTypeBounds>`
-   |
-   = help: the following implementations were found:
-             <Comp<P> as yew::BaseComponent>
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `new` exists for struct `VChild<Comp<MissingTypeBounds>>`, but its trait bounds were not satisfied
@@ -58,21 +82,3 @@ note: required by a bound in `Comp`
 11 |     P: Properties + PartialEq,
    |        ^^^^^^^^^^ required by this bound in `Comp`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0107]: missing generics for struct `Comp`
-  --> tests/function_component_attr/generic-props-fail.rs:30:14
-   |
-30 |     html! { <Comp /> };
-   |              ^^^^ expected 1 generic argument
-   |
-note: struct defined here, with 1 generic parameter: `P`
-  --> tests/function_component_attr/generic-props-fail.rs:8:22
-   |
-8  | #[function_component(Comp)]
-   |                      ^^^^
-9  | fn comp<P>(_props: &P) -> Html
-   |         -
-help: add missing generic argument
-   |
-30 |     html! { <Comp<P> /> };
-   |              ~~~~~~~

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -52,7 +52,7 @@ note: required because of the requirements on the impl of `HasAllProps<Props, (_
    |
 3  | #[derive(Clone, Properties, PartialEq)]
    |                 ^^^^^^^^^^
-   = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, PropsBuilder, (_,)>` for `AssertAllProps`
+   = note: required because of the requirements on the impl of `AllPropsFor<PropsBuilder, (_,)>` for `AssertAllProps`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `new` exists for struct `VChild<Comp<MissingTypeBounds>>`, but its trait bounds were not satisfied

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -339,7 +339,7 @@ error[E0599]: no method named `r#type` found for struct `ChildPropertiesBuilder`
    |                 ---------- method `r#type` not found for this
 ...
 71 |     html! { <Child type=0 /> };
-   |                    ^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
+   |                    ^^^^ method not found in `ChildPropertiesBuilder`
 
 error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:74:20
@@ -348,7 +348,7 @@ error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder
    |                 ---------- method `unknown` not found for this
 ...
 74 |     html! { <Child unknown="unknown" /> };
-   |                    ^^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
+   |                    ^^^^^^^ method not found in `ChildPropertiesBuilder`
 
 error[E0277]: the trait bound `(): IntoPropValue<String>` is not satisfied
   --> tests/html_macro/component-fail.rs:77:33
@@ -394,17 +394,23 @@ error[E0277]: the trait bound `u32: IntoPropValue<i32>` is not satisfied
 82 |     html! { <Child int=0u32 /> };
    |                        ^^^^ the trait `IntoPropValue<i32>` is not implemented for `u32`
 
-error[E0599]: no method named `string` found for struct `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-  --> tests/html_macro/component-fail.rs:83:20
+error[E0277]: the trait bound `AssertAllProps: HasAllProps<ChildProperties, _>` is not satisfied
+  --> tests/html_macro/component-fail.rs:83:5
+   |
+83 |     html! { <Child string="abc" /> };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<ChildProperties, _>`
+   |
+note: required because of the requirements on the impl of `HasAllProps<ChildProperties, (_,)>` for `CheckChildPropertiesAll<AssertAllProps>`
+  --> tests/html_macro/component-fail.rs:4:17
    |
 4  | #[derive(Clone, Properties, PartialEq)]
-   |                 ---------- method `string` not found for this
-...
-83 |     html! { <Child string="abc" /> };
-   |                    ^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
+   |                 ^^^^^^^^^^
+note: required by a bound in `finish_build`
+  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
    |
-   = note: the method was found for
-           - `ChildPropertiesBuilder<ChildPropertiesBuilderStepPropsBuilder>`
+   |     B::WrappedTok: HasAllProps<B::Output, How>,
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:87:14
@@ -413,34 +419,44 @@ error[E0599]: no method named `children` found for struct `ChildPropertiesBuilde
    |                 ---------- method `children` not found for this
 ...
 87 |     html! { <Child>{ "Not allowed" }</Child> };
-   |              ^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
+   |              ^^^^^ method not found in `ChildPropertiesBuilder`
    |
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: no method named `build` found for struct `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
-  --> tests/html_macro/component-fail.rs:99:14
+error[E0277]: the trait bound `AssertAllProps: HasAllProps<ChildContainerProperties, _>` is not satisfied
+  --> tests/html_macro/component-fail.rs:99:5
+   |
+99 |     html! { <ChildContainer /> };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<ChildContainerProperties, _>`
+   |
+note: required because of the requirements on the impl of `HasAllProps<ChildContainerProperties, (_,)>` for `CheckChildContainerPropertiesAll<AssertAllProps>`
+  --> tests/html_macro/component-fail.rs:24:17
    |
 24 | #[derive(Clone, Properties, PartialEq)]
-   |                 ---------- method `build` not found for this
-...
-99 |     html! { <ChildContainer /> };
-   |              ^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
+   |                 ^^^^^^^^^^
+note: required by a bound in `finish_build`
+  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
    |
-   = note: the method was found for
-           - `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStepPropsBuilder>`
+   |     B::WrappedTok: HasAllProps<B::Output, How>,
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: no method named `build` found for struct `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
-   --> tests/html_macro/component-fail.rs:100:14
+error[E0277]: the trait bound `AssertAllProps: HasAllProps<ChildContainerProperties, _>` is not satisfied
+   --> tests/html_macro/component-fail.rs:100:5
+    |
+100 |     html! { <ChildContainer></ChildContainer> };
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<ChildContainerProperties, _>`
+    |
+note: required because of the requirements on the impl of `HasAllProps<ChildContainerProperties, (_,)>` for `CheckChildContainerPropertiesAll<AssertAllProps>`
+   --> tests/html_macro/component-fail.rs:24:17
     |
 24  | #[derive(Clone, Properties, PartialEq)]
-    |                 ---------- method `build` not found for this
-...
-100 |     html! { <ChildContainer></ChildContainer> };
-    |              ^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
+    |                 ^^^^^^^^^^
+note: required by a bound in `finish_build`
+   --> $WORKSPACE/packages/yew/src/html/component/properties.rs
     |
-    = note: the method was found for
-            - `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStepPropsBuilder>`
+    |     B::WrappedTok: HasAllProps<B::Output, How>,
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
     = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `VChild<Child>: From<yew::virtual_dom::VText>` is not satisfied

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -279,17 +279,6 @@ error[E0425]: cannot find value `props` in this scope
 69 |     html! { <Child value=1 ..props /> };
    |                              ^^^^^ not found in this scope
 
-error[E0308]: mismatched types
-  --> tests/html_macro/component-fail.rs:53:22
-   |
-53 |     html! { <Child ..p1 ..p2 /> };
-   |              -----   ^^^^^^^ expected struct `ChildProperties`, found struct `std::ops::Range`
-   |              |
-   |              expected due to this
-   |
-   = note: expected struct `ChildProperties`
-              found struct `std::ops::Range<_>`
-
 error[E0609]: no field `value` on type `ChildProperties`
   --> tests/html_macro/component-fail.rs:69:20
    |
@@ -306,6 +295,43 @@ error[E0609]: no field `r#type` on type `ChildProperties`
    |
    = note: available fields are: `string`, `int`
 
+error[E0609]: no field `unknown` on type `ChildProperties`
+  --> tests/html_macro/component-fail.rs:74:20
+   |
+74 |     html! { <Child unknown="unknown" /> };
+   |                    ^^^^^^^ unknown field
+   |
+   = note: available fields are: `string`, `int`
+
+error[E0609]: no field `children` on type `ChildProperties`
+  --> tests/html_macro/component-fail.rs:87:14
+   |
+87 |     html! { <Child>{ "Not allowed" }</Child> };
+   |              ^^^^^ unknown field
+   |
+   = note: available fields are: `string`, `int`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `children` on type `ChildProperties`
+  --> tests/html_macro/component-fail.rs:94:10
+   |
+94 |         <Child ..ChildProperties { string: "hello".to_owned(), int: 5 }>
+   |          ^^^^^ unknown field
+   |
+   = note: available fields are: `string`, `int`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/html_macro/component-fail.rs:53:22
+   |
+53 |     html! { <Child ..p1 ..p2 /> };
+   |              -----   ^^^^^^^ expected struct `ChildProperties`, found struct `std::ops::Range`
+   |              |
+   |              expected due to this
+   |
+   = note: expected struct `ChildProperties`
+              found struct `std::ops::Range<_>`
+
 error[E0599]: no method named `r#type` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:71:20
    |
@@ -314,14 +340,6 @@ error[E0599]: no method named `r#type` found for struct `ChildPropertiesBuilder`
 ...
 71 |     html! { <Child type=0 /> };
    |                    ^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
-
-error[E0609]: no field `unknown` on type `ChildProperties`
-  --> tests/html_macro/component-fail.rs:74:20
-   |
-74 |     html! { <Child unknown="unknown" /> };
-   |                    ^^^^^^^ unknown field
-   |
-   = note: available fields are: `string`, `int`
 
 error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:74:20
@@ -388,15 +406,6 @@ error[E0599]: no method named `string` found for struct `ChildPropertiesBuilder<
    = note: the method was found for
            - `ChildPropertiesBuilder<ChildPropertiesBuilderStepPropsBuilder>`
 
-error[E0609]: no field `children` on type `ChildProperties`
-  --> tests/html_macro/component-fail.rs:87:14
-   |
-87 |     html! { <Child>{ "Not allowed" }</Child> };
-   |              ^^^^^ unknown field
-   |
-   = note: available fields are: `string`, `int`
-   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:87:14
    |
@@ -406,15 +415,6 @@ error[E0599]: no method named `children` found for struct `ChildPropertiesBuilde
 87 |     html! { <Child>{ "Not allowed" }</Child> };
    |              ^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
    |
-   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0609]: no field `children` on type `ChildProperties`
-  --> tests/html_macro/component-fail.rs:94:10
-   |
-94 |         <Child ..ChildProperties { string: "hello".to_owned(), int: 5 }>
-   |          ^^^^^ unknown field
-   |
-   = note: available fields are: `string`, `int`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `build` found for struct `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -394,22 +394,18 @@ error[E0277]: the trait bound `u32: IntoPropValue<i32>` is not satisfied
 82 |     html! { <Child int=0u32 /> };
    |                        ^^^^ the trait `IntoPropValue<i32>` is not implemented for `u32`
 
-error[E0277]: the trait bound `AssertAllProps: HasAllProps<ChildProperties, _>` is not satisfied
-  --> tests/html_macro/component-fail.rs:83:5
+error[E0277]: the trait bound `AssertAllProps: HasProp<int, _>` is not satisfied
+  --> tests/html_macro/component-fail.rs:83:14
    |
 83 |     html! { <Child string="abc" /> };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<ChildProperties, _>`
+   |              ^^^^^ the trait `HasProp<int, _>` is not implemented for `AssertAllProps`
    |
 note: required because of the requirements on the impl of `HasAllProps<ChildProperties, (_,)>` for `CheckChildPropertiesAll<AssertAllProps>`
   --> tests/html_macro/component-fail.rs:4:17
    |
 4  | #[derive(Clone, Properties, PartialEq)]
    |                 ^^^^^^^^^^
-note: required by a bound in `finish_build`
-  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
-   |
-   |     B::WrappedTok: HasAllProps<B::Output, How>,
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
+   = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, ChildPropertiesBuilder, (_,)>` for `AssertAllProps`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder` in the current scope
@@ -423,40 +419,32 @@ error[E0599]: no method named `children` found for struct `ChildPropertiesBuilde
    |
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AssertAllProps: HasAllProps<ChildContainerProperties, _>` is not satisfied
-  --> tests/html_macro/component-fail.rs:99:5
+error[E0277]: the trait bound `AssertAllProps: HasProp<_ChildContainerProperties::children, _>` is not satisfied
+  --> tests/html_macro/component-fail.rs:99:14
    |
 99 |     html! { <ChildContainer /> };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<ChildContainerProperties, _>`
+   |              ^^^^^^^^^^^^^^ the trait `HasProp<_ChildContainerProperties::children, _>` is not implemented for `AssertAllProps`
    |
 note: required because of the requirements on the impl of `HasAllProps<ChildContainerProperties, (_,)>` for `CheckChildContainerPropertiesAll<AssertAllProps>`
   --> tests/html_macro/component-fail.rs:24:17
    |
 24 | #[derive(Clone, Properties, PartialEq)]
    |                 ^^^^^^^^^^
-note: required by a bound in `finish_build`
-  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
-   |
-   |     B::WrappedTok: HasAllProps<B::Output, How>,
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
+   = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, ChildContainerPropertiesBuilder, (_,)>` for `AssertAllProps`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AssertAllProps: HasAllProps<ChildContainerProperties, _>` is not satisfied
-   --> tests/html_macro/component-fail.rs:100:5
+error[E0277]: the trait bound `AssertAllProps: HasProp<_ChildContainerProperties::children, _>` is not satisfied
+   --> tests/html_macro/component-fail.rs:100:14
     |
 100 |     html! { <ChildContainer></ChildContainer> };
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `HasAllProps<ChildContainerProperties, _>`
+    |              ^^^^^^^^^^^^^^ the trait `HasProp<_ChildContainerProperties::children, _>` is not implemented for `AssertAllProps`
     |
 note: required because of the requirements on the impl of `HasAllProps<ChildContainerProperties, (_,)>` for `CheckChildContainerPropertiesAll<AssertAllProps>`
    --> tests/html_macro/component-fail.rs:24:17
     |
 24  | #[derive(Clone, Properties, PartialEq)]
     |                 ^^^^^^^^^^
-note: required by a bound in `finish_build`
-   --> $WORKSPACE/packages/yew/src/html/component/properties.rs
-    |
-    |     B::WrappedTok: HasAllProps<B::Output, How>,
-    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `finish_build`
+    = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, ChildContainerPropertiesBuilder, (_,)>` for `AssertAllProps`
     = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `VChild<Child>: From<yew::virtual_dom::VText>` is not satisfied

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -405,7 +405,7 @@ note: required because of the requirements on the impl of `HasAllProps<ChildProp
    |
 4  | #[derive(Clone, Properties, PartialEq)]
    |                 ^^^^^^^^^^
-   = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, ChildPropertiesBuilder, (_,)>` for `AssertAllProps`
+   = note: required because of the requirements on the impl of `AllPropsFor<ChildPropertiesBuilder, (_,)>` for `AssertAllProps`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder` in the current scope
@@ -430,7 +430,7 @@ note: required because of the requirements on the impl of `HasAllProps<ChildCont
    |
 24 | #[derive(Clone, Properties, PartialEq)]
    |                 ^^^^^^^^^^
-   = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, ChildContainerPropertiesBuilder, (_,)>` for `AssertAllProps`
+   = note: required because of the requirements on the impl of `AllPropsFor<ChildContainerPropertiesBuilder, (_,)>` for `AssertAllProps`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AssertAllProps: HasProp<_ChildContainerProperties::children, _>` is not satisfied
@@ -444,7 +444,7 @@ note: required because of the requirements on the impl of `HasAllProps<ChildCont
     |
 24  | #[derive(Clone, Properties, PartialEq)]
     |                 ^^^^^^^^^^
-    = note: required because of the requirements on the impl of `AllPropsFrom<AssertAllProps, ChildContainerPropertiesBuilder, (_,)>` for `AssertAllProps`
+    = note: required because of the requirements on the impl of `AllPropsFor<ChildContainerPropertiesBuilder, (_,)>` for `AssertAllProps`
     = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `VChild<Child>: From<yew::virtual_dom::VText>` is not satisfied

--- a/packages/yew-macro/tests/props_macro/props-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/props-fail.stderr
@@ -30,6 +30,14 @@ error[E0609]: no field `fail` on type `Props`
    |
    = note: available fields are: `a`
 
+error[E0609]: no field `does_not_exist` on type `Props`
+  --> tests/props_macro/props-fail.rs:15:25
+   |
+15 |     yew::props!(Props { does_not_exist });
+   |                         ^^^^^^^^^^^^^^ unknown field
+   |
+   = note: available fields are: `a`
+
 error[E0599]: no method named `fail` found for struct `PropsBuilder` in the current scope
   --> tests/props_macro/props-fail.rs:10:31
    |
@@ -38,14 +46,6 @@ error[E0599]: no method named `fail` found for struct `PropsBuilder` in the curr
 ...
 10 |     yew::props!(Props { a: 5, fail: 10 });
    |                               ^^^^ method not found in `PropsBuilder<PropsBuilderStepPropsBuilder>`
-
-error[E0609]: no field `does_not_exist` on type `Props`
-  --> tests/props_macro/props-fail.rs:15:25
-   |
-15 |     yew::props!(Props { does_not_exist });
-   |                         ^^^^^^^^^^^^^^ unknown field
-   |
-   = note: available fields are: `a`
 
 error[E0599]: no method named `does_not_exist` found for struct `PropsBuilder` in the current scope
   --> tests/props_macro/props-fail.rs:15:25

--- a/packages/yew-macro/tests/props_macro/props-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/props-fail.stderr
@@ -45,7 +45,7 @@ error[E0599]: no method named `fail` found for struct `PropsBuilder` in the curr
    |                 ---------- method `fail` not found for this
 ...
 10 |     yew::props!(Props { a: 5, fail: 10 });
-   |                               ^^^^ method not found in `PropsBuilder<PropsBuilderStepPropsBuilder>`
+   |                               ^^^^ method not found in `PropsBuilder`
 
 error[E0599]: no method named `does_not_exist` found for struct `PropsBuilder` in the current scope
   --> tests/props_macro/props-fail.rs:15:25
@@ -54,4 +54,4 @@ error[E0599]: no method named `does_not_exist` found for struct `PropsBuilder` i
    |                 ---------- method `does_not_exist` not found for this
 ...
 15 |     yew::props!(Props { does_not_exist });
-   |                         ^^^^^^^^^^^^^^ method not found in `PropsBuilder<PropsBuilderStep_missing_required_prop_a>`
+   |                         ^^^^^^^^^^^^^^ method not found in `PropsBuilder`

--- a/packages/yew-macro/tests/props_macro/props-pass.rs
+++ b/packages/yew-macro/tests/props_macro/props-pass.rs
@@ -43,6 +43,12 @@ struct Props {
     b: ::std::primitive::usize,
 }
 
+fn pass_simple_props() {
+    ::yew::props!(Props { a: 5 });
+    let (a, b) = (3, 5);
+    ::yew::props!(Props { a, b });
+}
+
 #[derive(::yew::Properties, ::std::cmp::PartialEq)]
 pub struct RawIdentProps {
     r#true: ::std::primitive::usize,
@@ -50,13 +56,19 @@ pub struct RawIdentProps {
     r#pointless_raw_name: ::std::primitive::usize,
 }
 
-fn compile_pass() {
-    ::yew::props!(Props { a: 5 });
-    let (a, b) = (3, 5);
-    ::yew::props!(Props { a, b });
+fn pass_raw_idents() {
     ::yew::props!(RawIdentProps { r#true: 5 });
     let (r#true, r#pointless_raw_name) = (3, 5);
     ::yew::props!(RawIdentProps { r#true, r#pointless_raw_name });
+}
+
+#[derive(::std::clone::Clone, ::yew::Properties, ::std::cmp::PartialEq)]
+struct BuildProp {
+    build: ::std::primitive::usize,
+}
+
+fn pass_build_prop() {
+    ::yew::props!(BuildProp { build: 5 });
 }
 
 fn main() {}

--- a/packages/yew/src/html/component/properties.rs
+++ b/packages/yew/src/html/component/properties.rs
@@ -11,7 +11,8 @@ pub trait Properties: PartialEq {
     fn builder() -> Self::Builder;
 }
 
-mod macro_export {
+#[doc(hidden)]
+mod __macro {
     /// A marker trait to ensure that the builder has received a specific required prop.
     /// For each required impl in a property, we generate:
     /// - a struct with the name of the prop, which takes the place of `P`.
@@ -29,6 +30,8 @@ mod macro_export {
     /// A marker trait to ensure that the builder has received all required props.
     /// For each struct deriving [`Properties`], an impl is generated, requiring `HasProp<p>` for
     /// all properties marked as required as a bound on the impl.
+    ///
+    /// [`Properties`]: super::Properties
     pub trait HasAllProps<P, How> {}
 
     /// Trait finishing the builder and verifying all props were set.
@@ -113,4 +116,4 @@ mod macro_export {
 }
 
 #[doc(hidden)]
-pub use macro_export::{AllPropsFor, AssertAllProps, Buildable, HasAllProps, HasProp};
+pub use __macro::{AllPropsFor, AssertAllProps, Buildable, HasAllProps, HasProp};

--- a/packages/yew/src/html/component/properties.rs
+++ b/packages/yew/src/html/component/properties.rs
@@ -11,6 +11,13 @@ pub trait Properties: PartialEq {
     fn builder() -> Self::Builder;
 }
 
+/// Trait finishing the builder and verifying all props were set
+#[doc(hidden)]
+pub trait Buildable {
+    type Output;
+    fn build(this: Self) -> Self::Output;
+}
+
 /// Builder for when a component has no properties
 #[derive(Debug, PartialEq)]
 #[doc(hidden)]
@@ -24,7 +31,9 @@ impl Properties for () {
     }
 }
 
-impl EmptyBuilder {
+impl Buildable for EmptyBuilder {
+    type Output = ();
+
     /// Build empty properties
-    pub fn build(self) {}
+    fn build(_: Self) {}
 }

--- a/packages/yew/src/html/component/properties.rs
+++ b/packages/yew/src/html/component/properties.rs
@@ -11,81 +11,106 @@ pub trait Properties: PartialEq {
     fn builder() -> Self::Builder;
 }
 
-/// A marker trait to ensure that the builder has received a specific required prop
-#[doc(hidden)]
-pub trait HasProp<P, How> {}
+mod macro_export {
+    /// A marker trait to ensure that the builder has received a specific required prop.
+    /// For each required impl in a property, we generate:
+    /// - a struct with the name of the prop, which takes the place of `P`.
+    /// - a token wrapper, `HasP<TokenTail>`, that records that the build state represented includes
+    ///   the state in `TokenTail` + `P`. Such tokens are returned from the setter on the builder,
+    ///   to verify the build state.
+    /// - An `impl<T> HasP<T>: HasProp<P, _>` saying that a state represented by a token of
+    ///   `HasP<_>` indeed verifies P has been set.
+    /// - An `impl<Q> HasP<Tail>: HasProp<Q, _> where Tail: HasProp<Q>` saying that any props set
+    ///   previously (represented by the tail) is still set after P has been set.
+    /// - ^ the two impls would be overlapping, where it not for the `How` argument, which resolves
+    ///   the conflict.
+    pub trait HasProp<P, How> {}
 
-/// A marker trait to ensure that the builder has received all required props
-#[doc(hidden)]
-pub trait HasAllProps<P, How> {}
+    /// A marker trait to ensure that the builder has received all required props.
+    /// For each struct deriving [`Properties`], an impl is generated, requiring `HasProp<p>` for
+    /// all properties marked as required as a bound on the impl.
+    pub trait HasAllProps<P, How> {}
 
-/// Trait finishing the builder and verifying all props were set
-#[doc(hidden)]
-pub trait Buildable<Token: ?Sized> {
-    type Output;
-    type WrappedTok;
-    fn pre_build(builder: Self, _: &Token) -> PreBuild<Token, Self>
-    where
-        Self: Sized,
-    {
-        PreBuild {
-            builder,
-            _token: std::marker::PhantomData,
+    /// Trait finishing the builder and verifying all props were set.
+    /// The structure can be a bit surprising, and is related to how the proc macro reports errors
+    /// - why have a prepare_build method? This captures the argument types, but now `How`, and
+    ///   returns an internal type with a method that can be called without further qualification.
+    ///   We need the additional types, to avoid collision with property names in the Builder. We
+    ///   want to avoid qualification to persuade rust not to report the `finish_build` method name.
+    /// - why have a AllPropsFor trait? We want the trait to be on the Token, not on a type
+    ///   associated or derived from it, so that it shows up in errors directly instead of through
+    ///   convoluted traces.
+    pub trait Buildable<Token> {
+        /// Property type being built
+        type Output;
+        /// Instead of `Token` directly, a wrapped token type is checked for trait impls in macro
+        /// code. This avoids problems related to blanket impls.
+        type WrappedToken;
+        /// This method "captures" the builder and token type, but does not verify yet.
+        fn prepare_build(builder: Self, _: &Token) -> PreBuild<Token, Self>
+        where
+            Self: Sized,
+        {
+            PreBuild {
+                builder,
+                _token: std::marker::PhantomData,
+            }
+        }
+        /// Build the props from self. Expected to panic if not all props where set.
+        fn build(this: Self) -> Self::Output;
+    }
+    /// Helper alias for a Builder, also capturing the prop Token recording the provided props.
+    #[derive(Debug)]
+    pub struct PreBuild<Token, B> {
+        _token: std::marker::PhantomData<Token>,
+        builder: B,
+    }
+
+    impl<Token, B: Buildable<Token>> PreBuild<Token, B> {
+        /// This is the method that introduces the actual bound verifying all props where set.
+        pub fn build<How>(self) -> B::Output
+        where
+            Token: AllPropsFor<B, How>,
+        {
+            B::build(self.builder)
         }
     }
-    fn build(this: Self) -> Self::Output;
-}
-#[doc(hidden)]
-#[derive(Debug)]
-pub struct PreBuild<Token: ?Sized, B> {
-    _token: std::marker::PhantomData<Token>,
-    builder: B,
-}
 
-impl<Token, B: Buildable<Token>> PreBuild<Token, B> {
-    #[doc(hidden)]
-    pub fn build<How>(self) -> B::Output
-    where
-        Token: AllPropsFrom<Token, B, How>,
+    /// Trait to specify the requirement for Self to be a valid token signaling all props have been
+    /// provided to the builder.
+    pub trait AllPropsFor<Builder, How> {}
+
+    impl<Token, Builder: Buildable<Token>, How> AllPropsFor<Builder, How> for Token where
+        Builder::WrappedToken: HasAllProps<Builder::Output, How>
     {
-        B::build(self.builder)
     }
-}
 
-#[doc(hidden)]
-pub trait AllPropsFrom<Token, B: Buildable<Token>, How> {}
+    /// Dummy struct targeted by assertions that all props were set
+    #[derive(Debug)]
+    pub struct AssertAllProps;
 
-impl<Token, B, How> AllPropsFrom<Token, B, How> for Token
-where
-    B: Buildable<Token>,
-    B::WrappedTok: HasAllProps<B::Output, How>,
-{
-}
+    /// Builder for when a component has no properties
+    #[derive(Debug, PartialEq)]
+    pub struct EmptyBuilder;
 
-/// Dummy struct targeted by assertions that all props were set
-#[doc(hidden)]
-#[derive(Debug)]
-pub struct AssertAllProps;
+    impl super::Properties for () {
+        type Builder = EmptyBuilder;
 
-/// Builder for when a component has no properties
-#[derive(Debug, PartialEq)]
-#[doc(hidden)]
-pub struct EmptyBuilder;
-
-impl Properties for () {
-    type Builder = EmptyBuilder;
-
-    fn builder() -> Self::Builder {
-        EmptyBuilder
+        fn builder() -> Self::Builder {
+            EmptyBuilder
+        }
     }
+
+    impl<T> Buildable<T> for EmptyBuilder {
+        type Output = ();
+        type WrappedToken = ();
+
+        /// Build empty properties
+        fn build(_: Self) {}
+    }
+
+    impl<T> HasAllProps<(), T> for T {}
 }
 
-impl<T> Buildable<T> for EmptyBuilder {
-    type Output = ();
-    type WrappedTok = ();
-
-    /// Build empty properties
-    fn build(_: Self) {}
-}
-
-impl<T> HasAllProps<(), T> for T {}
+#[doc(hidden)]
+pub use macro_export::{AllPropsFor, AssertAllProps, Buildable, HasAllProps, HasProp};

--- a/packages/yew/src/html/component/properties.rs
+++ b/packages/yew/src/html/component/properties.rs
@@ -18,6 +18,11 @@ pub trait Buildable {
     fn build(this: Self) -> Self::Output;
 }
 
+/// Dummy struct targeted by assertions that all props were set
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct AssertAllProps;
+
 /// Builder for when a component has no properties
 #[derive(Debug, PartialEq)]
 #[doc(hidden)]


### PR DESCRIPTION
#### Description

This PR is a follow up to #2369. It solves the blocker towards inherited props by replacing the manual builder steps tracking the state of the builder (required props) with a trait-guided solution, based on the central `HasProp` and `HasAllProps` traits.

I suppose it would also make sense to have another look at #1634. Currently, all props are added in _alphabetical order_, but with the trait approach, the order shouldn't matter.

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
