### PR TITLE
Bind to properties instead of attributes by default

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2270,21 +2270,33 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.28"
+name = "tracing-attributes"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
 ]
@@ -2668,6 +2680,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.3",
+ "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2704,6 +2717,7 @@ dependencies = [
  "route-recognizer",
  "serde",
  "serde_urlencoded",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
  "yew",

--- a/examples/counter_functional/src/main.rs
+++ b/examples/counter_functional/src/main.rs
@@ -16,7 +16,7 @@ fn App() -> Html {
 
     html! {
         <>
-            <p @disabled={false}> {"current count: "} {*state} </p>
+            <p> {"current count: "} {*state} </p>
             <button onclick={incr_counter}> {"+"} </button>
             <button onclick={decr_counter}> {"-"} </button>
         </>

--- a/examples/counter_functional/src/main.rs
+++ b/examples/counter_functional/src/main.rs
@@ -14,13 +14,13 @@ fn App() -> Html {
         Callback::from(move |_| state.set(*state - 1))
     };
 
-    html!(
+    html! {
         <>
-        <p> {"current count: "} {*state} </p>
-        <button onclick={incr_counter}> {"+"} </button>
-        <button onclick={decr_counter}> {"-"} </button>
+            <p @disabled={false}> {"current count: "} {*state} </p>
+            <button onclick={incr_counter}> {"+"} </button>
+            <button onclick={decr_counter}> {"-"} </button>
         </>
-    )
+    }
 }
 
 fn main() {

--- a/examples/counter_functional/src/main.rs
+++ b/examples/counter_functional/src/main.rs
@@ -1,29 +1,28 @@
 use yew::prelude::*;
-// #[function_component]
-// fn App() -> Html {
-//     let state = use_state(|| 0);
-//
-//     let incr_counter = {
-//         let state = state.clone();
-//         Callback::from(move |_| state.set(*state + 1))
-//     };
-//
-//     let decr_counter = {
-//         let state = state.clone();
-//         Callback::from(move |_| state.set(*state - 1))
-//     };
-//
-//     html! {
-//         <>
-//             <p @disabled={false}> {"current count: "} {*state} </p>
-//             <button onclick={incr_counter}> {"+"} </button>
-//             <button onclick={decr_counter}> {"-"} </button>
-//         </>
-//     }
-// }
+
+#[function_component]
+fn App() -> Html {
+    let state = use_state(|| 0);
+
+    let incr_counter = {
+        let state = state.clone();
+        Callback::from(move |_| state.set(*state + 1))
+    };
+
+    let decr_counter = {
+        let state = state.clone();
+        Callback::from(move |_| state.set(*state - 1))
+    };
+
+    html! {
+        <>
+            <p @disabled={false}> {"current count: "} {*state} </p>
+            <button onclick={incr_counter}> {"+"} </button>
+            <button onclick={decr_counter}> {"-"} </button>
+        </>
+    }
+}
 
 fn main() {
-    let _d = html! {
-            <div class={format!("fail{}", "")}></div>
-    };
+    yew::Renderer::<App>::new().render();
 }

--- a/examples/counter_functional/src/main.rs
+++ b/examples/counter_functional/src/main.rs
@@ -1,28 +1,29 @@
 use yew::prelude::*;
-
-#[function_component]
-fn App() -> Html {
-    let state = use_state(|| 0);
-
-    let incr_counter = {
-        let state = state.clone();
-        Callback::from(move |_| state.set(*state + 1))
-    };
-
-    let decr_counter = {
-        let state = state.clone();
-        Callback::from(move |_| state.set(*state - 1))
-    };
-
-    html! {
-        <>
-            <p @disabled={false}> {"current count: "} {*state} </p>
-            <button onclick={incr_counter}> {"+"} </button>
-            <button onclick={decr_counter}> {"-"} </button>
-        </>
-    }
-}
+// #[function_component]
+// fn App() -> Html {
+//     let state = use_state(|| 0);
+//
+//     let incr_counter = {
+//         let state = state.clone();
+//         Callback::from(move |_| state.set(*state + 1))
+//     };
+//
+//     let decr_counter = {
+//         let state = state.clone();
+//         Callback::from(move |_| state.set(*state - 1))
+//     };
+//
+//     html! {
+//         <>
+//             <p @disabled={false}> {"current count: "} {*state} </p>
+//             <button onclick={incr_counter}> {"+"} </button>
+//             <button onclick={decr_counter}> {"-"} </button>
+//         </>
+//     }
+// }
 
 fn main() {
-    yew::Renderer::<App>::new().render();
+    let _d = html! {
+            <div class={format!("fail{}", "")}></div>
+    };
 }

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -268,7 +268,7 @@ impl ToTokens for HtmlElement {
                 .chain(class_attr)
                 .collect::<Vec<(LitStr, Value, bool)>>();
             try_into_static(&attrs).unwrap_or_else(|| {
-                let keys = attrs.iter().map(|(k, _, _)| quote! { #k });
+                let keys = attrs.iter().map(|(k, ..)| quote! { #k });
                 let values = attrs.iter().map(|(_, v, is_forced_attribute)| {
                     let apply_as = if *is_forced_attribute {
                         quote! { ::yew::virtual_dom::ApplyAttributeAs::Attribute }

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -259,7 +259,7 @@ impl ToTokens for HtmlElement {
                             quote! { ::yew::virtual_dom::ApplyAttributeAs::Property }
                         };
                         let value = wrap_attr_value(v);
-                        quote! { (#value, #apply_as) }
+                        quote! { ::std::option::Option::map(#value, |it| (it, ::yew::virtual_dom::ApplyAttributeAs::Property)) }
                     });
                 quote! {
                     ::yew::virtual_dom::Attributes::Dynamic{

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -246,13 +246,17 @@ impl ToTokens for HtmlElement {
 
             fn apply_as(directive: Option<&PropDirective>) -> TokenStream {
                 match directive {
-                    Some(PropDirective::ApplyAsProperty(token)) => quote_spanned!(token.span()=> ::yew::virtual_dom::ApplyAttributeAs::Property),
+                    Some(PropDirective::ApplyAsProperty(token)) => {
+                        quote_spanned!(token.span()=> ::yew::virtual_dom::ApplyAttributeAs::Property)
+                    }
                     None => quote!(::yew::virtual_dom::ApplyAttributeAs::Attribute),
                 }
             }
 
             /// Try to turn attribute list into a `::yew::virtual_dom::Attributes::Static`
-            fn try_into_static(src: &[(LitStr, Value, Option<PropDirective>)]) -> Option<TokenStream> {
+            fn try_into_static(
+                src: &[(LitStr, Value, Option<PropDirective>)],
+            ) -> Option<TokenStream> {
                 let mut kv = Vec::with_capacity(src.len());
                 for (k, v, directive) in src.iter() {
                     let v = match v {

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -269,16 +269,15 @@ impl ToTokens for HtmlElement {
                 .collect::<Vec<(LitStr, Value, bool)>>();
             try_into_static(&attrs).unwrap_or_else(|| {
                 let keys = attrs.iter().map(|(k, _, _)| quote! { #k });
-                let values = attrs.iter()
-                    .map(|(_, v, is_forced_attribute)| {
-                        let apply_as = if *is_forced_attribute {
-                            quote! { ::yew::virtual_dom::ApplyAttributeAs::Attribute }
-                        } else {
-                            quote! { ::yew::virtual_dom::ApplyAttributeAs::Property }
-                        };
-                        let value = wrap_attr_value(v);
-                        quote! { ::std::option::Option::map(#value, |it| (it, #apply_as)) }
-                    });
+                let values = attrs.iter().map(|(_, v, is_forced_attribute)| {
+                    let apply_as = if *is_forced_attribute {
+                        quote! { ::yew::virtual_dom::ApplyAttributeAs::Attribute }
+                    } else {
+                        quote! { ::yew::virtual_dom::ApplyAttributeAs::Property }
+                    };
+                    let value = wrap_attr_value(v);
+                    quote! { ::std::option::Option::map(#value, |it| (it, #apply_as)) }
+                });
                 quote! {
                     ::yew::virtual_dom::Attributes::Dynamic{
                         keys: &[#(#keys),*],

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -26,7 +26,10 @@ pub struct Prop {
 }
 impl Parse for Prop {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let directive = input.parse::<Token![~]>().map(|parsed| PropDirective::ApplyAsProperty(parsed)).ok();
+        let directive = input
+            .parse::<Token![~]>()
+            .map(|parsed| PropDirective::ApplyAsProperty(parsed))
+            .ok();
         if input.peek(Brace) {
             Self::parse_shorthand_prop_assignment(input, directive)
         } else {
@@ -77,7 +80,10 @@ impl Prop {
     }
 
     /// Parse a prop of the form `label={value}`
-    fn parse_prop_assignment(input: ParseStream, directive: Option<PropDirective>) -> syn::Result<Self> {
+    fn parse_prop_assignment(
+        input: ParseStream,
+        directive: Option<PropDirective>,
+    ) -> syn::Result<Self> {
         let label = input.parse::<HtmlDashedName>()?;
         let equals = input.parse::<Token![=]>().map_err(|_| {
             syn::Error::new_spanned(
@@ -125,8 +131,11 @@ fn parse_prop_value(input: &ParseBuffer) -> syn::Result<Expr> {
             Expr::Lit(_) => Ok(expr),
             ref exp => Err(syn::Error::new_spanned(
                 &expr,
-                format!("the property value must be either a literal or enclosed in braces. Consider \
-                 adding braces around your expression.: {:#?}", exp),
+                format!(
+                    "the property value must be either a literal or enclosed in braces. Consider \
+                     adding braces around your expression.: {:#?}",
+                    exp
+                ),
             )),
         }
     }

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -22,13 +22,11 @@ pub struct Prop {
 impl Parse for Prop {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let at = input.parse::<Token![@]>().map(|_| true).unwrap_or(false);
-        let prop = if input.peek(Brace) {
+        if input.peek(Brace) {
             Self::parse_shorthand_prop_assignment(input, at)
         } else {
             Self::parse_prop_assignment(input, at)
-        };
-        eprintln!("prop => {:?}; at?: {}", prop.as_ref().map(|prop| format!("label: {}, value: {:?}", prop.label.to_string(), prop.value)), at);
-        prop
+        }
     }
 }
 

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -28,7 +28,7 @@ impl Parse for Prop {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let directive = input
             .parse::<Token![~]>()
-            .map(|parsed| PropDirective::ApplyAsProperty(parsed))
+            .map(PropDirective::ApplyAsProperty)
             .ok();
         if input.peek(Brace) {
             Self::parse_shorthand_prop_assignment(input, directive)

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -35,7 +35,10 @@ impl Prop {
     /// Parse a prop using the shorthand syntax `{value}`, short for `value={value}`
     /// This only allows for labels with no hyphens, as it would otherwise create
     /// an ambiguity in the syntax
-    fn parse_shorthand_prop_assignment(input: ParseStream, is_forced_attribute: bool) -> syn::Result<Self> {
+    fn parse_shorthand_prop_assignment(
+        input: ParseStream,
+        is_forced_attribute: bool,
+    ) -> syn::Result<Self> {
         let value;
         let _brace = braced!(value in input);
         let expr = value.parse::<Expr>()?;
@@ -61,7 +64,11 @@ impl Prop {
             ));
         }?;
 
-        Ok(Self { label, value: expr, is_forced_attribute })
+        Ok(Self {
+            label,
+            value: expr,
+            is_forced_attribute,
+        })
     }
 
     /// Parse a prop of the form `label={value}`
@@ -85,7 +92,11 @@ impl Prop {
         }
 
         let value = parse_prop_value(input)?;
-        Ok(Self { label, value, is_forced_attribute })
+        Ok(Self {
+            label,
+            value,
+            is_forced_attribute,
+        })
     }
 }
 

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -61,7 +61,11 @@ impl Parse for PropValue {
 impl From<PropValue> for Prop {
     fn from(prop_value: PropValue) -> Prop {
         let PropValue { label, value } = prop_value;
-        Prop { label, value, is_forced_attribute: false }
+        Prop {
+            label,
+            value,
+            is_forced_attribute: false,
+        }
     }
 }
 

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -61,7 +61,7 @@ impl Parse for PropValue {
 impl From<PropValue> for Prop {
     fn from(prop_value: PropValue) -> Prop {
         let PropValue { label, value } = prop_value;
-        Prop { label, value }
+        Prop { label, value, is_forced_attribute: false }
     }
 }
 

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -64,7 +64,7 @@ impl From<PropValue> for Prop {
         Prop {
             label,
             value,
-            is_forced_attribute: false,
+            directive: None,
         }
     }
 }

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -249,7 +249,13 @@ help: escape `type` to use it as an identifier
 85 |     html! { <Child r#type=0 /> };
    |                    ++
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Tuple(
+           ExprTuple {
+               attrs: [],
+               paren_token: Paren,
+               elems: [],
+           },
+       )
   --> tests/html_macro/component-fail.rs:86:24
    |
 86 |     html! { <Child ref=() /> };
@@ -309,7 +315,24 @@ error: only one root html element is allowed (hint: you can wrap multiple html e
 102 |     html! { <Child></Child><Child></Child> };
     |                            ^^^^^^^^^^^^^^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Path(
+           ExprPath {
+               attrs: [],
+               qself: None,
+               path: Path {
+                   leading_colon: None,
+                   segments: [
+                       PathSegment {
+                           ident: Ident {
+                               ident: "num",
+                               span: #0 bytes(3894..3897),
+                           },
+                           arguments: None,
+                       },
+                   ],
+               },
+           },
+       )
    --> tests/html_macro/component-fail.rs:106:24
     |
 106 |     html! { <Child int=num ..props /> };

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -142,61 +142,260 @@ error: dynamic closing tags must not have a body (hint: replace it with just `</
 75 |     html! { <@{"test"}></@{"test"}> };
    |                           ^^^^^^^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Tuple(
+           ExprTuple {
+               attrs: [],
+               paren_token: Paren,
+               elems: [
+                   Lit(
+                       ExprLit {
+                           attrs: [],
+                           lit: Str(
+                               LitStr {
+                                   token: "deprecated",
+                               },
+                           ),
+                       },
+                   ),
+                   Comma,
+                   Lit(
+                       ExprLit {
+                           attrs: [],
+                           lit: Str(
+                               LitStr {
+                                   token: "warning",
+                               },
+                           ),
+                       },
+                   ),
+               ],
+           },
+       )
   --> tests/html_macro/element-fail.rs:83:24
    |
 83 |     html! { <div class=("deprecated", "warning") /> };
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Tuple(
+           ExprTuple {
+               attrs: [],
+               paren_token: Paren,
+               elems: [],
+           },
+       )
   --> tests/html_macro/element-fail.rs:84:24
    |
 84 |     html! { <input ref=() /> };
    |                        ^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Tuple(
+           ExprTuple {
+               attrs: [],
+               paren_token: Paren,
+               elems: [],
+           },
+       )
   --> tests/html_macro/element-fail.rs:85:24
    |
 85 |     html! { <input ref=() ref=() /> };
    |                        ^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Call(
+           ExprCall {
+               attrs: [],
+               func: Path(
+                   ExprPath {
+                       attrs: [],
+                       qself: None,
+                       path: Path {
+                           leading_colon: None,
+                           segments: [
+                               PathSegment {
+                                   ident: Ident {
+                                       ident: "Some",
+                                       span: #0 bytes(2632..2636),
+                                   },
+                                   arguments: None,
+                               },
+                           ],
+                       },
+                   },
+               ),
+               paren_token: Paren,
+               args: [
+                   Lit(
+                       ExprLit {
+                           attrs: [],
+                           lit: Int(
+                               LitInt {
+                                   token: 5,
+                               },
+                           ),
+                       },
+                   ),
+               ],
+           },
+       )
   --> tests/html_macro/element-fail.rs:86:28
    |
 86 |     html! { <input onfocus=Some(5) /> };
    |                            ^^^^^^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Path(
+           ExprPath {
+               attrs: [],
+               qself: None,
+               path: Path {
+                   leading_colon: None,
+                   segments: [
+                       PathSegment {
+                           ident: Ident {
+                               ident: "NotToString",
+                               span: #0 bytes(2672..2683),
+                           },
+                           arguments: None,
+                       },
+                   ],
+               },
+           },
+       )
   --> tests/html_macro/element-fail.rs:87:27
    |
 87 |     html! { <input string=NotToString /> };
    |                           ^^^^^^^^^^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Call(
+           ExprCall {
+               attrs: [],
+               func: Path(
+                   ExprPath {
+                       attrs: [],
+                       qself: None,
+                       path: Path {
+                           leading_colon: None,
+                           segments: [
+                               PathSegment {
+                                   ident: Ident {
+                                       ident: "Some",
+                                       span: #0 bytes(2711..2715),
+                                   },
+                                   arguments: None,
+                               },
+                           ],
+                       },
+                   },
+               ),
+               paren_token: Paren,
+               args: [
+                   Path(
+                       ExprPath {
+                           attrs: [],
+                           qself: None,
+                           path: Path {
+                               leading_colon: None,
+                               segments: [
+                                   PathSegment {
+                                       ident: Ident {
+                                           ident: "NotToString",
+                                           span: #0 bytes(2716..2727),
+                                       },
+                                       arguments: None,
+                                   },
+                               ],
+                           },
+                       },
+                   ),
+               ],
+           },
+       )
   --> tests/html_macro/element-fail.rs:88:22
    |
 88 |     html! { <a media=Some(NotToString) /> };
    |                      ^^^^^^^^^^^^^^^^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Call(
+           ExprCall {
+               attrs: [],
+               func: Path(
+                   ExprPath {
+                       attrs: [],
+                       qself: None,
+                       path: Path {
+                           leading_colon: None,
+                           segments: [
+                               PathSegment {
+                                   ident: Ident {
+                                       ident: "Some",
+                                       span: #0 bytes(2755..2759),
+                                   },
+                                   arguments: None,
+                               },
+                           ],
+                       },
+                   },
+               ),
+               paren_token: Paren,
+               args: [
+                   Lit(
+                       ExprLit {
+                           attrs: [],
+                           lit: Int(
+                               LitInt {
+                                   token: 5,
+                               },
+                           ),
+                       },
+                   ),
+               ],
+           },
+       )
   --> tests/html_macro/element-fail.rs:89:21
    |
 89 |     html! { <a href=Some(5) /> };
    |                     ^^^^^^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Tuple(
+           ExprTuple {
+               attrs: [],
+               paren_token: Paren,
+               elems: [],
+           },
+       )
   --> tests/html_macro/element-fail.rs:90:25
    |
 90 |     html! { <input type=() /> };
    |                         ^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Tuple(
+           ExprTuple {
+               attrs: [],
+               paren_token: Paren,
+               elems: [],
+           },
+       )
   --> tests/html_macro/element-fail.rs:91:26
    |
 91 |     html! { <input value=() /> };
    |                          ^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Path(
+           ExprPath {
+               attrs: [],
+               qself: None,
+               path: Path {
+                   leading_colon: None,
+                   segments: [
+                       PathSegment {
+                           ident: Ident {
+                               ident: "NotToString",
+                               span: #0 bytes(2862..2873),
+                           },
+                           arguments: None,
+                       },
+                   ],
+               },
+           },
+       )
   --> tests/html_macro/element-fail.rs:92:27
    |
 92 |     html! { <input string=NotToString /> };

--- a/packages/yew-macro/tests/html_macro/list-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/list-fail.stderr
@@ -1,65 +1,87 @@
 error: this opening fragment has no corresponding closing fragment
- --> $DIR/list-fail.rs:5:13
+ --> tests/html_macro/list-fail.rs:5:13
   |
 5 |     html! { <> };
   |             ^^
 
 error: this opening fragment has no corresponding closing fragment
- --> $DIR/list-fail.rs:6:15
+ --> tests/html_macro/list-fail.rs:6:15
   |
 6 |     html! { <><> };
   |               ^^
 
 error: this opening fragment has no corresponding closing fragment
- --> $DIR/list-fail.rs:7:13
+ --> tests/html_macro/list-fail.rs:7:13
   |
 7 |     html! { <><></> };
   |             ^^
 
 error: this closing fragment has no corresponding opening fragment
-  --> $DIR/list-fail.rs:10:13
+  --> tests/html_macro/list-fail.rs:10:13
    |
 10 |     html! { </> };
    |             ^^^
 
 error: this closing fragment has no corresponding opening fragment
-  --> $DIR/list-fail.rs:11:13
+  --> tests/html_macro/list-fail.rs:11:13
    |
 11 |     html! { </></> };
    |             ^^^
 
 error: only one root html element is allowed (hint: you can wrap multiple html elements in a fragment `<></>`)
-  --> $DIR/list-fail.rs:14:18
+  --> tests/html_macro/list-fail.rs:14:18
    |
 14 |     html! { <></><></> };
    |                  ^^^^^
 
 error: expected a valid html element
-  --> $DIR/list-fail.rs:16:15
+  --> tests/html_macro/list-fail.rs:16:15
    |
 16 |     html! { <>invalid</> };
    |               ^^^^^^^
 
 error: expected an expression following this equals sign
-  --> $DIR/list-fail.rs:18:17
+  --> tests/html_macro/list-fail.rs:18:17
    |
 18 |     html! { <key=></> };
    |                 ^^
 
-error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.
-  --> $DIR/list-fail.rs:20:18
+error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: MethodCall(
+           ExprMethodCall {
+               attrs: [],
+               receiver: Lit(
+                   ExprLit {
+                       attrs: [],
+                       lit: Str(
+                           LitStr {
+                               token: "key",
+                           },
+                       ),
+                   },
+               ),
+               dot_token: Dot,
+               method: Ident {
+                   ident: "to_string",
+                   span: #0 bytes(404..413),
+               },
+               turbofish: None,
+               paren_token: Paren,
+               args: [],
+           },
+       )
+  --> tests/html_macro/list-fail.rs:20:18
    |
 20 |     html! { <key="key".to_string()></key> };
    |                  ^^^^^^^^^^^^^^^^^
 
 error: only a single `key` prop is allowed on a fragment
-  --> $DIR/list-fail.rs:23:30
+  --> tests/html_macro/list-fail.rs:23:30
    |
 23 |     html! { <key="first key" key="second key" /> };
    |                              ^^^
 
 error: fragments only accept the `key` prop
-  --> $DIR/list-fail.rs:25:14
+  --> tests/html_macro/list-fail.rs:25:14
    |
 25 |     html! { <some_attr="test"></> };
    |              ^^^^^^^^^

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -149,15 +149,29 @@ impl Attributes {
     }
 
     fn set_attribute(el: &Element, key: &str, value: &str) {
-        let key = JsValue::from_str(key);
-        let value = JsValue::from_str(value);
-        js_sys::Reflect::set(el.as_ref(), &key, &value).expect("invalid attribute key");
+        match key {
+            // need to be attributes because, otherwise query selectors fail
+            "class" | "id" => el.set_attribute(key, value).expect("invalid attribute key"),
+            _ => {
+                let key = JsValue::from_str(key);
+                let value = JsValue::from_str(value);
+                js_sys::Reflect::set(el.as_ref(), &key, &value).expect("invalid attribute key");
+            }
+        }
     }
 
     fn remove_attribute(el: &Element, key: &str) {
-        let key = JsValue::from_str(key);
-        js_sys::Reflect::set(el.as_ref(), &key, &JsValue::UNDEFINED)
-            .expect("could not remove attribute");
+        match key {
+            // need to be attributes because, otherwise query selectors fail
+            "class" | "id" => el
+                .remove_attribute(key)
+                .expect("could not remove attribute"),
+            _ => {
+                let key = JsValue::from_str(key);
+                js_sys::Reflect::set(el.as_ref(), &key, &JsValue::UNDEFINED)
+                    .expect("could not remove attribute");
+            }
+        }
     }
 }
 

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -269,34 +269,40 @@ impl Apply for Attributes {
 #[cfg(target_arch = "wasm32")]
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
     use gloo::utils::document;
     use js_sys::Reflect;
+    use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+    use super::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
 
     fn create_element() -> (Element, BSubtree) {
-        let element = document().create_element("a").expect("failed to create element");
+        let element = document()
+            .create_element("a")
+            .expect("failed to create element");
         let btree = BSubtree::create_root(&element);
         (element, btree)
     }
 
     #[test]
     fn properties_are_set() {
-        let attrs = Attributes::Static(&[
-            ["href", "https://example.com/"],
-            ["alt", "somewhere"],
-        ]);
+        let attrs = Attributes::Static(&[["href", "https://example.com/"], ["alt", "somewhere"]]);
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
         assert_eq!(
-            Reflect::get(element.as_ref(), &JsValue::from_str("href")).expect("no href").as_string().expect("not a string"),
+            Reflect::get(element.as_ref(), &JsValue::from_str("href"))
+                .expect("no href")
+                .as_string()
+                .expect("not a string"),
             "https://example.com/",
             "property `href` not set properly"
         );
         assert_eq!(
-            Reflect::get(element.as_ref(), &JsValue::from_str("alt")).expect("no alt").as_string().expect("not a string"),
+            Reflect::get(element.as_ref(), &JsValue::from_str("alt"))
+                .expect("no alt")
+                .as_string()
+                .expect("not a string"),
             "somewhere",
             "property `alt` not set properly"
         );
@@ -304,10 +310,7 @@ mod tests {
 
     #[test]
     fn class_id_are_attrs() {
-        let attrs = Attributes::Static(&[
-            ["id", "foo"],
-            ["class", "thing"],
-        ]);
+        let attrs = Attributes::Static(&[["id", "foo"], ["class", "thing"]]);
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
         assert_eq!(element.get_attribute("id").unwrap(), "foo");

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -295,11 +295,13 @@ impl Apply for Attributes {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
+
     use gloo::utils::document;
     use js_sys::Reflect;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
-    use crate::{html, Html, function_component};
+
     use super::*;
+    use crate::{function_component, html, Html};
 
     wasm_bindgen_test_configure!(run_in_browser);
 
@@ -345,7 +347,11 @@ mod tests {
         ]);
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
-        assert_eq!(element.outer_html(), "<a href=\"https://example.com/\"></a>", "should be set as attribute");
+        assert_eq!(
+            element.outer_html(),
+            "<a href=\"https://example.com/\"></a>",
+            "should be set as attribute"
+        );
         assert_eq!(
             Reflect::get(element.as_ref(), &JsValue::from_str("alt"))
                 .expect("no alt")
@@ -358,13 +364,10 @@ mod tests {
 
     #[test]
     fn class_is_always_attrs() {
-        let attrs = Attributes::Static(&[
-            ("class", "thing", ApplyAttributeAs::Attribute),
-        ]);
+        let attrs = Attributes::Static(&[("class", "thing", ApplyAttributeAs::Attribute)]);
 
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
-        assert_eq!(element.get_attribute("id").unwrap(), "foo");
         assert_eq!(element.get_attribute("class").unwrap(), "thing");
     }
 
@@ -376,8 +379,8 @@ mod tests {
         }
 
         let output = gloo::utils::document().get_element_by_id("output").unwrap();
-        yew::Renderer::<Comp>::with_root(output.clone())
-            .render();
+        yew::Renderer::<Comp>::with_root(output.clone()).render();
+
         gloo::timers::future::sleep(Duration::from_secs(1)).await;
         let element = output.query_selector("a").unwrap().unwrap();
         assert_eq!(element.get_attribute("alt").unwrap(), "abc");

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -265,3 +265,52 @@ impl Apply for Attributes {
         }
     }
 }
+
+#[cfg(target_arch = "wasm32")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+    use gloo::utils::document;
+    use js_sys::Reflect;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn create_element() -> (Element, BSubtree) {
+        let element = document().create_element("a").expect("failed to create element");
+        let btree = BSubtree::create_root(&element);
+        (element, btree)
+    }
+
+    #[test]
+    fn properties_are_set() {
+        let attrs = Attributes::Static(&[
+            ["href", "https://example.com/"],
+            ["alt", "somewhere"],
+        ]);
+        let (element, btree) = create_element();
+        attrs.apply(&btree, &element);
+        assert_eq!(
+            Reflect::get(element.as_ref(), &JsValue::from_str("href")).expect("no href").as_string().expect("not a string"),
+            "https://example.com/",
+            "property `href` not set properly"
+        );
+        assert_eq!(
+            Reflect::get(element.as_ref(), &JsValue::from_str("alt")).expect("no alt").as_string().expect("not a string"),
+            "somewhere",
+            "property `alt` not set properly"
+        );
+    }
+
+    #[test]
+    fn class_id_are_attrs() {
+        let attrs = Attributes::Static(&[
+            ["id", "foo"],
+            ["class", "thing"],
+        ]);
+        let (element, btree) = create_element();
+        attrs.apply(&btree, &element);
+        assert_eq!(element.get_attribute("id").unwrap(), "foo");
+        assert_eq!(element.get_attribute("class").unwrap(), "thing");
+    }
+}

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -95,16 +95,16 @@ impl Attributes {
             match old.get(key) {
                 Some(old_value) => {
                     if value != old_value {
-                        Self::set_attribute(el, key, value.0.as_ref());
+                        Self::set(el, key, value.0.as_ref(), value.1);
                     }
                 }
-                None => Self::set_attribute(el, key, value.0.as_ref()),
+                None => Self::set(el, key, value.0.as_ref(), value.1),
             }
         }
 
-        for (key, _value) in old.iter() {
+        for (key, (_, apply_as)) in old.iter() {
             if !new.contains_key(key) {
-                Self::remove_attribute(el, key);
+                Self::remove(el, key, *apply_as);
             }
         }
     }
@@ -117,13 +117,22 @@ impl Attributes {
             use Attributes::*;
 
             match src {
-                Static(arr) => (*arr).iter().map(|(k, v, apply_as)| (*k, (*v, *apply_as))).collect(),
+                Static(arr) => (*arr)
+                    .iter()
+                    .map(|(k, v, apply_as)| (*k, (*v, *apply_as)))
+                    .collect(),
                 Dynamic { keys, values } => keys
                     .iter()
                     .zip(values.iter())
-                    .filter_map(|(k, v)| v.as_ref().map(|(v, apply_as)| (*k, (v.as_ref(), *apply_as))))
+                    .filter_map(|(k, v)| {
+                        v.as_ref()
+                            .map(|(v, apply_as)| (*k, (v.as_ref(), *apply_as)))
+                    })
                     .collect(),
-                IndexMap(m) => m.iter().map(|(k, (v, apply_as))| (k.as_ref(), (v.as_ref(), *apply_as))).collect(),
+                IndexMap(m) => m
+                    .iter()
+                    .map(|(k, (v, apply_as))| (k.as_ref(), (v.as_ref(), *apply_as)))
+                    .collect(),
             }
         }
 
@@ -142,35 +151,50 @@ impl Attributes {
         }
 
         // Remove missing
-        for k in old.keys() {
+        for (k, (_, apply_as)) in old.iter() {
             if !new.contains_key(k) {
-                Self::remove_attribute(el, k);
+                Self::remove(el, k, *apply_as);
             }
         }
     }
 
-    fn set_attribute(el: &Element, key: &str, value: &str) {
-        match key {
-            // need to be attributes because, otherwise query selectors fail
-            "class" | "id" => el.set_attribute(key, value).expect("invalid attribute key"),
-            _ => {
-                let key = JsValue::from_str(key);
-                let value = JsValue::from_str(value);
-                js_sys::Reflect::set(el.as_ref(), &key, &value).expect("invalid attribute key");
+    fn set(el: &Element, key: &str, value: &str, apply_as: ApplyAttributeAs) {
+        match apply_as {
+            ApplyAttributeAs::Attribute => {
+                el.set_attribute(key, value).expect("invalid attribute key")
+            }
+            ApplyAttributeAs::Property => {
+                match key {
+                    // need to be attributes because, otherwise query selectors fail
+                    "class" => el.set_attribute(key, value).expect("invalid attribute key"),
+                    _ => {
+                        let key = JsValue::from_str(key);
+                        let value = JsValue::from_str(value);
+                        js_sys::Reflect::set(el.as_ref(), &key, &value)
+                            .expect("could not set property");
+                    }
+                }
             }
         }
     }
 
-    fn remove_attribute(el: &Element, key: &str) {
-        match key {
-            // need to be attributes because, otherwise query selectors fail
-            "class" | "id" => el
+    fn remove(el: &Element, key: &str, apply_as: ApplyAttributeAs) {
+        match apply_as {
+            ApplyAttributeAs::Attribute => el
                 .remove_attribute(key)
                 .expect("could not remove attribute"),
-            _ => {
-                let key = JsValue::from_str(key);
-                js_sys::Reflect::set(el.as_ref(), &key, &JsValue::UNDEFINED)
-                    .expect("could not remove attribute");
+            ApplyAttributeAs::Property => {
+                match key {
+                    // need to be attributes because, otherwise query selectors fail
+                    "class" | "id" => el
+                        .remove_attribute(key)
+                        .expect("could not remove attribute"),
+                    _ => {
+                        let key = JsValue::from_str(key);
+                        js_sys::Reflect::set(el.as_ref(), &key, &JsValue::UNDEFINED)
+                            .expect("could not remove property");
+                    }
+                }
             }
         }
     }
@@ -183,20 +207,20 @@ impl Apply for Attributes {
     fn apply(self, _root: &BSubtree, el: &Element) -> Self {
         match &self {
             Self::Static(arr) => {
-                for (k, v, _) in arr.iter() {
-                    Self::set_attribute(el, *k, *v);
+                for (k, v, apply_as) in arr.iter() {
+                    Self::set(el, *k, *v, *apply_as);
                 }
             }
             Self::Dynamic { keys, values } => {
                 for (k, v) in keys.iter().zip(values.iter()) {
-                    if let Some((v, _)) = v {
-                        Self::set_attribute(el, k, v)
+                    if let Some((v, apply_as)) = v {
+                        Self::set(el, k, v, *apply_as)
                     }
                 }
             }
             Self::IndexMap(m) => {
-                for (k, (v, _)) in m.iter() {
-                    Self::set_attribute(el, k, v)
+                for (k, (v, apply_as)) in m.iter() {
+                    Self::set(el, k, v, *apply_as)
                 }
             }
         }
@@ -236,7 +260,7 @@ impl Apply for Attributes {
                     }
                     macro_rules! set {
                         ($new:expr) => {
-                            Self::set_attribute(el, key!(), $new.0.as_ref())
+                            Self::set(el, key!(), $new.0.as_ref(), $new.1)
                         };
                     }
 
@@ -247,8 +271,8 @@ impl Apply for Attributes {
                             }
                         }
                         (Some(new), None) => set!(new),
-                        (None, Some(_)) => {
-                            Self::remove_attribute(el, key!());
+                        (None, Some(old)) => {
+                            Self::remove(el, key!(), old.1);
                         }
                         (None, None) => (),
                     }
@@ -270,10 +294,11 @@ impl Apply for Attributes {
 #[cfg(target_arch = "wasm32")]
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
     use gloo::utils::document;
     use js_sys::Reflect;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
-
+    use crate::{html, Html, function_component};
     use super::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
@@ -288,7 +313,10 @@ mod tests {
 
     #[test]
     fn properties_are_set() {
-        let attrs = Attributes::Static(&[("href", "https://example.com/", ApplyAttributeAs::Property), ("alt", "somewhere", ApplyAttributeAs::Property)]);
+        let attrs = Attributes::Static(&[
+            ("href", "https://example.com/", ApplyAttributeAs::Property),
+            ("alt", "somewhere", ApplyAttributeAs::Property),
+        ]);
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
         assert_eq!(
@@ -310,11 +338,58 @@ mod tests {
     }
 
     #[test]
-    fn class_id_are_attrs() {
-        let attrs = Attributes::Static(&[("id", "foo", ApplyAttributeAs::Attribute), ("class", "thing", ApplyAttributeAs::Attribute)]);
+    fn respects_apply_as() {
+        let attrs = Attributes::Static(&[
+            ("href", "https://example.com/", ApplyAttributeAs::Attribute),
+            ("alt", "somewhere", ApplyAttributeAs::Property),
+        ]);
+        let (element, btree) = create_element();
+        attrs.apply(&btree, &element);
+        assert_eq!(element.outer_html(), "<a href=\"https://example.com/\"></a>", "should be set as attribute");
+        assert_eq!(
+            Reflect::get(element.as_ref(), &JsValue::from_str("alt"))
+                .expect("no alt")
+                .as_string()
+                .expect("not a string"),
+            "somewhere",
+            "property `alt` not set properly"
+        );
+    }
+
+    #[test]
+    fn class_id_are_always_attrs() {
+        let attrs = Attributes::Static(&[
+            ("id", "foo", ApplyAttributeAs::Property),
+            ("class", "thing", ApplyAttributeAs::Attribute),
+        ]);
+
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
         assert_eq!(element.get_attribute("id").unwrap(), "foo");
         assert_eq!(element.get_attribute("class").unwrap(), "thing");
+    }
+
+    #[test]
+    async fn macro_syntax_works() {
+        #[function_component]
+        fn Comp() -> Html {
+            html! { <a href="https://example.com/" @alt="abc" /> }
+        }
+
+        let output = gloo::utils::document().get_element_by_id("output").unwrap();
+        yew::Renderer::<Comp>::with_root(output.clone())
+            .render();
+        gloo::timers::future::sleep(Duration::from_secs(1)).await;
+        let element = output.query_selector("a").unwrap().unwrap();
+        assert_eq!(element.get_attribute("alt").unwrap(), "abc");
+
+        assert_eq!(
+            Reflect::get(element.as_ref(), &JsValue::from_str("href"))
+                .expect("no href")
+                .as_string()
+                .expect("not a string"),
+            "https://example.com/",
+            "property `href` not set properly"
+        );
     }
 }

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -367,7 +367,10 @@ mod tests {
 
         gloo::timers::future::sleep(Duration::from_secs(1)).await;
         let element = output.query_selector("a").unwrap().unwrap();
-        assert_eq!(element.get_attribute("href").unwrap(), "https://example.com/");
+        assert_eq!(
+            element.get_attribute("href").unwrap(),
+            "https://example.com/"
+        );
 
         assert_eq!(
             Reflect::get(element.as_ref(), &JsValue::from_str("alt"))

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -186,7 +186,7 @@ impl Attributes {
             ApplyAttributeAs::Property => {
                 match key {
                     // need to be attributes because, otherwise query selectors fail
-                    "class" | "id" => el
+                    "class" => el
                         .remove_attribute(key)
                         .expect("could not remove attribute"),
                     _ => {
@@ -357,9 +357,8 @@ mod tests {
     }
 
     #[test]
-    fn class_id_are_always_attrs() {
+    fn class_is_always_attrs() {
         let attrs = Attributes::Static(&[
-            ("id", "foo", ApplyAttributeAs::Property),
             ("class", "thing", ApplyAttributeAs::Attribute),
         ]);
 

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -145,7 +145,7 @@ impl Attributes {
                 Some(old) => old != new,
                 None => true,
             } {
-                Self::set(&el, k, new.0, new.1);
+                Self::set(el, k, new.0, new.1);
             }
         }
 

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::ops::Deref;
 
 use indexmap::IndexMap;
+use wasm_bindgen::JsValue;
 use web_sys::{Element, HtmlInputElement as InputElement, HtmlTextAreaElement as TextAreaElement};
 use yew::AttrValue;
 
@@ -148,12 +149,15 @@ impl Attributes {
     }
 
     fn set_attribute(el: &Element, key: &str, value: &str) {
-        el.set_attribute(key, value).expect("invalid attribute key")
+        let key = JsValue::from_str(key);
+        let value = JsValue::from_str(value);
+        js_sys::Reflect::set(el.as_ref(), &key, &value).expect("invalid attribute key");
     }
 
     fn remove_attribute(el: &Element, key: &str) {
-        el.remove_attribute(key)
-            .expect("could not remove attribute")
+        let key = JsValue::from_str(key);
+        js_sys::Reflect::set(el.as_ref(), &key, &JsValue::UNDEFINED)
+            .expect("could not remove attribute");
     }
 }
 

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn properties_are_set() {
-        let attrs = Attributes::Static(&[["href", "https://example.com/"], ["alt", "somewhere"]]);
+        let attrs = Attributes::Static(&[("href", "https://example.com/", ApplyAttributeAs::Property), ("alt", "somewhere", ApplyAttributeAs::Property)]);
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
         assert_eq!(
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn class_id_are_attrs() {
-        let attrs = Attributes::Static(&[["id", "foo"], ["class", "thing"]]);
+        let attrs = Attributes::Static(&[("id", "foo", ApplyAttributeAs::Attribute), ("class", "thing", ApplyAttributeAs::Attribute)]);
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
         assert_eq!(element.get_attribute("id").unwrap(), "foo");

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -722,12 +722,12 @@ mod tests {
         assert!(vtag.reference().has_attribute("class"));
     }
 
-    // #[test]
+    #[test]
     fn it_sets_class_name_static() {
         test_set_class_name(|| html! { <div class="ferris the crab"></div> });
     }
 
-    // #[test]
+    #[test]
     fn it_sets_class_name_dynamic() {
         test_set_class_name(|| html! { <div class={"ferris the crab".to_owned()}></div> });
     }

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -386,7 +386,7 @@ mod feat_hydration {
 #[cfg(test)]
 mod tests {
     use gloo::utils::document;
-    use wasm_bindgen::{JsCast, JsValue};
+    use wasm_bindgen::{JsCast};
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
     use web_sys::HtmlInputElement as InputElement;
 
@@ -969,19 +969,7 @@ mod tests {
                 .dyn_ref::<web_sys::Element>()
                 .unwrap()
                 .outer_html(),
-            "<div></div>"
-        );
-
-        assert_eq!(
-            js_sys::Reflect::get(
-                test_ref.get().unwrap().as_ref(),
-                &JsValue::from_str("tabindex")
-            )
-            .expect("no tabindex")
-            .as_string()
-            .expect("not a string"),
-            "0",
-            "property `tabindex` not set properly"
+            "<div tabindex=\"0\"></div>"
         );
     }
 }

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -722,12 +722,12 @@ mod tests {
         assert!(vtag.reference().has_attribute("class"));
     }
 
-    #[test]
+    // #[test]
     fn it_sets_class_name_static() {
         test_set_class_name(|| html! { <div class="ferris the crab"></div> });
     }
 
-    #[test]
+    // #[test]
     fn it_sets_class_name_dynamic() {
         test_set_class_name(|| html! { <div class={"ferris the crab".to_owned()}></div> });
     }
@@ -932,7 +932,7 @@ mod tests {
     }
 
     // test for bug: https://github.com/yewstack/yew/pull/2653
-    #[test]
+    // #[test]
     fn test_index_map_attribute_diff() {
         let (root, scope, parent) = setup_parent();
 

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -386,7 +386,7 @@ mod feat_hydration {
 #[cfg(test)]
 mod tests {
     use gloo::utils::document;
-    use wasm_bindgen::JsCast;
+    use wasm_bindgen::{JsCast, JsValue};
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
     use web_sys::HtmlInputElement as InputElement;
 
@@ -932,7 +932,7 @@ mod tests {
     }
 
     // test for bug: https://github.com/yewstack/yew/pull/2653
-    // #[test]
+    #[test]
     fn test_index_map_attribute_diff() {
         let (root, scope, parent) = setup_parent();
 
@@ -969,8 +969,20 @@ mod tests {
                 .dyn_ref::<web_sys::Element>()
                 .unwrap()
                 .outer_html(),
-            "<div tabindex=\"0\"></div>"
-        )
+            "<div></div>"
+        );
+
+        assert_eq!(
+            js_sys::Reflect::get(
+                test_ref.get().unwrap().as_ref(),
+                &JsValue::from_str("tabindex")
+            )
+            .expect("no tabindex")
+            .as_string()
+            .expect("not a string"),
+            "0",
+            "property `tabindex` not set properly"
+        );
     }
 }
 

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -386,7 +386,7 @@ mod feat_hydration {
 #[cfg(test)]
 mod tests {
     use gloo::utils::document;
-    use wasm_bindgen::{JsCast};
+    use wasm_bindgen::JsCast;
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
     use web_sys::HtmlInputElement as InputElement;
 

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -242,7 +242,7 @@ impl From<IndexMap<AttrValue, AttrValue>> for Attributes {
     fn from(map: IndexMap<AttrValue, AttrValue>) -> Self {
         let v = map
             .into_iter()
-            .map(|(k, v)| (k, (v, ApplyAttributeAs::Property)))
+            .map(|(k, v)| (k, (v, ApplyAttributeAs::Attribute)))
             .collect();
         Self::IndexMap(v)
     }
@@ -252,7 +252,7 @@ impl From<IndexMap<&'static str, AttrValue>> for Attributes {
     fn from(v: IndexMap<&'static str, AttrValue>) -> Self {
         let v = v
             .into_iter()
-            .map(|(k, v)| (AttrValue::Static(k), (v, ApplyAttributeAs::Property)))
+            .map(|(k, v)| (AttrValue::Static(k), (v, ApplyAttributeAs::Attribute)))
             .collect();
         Self::IndexMap(v)
     }

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -150,7 +150,7 @@ mod feat_ssr {
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum ApplyAttributeAs {
     Attribute,
-    Property
+    Property,
 }
 
 /// A collection of attributes for an element
@@ -191,9 +191,7 @@ impl Attributes {
     /// This function is suboptimal and does not inline well. Avoid on hot paths.
     pub fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&'a str, &'a str)> + 'a> {
         match self {
-            Self::Static(arr) => Box::new(
-                arr.iter().map(|(k, v, _)| (*k, *v as &'a str))
-            ),
+            Self::Static(arr) => Box::new(arr.iter().map(|(k, v, _)| (*k, *v as &'a str))),
             Self::Dynamic { keys, values } => Box::new(
                 keys.iter()
                     .zip(values.iter())
@@ -219,7 +217,11 @@ impl Attributes {
         match self {
             Self::IndexMap(m) => m,
             Self::Static(arr) => {
-                *self = Self::IndexMap(arr.iter().map(|(k, v, ty)| ((*k).into(), ((*v).into(), *ty))).collect());
+                *self = Self::IndexMap(
+                    arr.iter()
+                        .map(|(k, v, ty)| ((*k).into(), ((*v).into(), *ty)))
+                        .collect(),
+                );
                 unpack!()
             }
             Self::Dynamic { keys, values } => {
@@ -238,7 +240,10 @@ impl Attributes {
 
 impl From<IndexMap<AttrValue, AttrValue>> for Attributes {
     fn from(map: IndexMap<AttrValue, AttrValue>) -> Self {
-        let v= map.into_iter().map(|(k, v)| (k, (v, ApplyAttributeAs::Property))).collect();
+        let v = map
+            .into_iter()
+            .map(|(k, v)| (k, (v, ApplyAttributeAs::Property)))
+            .collect();
         Self::IndexMap(v)
     }
 }

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -371,8 +371,8 @@ impl VTag {
 
     /// Adds a key-value pair to element's property
     ///
-    /// Not every property works when it set as an attribute. We use workarounds for:
-    /// `class` and `id`, which are both set as attributes.
+    /// Not everything works when it set as an property. We use workarounds for:
+    /// `class`, which is set as attribute.
     pub fn set_property(&mut self, key: &'static str, value: impl Into<AttrValue>) {
         self.attributes.get_mut_index_map().insert(
             AttrValue::Static(key),

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 
 use web_sys::{HtmlInputElement as InputElement, HtmlTextAreaElement as TextAreaElement};
 
-use super::{AttrValue, Attributes, Key, Listener, Listeners, VList, VNode, ApplyAttributeAs};
+use super::{ApplyAttributeAs, AttrValue, Attributes, Key, Listener, Listeners, VList, VNode};
 use crate::html::{IntoPropValue, NodeRef};
 
 /// SVG namespace string used for creating svg elements
@@ -363,9 +363,10 @@ impl VTag {
     /// Not every attribute works when it set as an attribute. We use workarounds for:
     /// `value` and `checked`.
     pub fn add_attribute(&mut self, key: &'static str, value: impl Into<AttrValue>) {
-        self.attributes
-            .get_mut_index_map()
-            .insert(AttrValue::Static(key), (value.into(), ApplyAttributeAs::Attribute));
+        self.attributes.get_mut_index_map().insert(
+            AttrValue::Static(key),
+            (value.into(), ApplyAttributeAs::Attribute),
+        );
     }
 
     /// Adds a key-value pair to element's property
@@ -373,9 +374,10 @@ impl VTag {
     /// Not every property works when it set as an attribute. We use workarounds for:
     /// `class` and `id`, which are both set as attributes.
     pub fn set_property(&mut self, key: &'static str, value: impl Into<AttrValue>) {
-        self.attributes
-            .get_mut_index_map()
-            .insert(AttrValue::Static(key), (value.into(), ApplyAttributeAs::Property));
+        self.attributes.get_mut_index_map().insert(
+            AttrValue::Static(key),
+            (value.into(), ApplyAttributeAs::Property),
+        );
     }
 
     /// Sets attributes to a virtual node.
@@ -388,9 +390,10 @@ impl VTag {
 
     #[doc(hidden)]
     pub fn __macro_push_attr(&mut self, key: &'static str, value: impl IntoPropValue<AttrValue>) {
-        self.attributes
-            .get_mut_index_map()
-            .insert(AttrValue::from(key), (value.into_prop_value(), ApplyAttributeAs::Property));
+        self.attributes.get_mut_index_map().insert(
+            AttrValue::from(key),
+            (value.into_prop_value(), ApplyAttributeAs::Property),
+        );
     }
 
     /// Add event listener on the [VTag]'s  [Element](web_sys::Element).

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -369,11 +369,10 @@ impl VTag {
         );
     }
 
-    /// Adds a key-value pair to element's property
+    /// Set the given key as property on the element
     ///
-    /// Not everything works when it set as an property. We use workarounds for:
-    /// `class`, which is set as attribute.
-    pub fn set_property(&mut self, key: &'static str, value: impl Into<AttrValue>) {
+    /// [`js_sys::Reflect`] is used for setting properties.
+    pub fn add_property(&mut self, key: &'static str, value: impl Into<AttrValue>) {
         self.attributes.get_mut_index_map().insert(
             AttrValue::Static(key),
             (value.into(), ApplyAttributeAs::Property),

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 
 use web_sys::{HtmlInputElement as InputElement, HtmlTextAreaElement as TextAreaElement};
 
-use super::{AttrValue, Attributes, Key, Listener, Listeners, VList, VNode};
+use super::{AttrValue, Attributes, Key, Listener, Listeners, VList, VNode, ApplyAttributeAs};
 use crate::html::{IntoPropValue, NodeRef};
 
 /// SVG namespace string used for creating svg elements
@@ -365,7 +365,17 @@ impl VTag {
     pub fn add_attribute(&mut self, key: &'static str, value: impl Into<AttrValue>) {
         self.attributes
             .get_mut_index_map()
-            .insert(AttrValue::Static(key), value.into());
+            .insert(AttrValue::Static(key), (value.into(), ApplyAttributeAs::Attribute));
+    }
+
+    /// Adds a key-value pair to element's property
+    ///
+    /// Not every property works when it set as an attribute. We use workarounds for:
+    /// `class` and `id`, which are both set as attributes.
+    pub fn set_property(&mut self, key: &'static str, value: impl Into<AttrValue>) {
+        self.attributes
+            .get_mut_index_map()
+            .insert(AttrValue::Static(key), (value.into(), ApplyAttributeAs::Property));
     }
 
     /// Sets attributes to a virtual node.
@@ -380,7 +390,7 @@ impl VTag {
     pub fn __macro_push_attr(&mut self, key: &'static str, value: impl IntoPropValue<AttrValue>) {
         self.attributes
             .get_mut_index_map()
-            .insert(AttrValue::from(key), value.into_prop_value());
+            .insert(AttrValue::from(key), (value.into_prop_value(), ApplyAttributeAs::Property));
     }
 
     /// Add event listener on the [VTag]'s  [Element](web_sys::Element).

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -15,9 +15,9 @@ use yew::platform::time::sleep;
 use yew::prelude::*;
 use yew::suspense::{use_future, use_future_with_deps, Suspension, SuspensionResult};
 
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+wasm_bindgen_test_configure!(run_in_browser);
 
-#[wasm_bindgen_test]
+// #[wasm_bindgen_test]
 async fn suspense_works() {
     #[derive(PartialEq)]
     pub struct SleepState {
@@ -161,7 +161,7 @@ async fn suspense_works() {
     );
 }
 
-#[wasm_bindgen_test]
+// #[wasm_bindgen_test]
 async fn suspense_not_suspended_at_start() {
     #[derive(PartialEq)]
     pub struct SleepState {
@@ -278,7 +278,7 @@ async fn suspense_not_suspended_at_start() {
     );
 }
 
-#[wasm_bindgen_test]
+// #[wasm_bindgen_test]
 async fn suspense_nested_suspense_works() {
     #[derive(PartialEq)]
     pub struct SleepState {
@@ -413,7 +413,7 @@ async fn suspense_nested_suspense_works() {
     );
 }
 
-#[wasm_bindgen_test]
+// #[wasm_bindgen_test]
 async fn effects_not_run_when_suspended() {
     #[derive(PartialEq)]
     pub struct SleepState {

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -17,7 +17,7 @@ use yew::suspense::{use_future, use_future_with_deps, Suspension, SuspensionResu
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-// #[wasm_bindgen_test]
+#[wasm_bindgen_test]
 async fn suspense_works() {
     #[derive(PartialEq)]
     pub struct SleepState {
@@ -161,7 +161,7 @@ async fn suspense_works() {
     );
 }
 
-// #[wasm_bindgen_test]
+#[wasm_bindgen_test]
 async fn suspense_not_suspended_at_start() {
     #[derive(PartialEq)]
     pub struct SleepState {
@@ -278,7 +278,7 @@ async fn suspense_not_suspended_at_start() {
     );
 }
 
-// #[wasm_bindgen_test]
+#[wasm_bindgen_test]
 async fn suspense_nested_suspense_works() {
     #[derive(PartialEq)]
     pub struct SleepState {
@@ -413,7 +413,7 @@ async fn suspense_nested_suspense_works() {
     );
 }
 
-// #[wasm_bindgen_test]
+#[wasm_bindgen_test]
 async fn effects_not_run_when_suspended() {
     #[derive(PartialEq)]
     pub struct SleepState {


### PR DESCRIPTION
#### Description

Fixes #1322  
Fixes #2530

Properties are set by using `js_sys::Reflect`. While it doesn't give much benifit today (they're still strings), it opens the door for more opportunities since we can now define specific types for properties. This will help with statically typed DOM, whenever that becomes a thing.  
This PR also introduces new syntax, `@key="value"` which can be used to forcefully set to attributes.

`class` is set as always attribute, since it is not a property. Classes are stored in `classList` in DOM. Since they're _always_ strings, it's not worth the extra JS calls to add to `classList`.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
