### PR TITLE
Simple `NodeRef` passing to `<Link>` for yew-router

### DIFF
--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -26,7 +26,7 @@ where
     pub disabled: bool,
     /// [`NodeRef`](yew::html::NodeRef) for the `<a>` element.
     #[prop_or_default]
-    pub a_ref: NodeRef,
+    pub anchor_ref: NodeRef,
     #[prop_or_default]
     pub children: Children,
 }
@@ -44,7 +44,7 @@ where
         children,
         disabled,
         query,
-        a_ref,
+        anchor_ref,
     } = props.clone();
 
     let navigator = use_navigator().expect_throw("failed to get navigator");
@@ -90,7 +90,7 @@ where
             {href}
             {onclick}
             {disabled}
-            ref={a_ref}
+            ref={anchor_ref}
         >
             { children }
         </a>

--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -24,6 +24,9 @@ where
     pub query: Option<Q>,
     #[prop_or_default]
     pub disabled: bool,
+    /// [`NodeRef`](yew::html::NodeRef) for the `<a>` element.
+    #[prop_or_default]
+    pub a_ref: NodeRef,
     #[prop_or_default]
     pub children: Children,
 }
@@ -41,6 +44,7 @@ where
         children,
         disabled,
         query,
+        a_ref,
     } = props.clone();
 
     let navigator = use_navigator().expect_throw("failed to get navigator");
@@ -86,6 +90,7 @@ where
             {href}
             {onclick}
             {disabled}
+            ref={a_ref}
         >
             { children }
         </a>


### PR DESCRIPTION
#### Description

Implementation of the proposal to add `NodeRef` access to a `<Link>` component.

Discussion: https://github.com/yewstack/yew/discussions/2876

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
