### PR TITLE
Fixes double "already" in website tutorial

### DIFF
--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -29,7 +29,7 @@ the free [Rust Book](https://doc.rust-lang.org/book/ch00-00-introduction.html) o
 beginners and continues to be an excellent resource even for experienced Rust developers.
 
 Ensure the latest version of Rust is installed by running `rustup update` or by
-[installing rust](https://www.rust-lang.org/tools/install) if you haven't already done so already.
+[installing rust](https://www.rust-lang.org/tools/install) if you haven't already done so.
 
 After installing Rust, you can use Cargo to install `trunk` by running:
 


### PR DESCRIPTION
Removes double "already" in sentence.

#### Description

Removes double "already" in sentence.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
