### PR TITLE
Fix VList Stream in SSR

### DIFF
--- a/.github/workflows/benchmark-ssr.yml
+++ b/.github/workflows/benchmark-ssr.yml
@@ -6,9 +6,10 @@ on:
     branches: [master]
     paths:
       - .github/workflows/benchmark-ssr.yml
-      - "packages/yew"
-      - "examples/function_router"
-      - "tools/benchmark-ssr"
+      - "packages/yew/**"
+      - "packages/yew-router/**"
+      - "examples/function_router/**"
+      - "tools/benchmark-ssr/**"
 
 jobs:
   benchmark-ssr:

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -177,7 +177,7 @@ mod feat_ssr {
                 }
                 _ => {
                     let buf_capacity = w.capacity();
-                    let mut child_streams = Vec::with_capacity(self.children.len());
+                    let mut child_streams = Vec::with_capacity(self.children.len() - 1);
                     let mut child_furs = FuturesUnordered::new();
 
                     let mut children = self.children.iter();
@@ -212,7 +212,7 @@ mod feat_ssr {
                         }
                     };
 
-                    future::join(transfer_fur, resolve_fur).await;
+                    future::join(resolve_fur, transfer_fur).await;
                 }
             }
         }

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -195,7 +195,8 @@ mod feat_ssr {
                     // Concurrently resolve all child futures.
                     let resolve_fur = if rest_children.len() <= 30 {
                         // 30 is selected by join_all to be deemed small.
-                        future::join_all(rest_child_furs).map(|_| {}).left_future()
+                        let rest_child_furs = future::join_all(rest_child_furs);
+                        async move { rest_child_furs.map(|_| {}).await }.left_future()
                     } else {
                         let mut rest_child_furs: FuturesUnordered<_> = rest_child_furs.collect();
                         async move { while rest_child_furs.next().await.is_some() {} }

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -196,7 +196,10 @@ mod feat_ssr {
                     let resolve_fur = if rest_children.len() <= 30 {
                         // 30 is selected by join_all to be deemed small.
                         let rest_child_furs = future::join_all(rest_child_furs);
-                        async move { rest_child_furs.await; }.left_future()
+                        async move {
+                            rest_child_furs.await;
+                        }
+                        .left_future()
                     } else {
                         let mut rest_child_furs: FuturesUnordered<_> = rest_child_furs.collect();
                         async move { while rest_child_furs.next().await.is_some() {} }

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -196,7 +196,7 @@ mod feat_ssr {
                     let resolve_fur = if rest_children.len() <= 30 {
                         // 30 is selected by join_all to be deemed small.
                         let rest_child_furs = future::join_all(rest_child_furs);
-                        async move { rest_child_furs.map(|_| {}).await }.left_future()
+                        async move { rest_child_furs.await; }.left_future()
                     } else {
                         let mut rest_child_furs: FuturesUnordered<_> = rest_child_furs.collect();
                         async move { while rest_child_furs.next().await.is_some() {} }


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This pull request fixes the rendering stream in VList.

Previously, the VList would block until a child future has finished before the child stream was returned.
This pull request allows items to be yielded to the parent stream as soon as an item is written to the child stream.

As a result, this pull request increases function router benchmark performance for ~10%.


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->

pull request:

```
╭─────────────────┬───────┬──────────┬──────────┬───────────┬────────────────────╮
│    Benchmark    │ Round │ Min (ms) │ Max (ms) │ Mean (ms) │ Standard Deviation │
├─────────────────┼───────┼──────────┼──────────┼───────────┼────────────────────┤
│    Baseline     │  10   │ 328.295  │ 350.396  │  343.984  │       6.029        │
│   Hello World   │  10   │ 476.104  │ 493.962  │  481.288  │       5.170        │
│ Function Router │  10   │ 1532.462 │ 1553.854 │ 1540.794  │       5.968        │
│ Concurrent Task │  10   │ 1011.433 │ 1017.915 │ 1015.075  │       2.250        │
╰─────────────────┴───────┴──────────┴──────────┴───────────┴────────────────────╯
```

master:

```
╭─────────────────┬───────┬──────────┬──────────┬───────────┬────────────────────╮
│    Benchmark    │ Round │ Min (ms) │ Max (ms) │ Mean (ms) │ Standard Deviation │
├─────────────────┼───────┼──────────┼──────────┼───────────┼────────────────────┤
│    Baseline     │  10   │ 372.443  │ 384.248  │  376.874  │       3.182        │
│   Hello World   │  10   │ 472.603  │ 498.872  │  478.182  │       7.599        │
│ Function Router │  10   │ 1816.955 │ 1861.456 │ 1834.111  │       14.948       │
│ Concurrent Task │  10   │ 1009.515 │ 1015.743 │ 1012.627  │       2.061        │
╰─────────────────┴───────┴──────────┴──────────┴───────────┴────────────────────╯
```