### PR TITLE
Fixed `NodeRef` not being implicitly cloned with components

### DIFF
--- a/examples/node_refs/src/main.rs
+++ b/examples/node_refs/src/main.rs
@@ -79,7 +79,7 @@ impl Component for App {
                             <label>{ "Email" }</label>
                             <input
                                 type="text"
-                                ref={self.refs[0].clone()}
+                                ref={&self.refs[0]}
                                 class="input-element"
                                 onmouseover={ctx.link().callback(|_| Msg::HoverIndex(0))}
                                 placeholder="abcd@xyz.com"
@@ -89,7 +89,7 @@ impl Component for App {
                         <div class="input-container">
                             <label>{ "Password" }</label>
                             <InputComponent
-                                ref={self.refs[1].clone()}
+                                ref={&self.refs[1]}
                                 on_hover={ctx.link().callback(|_| Msg::HoverIndex(1))}
                                 placeholder="password"
                             />

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -386,11 +386,14 @@ note: required by a bound in `ChildPropertiesBuilder::string`
    |         ------ required by a bound in this
    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0308]: mismatched types
+error[E0277]: the trait bound `(): IntoPropValue<NodeRef>` is not satisfied
   --> tests/html_macro/component-fail.rs:80:31
    |
 80 |     html! { <Child int=1 ref={()} /> };
-   |                               ^^ expected struct `NodeRef`, found `()`
+   |                               ^^
+   |                               |
+   |                               the trait `IntoPropValue<NodeRef>` is not implemented for `()`
+   |                               required by a bound introduced by this call
 
 error[E0277]: the trait bound `u32: IntoPropValue<i32>` is not satisfied
   --> tests/html_macro/component-fail.rs:82:24

--- a/packages/yew-macro/tests/html_macro/component-pass.rs
+++ b/packages/yew-macro/tests/html_macro/component-pass.rs
@@ -55,6 +55,7 @@ impl ::yew::Component for Container {
     fn create(_ctx: &::yew::Context<Self>) -> Self {
         ::std::unimplemented!()
     }
+
     fn view(&self, _ctx: &::yew::Context<Self>) -> ::yew::Html {
         ::std::unimplemented!()
     }
@@ -116,6 +117,7 @@ impl ::yew::Component for Child {
     fn create(_ctx: &::yew::Context<Self>) -> Self {
         ::std::unimplemented!()
     }
+
     fn view(&self, _ctx: &::yew::Context<Self>) -> ::yew::Html {
         ::std::unimplemented!()
     }
@@ -129,6 +131,7 @@ impl ::yew::Component for AltChild {
     fn create(_ctx: &::yew::Context<Self>) -> Self {
         ::std::unimplemented!()
     }
+
     fn view(&self, _ctx: &::yew::Context<Self>) -> ::yew::Html {
         ::std::unimplemented!()
     }
@@ -151,14 +154,14 @@ impl ::yew::Component for ChildContainer {
     fn create(_ctx: &::yew::Context<Self>) -> Self {
         ::std::unimplemented!()
     }
+
     fn view(&self, _ctx: &::yew::Context<Self>) -> ::yew::Html {
         ::std::unimplemented!()
     }
 }
 
 mod scoped {
-    pub use super::Child;
-    pub use super::Container;
+    pub use super::{Child, Container};
 }
 
 fn compile_pass() {
@@ -181,6 +184,7 @@ fn compile_pass() {
             <Child ref={::std::clone::Clone::clone(&node_ref)} int={2} ..::yew::props!(Child::Properties { int: 5 }) />
             <Child int=3 ref={::std::clone::Clone::clone(&node_ref)} ..::yew::props!(Child::Properties { int: 5 }) />
             <Child ref={::std::clone::Clone::clone(&node_ref)} ..::yew::props!(Child::Properties { int: 5 }) />
+            <Child ref={&node_ref} ..<<Child as ::yew::Component>::Properties as ::std::default::Default>::default() />
             <Child ref={node_ref} ..<<Child as ::yew::Component>::Properties as ::std::default::Default>::default() />
         </>
     };

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -51,6 +51,7 @@ fn compile_pass() {
     ::yew::html! {
         <div>
             <div data-key="abc"></div>
+            <div ref={&parent_ref}></div>
             <div ref={parent_ref} class="parent">
                 <span class="child" value="anything"></span>
                 <label for="first-name">{"First Name"}</label>


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->
Passing a `&NodeRef` to a html component `ref` attribute would throw an error whereas with a html element it wouldn't.
A html component didn't use `IntoPropValue` on the `ref` attribute and thus didn't use `ImplicitClone`. 

I've made 
[packages/yew-macro/src/html_tree/html_component.rs](https://github.com/wdcocq/yew/blob/5a94b874a1d84efdc52bae8121652a8866e74d73/packages/yew-macro/src/html_tree/html_component.rs) 
more inline with how the `ref` and `key` attributes are implemented in 
[packages/yew-macro/src/html_tree/html_element.rs](https://github.com/wdcocq/yew/blob/5a94b874a1d84efdc52bae8121652a8866e74d73/packages/yew-macro/src/html_tree/html_element.rs) 
To make subtle differences between the implementations clearer (e.g. notice the missing `optimize_literals()` on the key value before)

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
