### PR TITLE
Resume Suspension upon unmount

### DIFF
--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -403,6 +403,15 @@ impl ComponentState {
                 let _ = parent_to_detach;
             }
         }
+
+        if let Some(m) = self.suspension.take() {
+            let comp_scope = self.inner.any_scope();
+
+            let suspense_scope = comp_scope.find_parent_scope::<BaseSuspense>().unwrap();
+            let suspense = suspense_scope.get_component().unwrap();
+
+            suspense.resume(m);
+        }
     }
 }
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Fixes #2873 

This behaviour was initially implemented but was wrongly removed in a subsequent pull request causing the suspension to be unable to resume upon destroy.
This pull request restores this behaviour.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
