### PR TITLE
Make Yew lints opt-in

### DIFF
--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -219,4 +219,4 @@ jobs:
           RUSTFLAGS: --cfg nightly_yew --cfg yew_lints
         with:
           command: test
-          args: -p yew-macro test_html_lints --features lints
+          args: -p yew-macro test_html_lints

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Run tests
         uses: actions-rs/cargo@v1
         env:
-          RUSTFLAGS: --cfg nightly_yew
+          RUSTFLAGS: --cfg nightly_yew --cfg yew_lints
         with:
           command: test
           args: -p yew-macro test_html_lints --features lints

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -29,8 +29,3 @@ prettyplease = "0.1.1"
 rustversion = "1"
 trybuild = "1"
 yew = { path = "../yew" }
-
-[build-dependencies]
-
-[features]
-lints = []

--- a/packages/yew-macro/src/html_tree/lint/mod.rs
+++ b/packages/yew-macro/src/html_tree/lint/mod.rs
@@ -26,6 +26,9 @@ pub fn lint<L>(tree: &HtmlTree)
 where
     L: Lint,
 {
+    #[cfg(not(yew_lints))]
+    let _ = tree;
+    #[cfg(yew_lints)]
     match tree {
         HtmlTree::List(list) => {
             for child in &list.children.0 {

--- a/packages/yew-macro/tests/html_lints/fail.stderr
+++ b/packages/yew-macro/tests/html_lints/fail.stderr
@@ -1,27 +1,3 @@
-warning: All `<a>` elements should have a `href` attribute. This makes it possible for assistive technologies to correctly interpret what your links point to. https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML#more_on_links
- --> tests/html_lints/fail.rs:5:10
-  |
-5 |         <a>{ "I don't have a href attribute" }</a>
-  |          ^
-
-warning: '#' is not a suitable value for the `href` attribute. Without a meaningful attribute assistive technologies will struggle to understand your webpage. https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML#onclick_events
- --> tests/html_lints/fail.rs:8:17
-  |
-8 |         <a href="#">{ "I have a malformed href attribute" }</a>
-  |                 ^^^
-
-warning: 'javascript:void(0)' is not a suitable value for the `href` attribute. Without a meaningful attribute assistive technologies will struggle to understand your webpage. https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML#onclick_events
-  --> tests/html_lints/fail.rs:11:17
-   |
-11 |         <a href="javascript:void(0)">{ "I have a malformed href attribute" }</a>
-   |                 ^^^^^^^^^^^^^^^^^^^^
-
-warning: All `<img>` tags should have an `alt` attribute which provides a human-readable description
-  --> tests/html_lints/fail.rs:14:10
-   |
-14 |         <img src="img.jpeg"/>
-   |          ^^^
-
 warning: The tag 'tExTAreA' is not matching its normalized form 'textarea'. If you want to keep this form, change this to a dynamic tag `@{"tExTAreA"}`.
   --> tests/html_lints/fail.rs:17:10
    |

--- a/packages/yew-macro/tests/html_lints_test.rs
+++ b/packages/yew-macro/tests/html_lints_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[cfg(feature = "lints")]
+#[cfg(yew_lints)]
 #[rustversion::attr(nightly, test)]
 fn test_html_lints() {
     let t = trybuild::TestCases::new();


### PR DESCRIPTION
#### Description

Add a compiler flag (`--cfg yew_lints`) to enable lints for `html!` macro

Fixes #2360

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
