### PR TITLE
Evaluate props in the order they're defined

### DIFF
--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -23,15 +23,6 @@ pub struct Prop {
     pub value: Expr,
 }
 
-// impl std::fmt::Debug for Prop {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         f.debug_struct("Prop")
-//             .field("label", &self.label.to_string())
-//             .field("label", &self.value)
-//             .finish_non_exhaustive()
-//     }
-// }
-
 impl Parse for Prop {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let directive = input

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -224,8 +224,8 @@ fn advance_until_next_dot2(input: &ParseBuffer) -> syn::Result<()> {
 ///
 /// The list may contain multiple props with the same label.
 /// Use `check_no_duplicates` to ensure that there are no duplicates.
-pub struct SortedPropList(Vec<Prop>);
-impl SortedPropList {
+pub struct PropList(Vec<Prop>);
+impl PropList {
     /// Create a new `SortedPropList` from a vector of props.
     /// The given `props` doesn't need to be sorted.
     pub fn new(props: Vec<Prop>) -> Self {
@@ -305,7 +305,7 @@ impl SortedPropList {
         }))
     }
 }
-impl Parse for SortedPropList {
+impl Parse for PropList {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut props: Vec<Prop> = Vec::new();
         // Stop parsing props if a base expression preceded by `..` is reached
@@ -316,7 +316,7 @@ impl Parse for SortedPropList {
         Ok(Self::new(props))
     }
 }
-impl Deref for SortedPropList {
+impl Deref for PropList {
     type Target = [Prop];
 
     fn deref(&self) -> &Self::Target {
@@ -333,7 +333,7 @@ impl SpecialProps {
     const KEY_LABEL: &'static str = "key";
     const REF_LABEL: &'static str = "ref";
 
-    fn pop_from(props: &mut SortedPropList) -> syn::Result<Self> {
+    fn pop_from(props: &mut PropList) -> syn::Result<Self> {
         let node_ref = props.pop_unique(Self::REF_LABEL)?;
         let key = props.pop_unique(Self::KEY_LABEL)?;
         Ok(Self { node_ref, key })
@@ -379,15 +379,15 @@ impl SpecialProps {
 
 pub struct Props {
     pub special: SpecialProps,
-    pub prop_list: SortedPropList,
+    pub prop_list: PropList,
 }
 impl Parse for Props {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        Self::try_from(input.parse::<SortedPropList>()?)
+        Self::try_from(input.parse::<PropList>()?)
     }
 }
 impl Deref for Props {
-    type Target = SortedPropList;
+    type Target = PropList;
 
     fn deref(&self) -> &Self::Target {
         &self.prop_list
@@ -399,10 +399,10 @@ impl DerefMut for Props {
     }
 }
 
-impl TryFrom<SortedPropList> for Props {
+impl TryFrom<PropList> for Props {
     type Error = syn::Error;
 
-    fn try_from(mut prop_list: SortedPropList) -> Result<Self, Self::Error> {
+    fn try_from(mut prop_list: PropList) -> Result<Self, Self::Error> {
         let special = SpecialProps::pop_from(&mut prop_list)?;
         Ok(Self { special, prop_list })
     }

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -8,7 +8,7 @@ use syn::spanned::Spanned;
 use syn::token::Brace;
 use syn::{Expr, Token, TypePath};
 
-use super::{ComponentProps, Prop, Props, SortedPropList};
+use super::{ComponentProps, Prop, Props, PropList};
 use crate::html_tree::HtmlDashedName;
 
 /// Pop from `Punctuated` without leaving it in a state where it has trailing punctuation.
@@ -106,7 +106,7 @@ pub struct PropsMacroInput {
 impl Parse for PropsMacroInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let PropsExpr { ty, fields, .. } = input.parse()?;
-        let prop_list = SortedPropList::new(fields.into_iter().map(Into::into).collect());
+        let prop_list = PropList::new(fields.into_iter().map(Into::into).collect());
         let props: Props = prop_list.try_into()?;
         props.special.check_all(|prop| {
             let label = &prop.label;

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -8,7 +8,7 @@ use syn::spanned::Spanned;
 use syn::token::Brace;
 use syn::{Expr, Token, TypePath};
 
-use super::{ComponentProps, Prop, Props, PropList};
+use super::{ComponentProps, Prop, PropList, Props};
 use crate::html_tree::HtmlDashedName;
 
 /// Pop from `Punctuated` without leaving it in a state where it has trailing punctuation.

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -143,10 +143,10 @@ error: `with` doesn't have a value. (hint: set the value to `true` or `false` fo
    |                                               ^^^^
 
 error: `ref` can only be specified once
-  --> tests/html_macro/component-fail.rs:67:20
+  --> tests/html_macro/component-fail.rs:67:29
    |
 67 |     html! { <Child ref={()} ref={()} value=1 ..props  /> };
-   |                    ^^^
+   |                             ^^^
 
 error: `with` doesn't have a value. (hint: set the value to `true` or `false` for boolean attributes)
   --> tests/html_macro/component-fail.rs:68:20

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -101,16 +101,16 @@ error: `class` can only be specified once but is given here again
    |                                ^^^^^
 
 error: `ref` can only be specified once
-  --> tests/html_macro/element-fail.rs:33:20
+  --> tests/html_macro/element-fail.rs:33:29
    |
 33 |     html! { <input ref={()} ref={()} /> };
-   |                    ^^^
+   |                             ^^^
 
 error: `ref` can only be specified once
-  --> tests/html_macro/element-fail.rs:63:20
+  --> tests/html_macro/element-fail.rs:63:29
    |
 63 |     html! { <input ref={()} ref={()} /> };
-   |                    ^^^
+   |                             ^^^
 
 error: the tag `<input>` is a void element and cannot have children (hint: rewrite this as `<input/>`)
   --> tests/html_macro/element-fail.rs:66:13

--- a/packages/yew-macro/tests/props_macro_test.rs
+++ b/packages/yew-macro/tests/props_macro_test.rs
@@ -8,35 +8,13 @@ fn props_macro() {
 
 #[test]
 fn props_order() {
-    yew::html!( <div ref={yew::NodeRef::default()} />);
-
-    #[derive(Default)]
-    struct Gen {
-        state: usize,
-    }
-    impl Gen {
-        fn next(&mut self) -> usize {
-            self.state += 1;
-            self.state
-        }
-    }
-
     #[derive(yew::Properties, PartialEq)]
-    struct Props {
-        my_first: usize,
-        second: usize,
-        last: usize,
-    }
+    struct Props { first: usize, second: usize, last: usize }
 
-    let mut g = Gen::default();
-    let props = yew::props!(Props {
-        my_first: g.next(),
-        second: g.next(),
-        last: g.next(),
-    });
+    let mut g = 1..=3;
+    let props = yew::props!(Props { first: g.next().unwrap(), second: g.next().unwrap(), last: g.next().unwrap() });
 
-
-    assert_eq!(props.my_first, 1);
+    assert_eq!(props.first, 1);
     assert_eq!(props.second, 2);
     assert_eq!(props.last, 3);
 }

--- a/packages/yew-macro/tests/props_macro_test.rs
+++ b/packages/yew-macro/tests/props_macro_test.rs
@@ -9,10 +9,18 @@ fn props_macro() {
 #[test]
 fn props_order() {
     #[derive(yew::Properties, PartialEq)]
-    struct Props { first: usize, second: usize, last: usize }
+    struct Props {
+        first: usize,
+        second: usize,
+        last: usize,
+    }
 
     let mut g = 1..=3;
-    let props = yew::props!(Props { first: g.next().unwrap(), second: g.next().unwrap(), last: g.next().unwrap() });
+    let props = yew::props!(Props {
+        first: g.next().unwrap(),
+        second: g.next().unwrap(),
+        last: g.next().unwrap()
+    });
 
     assert_eq!(props.first, 1);
     assert_eq!(props.second, 2);

--- a/packages/yew-macro/tests/props_macro_test.rs
+++ b/packages/yew-macro/tests/props_macro_test.rs
@@ -5,3 +5,38 @@ fn props_macro() {
     t.pass("tests/props_macro/*-pass.rs");
     t.compile_fail("tests/props_macro/*-fail.rs");
 }
+
+#[test]
+fn props_order() {
+    yew::html!( <div ref={yew::NodeRef::default()} />);
+
+    #[derive(Default)]
+    struct Gen {
+        state: usize,
+    }
+    impl Gen {
+        fn next(&mut self) -> usize {
+            self.state += 1;
+            self.state
+        }
+    }
+
+    #[derive(yew::Properties, PartialEq)]
+    struct Props {
+        my_first: usize,
+        second: usize,
+        last: usize,
+    }
+
+    let mut g = Gen::default();
+    let props = yew::props!(Props {
+        my_first: g.next(),
+        second: g.next(),
+        last: g.next(),
+    });
+
+
+    assert_eq!(props.my_first, 1);
+    assert_eq!(props.second, 2);
+    assert_eq!(props.last, 3);
+}

--- a/website/docs/concepts/function-components/properties.mdx
+++ b/website/docs/concepts/function-components/properties.mdx
@@ -263,6 +263,24 @@ fn App() -> Html {
 }
 ```
 
+## Evaluation Order
+
+Props are evaluated in the order they're specified, as shown by the following example:
+
+```rust
+#[derive(yew::Properties, PartialEq)]
+struct Props { first: usize, second: usize, last: usize }
+
+fn main() {
+    let mut g = 1..=3;
+    let props = yew::props!(Props { first: g.next().unwrap(), second: g.next().unwrap(), last: g.next().unwrap() });
+
+    assert_eq!(props.first, 1);
+    assert_eq!(props.second, 2);
+    assert_eq!(props.last, 3);
+}
+```
+
 ## Anti Patterns
 
 While almost any Rust type can be passed as properties, there are some anti-patterns that should be avoided.


### PR DESCRIPTION
#### Description

Evaluate props in the order they're defined and document this behavior

Fixes #1634 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
