### PR TITLE
Allow keywords after dash in element and attribute names

### DIFF
--- a/packages/yew-macro/src/html_tree/html_dashed_name.rs
+++ b/packages/yew-macro/src/html_tree/html_dashed_name.rs
@@ -79,7 +79,7 @@ impl Parse for HtmlDashedName {
         let name = input.call(Ident::parse_any)?;
         let mut extended = Vec::new();
         while input.peek(Token![-]) {
-            extended.push((input.parse::<Token![-]>()?, input.parse::<Ident>()?));
+            extended.push((input.parse::<Token![-]>()?, input.call(Ident::parse_any)?));
         }
 
         Ok(HtmlDashedName { name, extended })

--- a/packages/yew-macro/tests/html_macro/html-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-element-pass.rs
@@ -118,6 +118,9 @@ fn compile_pass() {
     // handle misleading angle brackets
     ::yew::html! { <div data-val={<::std::string::String as ::std::default::Default>::default()}></div> };
     ::yew::html! { <div><a data-val={<::std::string::String as ::std::default::Default>::default()} /></div> };
+
+    // test for https://github.com/yewstack/yew/issues/2810
+    ::yew::html! {  <div data-type="date" data-as="calender" /> };
 }
 
 fn main() {}


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Fixes https://github.com/yewstack/yew/issues/2810

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
