### PR TITLE
Remove mentions of wee_alloc

### DIFF
--- a/website/docs/advanced-topics/optimizations.mdx
+++ b/website/docs/advanced-topics/optimizations.mdx
@@ -82,24 +82,11 @@ implementation of the main page and render the component you are working on on t
 ## Reducing binary sizes
 
 -   optimize Rust code
-    -   `wee_alloc` \( using tiny allocator \)
-    -   `cargo.toml` \( defining release profile \)
+-   `cargo.toml` \( defining release profile \)
 -   optimize wasm code using `wasm-opt`
 
 **Note: more information about reducing binary sizes can be found in the
 [Rust Wasm Book](https://rustwasm.github.io/book/reference/code-size.html#optimizing-builds-for-code-size).**
-
-### wee_alloc
-
-[wee_alloc](https://github.com/rustwasm/wee_alloc) is a tiny allocator that is much smaller than the allocator that is normally used in Rust binaries. Replacing the default allocator with this one will result in smaller Wasm file sizes, at the expense of speed and memory overhead.
-
-The slower speed and memory overhead are minor in comparison to the size gains made by not including the default allocator. This smaller file size means that your page will load faster, and so it is generally recommended that you use this allocator over the default, unless your app is doing some allocation-heavy work.
-
-```rust ,ignore
-// Use `wee_alloc` as the global allocator.
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-```
 
 ### Cargo.toml
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/advanced-topics/optimizations.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/advanced-topics/optimizations.mdx
@@ -116,26 +116,10 @@ Yew は純粋な関数やコンポーネントをサポートしていません�
 ## バイナリサイズを小さくする
 
 -   Rust のコードを最適化する
-    -   `wee_alloc` \( tiny allocator を使用 \)
-    -   `cargo.toml` \( release profile を定義 \)
+-   `cargo.toml` \( release profile を定義 \)
 -   `wasm-opt`を用いて wasm のコードを最適化する
 
 **注意: バイナリサイズを小さくするのについては[Rust Wasm Book](https://rustwasm.github.io/book/reference/code-size.html#optimizing-builds-for-code-size)に詳しく書いてあります。**
-
-### wee_alloc
-
-[wee_alloc](https://github.com/rustwasm/wee_alloc)は小さなアロケーターで、Rust のバイナリで使用される通常のものより遥かに小さなものです。
-デフォルトのアロケーターと置き換えることで、Wasm ファイルをより小さくすることができ、速度とメモリのオーバーヘッドを軽減できます。
-
-デフォルトのアロケータを含めないことによるサイズの増加と比較して、速度とメモリのオーバーヘッドが悪くなります。
-ファイルサイズが小さいことで、ページの読み込みが速くなります。
-そのため、アロケーションのタスクが非常に多い場合でなければデフォルトのものではなく tiny allocator を利用することが一般的に推奨されています。
-
-```rust
-// `wee_alloc`を使用する。
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-```
 
 ### Cargo.toml
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/advanced-topics/optimizations.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/advanced-topics/optimizations.mdx
@@ -62,18 +62,6 @@ fn change(&mut self, props: Self::Properties) -> ShouldRender {
 
 你不仅限在 `change` 函数中使用它。通常，在 `update` 函数中执行此操作也是有意义的，尽管性能提升在那里不太明显。
 
-## wee_alloc
-
-[wee_alloc](https://github.com/rustwasm/wee_alloc) 是一个比 Rust 二进制文件中通常使用的分配器还小得多的微型分配器。用这个分配器来替代默认的分配器将使 Wasm 文件体积更小，但会牺牲速度和内存开销。
-
-对比不包含默认分配器换取的体积大小，牺牲的速度和内存开销是微不足道的。较小的文件体积意味着你的页面将加载更快，因此通常建议使用此分配器而不是默认分配器，除非你的应用程序会执行一些繁重的内存分配任务。
-
-```rust
-// 将 `wee_alloc` 作为全局分配器
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-```
-
 ## RC
 
 为了避免在重新渲染时为了创建 props 而克隆大块数据，我们可以使用智能指针来只克隆指针。如果在 props 和子组件中使用 `Rc<_>` 而不是普通未装箱的值，则可以延迟克隆直到需要修改子组件中的数据为止，在该组件中可以使用 `Rc::make_mut` 来对要更改数据进行克隆和获取可变引用。通过在要修改前不进行克隆，子组件可以在几乎没有性能成本的情况下拒绝与它们在 `Component::change` 中拥有状态的 props 相同的 props，这与数据本身需要先复制到父级 props 结构体中，然后在子级中进行比较和拒绝的情况相反。

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/advanced-topics/optimizations.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/advanced-topics/optimizations.mdx
@@ -67,23 +67,10 @@ Yew 最大的缺點就是花太多時間在編譯上了。編譯時間似乎和 
 ## 編譯大小的優化 <a id="build-size-optimization"></a>
 
 -   優化 Rust 的程式碼
-    -   `wee_alloc` （使用輕量的分配器）
-    -   `cargo.toml` （定義釋出的設定檔）
+-   `cargo.toml` （定義釋出的設定檔）
 -   使用 `wasm-opt` 優化 wasm 程式碼
 
 更多關於程式碼大小的資訊，請參考： [rustwasm book](https://rustwasm.github.io/book/reference/code-size.html#optimizing-builds-for-code-size)
-
-### wee_alloc
-
-[wee_alloc](https://github.com/rustwasm/wee_alloc) 是一個比一般用在 Rust 二進制檔中的分配器更輕量的分配器。用他取代預設的分配器，可以讓 Wasm 的檔案大小更小，但是會造成速度和記憶體的開銷變大。
-
-但比起檔案大小，速度和記憶體的開銷比較次要。更小的檔案大小意味著你的頁面可以載入的更快，因此我們通常建議你使用這個分配器作為預設的分配器，除分你的專案有很多吃重的記憶體分配工作。
-
-```rust
-// 使用 `wee_alloc` 作為全局的分配器
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-```
 
 ### Cargo.toml <a id="cargo-toml"></a>
 

--- a/website/versioned_docs/version-0.19.0/advanced-topics/optimizations.mdx
+++ b/website/versioned_docs/version-0.19.0/advanced-topics/optimizations.mdx
@@ -82,24 +82,11 @@ implementation of the main page and render the component you are working on on t
 ## Reducing binary sizes
 
 -   optimize Rust code
-    -   `wee_alloc` \( using tiny allocator \)
-    -   `cargo.toml` \( defining release profile \)
+-   `cargo.toml` \( defining release profile \)
 -   optimize wasm code using `wasm-opt`
 
 **Note: more information about reducing binary sizes can be found in the
 [Rust Wasm Book](https://rustwasm.github.io/book/reference/code-size.html#optimizing-builds-for-code-size).**
-
-### wee_alloc
-
-[wee_alloc](https://github.com/rustwasm/wee_alloc) is a tiny allocator that is much smaller than the allocator that is normally used in Rust binaries. Replacing the default allocator with this one will result in smaller Wasm file sizes, at the expense of speed and memory overhead.
-
-The slower speed and memory overhead are minor in comparison to the size gains made by not including the default allocator. This smaller file size means that your page will load faster, and so it is generally recommended that you use this allocator over the default, unless your app is doing some allocation-heavy work.
-
-```rust ,ignore
-// Use `wee_alloc` as the global allocator.
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-```
 
 ### Cargo.toml
 


### PR DESCRIPTION
#### Description

As mentioned in https://www.reddit.com/r/rust/comments/x1cle0/dont_use_wee_alloc_in_production_code_targeting/ and referring to rustwasm/wee_alloc#106, `wee_alloc` seems for the most part unmaintained and outdated. Moreover, the std now includes a tinier allocator builtin, compared to the time this tip was initially added. There is not much point in having this comment in the docs.

#### Checklist

- [x] I have reviewed my own code
