### PR TITLE
onsubmit should be a SubmitEvent

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -66,6 +66,7 @@ features = [
   "WheelEvent",
   "Window",
   "HtmlScriptElement",
+  "SubmitEvent"
 ]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.19", features = ["sync"] }
 tokio-stream = { version = "0.1.9", features = ["sync"] }
 
 [dependencies.web-sys]
-version = "0.3"
+version = "^0.3.59"
 features = [
   "AnimationEvent",
   "Document",

--- a/packages/yew/src/html/listener/events.rs
+++ b/packages/yew/src/html/listener/events.rs
@@ -166,7 +166,7 @@ impl_short! {
 
     oninput(InputEvent)
 
-    onsubmit(FocusEvent)
+    onsubmit(SubmitEvent)
 
     onanimationcancel(AnimationEvent)
     onanimationend(AnimationEvent)

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -309,6 +309,7 @@ pub mod events {
     pub use web_sys::{
         AnimationEvent, DragEvent, ErrorEvent, Event, FocusEvent, InputEvent, KeyboardEvent,
         MouseEvent, PointerEvent, ProgressEvent, TouchEvent, TransitionEvent, UiEvent, WheelEvent,
+        SubmitEvent,
     };
 
     #[cfg(feature = "csr")]

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -308,8 +308,8 @@ pub mod events {
     #[doc(no_inline)]
     pub use web_sys::{
         AnimationEvent, DragEvent, ErrorEvent, Event, FocusEvent, InputEvent, KeyboardEvent,
-        MouseEvent, PointerEvent, ProgressEvent, TouchEvent, TransitionEvent, UiEvent, WheelEvent,
-        SubmitEvent,
+        MouseEvent, PointerEvent, ProgressEvent, SubmitEvent, TouchEvent, TransitionEvent, UiEvent,
+        WheelEvent,
     };
 
     #[cfg(feature = "csr")]


### PR DESCRIPTION
#### Description

`onsubmit` should be a `SubmitEvent`, not a `FocusEvent`

Fixes #2691 <!-- replace with issue number or remove if not applicable -->

This is a breaking change as it changes the public API for the `onsubmit` event

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
