### PR TITLE
docs: remove repeated word

### DIFF
--- a/packages/yew/src/html/component/mod.rs
+++ b/packages/yew/src/html/component/mod.rs
@@ -67,7 +67,7 @@ pub(crate) enum RenderMode {
 #[cfg(any(feature = "csr", feature = "ssr"))]
 pub(crate) use feat_csr_ssr::*;
 
-/// The [`Component`]'s context. This contains component's [`Scope`] and and props and
+/// The [`Component`]'s context. This contains component's [`Scope`] and props and
 /// is passed to every lifecycle method.
 #[derive(Debug)]
 pub struct Context<COMP: BaseComponent> {


### PR DESCRIPTION
#### Description

Just removed a repeated "and" from Context's documentation.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
