### PR TITLE
Allow using Option<VNode> in html!() macro

### DIFF
--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -121,6 +121,9 @@ fn compile_pass() {
 
     // test for https://github.com/yewstack/yew/issues/2810
     ::yew::html! {  <div data-type="date" data-as="calender" /> };
+
+    let option_vnode = ::std::option::Option::Some(::yew::html! {});
+    ::yew::html! { <div>{option_vnode}</div> };
 }
 
 fn main() {}

--- a/packages/yew/src/utils/mod.rs
+++ b/packages/yew/src/utils/mod.rs
@@ -23,6 +23,15 @@ impl<IN: Into<OUT>, OUT> From<IN> for NodeSeq<IN, OUT> {
     }
 }
 
+impl<IN: Into<OUT>, OUT> From<Option<IN>> for NodeSeq<IN, OUT> {
+    fn from(val: Option<IN>) -> Self {
+        Self(
+            val.map(|s| vec![s.into()]).unwrap_or_default(),
+            PhantomData::default(),
+        )
+    }
+}
+
 impl<IN: Into<OUT>, OUT> From<Vec<IN>> for NodeSeq<IN, OUT> {
     fn from(val: Vec<IN>) -> Self {
         Self(


### PR DESCRIPTION
#### Description

Quality of life improvement that allows using `Option<html! {}>` inside `html! {}` macros.

Example:

```rust
fn view() {
    let inner = some_condition.then(|| {
        html! {
            <div>{"Some conditional stuff"}</div>
        }
    });

    html! {
        <>
        <div>{"Permanent stuff"}</div>
        {inner}
        </>
    }
}
```

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
