### PR TITLE
[examples::ssr_router] fix bug in example preventing `/` from rendering

### DIFF
--- a/examples/ssr_router/src/bin/ssr_router_server.rs
+++ b/examples/ssr_router/src/bin/ssr_router_server.rs
@@ -72,8 +72,6 @@ async fn main() {
 
     let app = Router::new()
         .route("/api/test", get(|| async move { "Hello World" }))
-        // needed because https://github.com/tower-rs/tower-http/issues/262
-        .route("/", get(render))
         .fallback(HandleError::new(
             ServeDir::new(opts.dir)
                 .append_index_html_on_directories(false)


### PR DESCRIPTION
#### Description

move axum extension to end so it is always present

otherwise I was seeing

```
Missing request extension: Extension of type `alloc::string::String` was not
found. Perhaps you forgot to add it? See `axum::Extension`.
```

when navigating to localhost:8080



#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  - i believe catching this would require a full end-to-end browser test, which feels out of scope for this PR ;)... it would be great if yew had the setup for it though!

