### PR TITLE
Enable Dependabot for Examples and Tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,22 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "friday"
     open-pull-requests-limit: 5
   
   - package-ecosystem: "cargo"
     directory: "/examples"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "friday"
     open-pull-requests-limit: 5
   
   - package-ecosystem: "cargo"
     directory: "/tools"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "friday"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,19 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"
+    open-pull-requests-limit: 5
+  
+  - package-ecosystem: "cargo"
+    directory: "/examples"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+  
+  - package-ecosystem: "cargo"
+    directory: "/tools"
+    schedule:
+      interval: "monthly"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-  "packages/*",
+    "packages/*",
 ]
 exclude = [
     "tools/*",

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,4 @@
 # trunk output
 dist/
+
+!Cargo.lock

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +35,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +61,51 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
 
 [[package]]
 name = "base64"
@@ -62,10 +129,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "boids"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "getrandom",
+ "gloo",
+ "rand",
+ "serde",
+ "web-sys",
+ "yew",
+]
 
 [[package]]
 name = "boolinator"
@@ -74,10 +187,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -90,9 +219,6 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -101,31 +227,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "changelog"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "git2",
- "once_cell",
- "regex",
- "reqwest",
- "semver",
- "serde",
- "strum",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "js-sys",
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -179,10 +291,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+name = "contexts"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "yew",
+ "yew-agent",
+]
 
 [[package]]
 name = "core-foundation"
@@ -201,17 +316,144 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+name = "counter"
+version = "0.1.1"
 dependencies = [
- "convert_case",
+ "gloo-console",
+ "js-sys",
+ "wasm-bindgen",
+ "yew",
+]
+
+[[package]]
+name = "counter_functional"
+version = "0.1.0"
+dependencies = [
+ "yew",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "strsim",
  "syn",
 ]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+]
+
+[[package]]
+name = "dyn_create_destroy_apps"
+version = "0.1.0"
+dependencies = [
+ "gloo",
+ "gloo-utils",
+ "js-sys",
+ "slab",
+ "wasm-bindgen",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
+name = "either"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "encoding_rs"
@@ -223,12 +465,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "fake"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d68f517805463f3a896a9d29c1d6ff09d3579ded64a7201b4069f8f9c0d52fd"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95b4efe5be9104a4a18a9916e86654319895138be727b229820c39257c30dda"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "file_upload"
+version = "0.1.0"
+dependencies = [
+ "gloo-file",
+ "js-sys",
+ "web-sys",
+ "yew",
 ]
 
 [[package]]
@@ -260,6 +544,62 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "function_memory_game"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "gloo",
+ "nanoid",
+ "rand",
+ "serde",
+ "strum",
+ "strum_macros",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
+name = "function_router"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "gloo-timers",
+ "instant",
+ "lipsum",
+ "log",
+ "once_cell",
+ "rand",
+ "serde",
+ "wasm-logger",
+ "yew",
+ "yew-router",
+]
+
+[[package]]
+name = "function_todomvc"
+version = "0.1.0"
+dependencies = [
+ "gloo",
+ "serde",
+ "strum",
+ "strum_macros",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
+name = "futures"
+version = "0.1.0"
+dependencies = [
+ "gloo-utils",
+ "pulldown-cmark",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yew",
 ]
 
 [[package]]
@@ -352,6 +692,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "game_of_life"
+version = "0.1.4"
+dependencies = [
+ "getrandom",
+ "gloo-timers",
+ "log",
+ "rand",
+ "wasm-logger",
+ "yew",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,43 +724,6 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "git2"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "gloo"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23947965eee55e3e97a5cd142dd4c10631cc349b48cecca0ed230fd296f568cd"
-dependencies = [
- "gloo-console",
- "gloo-dialogs",
- "gloo-events",
- "gloo-file",
- "gloo-render",
- "gloo-storage",
- "gloo-timers",
- "gloo-utils",
 ]
 
 [[package]]
@@ -598,7 +923,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.3",
  "tracing",
 ]
 
@@ -607,6 +932,34 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha-1 0.10.0",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -655,6 +1008,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +1024,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -704,6 +1069,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +1083,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "immutable"
+version = "0.1.0"
+dependencies = [
+ "implicit-clone",
+ "wasm-bindgen",
+ "web-sys",
+ "yew",
 ]
 
 [[package]]
@@ -734,12 +1115,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inner_html"
+version = "0.1.0"
+dependencies = [
+ "gloo-utils",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -749,41 +1142,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
-
-[[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "js-framework-benchmark-yew"
-version = "1.0.0"
-dependencies = [
- "getrandom",
- "rand",
- "wasm-bindgen",
- "web-sys",
- "yew 0.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "js-framework-benchmark-yew-hooks"
-version = "1.0.0"
-dependencies = [
- "getrandom",
- "rand",
- "wasm-bindgen",
- "web-sys",
- "yew 0.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "js-sys"
@@ -792,6 +1163,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "js_callback"
+version = "0.1.0"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "yew",
+]
+
+[[package]]
+name = "keyed_list"
+version = "0.1.0"
+dependencies = [
+ "fake",
+ "getrandom",
+ "instant",
+ "log",
+ "rand",
+ "wasm-logger",
+ "web-sys",
+ "yew",
 ]
 
 [[package]]
@@ -807,43 +1203,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.13.4+1.4.2"
+name = "lipsum"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+checksum = "a8451846f1f337e44486666989fbce40be804da139d5a4477d6b88ece5dc69f4"
 dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
+ "rand",
+ "rand_chacha",
 ]
 
 [[package]]
-name = "libssh2-sys"
-version = "0.2.23"
+name = "lock_api"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -862,6 +1238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +1256,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +1275,43 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "mount_point"
+version = "0.1.0"
+dependencies = [
+ "gloo-utils",
+ "wasm-bindgen",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
+name = "multipart"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log",
+ "mime",
+ "mime_guess",
+ "quick-error 1.2.3",
+ "rand",
+ "safemem",
+ "tempfile",
+ "twoway",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
@@ -901,6 +1330,23 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nested_list"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "wasm-logger",
+ "yew",
+]
+
+[[package]]
+name = "node_refs"
+version = "0.1.0"
+dependencies = [
+ "web-sys",
+ "yew",
 ]
 
 [[package]]
@@ -933,10 +1379,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -990,6 +1451,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
+name = "password_strength"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "js-sys",
+ "time 0.3.9",
+ "wasm-bindgen",
+ "web-sys",
+ "yew",
+ "zxcvbn",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1529,16 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "portals"
+version = "0.1.0"
+dependencies = [
+ "gloo-utils",
+ "wasm-bindgen",
+ "web-sys",
+ "yew",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1083,13 +1590,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "process-benchmark-results"
-version = "0.1.0"
+name = "pulldown-cmark"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f197a544b0c9ab3ae46c359a7ec9cbbb5c7bf97054266fecb7ead794a181d6"
 dependencies = [
- "anyhow",
- "serde",
- "serde_json",
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1209,12 +1730,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+name = "router"
+version = "0.1.0"
 dependencies = [
- "semver",
+ "getrandom",
+ "gloo-timers",
+ "instant",
+ "lipsum",
+ "log",
+ "once_cell",
+ "rand",
+ "serde",
+ "wasm-logger",
+ "yew",
+ "yew-router",
 ]
 
 [[package]]
@@ -1230,6 +1759,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "schannel"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,10 +1775,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls-hkt"
-version = "0.1.2"
+name = "scoped-tls"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e9d7eaddb227e8fbaaa71136ae0e1e913ca159b86c7da82f3e8f0044ad3a63"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
@@ -1267,12 +1808,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
@@ -1330,6 +1865,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "simple_ssr"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "clap",
+ "futures 0.3.21",
+ "log",
+ "reqwest",
+ "serde",
+ "tokio",
+ "uuid",
+ "warp",
+ "wasm-bindgen-futures",
+ "wasm-logger",
+ "yew",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1938,24 @@ checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "ssr_router"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "clap",
+ "env_logger",
+ "function_router",
+ "futures 0.3.21",
+ "log",
+ "tokio",
+ "tower",
+ "tower-http",
+ "wasm-bindgen-futures",
+ "wasm-logger",
+ "yew",
 ]
 
 [[package]]
@@ -1359,9 +1969,6 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros",
-]
 
 [[package]]
 name = "strum_macros"
@@ -1377,6 +1984,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "suspense"
+version = "0.1.0"
+dependencies = [
+ "gloo-timers",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +2004,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "tempfile"
@@ -1448,6 +2072,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "libc",
+ "num_threads",
+]
+
+[[package]]
+name = "timer"
+version = "0.1.0"
+dependencies = [
+ "gloo",
+ "js-sys",
+ "wasm-bindgen",
+ "yew",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +2107,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "todomvc"
+version = "0.1.0"
+dependencies = [
+ "gloo",
+ "serde",
+ "serde_derive",
+ "strum",
+ "strum_macros",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
 name = "tokio"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,7 +2132,9 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -1511,7 +2170,34 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.3",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1523,10 +2209,59 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown",
  "pin-project-lite",
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util 0.7.3",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
@@ -1541,6 +2276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -1559,6 +2295,57 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tungstenite"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha-1 0.9.8",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "two_apps"
+version = "0.1.0"
+dependencies = [
+ "gloo-utils",
+ "yew",
+]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -1594,10 +2381,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -1619,6 +2421,36 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multipart",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util 0.6.10",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1702,6 +2534,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
+name = "wasm-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074649a66bb306c8f2068c9016395fa65d8e08d2affcbf95acf3c24c3ab19718"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,44 +2555,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "weblog"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eec0958e0181982bc8b4577b1363f21300a670603615c58643f172c92c47357"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
- "weblog-proc-macro",
-]
-
-[[package]]
-name = "weblog-proc-macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9abb8ee84ede5408a346721d72fb216a27f53a539ff3c83ed1bf7625af7104"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "website-test"
+name = "webgl"
 version = "0.1.0"
 dependencies = [
- "boolinator",
- "derive_more",
- "glob",
- "gloo 0.8.0",
+ "gloo-render",
  "js-sys",
- "tokio",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
- "weblog",
- "yew 0.19.3",
- "yew-agent",
- "yew-router",
+ "yew",
 ]
 
 [[package]]
@@ -1842,42 +2655,25 @@ dependencies = [
  "base64ct",
  "bincode",
  "console_error_panic_hook",
- "futures",
- "gloo 0.8.0",
+ "futures 0.3.21",
+ "gloo",
  "gloo-utils",
  "html-escape",
  "implicit-clone",
  "indexmap",
  "js-sys",
+ "num_cpus",
  "once_cell",
  "serde",
  "slab",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.3",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "yew-macro 0.19.3",
-]
-
-[[package]]
-name = "yew"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1ccb53e57d3f7d847338cf5758befa811cabe207df07f543c06f502f9998cd"
-dependencies = [
- "console_error_panic_hook",
- "gloo 0.4.2",
- "gloo-utils",
- "indexmap",
- "js-sys",
- "scoped-tls-hkt",
- "slab",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "yew-macro 0.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yew-macro",
 ]
 
 [[package]]
@@ -1885,7 +2681,7 @@ name = "yew-agent"
 version = "0.1.0"
 dependencies = [
  "gloo-worker 0.1.2",
- "yew 0.19.3",
+ "yew",
 ]
 
 [[package]]
@@ -1902,31 +2698,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "yew-macro"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fab79082b556d768d6e21811869c761893f0450e1d550a67892b9bce303b7bb"
-dependencies = [
- "boolinator",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "yew-router"
 version = "0.16.0"
 dependencies = [
- "gloo 0.8.0",
+ "gloo",
  "js-sys",
  "route-recognizer",
  "serde",
  "serde_urlencoded",
  "wasm-bindgen",
  "web-sys",
- "yew 0.19.3",
+ "yew",
  "yew-router-macro",
 ]
 
@@ -1937,4 +2719,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "yew-worker-fib"
+version = "0.1.0"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+ "web-sys",
+ "yew",
+ "yew-agent",
+]
+
+[[package]]
+name = "zxcvbn"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568becce91e872373a4b33f24ddc67e5280ae2536ccb8c9d22a25d398b72c8b0"
+dependencies = [
+ "derive_builder",
+ "fancy-regex",
+ "itertools",
+ "js-sys",
+ "lazy_static",
+ "quick-error 2.0.1",
+ "regex",
+ "time 0.3.9",
 ]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 name = "counter"
 version = "0.1.1"
 dependencies = [
- "gloo-console",
+ "gloo",
  "js-sys",
  "wasm-bindgen",
  "yew",
@@ -441,7 +441,6 @@ name = "dyn_create_destroy_apps"
 version = "0.1.0"
 dependencies = [
  "gloo",
- "gloo-utils",
  "js-sys",
  "slab",
  "wasm-bindgen",
@@ -509,7 +508,7 @@ dependencies = [
 name = "file_upload"
 version = "0.1.0"
 dependencies = [
- "gloo-file",
+ "gloo",
  "js-sys",
  "web-sys",
  "yew",
@@ -566,7 +565,7 @@ name = "function_router"
 version = "0.1.0"
 dependencies = [
  "getrandom",
- "gloo-timers",
+ "gloo",
  "instant",
  "lipsum",
  "log",
@@ -594,7 +593,7 @@ dependencies = [
 name = "futures"
 version = "0.1.0"
 dependencies = [
- "gloo-utils",
+ "gloo",
  "pulldown-cmark",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -696,7 +695,7 @@ name = "game_of_life"
 version = "0.1.4"
 dependencies = [
  "getrandom",
- "gloo-timers",
+ "gloo",
  "log",
  "rand",
  "wasm-logger",
@@ -1118,7 +1117,7 @@ dependencies = [
 name = "inner_html"
 version = "0.1.0"
 dependencies = [
- "gloo-utils",
+ "gloo",
  "web-sys",
  "yew",
 ]
@@ -1281,7 +1280,7 @@ dependencies = [
 name = "mount_point"
 version = "0.1.0"
 dependencies = [
- "gloo-utils",
+ "gloo",
  "wasm-bindgen",
  "web-sys",
  "yew",
@@ -1534,7 +1533,7 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 name = "portals"
 version = "0.1.0"
 dependencies = [
- "gloo-utils",
+ "gloo",
  "wasm-bindgen",
  "web-sys",
  "yew",
@@ -1734,7 +1733,7 @@ name = "router"
 version = "0.1.0"
 dependencies = [
  "getrandom",
- "gloo-timers",
+ "gloo",
  "instant",
  "lipsum",
  "log",
@@ -1987,7 +1986,7 @@ dependencies = [
 name = "suspense"
 version = "0.1.0"
 dependencies = [
- "gloo-timers",
+ "gloo",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2319,7 +2318,7 @@ dependencies = [
 name = "two_apps"
 version = "0.1.0"
 dependencies = [
- "gloo-utils",
+ "gloo",
  "yew",
 ]
 
@@ -2558,7 +2557,7 @@ dependencies = [
 name = "webgl"
 version = "0.1.0"
 dependencies = [
- "gloo-render",
+ "gloo",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -2657,7 +2656,6 @@ dependencies = [
  "console_error_panic_hook",
  "futures 0.3.21",
  "gloo",
- "gloo-utils",
  "html-escape",
  "implicit-clone",
  "indexmap",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 members = [
-  "*",
+    "*",
 ]
 exclude = [
-  "target",
-  ".cargo"
+    "target",
+    ".cargo"
 ]
 resolver = "2"
 

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-gloo-console = "0.2"
+gloo = "0.8"
 js-sys = "0.3"
 yew = { path = "../../packages/yew", features = ["csr"] }
 wasm-bindgen = "0.2"

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,4 +1,4 @@
-use gloo_console as console;
+use gloo::console;
 use js_sys::Date;
 use yew::{html, Component, Context, Html};
 

--- a/examples/dyn_create_destroy_apps/Cargo.toml
+++ b/examples/dyn_create_destroy_apps/Cargo.toml
@@ -11,7 +11,6 @@ yew = { path = "../../packages/yew", features = ["csr"] }
 slab = "0.4.3"
 gloo = "0.8"
 wasm-bindgen = "0.2"
-gloo-utils = "0.1"
 
 [dependencies.web-sys]
 version = "0.3.50"

--- a/examples/dyn_create_destroy_apps/src/main.rs
+++ b/examples/dyn_create_destroy_apps/src/main.rs
@@ -1,4 +1,4 @@
-use gloo_utils::document;
+use gloo::utils::document;
 use slab::Slab;
 use web_sys::Element;
 use yew::prelude::*;

--- a/examples/file_upload/Cargo.toml
+++ b/examples/file_upload/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 js-sys = "0.3"
 yew = { path = "../../packages/yew", features = ["csr"] }
-gloo-file = "0.2"
+gloo = "0.8"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/examples/file_upload/src/main.rs
+++ b/examples/file_upload/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use gloo_file::callbacks::FileReader;
-use gloo_file::File;
+use gloo::file::callbacks::FileReader;
+use gloo::file::File;
 use web_sys::{Event, HtmlInputElement};
 use yew::html::TargetCast;
 use yew::{html, Component, Context, Html};
@@ -55,14 +55,14 @@ impl Component for App {
                         let link = ctx.link().clone();
 
                         if bytes {
-                            gloo_file::callbacks::read_as_bytes(&file, move |res| {
+                            gloo::file::callbacks::read_as_bytes(&file, move |res| {
                                 link.send_message(Msg::LoadedBytes(
                                     file_name,
                                     res.expect("failed to read file"),
                                 ))
                             })
                         } else {
-                            gloo_file::callbacks::read_as_text(&file, move |res| {
+                            gloo::file::callbacks::read_as_text(&file, move |res| {
                                 link.send_message(Msg::Loaded(
                                     file_name,
                                     res.unwrap_or_else(|e| e.to_string()),

--- a/examples/function_router/Cargo.toml
+++ b/examples/function_router/Cargo.toml
@@ -11,7 +11,7 @@ rand = { version = "0.8", features = ["small_rng"] }
 yew = { path = "../../packages/yew" }
 yew-router = { path = "../../packages/yew-router" }
 serde = { version = "1.0", features = ["derive"] }
-gloo-timers = "0.2"
+gloo = "0.8"
 wasm-logger = "0.2"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 once_cell = "1"

--- a/examples/function_router/src/components/progress_delay.rs
+++ b/examples/function_router/src/components/progress_delay.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use gloo_timers::callback::Interval;
+use gloo::timers::callback::Interval;
 use instant::Instant;
 use yew::prelude::*;
 

--- a/examples/futures/Cargo.toml
+++ b/examples/futures/Cargo.toml
@@ -10,7 +10,7 @@ pulldown-cmark = { version = "0.9", default-features = false }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 yew = { path = "../../packages/yew", features = ["tokio", "csr"] }
-gloo-utils = "0.1"
+gloo = "0.8"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/examples/futures/src/main.rs
+++ b/examples/futures/src/main.rs
@@ -49,7 +49,7 @@ async fn fetch_markdown(url: &'static str) -> Result<String, FetchError> {
 
     let request = Request::new_with_str_and_init(url, &opts)?;
 
-    let window = gloo_utils::window();
+    let window = gloo::utils::window();
     let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
     let resp: Response = resp_value.dyn_into().unwrap();
 

--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -15,4 +15,4 @@ log = "0.4"
 rand = "0.8"
 wasm-logger = "0.2"
 yew = { path = "../../packages/yew", features = ["csr"] }
-gloo-timers = "0.2"
+gloo = "0.8"

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -1,5 +1,5 @@
 use cell::Cellule;
-use gloo_timers::callback::Interval;
+use gloo::timers::callback::Interval;
 use rand::Rng;
 use yew::html::Scope;
 use yew::{classes, html, Component, Context, Html};

--- a/examples/inner_html/Cargo.toml
+++ b/examples/inner_html/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 yew = { path = "../../packages/yew", features = ["csr"] }
-gloo-utils = "0.1"
+gloo = "0.8"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/examples/inner_html/src/main.rs
+++ b/examples/inner_html/src/main.rs
@@ -16,7 +16,7 @@ impl Component for App {
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
-        let div = gloo_utils::document().create_element("div").unwrap();
+        let div = gloo::utils::document().create_element("div").unwrap();
         div.set_inner_html(HTML);
         // See <https://github.com/yewstack/yew/issues/1546>
         console::log_1(&div);

--- a/examples/mount_point/Cargo.toml
+++ b/examples/mount_point/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 wasm-bindgen = "0.2"
 yew = { path = "../../packages/yew", features = ["csr"] }
-gloo-utils = "0.1"
+gloo = "0.8"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/examples/mount_point/src/main.rs
+++ b/examples/mount_point/src/main.rs
@@ -60,7 +60,7 @@ fn create_canvas(document: &Document) -> HtmlCanvasElement {
 }
 
 fn main() {
-    let document = gloo_utils::document();
+    let document = gloo::utils::document();
     let body = document.query_selector("body").unwrap().unwrap();
 
     let canvas = create_canvas(&document);

--- a/examples/portals/Cargo.toml
+++ b/examples/portals/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 yew = { path = "../../packages/yew", features = ["csr"] }
-gloo-utils = "0.1"
+gloo = "0.8"
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]

--- a/examples/portals/src/main.rs
+++ b/examples/portals/src/main.rs
@@ -33,7 +33,7 @@ impl Component for ShadowDOMHost {
                 .unchecked_into::<Element>()
                 .attach_shadow(&ShadowRootInit::new(ShadowRootMode::Open))
                 .expect("installing shadow root succeeds");
-            let inner_host = gloo_utils::document()
+            let inner_host = gloo::utils::document()
                 .create_element("div")
                 .expect("can create inner wrapper");
             shadow_root
@@ -82,7 +82,7 @@ impl Component for App {
     type Properties = ();
 
     fn create(_ctx: &Context<Self>) -> Self {
-        let document_head = gloo_utils::document()
+        let document_head = gloo::utils::document()
             .head()
             .expect("head element to be present");
         let title_element = document_head

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -15,4 +15,4 @@ yew = { path = "../../packages/yew", features = ["csr"] }
 yew-router = { path = "../../packages/yew-router" }
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1"
-gloo-timers = "0.2"
+gloo = "0.8"

--- a/examples/router/src/components/progress_delay.rs
+++ b/examples/router/src/components/progress_delay.rs
@@ -1,4 +1,4 @@
-use gloo_timers::callback::Interval;
+use gloo::timers::callback::Interval;
 use instant::Instant;
 use yew::prelude::*;
 

--- a/examples/simple_ssr/Cargo.toml
+++ b/examples/simple_ssr/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "simple_ssr_hydrate"
+required-features = ["hydration"]
+
+[[bin]]
+name = "simple_ssr_server"
+required-features = ["ssr"]
 
 [dependencies]
 yew = { path = "../../packages/yew" }

--- a/examples/ssr_router/Cargo.toml
+++ b/examples/ssr_router/Cargo.toml
@@ -5,6 +5,14 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "ssr_router_hydrate"
+required-features = ["hydration"]
+
+[[bin]]
+name = "ssr_router_server"
+required-features = ["ssr"]
+
 [dependencies]
 yew = { path = "../../packages/yew" }
 function_router = { path = "../function_router" }

--- a/examples/suspense/Cargo.toml
+++ b/examples/suspense/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 yew = { path = "../../packages/yew", features = ["csr"] }
-gloo-timers = { version = "0.2.2", features = ["futures"] }
+gloo = { version = "0.8", features = ["futures"] }
 wasm-bindgen-futures = "0.4"
 wasm-bindgen = "0.2"
 

--- a/examples/suspense/src/use_sleep.rs
+++ b/examples/suspense/src/use_sleep.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use std::time::Duration;
 
-use gloo_timers::future::sleep;
+use gloo::timers::future::sleep;
 use yew::prelude::*;
 use yew::suspense::{Suspension, SuspensionResult};
 

--- a/examples/two_apps/Cargo.toml
+++ b/examples/two_apps/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 yew = { path = "../../packages/yew", features = ["csr"] }
-gloo-utils = "0.1"
+gloo = "0.8"

--- a/examples/two_apps/src/main.rs
+++ b/examples/two_apps/src/main.rs
@@ -70,7 +70,7 @@ impl Component for App {
 }
 
 fn mount_app(selector: &'static str) -> AppHandle<App> {
-    let document = gloo_utils::document();
+    let document = gloo::utils::document();
     let element = document.query_selector(selector).unwrap().unwrap();
     yew::Renderer::<App>::with_root(element).render()
 }

--- a/examples/webgl/Cargo.toml
+++ b/examples/webgl/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 js-sys = "0.3"
 wasm-bindgen = "0.2"
 yew = { path = "../../packages/yew", features = ["csr"] }
-gloo-render = "0.1"
+gloo = "0.8"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/examples/webgl/src/main.rs
+++ b/examples/webgl/src/main.rs
@@ -1,4 +1,4 @@
-use gloo_render::{request_animation_frame, AnimationFrame};
+use gloo::render::{request_animation_frame, AnimationFrame};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlCanvasElement, WebGlRenderingContext as GL};
 use yew::html::Scope;

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -19,7 +19,6 @@ rust-version = "1.60.0"
 [dependencies]
 console_error_panic_hook = "0.1"
 gloo = "0.8"
-gloo-utils = "0.1.0"
 indexmap = { version = "1", features = ["std"] }
 js-sys = "0.3"
 slab = "0.4"
@@ -82,7 +81,6 @@ once_cell = "1"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 gloo = { version = "0.8", features = ["futures"] }
-gloo-net = { version = "0.2", features = ["http"] }
 wasm-bindgen-futures = "0.4"
 rustversion = "1"
 trybuild = "1"

--- a/packages/yew/src/dom_bundle/bcomp.rs
+++ b/packages/yew/src/dom_bundle/bcomp.rs
@@ -181,7 +181,7 @@ mod feat_hydration {
 mod tests {
     use std::ops::Deref;
 
-    use gloo_utils::document;
+    use gloo::utils::document;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
     use web_sys::{Element, Node};
 

--- a/packages/yew/src/dom_bundle/blist.rs
+++ b/packages/yew/src/dom_bundle/blist.rs
@@ -652,7 +652,7 @@ mod layout_tests_keys {
     fn diff() {
         let mut layouts = vec![];
 
-        let vref_node: Node = gloo_utils::document().create_element("i").unwrap().into();
+        let vref_node: Node = gloo::utils::document().create_element("i").unwrap().into();
         layouts.push(TestLayout {
             name: "All VNode types as children",
             node: html! {

--- a/packages/yew/src/dom_bundle/bnode.rs
+++ b/packages/yew/src/dom_bundle/bnode.rs
@@ -303,7 +303,7 @@ mod layout_tests {
 
     #[test]
     fn diff() {
-        let document = gloo_utils::document();
+        let document = gloo::utils::document();
         let vref_node_1 = VNode::VRef(document.create_element("i").unwrap().into());
         let vref_node_2 = VNode::VRef(document.create_element("b").unwrap().into());
 

--- a/packages/yew/src/dom_bundle/bportal.rs
+++ b/packages/yew/src/dom_bundle/bportal.rs
@@ -135,10 +135,10 @@ mod layout_tests {
     #[test]
     fn diff() {
         let mut layouts = vec![];
-        let first_target = gloo_utils::document().create_element("i").unwrap();
-        let second_target = gloo_utils::document().create_element("o").unwrap();
-        let target_with_child = gloo_utils::document().create_element("i").unwrap();
-        let target_child = gloo_utils::document().create_element("s").unwrap();
+        let first_target = gloo::utils::document().create_element("i").unwrap();
+        let second_target = gloo::utils::document().create_element("o").unwrap();
+        let target_with_child = gloo::utils::document().create_element("i").unwrap();
+        let target_child = gloo::utils::document().create_element("s").unwrap();
         target_with_child.append_child(&target_child).unwrap();
 
         layouts.push(TestLayout {

--- a/packages/yew/src/dom_bundle/btag/listeners.rs
+++ b/packages/yew/src/dom_bundle/btag/listeners.rs
@@ -205,7 +205,7 @@ mod tests {
     use web_sys::{Event, EventInit, FocusEvent, HtmlElement, MouseEvent};
     wasm_bindgen_test_configure!(run_in_browser);
 
-    use gloo_utils::document;
+    use gloo::utils::document;
     use wasm_bindgen::JsCast;
     use yew::Callback;
 

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -8,7 +8,7 @@ use std::hint::unreachable_unchecked;
 use std::ops::DerefMut;
 
 use gloo::console;
-use gloo_utils::document;
+use gloo::utils::document;
 use listeners::ListenerRegistration;
 pub use listeners::Registry;
 use wasm_bindgen::JsCast;
@@ -386,7 +386,7 @@ mod feat_hydration {
 #[cfg(target_arch = "wasm32")]
 #[cfg(test)]
 mod tests {
-    use gloo_utils::document;
+    use gloo::utils::document;
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
     use web_sys::HtmlInputElement as InputElement;

--- a/packages/yew/src/dom_bundle/btext.rs
+++ b/packages/yew/src/dom_bundle/btext.rs
@@ -1,7 +1,7 @@
 //! This module contains the bundle implementation of text [BText].
 
 use gloo::console;
-use gloo_utils::document;
+use gloo::utils::document;
 use web_sys::{Element, Text as TextNode};
 
 use super::{insert_node, BNode, BSubtree, Reconcilable, ReconcileTarget};

--- a/packages/yew/src/functional/hooks/use_effect.rs
+++ b/packages/yew/src/functional/hooks/use_effect.rs
@@ -125,10 +125,10 @@ where
 ///     let counter_one = counter.clone();
 ///     use_effect(move || {
 ///         // Make a call to DOM API after component is rendered
-///         gloo_utils::document().set_title(&format!("You clicked {} times", *counter_one));
+///         gloo::utils::document().set_title(&format!("You clicked {} times", *counter_one));
 ///
 ///         // Perform the cleanup
-///         || gloo_utils::document().set_title(&format!("You clicked 0 times"))
+///         || gloo::utils::document().set_title(&format!("You clicked 0 times"))
 ///     });
 ///
 ///     let onclick = {

--- a/packages/yew/src/functional/hooks/use_prepared_state/feat_hydration.rs
+++ b/packages/yew/src/functional/hooks/use_prepared_state/feat_hydration.rs
@@ -14,7 +14,7 @@ use crate::suspense::{Suspension, SuspensionResult};
 
 #[cfg(target_arch = "wasm32")]
 async fn decode_base64(s: &str) -> Result<Vec<u8>, JsValue> {
-    use gloo_utils::window;
+    use gloo::utils::window;
     use js_sys::Uint8Array;
     use wasm_bindgen::JsCast;
     use wasm_bindgen_futures::JsFuture;

--- a/packages/yew/src/functional/hooks/use_ref.rs
+++ b/packages/yew/src/functional/hooks/use_ref.rs
@@ -38,7 +38,7 @@ impl<T: 'static, F: FnOnce() -> T> Hook for UseMutRef<F> {
 ///     let message_count = use_mut_ref(|| 0);
 ///
 ///     let onclick = Callback::from(move |e| {
-///         let window = gloo_utils::window();
+///         let window = gloo::utils::window();
 ///
 ///         if *message_count.borrow_mut() > 3 {
 ///             window.alert_with_message("Message limit reached");

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -823,7 +823,7 @@ mod tests {
     }
 
     fn test_lifecycle(props: Props, expected: &[&str]) {
-        let document = gloo_utils::document();
+        let document = gloo::utils::document();
         let scope = Scope::<Comp>::new(None);
         let parent = document.create_element("div").unwrap();
         let root = BSubtree::create_root(&parent);

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -220,7 +220,7 @@ pub fn create_portal(child: Html, host: Element) -> Html {
 #[cfg(target_arch = "wasm32")]
 #[cfg(test)]
 mod tests {
-    use gloo_utils::document;
+    use gloo::utils::document;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
     use super::*;

--- a/packages/yew/src/renderer.rs
+++ b/packages/yew/src/renderer.rs
@@ -73,7 +73,7 @@ where
     /// Creates a [Renderer] that renders into the document body with custom properties.
     pub fn with_props(props: COMP::Properties) -> Self {
         Self::with_root_and_props(
-            gloo_utils::document()
+            gloo::utils::document()
                 .body()
                 .expect("no body node found")
                 .into(),

--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -44,7 +44,7 @@ impl<T: fmt::Debug> fmt::Debug for UseFutureHandle<T> {
 /// ```
 /// # use yew::prelude::*;
 /// # use yew::suspense::use_future;
-/// use gloo_net::http::Request;
+/// use gloo::net::http::Request;
 ///
 /// const URL: &str = "https://en.wikipedia.org/w/api.php?\
 ///                    action=query&origin=*&format=json&generator=search&\

--- a/packages/yew/src/tests/layout_tests.rs
+++ b/packages/yew/src/tests/layout_tests.rs
@@ -39,7 +39,7 @@ pub struct TestLayout<'a> {
 }
 
 pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
-    let document = gloo_utils::document();
+    let document = gloo::utils::document();
     let scope: AnyScope = AnyScope::test();
     let parent_element = document.create_element("div").unwrap();
     let root = BSubtree::create_root(&parent_element);

--- a/packages/yew/tests/common/mod.rs
+++ b/packages/yew/tests/common/mod.rs
@@ -1,14 +1,14 @@
 #![allow(dead_code)]
 
 pub fn obtain_result() -> String {
-    gloo_utils::document()
+    gloo::utils::document()
         .get_element_by_id("result")
         .expect("No result found. Most likely, the application crashed and burned")
         .inner_html()
 }
 
 pub fn obtain_result_by_id(id: &str) -> String {
-    gloo_utils::document()
+    gloo::utils::document()
         .get_element_by_id(id)
         .expect("No result found. Most likely, the application crashed and burned")
         .inner_html()

--- a/packages/yew/tests/hydration.rs
+++ b/packages/yew/tests/hydration.rs
@@ -63,7 +63,7 @@ async fn hydration_works() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     sleep(Duration::ZERO).await;
@@ -76,7 +76,7 @@ async fn hydration_works() {
         r#"<div><div>Counter: 0<button class="increase">+1</button></div></div>"#
     );
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".increase")
         .unwrap()
         .unwrap()
@@ -184,7 +184,7 @@ async fn hydration_with_suspense() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     sleep(Duration::from_millis(10)).await;
@@ -207,7 +207,7 @@ async fn hydration_with_suspense() {
         r#"<div class="content-area"><div class="actual-result">0</div><button class="increase">increase</button><div class="action-area"><button class="take-a-break">Take a break!</button></div></div>"#
     );
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".increase")
         .unwrap()
         .unwrap()
@@ -223,7 +223,7 @@ async fn hydration_with_suspense() {
         r#"<div class="content-area"><div class="actual-result">1</div><button class="increase">increase</button><div class="action-area"><button class="take-a-break">Take a break!</button></div></div>"#
     );
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".take-a-break")
         .unwrap()
         .unwrap()
@@ -340,7 +340,7 @@ async fn hydration_with_suspense_not_suspended_at_start() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     sleep(Duration::from_millis(10)).await;
@@ -351,7 +351,7 @@ async fn hydration_with_suspense_not_suspended_at_start() {
         result.as_str(),
         r#"<div class="content-area"><textarea>I am writing a long story...</textarea><div class="action-area"><button class="take-a-break">Take a break!</button></div></div>"#
     );
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".take-a-break")
         .unwrap()
         .unwrap()
@@ -471,7 +471,7 @@ async fn hydration_nested_suspense_works() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     // outer suspense is hydrating...
@@ -500,7 +500,7 @@ async fn hydration_nested_suspense_works() {
         r#"<div class="content-area"><div class="action-area"><button class="take-a-break">Take a break!</button></div><div class="content-area"><div class="action-area"><button class="take-a-break2">Take a break!</button></div></div></div>"#
     );
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".take-a-break")
         .unwrap()
         .unwrap()
@@ -521,7 +521,7 @@ async fn hydration_nested_suspense_works() {
         r#"<div class="content-area"><div class="action-area"><button class="take-a-break">Take a break!</button></div><div class="content-area"><div class="action-area"><button class="take-a-break2">Take a break!</button></div></div></div>"#
     );
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".take-a-break2")
         .unwrap()
         .unwrap()
@@ -608,7 +608,7 @@ async fn hydration_node_ref_works() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     sleep(Duration::ZERO).await;
@@ -619,7 +619,7 @@ async fn hydration_node_ref_works() {
         r#"<div><span>test</span><span>test</span><span>test</span><span>test</span></div>"#
     );
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector("span")
         .unwrap()
         .unwrap()
@@ -701,7 +701,7 @@ async fn hydration_list_order_works() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     // Wait until all suspended components becomes revealed.
@@ -784,7 +784,7 @@ async fn hydration_suspense_no_flickering() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     // Wait until all suspended components becomes revealed.
@@ -897,7 +897,7 @@ async fn hydration_order_issue_nested_suspense() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     // Wait until all suspended components becomes revealed.

--- a/packages/yew/tests/layout.rs
+++ b/packages/yew/tests/layout.rs
@@ -70,7 +70,7 @@ async fn change_nested_after_append() {
         }
     }
 
-    yew::Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    yew::Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .render();
 
     sleep(Duration::from_millis(100)).await;

--- a/packages/yew/tests/mod.rs
+++ b/packages/yew/tests/mod.rs
@@ -29,7 +29,7 @@ async fn props_are_passed() {
     }
 
     yew::Renderer::<PropsComponent>::with_root_and_props(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
         PropsPassedFunctionProps {
             value: "props".to_string(),
         },

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -97,7 +97,7 @@ async fn suspense_works() {
         }
     }
 
-    yew::Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    yew::Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .render();
 
     TimeoutFuture::new(10).await;
@@ -114,7 +114,7 @@ async fn suspense_works() {
 
     TimeoutFuture::new(10).await;
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".increase")
         .unwrap()
         .unwrap()
@@ -124,7 +124,7 @@ async fn suspense_works() {
 
     TimeoutFuture::new(0).await;
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".increase")
         .unwrap()
         .unwrap()
@@ -140,7 +140,7 @@ async fn suspense_works() {
         r#"<div class="content-area"><div class="actual-result">2</div><button class="increase">increase</button><div class="action-area"><button class="take-a-break">Take a break!</button></div></div>"#
     );
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".take-a-break")
         .unwrap()
         .unwrap()
@@ -247,7 +247,7 @@ async fn suspense_not_suspended_at_start() {
         }
     }
 
-    yew::Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    yew::Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .render();
 
     TimeoutFuture::new(10).await;
@@ -257,7 +257,7 @@ async fn suspense_not_suspended_at_start() {
         result.as_str(),
         r#"<div class="content-area"><textarea></textarea><div class="action-area"><button class="take-a-break">Take a break!</button></div></div>"#
     );
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".take-a-break")
         .unwrap()
         .unwrap()
@@ -366,7 +366,7 @@ async fn suspense_nested_suspense_works() {
         }
     }
 
-    yew::Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    yew::Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .render();
 
     TimeoutFuture::new(10).await;
@@ -389,7 +389,7 @@ async fn suspense_nested_suspense_works() {
         r#"<div class="content-area"><div class="action-area"><button class="take-a-break">Take a break!</button></div><div class="content-area"><div class="action-area"><button class="take-a-break2">Take a break!</button></div></div></div>"#
     );
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".take-a-break2")
         .unwrap()
         .unwrap()
@@ -523,7 +523,7 @@ async fn effects_not_run_when_suspended() {
     };
 
     yew::Renderer::<App>::with_root_and_props(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
         props,
     )
     .render();
@@ -544,7 +544,7 @@ async fn effects_not_run_when_suspended() {
 
     TimeoutFuture::new(10).await;
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".increase")
         .unwrap()
         .unwrap()
@@ -554,7 +554,7 @@ async fn effects_not_run_when_suspended() {
 
     TimeoutFuture::new(0).await;
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".increase")
         .unwrap()
         .unwrap()
@@ -571,7 +571,7 @@ async fn effects_not_run_when_suspended() {
     );
     assert_eq!(*counter.borrow(), 3); // effects ran 3 times.
 
-    gloo_utils::document()
+    gloo::utils::document()
         .query_selector(".take-a-break")
         .unwrap()
         .unwrap()
@@ -622,7 +622,7 @@ async fn use_suspending_future_works() {
         }
     }
 
-    yew::Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    yew::Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .render();
 
     TimeoutFuture::new(10).await;
@@ -672,7 +672,7 @@ async fn use_suspending_future_with_deps_works() {
         }
     }
 
-    yew::Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    yew::Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .render();
 
     TimeoutFuture::new(10).await;

--- a/packages/yew/tests/use_callback.rs
+++ b/packages/yew/tests/use_callback.rs
@@ -61,7 +61,7 @@ async fn use_callback_works() {
     }
 
     yew::Renderer::<UseCallbackComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
 

--- a/packages/yew/tests/use_context.rs
+++ b/packages/yew/tests/use_context.rs
@@ -65,7 +65,7 @@ async fn use_context_scoping_works() {
     }
 
     yew::Renderer::<UseContextComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
 
@@ -148,7 +148,7 @@ async fn use_context_works_with_multiple_types() {
     }
 
     yew::Renderer::<TestComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
 
@@ -248,7 +248,7 @@ async fn use_context_update_works() {
     }
 
     yew::Renderer::<TestComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
 

--- a/packages/yew/tests/use_effect.rs
+++ b/packages/yew/tests/use_effect.rs
@@ -68,7 +68,7 @@ async fn use_effect_destroys_on_component_drop() {
     let destroy_counter = Rc::new(std::cell::RefCell::new(0));
     let destroy_counter_c = destroy_counter.clone();
     yew::Renderer::<UseEffectWrapperComponent>::with_root_and_props(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
         WrapperProps {
             destroy_called: Rc::new(move || *destroy_counter_c.borrow_mut().deref_mut() += 1),
         },
@@ -107,7 +107,7 @@ async fn use_effect_works_many_times() {
     }
 
     yew::Renderer::<UseEffectComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
 
@@ -141,7 +141,7 @@ async fn use_effect_works_once() {
     }
 
     yew::Renderer::<UseEffectComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
     sleep(Duration::ZERO).await;
@@ -189,7 +189,7 @@ async fn use_effect_refires_on_dependency_change() {
     }
 
     yew::Renderer::<UseEffectComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
 

--- a/packages/yew/tests/use_memo.rs
+++ b/packages/yew/tests/use_memo.rs
@@ -50,7 +50,7 @@ async fn use_memo_works() {
     }
 
     yew::Renderer::<UseMemoComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
 

--- a/packages/yew/tests/use_prepared_state.rs
+++ b/packages/yew/tests/use_prepared_state.rs
@@ -53,7 +53,7 @@ async fn use_prepared_state_works() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     sleep(Duration::from_millis(100)).await;
@@ -103,7 +103,7 @@ async fn use_prepared_state_with_suspension_works() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     sleep(Duration::from_millis(100)).await;

--- a/packages/yew/tests/use_reducer.rs
+++ b/packages/yew/tests/use_reducer.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use gloo::timers::future::sleep;
-use gloo_utils::document;
+use gloo::utils::document;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 use web_sys::HtmlElement;
@@ -57,7 +57,7 @@ async fn use_reducer_works() {
     }
 
     yew::Renderer::<UseReducerComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
     sleep(Duration::ZERO).await;

--- a/packages/yew/tests/use_ref.rs
+++ b/packages/yew/tests/use_ref.rs
@@ -32,7 +32,7 @@ async fn use_ref_works() {
     }
 
     yew::Renderer::<UseRefComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
     sleep(Duration::ZERO).await;

--- a/packages/yew/tests/use_state.rs
+++ b/packages/yew/tests/use_state.rs
@@ -29,7 +29,7 @@ async fn use_state_works() {
     }
 
     yew::Renderer::<UseComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
     sleep(Duration::ZERO).await;
@@ -72,7 +72,7 @@ async fn multiple_use_state_setters() {
     }
 
     yew::Renderer::<UseComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
     sleep(Duration::ZERO).await;
@@ -101,7 +101,7 @@ async fn use_state_eq_works() {
     }
 
     yew::Renderer::<UseComponent>::with_root(
-        gloo_utils::document().get_element_by_id("output").unwrap(),
+        gloo::utils::document().get_element_by_id("output").unwrap(),
     )
     .render();
     sleep(Duration::ZERO).await;

--- a/packages/yew/tests/use_transitive_state.rs
+++ b/packages/yew/tests/use_transitive_state.rs
@@ -53,7 +53,7 @@ async fn use_transitive_state_works() {
 
     sleep(Duration::ZERO).await;
 
-    Renderer::<App>::with_root(gloo_utils::document().get_element_by_id("output").unwrap())
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .hydrate();
 
     sleep(Duration::from_millis(100)).await;

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 members = [
-  "*",
+    "*",
 ]
 exclude = [
-  "target"
+    "target"
 ]
 resolver = "2"


### PR DESCRIPTION
#### Description

This pull request consists of the following changes:

- Enable dependabot for examples and tools.
- Include `Cargo.lock` for examples.
- Use `gloo` for all crates.


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
