### PR TITLE
Fix: prevent bubbling of !bubbles() events

### DIFF
--- a/packages/yew/src/dom_bundle/btag/listeners.rs
+++ b/packages/yew/src/dom_bundle/btag/listeners.rs
@@ -202,7 +202,7 @@ mod tests {
     use std::marker::PhantomData;
 
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
-    use web_sys::{Event, EventInit, HtmlElement, MouseEvent, FocusEvent};
+    use web_sys::{Event, EventInit, FocusEvent, HtmlElement, MouseEvent};
     wasm_bindgen_test_configure!(run_in_browser);
 
     use gloo_utils::document;
@@ -565,7 +565,12 @@ mod tests {
         let (_, el) = init::<NonBubbling>();
 
         assert_count(&el, 0);
-        el.get().unwrap().dyn_into::<HtmlElement>().unwrap().focus().unwrap();
+        el.get()
+            .unwrap()
+            .dyn_into::<HtmlElement>()
+            .unwrap()
+            .focus()
+            .unwrap();
         scheduler::start_now();
         assert_count(&el, 1);
     }

--- a/packages/yew/src/dom_bundle/btag/listeners.rs
+++ b/packages/yew/src/dom_bundle/btag/listeners.rs
@@ -202,7 +202,7 @@ mod tests {
     use std::marker::PhantomData;
 
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
-    use web_sys::{Event, EventInit, HtmlElement, MouseEvent};
+    use web_sys::{Event, EventInit, HtmlElement, MouseEvent, FocusEvent};
     wasm_bindgen_test_configure!(run_in_browser);
 
     use gloo_utils::document;
@@ -534,6 +534,40 @@ mod tests {
         assert_count(&el, 1);
         click(&el);
         assert_count(&el, 2);
+    }
+
+    #[test]
+    fn non_bubbling() {
+        #[derive(Default, PartialEq, Properties)]
+        struct NonBubbling;
+
+        impl Mixin for NonBubbling {
+            fn view<C>(ctx: &Context<C>, state: &State) -> Html
+            where
+                C: Component<Message = Message, Properties = MixinProps<Self>>,
+            {
+                let onfocus = ctx.link().callback(|_| Message::Action);
+                let onfocus_inner = ctx.link().callback(|e: FocusEvent| {
+                    assert!(!e.bubbles(), "event should be non-bubbling");
+                    Message::Action
+                });
+
+                html! {
+                    <div {onfocus}>
+                        <button onfocus={onfocus_inner} ref={&ctx.props().state_ref}>
+                            {state.action}
+                        </button>
+                    </div>
+                }
+            }
+        }
+        // Should only trigger the inner listener, not also the outer one
+        let (_, el) = init::<NonBubbling>();
+
+        assert_count(&el, 0);
+        el.get().unwrap().dyn_into::<HtmlElement>().unwrap().focus().unwrap();
+        scheduler::start_now();
+        assert_count(&el, 1);
     }
 
     /// Here an event is being delivered to a DOM node which is contained

--- a/packages/yew/src/dom_bundle/subtree_root.rs
+++ b/packages/yew/src/dom_bundle/subtree_root.rs
@@ -370,7 +370,7 @@ impl SubtreeData {
         // We're tasked with finding the subtree that is reponsible with handling the event, and/or
         // run the handling if that's `self`.
         let target = event_path.get(0).dyn_into::<Element>().ok()?;
-        let should_bubble = BUBBLE_EVENTS.load(Ordering::Relaxed);
+        let should_bubble = BUBBLE_EVENTS.load(Ordering::Relaxed) && event.bubbles();
         // We say that the most deeply nested subtree is "responsible" for handling the event.
         let (responsible_tree_id, bubbling_start) = if let Some(branding) = cached_branding {
             (branding, target.clone())


### PR DESCRIPTION
#### Description

Events with `bubbles: false` should not cause bubbling to happen, even if event bubbling is enabled.

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
