### PR TITLE
Fix generic props structs

### DIFF
--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -135,6 +135,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
+        # for wasm-bindgen-cli, always use stable rust
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
           target: wasm32-unknown-unknown
@@ -153,7 +159,7 @@ jobs:
             cargo fetch
           fi
           VERSION=`cargo pkgid --frozen wasm-bindgen | cut -d ":" -f 3`
-          cargo install --version $VERSION wasm-bindgen-cli
+          cargo +stable install --version $VERSION wasm-bindgen-cli
 
       - name: Run tests - yew
         run: |

--- a/examples/password_strength/Cargo.toml
+++ b/examples/password_strength/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 yew = { path = "../../packages/yew", features = ["csr"] }
 zxcvbn = "2.2.1"
+time = "=0.3.9" # remove version pin with msrv 1.60
 js-sys = "0.3.46"
 web-sys = { version = "0.3", features = ["Event","EventTarget","InputEvent"] }
 wasm-bindgen = "0.2"

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -70,7 +70,8 @@ impl ComponentProps {
             .collect();
 
         quote_spanned! {props_ty.span()=>
-            const __YEW_PROPS_CHECK: () = {
+            #[allow(clippy::no_effect)]
+            if false {
                 let _ = |#props_ident: #props_ty| {
                     #check_children
                     #check_props

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -1,45 +1,11 @@
 error[E0412]: cannot find type `INVALID` in this scope
   --> tests/function_component_attr/generic-props-fail.rs:25:19
    |
-25 |     html! { <Comp<INVALID> /> };
-   |                   ^^^^^^^ not found in this scope
-
-error[E0412]: cannot find type `INVALID` in this scope
-  --> tests/function_component_attr/generic-props-fail.rs:25:19
-   |
 20 | fn compile_fail() {
    |                - help: you might be missing a type parameter: `<INVALID>`
 ...
 25 |     html! { <Comp<INVALID> /> };
    |                   ^^^^^^^ not found in this scope
-
-error[E0277]: the trait bound `Comp<MissingTypeBounds>: yew::BaseComponent` is not satisfied
-  --> tests/function_component_attr/generic-props-fail.rs:27:14
-   |
-27 |     html! { <Comp<MissingTypeBounds> /> };
-   |              ^^^^ the trait `yew::BaseComponent` is not implemented for `Comp<MissingTypeBounds>`
-   |
-   = help: the following implementations were found:
-             <Comp<P> as yew::BaseComponent>
-   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0107]: missing generics for struct `Comp`
-  --> tests/function_component_attr/generic-props-fail.rs:30:14
-   |
-30 |     html! { <Comp /> };
-   |              ^^^^ expected 1 generic argument
-   |
-note: struct defined here, with 1 generic parameter: `P`
-  --> tests/function_component_attr/generic-props-fail.rs:8:22
-   |
-8  | #[function_component(Comp)]
-   |                      ^^^^
-9  | fn comp<P>(_props: &P) -> Html
-   |         -
-help: add missing generic argument
-   |
-30 |     html! { <Comp<P> /> };
-   |              ~~~~~~~
 
 error[E0277]: the trait bound `AssertAllProps: HasProp<a, _>` is not satisfied
   --> tests/function_component_attr/generic-props-fail.rs:22:14
@@ -53,6 +19,16 @@ note: required because of the requirements on the impl of `HasAllProps<Props, (_
 3  | #[derive(Clone, Properties, PartialEq)]
    |                 ^^^^^^^^^^
    = note: required because of the requirements on the impl of `AllPropsFor<PropsBuilder, (_,)>` for `AssertAllProps`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Comp<MissingTypeBounds>: yew::BaseComponent` is not satisfied
+  --> tests/function_component_attr/generic-props-fail.rs:27:14
+   |
+27 |     html! { <Comp<MissingTypeBounds> /> };
+   |              ^^^^ the trait `yew::BaseComponent` is not implemented for `Comp<MissingTypeBounds>`
+   |
+   = help: the following implementations were found:
+             <Comp<P> as yew::BaseComponent>
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `new` exists for struct `VChild<Comp<MissingTypeBounds>>`, but its trait bounds were not satisfied
@@ -83,3 +59,21 @@ note: required by a bound in `Comp`
 11 |     P: Properties + PartialEq,
    |        ^^^^^^^^^^ required by this bound in `Comp`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0107]: missing generics for struct `Comp`
+  --> tests/function_component_attr/generic-props-fail.rs:30:14
+   |
+30 |     html! { <Comp /> };
+   |              ^^^^ expected 1 generic argument
+   |
+note: struct defined here, with 1 generic parameter: `P`
+  --> tests/function_component_attr/generic-props-fail.rs:8:22
+   |
+8  | #[function_component(Comp)]
+   |                      ^^^^
+9  | fn comp<P>(_props: &P) -> Html
+   |         -
+help: add missing generic argument
+   |
+30 |     html! { <Comp<P> /> };
+   |              ~~~~~~~

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -279,6 +279,17 @@ error[E0425]: cannot find value `props` in this scope
 69 |     html! { <Child value=1 ..props /> };
    |                              ^^^^^ not found in this scope
 
+error[E0308]: mismatched types
+  --> tests/html_macro/component-fail.rs:53:22
+   |
+53 |     html! { <Child ..p1 ..p2 /> };
+   |              -----   ^^^^^^^ expected struct `ChildProperties`, found struct `std::ops::Range`
+   |              |
+   |              expected due to this
+   |
+   = note: expected struct `ChildProperties`
+              found struct `std::ops::Range<_>`
+
 error[E0609]: no field `value` on type `ChildProperties`
   --> tests/html_macro/component-fail.rs:69:20
    |
@@ -295,43 +306,6 @@ error[E0609]: no field `r#type` on type `ChildProperties`
    |
    = note: available fields are: `string`, `int`
 
-error[E0609]: no field `unknown` on type `ChildProperties`
-  --> tests/html_macro/component-fail.rs:74:20
-   |
-74 |     html! { <Child unknown="unknown" /> };
-   |                    ^^^^^^^ unknown field
-   |
-   = note: available fields are: `string`, `int`
-
-error[E0609]: no field `children` on type `ChildProperties`
-  --> tests/html_macro/component-fail.rs:87:14
-   |
-87 |     html! { <Child>{ "Not allowed" }</Child> };
-   |              ^^^^^ unknown field
-   |
-   = note: available fields are: `string`, `int`
-   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0609]: no field `children` on type `ChildProperties`
-  --> tests/html_macro/component-fail.rs:94:10
-   |
-94 |         <Child ..ChildProperties { string: "hello".to_owned(), int: 5 }>
-   |          ^^^^^ unknown field
-   |
-   = note: available fields are: `string`, `int`
-   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/html_macro/component-fail.rs:53:22
-   |
-53 |     html! { <Child ..p1 ..p2 /> };
-   |              -----   ^^^^^^^ expected struct `ChildProperties`, found struct `std::ops::Range`
-   |              |
-   |              expected due to this
-   |
-   = note: expected struct `ChildProperties`
-              found struct `std::ops::Range<_>`
-
 error[E0599]: no method named `r#type` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:71:20
    |
@@ -340,6 +314,14 @@ error[E0599]: no method named `r#type` found for struct `ChildPropertiesBuilder`
 ...
 71 |     html! { <Child type=0 /> };
    |                    ^^^^ method not found in `ChildPropertiesBuilder`
+
+error[E0609]: no field `unknown` on type `ChildProperties`
+  --> tests/html_macro/component-fail.rs:74:20
+   |
+74 |     html! { <Child unknown="unknown" /> };
+   |                    ^^^^^^^ unknown field
+   |
+   = note: available fields are: `string`, `int`
 
 error[E0599]: no method named `unknown` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:74:20
@@ -408,6 +390,15 @@ note: required because of the requirements on the impl of `HasAllProps<ChildProp
    = note: required because of the requirements on the impl of `AllPropsFor<ChildPropertiesBuilder, (_,)>` for `AssertAllProps`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0609]: no field `children` on type `ChildProperties`
+  --> tests/html_macro/component-fail.rs:87:14
+   |
+87 |     html! { <Child>{ "Not allowed" }</Child> };
+   |              ^^^^^ unknown field
+   |
+   = note: available fields are: `string`, `int`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder` in the current scope
   --> tests/html_macro/component-fail.rs:87:14
    |
@@ -417,6 +408,15 @@ error[E0599]: no method named `children` found for struct `ChildPropertiesBuilde
 87 |     html! { <Child>{ "Not allowed" }</Child> };
    |              ^^^^^ method not found in `ChildPropertiesBuilder`
    |
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `children` on type `ChildProperties`
+  --> tests/html_macro/component-fail.rs:94:10
+   |
+94 |         <Child ..ChildProperties { string: "hello".to_owned(), int: 5 }>
+   |          ^^^^^ unknown field
+   |
+   = note: available fields are: `string`, `int`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AssertAllProps: HasProp<_ChildContainerProperties::children, _>` is not satisfied

--- a/packages/yew-macro/tests/props_macro/props-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/props-fail.stderr
@@ -30,14 +30,6 @@ error[E0609]: no field `fail` on type `Props`
    |
    = note: available fields are: `a`
 
-error[E0609]: no field `does_not_exist` on type `Props`
-  --> tests/props_macro/props-fail.rs:15:25
-   |
-15 |     yew::props!(Props { does_not_exist });
-   |                         ^^^^^^^^^^^^^^ unknown field
-   |
-   = note: available fields are: `a`
-
 error[E0599]: no method named `fail` found for struct `PropsBuilder` in the current scope
   --> tests/props_macro/props-fail.rs:10:31
    |
@@ -46,6 +38,14 @@ error[E0599]: no method named `fail` found for struct `PropsBuilder` in the curr
 ...
 10 |     yew::props!(Props { a: 5, fail: 10 });
    |                               ^^^^ method not found in `PropsBuilder`
+
+error[E0609]: no field `does_not_exist` on type `Props`
+  --> tests/props_macro/props-fail.rs:15:25
+   |
+15 |     yew::props!(Props { does_not_exist });
+   |                         ^^^^^^^^^^^^^^ unknown field
+   |
+   = note: available fields are: `a`
 
 error[E0599]: no method named `does_not_exist` found for struct `PropsBuilder` in the current scope
   --> tests/props_macro/props-fail.rs:15:25

--- a/packages/yew-macro/tests/props_macro/props-pass.rs
+++ b/packages/yew-macro/tests/props_macro/props-pass.rs
@@ -71,4 +71,13 @@ fn pass_build_prop() {
     ::yew::props!(BuildProp { build: 5 });
 }
 
+#[derive(::yew::Properties, ::std::cmp::PartialEq)]
+struct GenericProps<T: ::std::cmp::PartialEq> {
+    item: T,
+}
+
+fn pass_generic_props<T: ::std::cmp::PartialEq>(the_item: T) {
+    ::yew::props!(GenericProps<T> { item: the_item });
+}
+
 fn main() {}


### PR DESCRIPTION
#### Description

Fixup of #2729  for generic property structs. I mistakenly converted the checks guarded by `if false` to a `const _: ()` check, which makes generic arguments from the context invisible, leading to [the problem](https://github.com/yewstack/yew/commit/75bb9031cd7614269f479d3fb7480bb4bb345a2b#commitcomment-76692416)

This also for some reason changes the order in which errors are reported with trybuild.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
