### PR TITLE
Fix portal shifting on reconciliation too often

### DIFF
--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -124,13 +124,6 @@ impl NodeRef {
         let node = self.get();
         node.map(Into::into).map(INTO::from)
     }
-
-    /// Place a Node in a reference for later use
-    pub(crate) fn set(&self, node: Option<Node>) {
-        let mut this = self.0.borrow_mut();
-        this.node = node;
-        this.link = None;
-    }
 }
 
 #[cfg(feature = "csr")]
@@ -155,6 +148,13 @@ mod feat_csr {
             let node_ref = NodeRef::default();
             node_ref.set(Some(node));
             node_ref
+        }
+
+        /// Place a Node in a reference for later use
+        pub(crate) fn set(&self, node: Option<Node>) {
+            let mut this = self.0.borrow_mut();
+            this.node = node;
+            this.link = None;
         }
     }
 }

--- a/packages/yew/src/virtual_dom/vportal.rs
+++ b/packages/yew/src/virtual_dom/vportal.rs
@@ -3,14 +3,13 @@
 use web_sys::{Element, Node};
 
 use super::VNode;
-use crate::html::NodeRef;
 
 #[derive(Debug, Clone)]
 pub struct VPortal {
     /// The element under which the content is inserted.
     pub host: Element,
     /// The next sibling after the inserted content. Most be a child of `host`.
-    pub inner_sibling: NodeRef,
+    pub inner_sibling: Option<Node>,
     /// The inserted node
     pub node: Box<VNode>,
 }
@@ -20,7 +19,7 @@ impl VPortal {
     pub fn new(content: VNode, host: Element) -> Self {
         Self {
             host,
-            inner_sibling: NodeRef::default(),
+            inner_sibling: None,
             node: Box::new(content),
         }
     }
@@ -31,11 +30,7 @@ impl VPortal {
     pub fn new_before(content: VNode, host: Element, inner_sibling: Option<Node>) -> Self {
         Self {
             host,
-            inner_sibling: {
-                let sib_ref = NodeRef::default();
-                sib_ref.set(inner_sibling);
-                sib_ref
-            },
+            inner_sibling,
             node: Box::new(content),
         }
     }

--- a/website/docs/concepts/html/introduction.mdx
+++ b/website/docs/concepts/html/introduction.mdx
@@ -156,14 +156,18 @@ free to [chime in on this issue](https://github.com/yewstack/yew/issues/1334).
 Attributes are set on elements in the same way as in normal HTML:
 
 ```rust
+use yew::prelude::*;
+
 let value = "something";
-html! { <div attribute={value} />
+html! { <div attribute={value} /> };
 ```
 
 Properties are specified with `~` before the element name:
 
 ```rust
-html! { <my-element ~property="abc" /> }
+use yew::prelude::*;
+
+html! { <my-element ~property="abc" /> };
 ```
 
 :::tip


### PR DESCRIPTION
#### Description

Fixes #2890 

The public vdom api changes to only allow directly setting a Node as sibling (still optional) instead of a NodeRef. This was the intention all along, since the NodeRef was not dynamically tracked, and creating a portal into a subtree already controlled by yew is not supported anway.

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
