### PR TITLE
Replace reqwasm with gloo-net

### DIFF
--- a/website/community/external-libs.mdx
+++ b/website/community/external-libs.mdx
@@ -22,13 +22,9 @@ libraries with Rust and Wasm. Gloo provides ergonomic Rust APIs for working with
 -   [Dialogs](https://crates.io/crates/gloo-dialogs)
 -   [Events](https://crates.io/crates/gloo-events)
 -   [Files](https://crates.io/crates/gloo-file)
+-   [Requests](https://crates.io/crates/gloo-net)
 -   [Timers](https://crates.io/crates/gloo-timers)
 -   [Web Storage](https://crates.io/crates/gloo-storage)
-
-## Reqwasm
-
-[Reqwasm](https://crates.io/crates/reqwasm) is an HTTP requests library for WASM Apps.
-It provides idiomatic Rust API for the browser's `fetch` and `WebSocket` API.
 
 ## Looking For
 

--- a/website/docs/migration-guides/yew/from-0_18_0-to-0_19_0.mdx
+++ b/website/docs/migration-guides/yew/from-0_18_0-to-0_19_0.mdx
@@ -125,9 +125,9 @@ html! {
 -   `TimeoutService`
     Use [`gloo-timers`](https://docs.rs/gloo-timers/) instead.
 -   `WebSocketService`
-    Use [`wasm-sockets`](https://github.com/scratchyone/wasm-sockets) or [`gloo-net`](https://github.com/rustwasm/gloo) instead.
+    Use [`wasm-sockets`](https://github.com/scratchyone/wasm-sockets) or [`gloo-net`](https://crates.io/crates/gloo-net) instead.
 -   `FetchService`
-    Use [`reqwest`](https://crates.io/crates/reqwest) or [`gloo-net`](https://github.com/rustwasm/gloo) instead.
+    Use [`reqwest`](https://crates.io/crates/reqwest) or [`gloo-net`](https://crates.io/crates/gloo-net) instead.
 
 ## New crate - yew-agent
 

--- a/website/docs/migration-guides/yew/from-0_18_0-to-0_19_0.mdx
+++ b/website/docs/migration-guides/yew/from-0_18_0-to-0_19_0.mdx
@@ -125,9 +125,9 @@ html! {
 -   `TimeoutService`
     Use [`gloo-timers`](https://docs.rs/gloo-timers/) instead.
 -   `WebSocketService`
-    Use [`wasm-sockets`](https://github.com/scratchyone/wasm-sockets) or [`reqwasm`](https://github.com/hamza1311/reqwasm) instead.
+    Use [`wasm-sockets`](https://github.com/scratchyone/wasm-sockets) or [`gloo-net`](https://github.com/rustwasm/gloo) instead.
 -   `FetchService`
-    Use [`reqwest`](https://crates.io/crates/reqwest) or [`reqwasm`](https://github.com/hamza1311/reqwasm) instead.
+    Use [`reqwest`](https://crates.io/crates/reqwest) or [`gloo-net`](https://github.com/rustwasm/gloo) instead.
 
 ## New crate - yew-agent
 

--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -471,7 +471,7 @@ Struct components act differently. See [the documentation](advanced-topics/struc
 In a real world application, data will usually come from an API instead of being hardcoded. Let's fetch our
 videos list from external source. For this we will need to add the following crates:
 
--   [`gloo-net`](https://github.com/rustwasm/gloo)
+-   [`gloo-net`](https://crates.io/crates/gloo-net)
     For making the fetch call.
 -   [`serde`](https://serde.rs) with derive features
     For de-serializing the JSON response

--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -471,7 +471,7 @@ Struct components act differently. See [the documentation](advanced-topics/struc
 In a real world application, data will usually come from an API instead of being hardcoded. Let's fetch our
 videos list from external source. For this we will need to add the following crates:
 
--   [`reqwasm`](https://crates.io/crates/reqwasm)
+-   [`gloo-net`](https://github.com/rustwasm/gloo)
     For making the fetch call.
 -   [`serde`](https://serde.rs) with derive features
     For de-serializing the JSON response
@@ -482,7 +482,7 @@ Let's update the dependencies in `Cargo.toml` file:
 
 ```toml title="Cargo.toml"
 [dependencies]
-reqwasm = "0.2"
+gloo-net = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen-futures = "0.4"
 ```
@@ -505,7 +505,7 @@ struct Video {
 Now as the last step, we need to update our `App` component to make the fetch request instead of using hardcoded data
 
 ```rust ,ignore {3-23,32-33}
-+ use reqwasm::http::Request;
++ use gloo_net::http::Request;
 
 #[function_component(App)]
 fn app() -> Html {

--- a/website/versioned_docs/version-0.19.0/migration-guides/yew/from-0_18_0-to-0_19_0.mdx
+++ b/website/versioned_docs/version-0.19.0/migration-guides/yew/from-0_18_0-to-0_19_0.mdx
@@ -122,9 +122,9 @@ html! {
 -   `TimeoutService`
     Use [`gloo-timers`](https://docs.rs/gloo-timers/) instead.
 -   `WebSocketService`
-    Use [`wasm-sockets`](https://github.com/scratchyone/wasm-sockets) or [`reqwasm`](https://github.com/hamza1311/reqwasm) instead.
+    Use [`wasm-sockets`](https://github.com/scratchyone/wasm-sockets) or [`gloo-net`](https://github.com/rustwasm/gloo) instead.
 -   `FetchService`
-    Use [`reqwest`](https://crates.io/crates/reqwest) or [`reqwasm`](https://github.com/hamza1311/reqwasm) instead.
+    Use [`reqwest`](https://crates.io/crates/reqwest) or [`gloo-net`](https://github.com/rustwasm/gloo) instead.
 
 ## New crate - yew-agent
 

--- a/website/versioned_docs/version-0.19.0/migration-guides/yew/from-0_18_0-to-0_19_0.mdx
+++ b/website/versioned_docs/version-0.19.0/migration-guides/yew/from-0_18_0-to-0_19_0.mdx
@@ -122,9 +122,9 @@ html! {
 -   `TimeoutService`
     Use [`gloo-timers`](https://docs.rs/gloo-timers/) instead.
 -   `WebSocketService`
-    Use [`wasm-sockets`](https://github.com/scratchyone/wasm-sockets) or [`gloo-net`](https://github.com/rustwasm/gloo) instead.
+    Use [`wasm-sockets`](https://github.com/scratchyone/wasm-sockets) or [`gloo-net`](https://crates.io/crates/gloo-net) instead.
 -   `FetchService`
-    Use [`reqwest`](https://crates.io/crates/reqwest) or [`gloo-net`](https://github.com/rustwasm/gloo) instead.
+    Use [`reqwest`](https://crates.io/crates/reqwest) or [`gloo-net`](https://crates.io/crates/gloo-net) instead.
 
 ## New crate - yew-agent
 

--- a/website/versioned_docs/version-0.19.0/more/external-libs.mdx
+++ b/website/versioned_docs/version-0.19.0/more/external-libs.mdx
@@ -22,13 +22,9 @@ libraries with Rust and Wasm. Gloo provides ergonomic Rust APIs for working with
 -   [Dialogs](https://crates.io/crates/gloo-dialogs)
 -   [Events](https://crates.io/crates/gloo-events)
 -   [Files](https://crates.io/crates/gloo-file)
+-   [Requests](https://crates.io/crates/gloo-net)
 -   [Timers](https://crates.io/crates/gloo-timers)
 -   [Web Storage](https://crates.io/crates/gloo-storage)
-
-## Reqwasm
-
-[Reqwasm](https://crates.io/crates/reqwasm) is an HTTP requests library for WASM Apps.
-It provides idiomatic Rust API for the browser's `fetch` and `WebSocket` API.
 
 ## Looking For
 

--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -464,7 +464,7 @@ Struct components act differently. See [the documentation](concepts/components/i
 In a real world application, data will usually come from an API instead of being hardcoded. Let's fetch our
 videos list from external source. For this we will need to add the following crates:
 
--   [`reqwasm`](https://crates.io/crates/reqwasm)
+-   [`gloo-net`](https://github.com/rustwasm/gloo)
     For making the fetch call.
 -   [`serde`](https://serde.rs) with derive features
     For de-serializing the JSON response
@@ -475,7 +475,7 @@ Let's update the dependencies in `Cargo.toml` file:
 
 ```toml title="Cargo.toml"
 [dependencies]
-reqwasm = "0.2"
+gloo-net = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen-futures = "0.4"
 ```
@@ -498,7 +498,7 @@ struct Video {
 Now as the last step, we need to update our `App` component to make the fetch request instead of using hardcoded data
 
 ```rust ,ignore {3-23,32-33}
-+ use reqwasm::http::Request;
++ use gloo_net::http::Request;
 
 #[function_component(App)]
 fn app() -> Html {

--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -464,7 +464,7 @@ Struct components act differently. See [the documentation](concepts/components/i
 In a real world application, data will usually come from an API instead of being hardcoded. Let's fetch our
 videos list from external source. For this we will need to add the following crates:
 
--   [`gloo-net`](https://github.com/rustwasm/gloo)
+-   [`gloo-net`](https://crates.io/crates/gloo-net)
     For making the fetch call.
 -   [`serde`](https://serde.rs) with derive features
     For de-serializing the JSON response


### PR DESCRIPTION
#### Description

This replaces any references in the 0.19 docs to `reqwasm` with `gloo-net`. It looks like `reqwasm` is just a re-export of `gloo-net` anyway but it hasn't been updated in a while and is missing some important features like the `.json()` method on `Request`.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
