### PR TITLE
Update introduction.mdx

### DIFF
--- a/website/docs/concepts/html/conditional-rendering.mdx
+++ b/website/docs/concepts/html/conditional-rendering.mdx
@@ -31,7 +31,7 @@ use yew::prelude::*;
 let some_condition = true;
 
 html! {
-    if false {
+    if some_condition {
         <p>{ "True case" }</p>
     } else {
         <p>{ "False case" }</p>

--- a/website/versioned_docs/version-0.19.0/concepts/html/introduction.mdx
+++ b/website/versioned_docs/version-0.19.0/concepts/html/introduction.mdx
@@ -189,7 +189,7 @@ use yew::html;
 let some_condition = true;
 
 html! {
-    if false {
+    if some_condition {
         <p>{ "True case" }</p>
     } else {
         <p>{ "False case" }</p>


### PR DESCRIPTION

#### Description

The `if else` example was syntactically correct, but had a semantic issue of not using the condition variable. Could lead to confusion if you are a newbie.
