### PR TITLE
Proposed Documentation Improvements

### DIFF
--- a/website/docs/concepts/basic-web-technologies/wasm-bindgen.mdx
+++ b/website/docs/concepts/basic-web-technologies/wasm-bindgen.mdx
@@ -162,7 +162,7 @@ method is a checked cast that returns an `Option<&T>` which means the original t
 can be used again if the cast failed and thus returned `None`. The
 [`dyn_into`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html#method.dyn_into)
 method will consume `self`, as per convention for into methods in Rust, and the type returned is
-`Result<T, Self>` this means if the casting fails then the value in `Err` is so you can try again
+`Result<T, Self>`. If the casting fails, the original `Self` value is returned in `Err`. You can try again
 or do something else with the original type.
 
 _[`JsCast` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html)._

--- a/website/versioned_docs/version-0.19.0/concepts/wasm-bindgen/introduction.mdx
+++ b/website/versioned_docs/version-0.19.0/concepts/wasm-bindgen/introduction.mdx
@@ -164,7 +164,7 @@ method is a checked cast that returns an `Option<&T>` which means the original t
 can be used again if the cast failed and thus returned `None`. The
 [`dyn_into`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html#method.dyn_into)
 method will consume `self`, as per convention for into methods in Rust, and the type returned is
-`Result<T, Self>`. This means if the casting fails then the `Self` value in `Err` preserved. So you can try again
+`Result<T, Self>`. If the casting fails, the original `Self` value is returned in `Err`. You can try again
 or do something else with the original type.
 
 _[`JsCast` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html)._

--- a/website/versioned_docs/version-0.19.0/concepts/wasm-bindgen/introduction.mdx
+++ b/website/versioned_docs/version-0.19.0/concepts/wasm-bindgen/introduction.mdx
@@ -164,7 +164,7 @@ method is a checked cast that returns an `Option<&T>` which means the original t
 can be used again if the cast failed and thus returned `None`. The
 [`dyn_into`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html#method.dyn_into)
 method will consume `self`, as per convention for into methods in Rust, and the type returned is
-`Result<T, Self>` this means if the casting fails then the value in `Err` is so you can try again
+`Result<T, Self>`. This means if the casting fails then the `Self` value in `Err` preserved. So you can try again
 or do something else with the original type.
 
 _[`JsCast` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html)._


### PR DESCRIPTION
#### Description

`JsCast` is nicely structured so far, although I thought this section was worded strangely.

> The `dyn_into` method will consume `self`, as per convention for into methods in Rust, __and the type returned is `Result<T, Self>` this means if the casting fails then the value in `Err` is so you can try again or do something else with the original type.__ (Retrieved from https://yew.rs/docs/concepts/wasm-bindgen#jsvalue on 9/24/2022 )

I believe this edit conveys the original idea, but makes more sense to the reader:

> The [`dyn_into`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html#method.dyn_into) method will consume `self`, as per convention for into methods in Rust, and the type returned is `Result<T, Self>`. This means if the casting fails then the `Self` value in `Err` is preserved. You could try again or do something else with the original type.