### PR TITLE
Allow functions returning unit in `use_effect`

### DIFF
--- a/packages/yew/src/functional/hooks/use_effect.rs
+++ b/packages/yew/src/functional/hooks/use_effect.rs
@@ -5,10 +5,12 @@ use crate::functional::{hook, Effect, Hook, HookContext};
 /// Trait describing the destructor of [`use_effect`] hook.
 pub trait TearDown: Sized + 'static {
     /// The function that is executed when destructor is called
-    fn tear_down(self) {}
+    fn tear_down(self);
 }
 
-impl TearDown for () {}
+impl TearDown for () {
+    fn tear_down(self) {}
+}
 
 impl<F: FnOnce() + 'static> TearDown for F {
     fn tear_down(self) {

--- a/packages/yew/src/functional/hooks/use_effect.rs
+++ b/packages/yew/src/functional/hooks/use_effect.rs
@@ -155,6 +155,15 @@ where
 ///     }
 /// }
 /// ```
+///
+/// # Destructor
+///
+/// Any type implementing [`TearDown`] can be used as destructor, which is called when the component
+/// is re-rendered
+///
+/// ## Tip
+///
+/// The callback can return [`()`] if there is no destructor to run.
 #[hook]
 pub fn use_effect<F, D>(f: F)
 where
@@ -190,7 +199,6 @@ where
 ///     use_effect_with_deps(
 ///         move |_| {
 ///             log!(" Is loading prop changed!");
-///             || ()
 ///         },
 ///         is_loading,
 ///     );
@@ -215,7 +223,6 @@ where
 ///     use_effect_with_deps(
 ///         move |_| {
 ///             log!("I got rendered, yay!");
-///             || ()
 ///         },
 ///         (),
 ///     );
@@ -246,6 +253,12 @@ where
 ///     html! { "Hello" }
 /// }
 /// ```
+///
+/// Any type implementing [`TearDown`] can be used as destructor
+///
+/// ### Tip
+///
+/// The callback can return [`()`] if there is no destructor to run.
 #[hook]
 pub fn use_effect_with_deps<T, F, D>(f: F, deps: T)
 where


### PR DESCRIPTION
#### Description

Add a new `TearDown` trait as that is used as destructor for `use_effect` hook

Fixes #2844

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
