### PR TITLE
Document features automatically.

### DIFF
--- a/packages/yew/src/app_handle.rs
+++ b/packages/yew/src/app_handle.rs
@@ -65,7 +65,6 @@ fn clear_element(host: &Element) {
     }
 }
 
-#[cfg_attr(documenting, doc(cfg(feature = "hydration")))]
 #[cfg(feature = "hydration")]
 mod feat_hydration {
     use super::*;

--- a/packages/yew/src/app_handle.rs
+++ b/packages/yew/src/app_handle.rs
@@ -9,7 +9,7 @@ use crate::dom_bundle::BSubtree;
 use crate::html::{BaseComponent, NodeRef, Scope, Scoped};
 
 /// An instance of an application.
-#[cfg_attr(documenting, doc(cfg(feature = "csr")))]
+#[cfg(feature = "csr")]
 #[derive(Debug)]
 pub struct AppHandle<COMP: BaseComponent> {
     /// `Scope` holder

--- a/packages/yew/src/dom_bundle/subtree_root.rs
+++ b/packages/yew/src/dom_bundle/subtree_root.rs
@@ -232,7 +232,7 @@ static BUBBLE_EVENTS: AtomicBool = AtomicBool::new(true);
 /// handler has no effect.
 ///
 /// This function should be called before any component is mounted.
-#[cfg_attr(documenting, doc(cfg(feature = "csr")))]
+#[cfg(feature = "csr")]
 pub fn set_event_bubbling(bubble: bool) {
     BUBBLE_EVENTS.store(bubble, Ordering::Relaxed);
 }

--- a/packages/yew/src/functional/hooks/mod.rs
+++ b/packages/yew/src/functional/hooks/mod.rs
@@ -3,14 +3,10 @@ mod use_context;
 mod use_effect;
 mod use_force_update;
 mod use_memo;
-#[cfg_attr(documenting, doc(cfg(any(target_arch = "wasm32", feature = "tokio"))))]
-#[cfg(any(target_arch = "wasm32", feature = "tokio"))]
 mod use_prepared_state;
 mod use_reducer;
 mod use_ref;
 mod use_state;
-#[cfg_attr(documenting, doc(cfg(any(target_arch = "wasm32", feature = "tokio"))))]
-#[cfg(any(target_arch = "wasm32", feature = "tokio"))]
 mod use_transitive_state;
 
 pub use use_callback::*;
@@ -18,14 +14,10 @@ pub use use_context::*;
 pub use use_effect::*;
 pub use use_force_update::*;
 pub use use_memo::*;
-#[cfg_attr(documenting, doc(cfg(any(target_arch = "wasm32", feature = "tokio"))))]
-#[cfg(any(target_arch = "wasm32", feature = "tokio"))]
 pub use use_prepared_state::*;
 pub use use_reducer::*;
 pub use use_ref::*;
 pub use use_state::*;
-#[cfg_attr(documenting, doc(cfg(any(target_arch = "wasm32", feature = "tokio"))))]
-#[cfg(any(target_arch = "wasm32", feature = "tokio"))]
 pub use use_transitive_state::*;
 
 use crate::functional::HookContext;

--- a/packages/yew/src/functional/hooks/use_prepared_state/mod.rs
+++ b/packages/yew/src/functional/hooks/use_prepared_state/mod.rs
@@ -89,7 +89,6 @@ pub use feat_ssr::*;
 /// Whilst async closure is an unstable feature, the procedural macro will rewrite this to a
 /// closure that returns an async block automatically. You can use this hook with async closure
 /// in stable Rust.
-#[cfg_attr(documenting, doc(cfg(any(target_arch = "wasm32", feature = "tokio"))))]
 pub use use_prepared_state_macro as use_prepared_state;
 // With SSR.
 #[doc(hidden)]

--- a/packages/yew/src/functional/hooks/use_transitive_state/mod.rs
+++ b/packages/yew/src/functional/hooks/use_transitive_state/mod.rs
@@ -55,7 +55,6 @@ pub use feat_ssr::*;
 /// You MUST denote the return type of the closure with `|deps| -> ReturnType { ... }`. This
 /// type is used during client side rendering to deserialize the state prepared on the server
 /// side.
-#[cfg_attr(documenting, doc(cfg(any(target_arch = "wasm32", feature = "tokio"))))]
 pub use use_transitive_state_macro as use_transitive_state;
 // With SSR.
 #[doc(hidden)]

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -609,7 +609,6 @@ mod feat_csr {
 #[cfg(feature = "csr")]
 pub(crate) use feat_csr::*;
 
-#[cfg_attr(documenting, doc(cfg(feature = "hydration")))]
 #[cfg(feature = "hydration")]
 mod feat_hydration {
     use wasm_bindgen::JsCast;

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::needless_doctest_main)]
 #![doc(html_logo_url = "https://yew.rs/img/logo.png")]
 #![cfg_attr(documenting, feature(doc_cfg))]
+#![cfg_attr(documenting, feature(doc_auto_cfg))]
 #![cfg_attr(
     feature = "nightly",
     feature(fn_traits, async_closure, unboxed_closures)

--- a/packages/yew/src/renderer.rs
+++ b/packages/yew/src/renderer.rs
@@ -14,7 +14,7 @@ thread_local! {
 /// Set a custom panic hook.
 /// Unless a panic hook is set through this function, Yew will
 /// overwrite any existing panic hook when an application is rendered with [Renderer].
-#[cfg_attr(documenting, doc(cfg(feature = "csr")))]
+#[cfg(feature = "csr")]
 pub fn set_custom_panic_hook(hook: Box<dyn Fn(&PanicInfo<'_>) + Sync + Send + 'static>) {
     std::panic::set_hook(hook);
     PANIC_HOOK_IS_SET.with(|hook_is_set| hook_is_set.set(true));
@@ -29,7 +29,7 @@ fn set_default_panic_hook() {
 /// The Yew Renderer.
 ///
 /// This is the main entry point of a Yew application.
-#[cfg_attr(documenting, doc(cfg(feature = "csr")))]
+#[cfg(feature = "csr")]
 #[derive(Debug)]
 #[must_use = "Renderer does nothing unless render() is called."]
 pub struct Renderer<COMP>

--- a/packages/yew/src/renderer.rs
+++ b/packages/yew/src/renderer.rs
@@ -93,7 +93,6 @@ where
     }
 }
 
-#[cfg_attr(documenting, doc(cfg(feature = "hydration")))]
 #[cfg(feature = "hydration")]
 mod feat_hydration {
     use super::*;

--- a/packages/yew/src/server_renderer.rs
+++ b/packages/yew/src/server_renderer.rs
@@ -7,7 +7,7 @@ use crate::platform::io::{self, DEFAULT_BUF_SIZE};
 use crate::platform::{run_pinned, spawn_local};
 
 /// A Yew Server-side Renderer that renders on the current thread.
-#[cfg_attr(documenting, doc(cfg(feature = "ssr")))]
+#[cfg(feature = "ssr")]
 #[derive(Debug)]
 pub struct LocalServerRenderer<COMP>
 where
@@ -112,7 +112,7 @@ where
 /// the rendering process has finished.
 ///
 /// See [`yew::platform`] for more information.
-#[cfg_attr(documenting, doc(cfg(feature = "ssr")))]
+#[cfg(feature = "ssr")]
 pub struct ServerRenderer<COMP>
 where
     COMP: BaseComponent,


### PR DESCRIPTION
#### Description

This pull request enables the `doc_auto_cfg` feature which documents the required feature flags automatically.

However, if an item is re-exported with `pub use`, it's not documented automatically unless the item itself has a `#[doc(cfg(...))]` or `#[cfg(...)]`. I have modified those to use `#[cfg(...)]` instead of `#[doc(cfg(...))]`.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
