### PR TITLE
Add rewind buttons to the Counter example

### DIFF
--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+gloo = "0.7"
 gloo-console = "0.2"
 js-sys = "0.3"
 yew = { path = "../../packages/yew", features = ["csr"] }


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->
I added two buttons rewind forward and backward to demonstrate a work with the Interval. Now it looks like a "player"

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [v] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
