### PR TITLE
Reduce SSR Buffers in VList

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -25,7 +25,7 @@ slab = "0.4"
 wasm-bindgen = "0.2"
 yew-macro = { version = "^0.19.0", path = "../yew-macro" }
 thiserror = "1.0"
-futures = { version = "0.3", default-features = false, features = ["std"] }
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 html-escape = { version = "0.2.9", optional = true }
 implicit-clone = { version = "0.3", features = ["map"] }
 base64ct = { version = "1.5.0", features = ["std"], optional = true }


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This pull request updates the VList rendering logic that a new buffer is created only when a child VNode does not resolve immediately.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
