### PR TITLE
* fix bug - filter the exact entry to set state.edit_value in examples/todomvc

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -65,7 +65,14 @@ impl Component for App {
                 self.state.filter = filter;
             }
             Msg::ToggleEdit(idx) => {
-                self.state.edit_value = self.state.entries[idx].description.clone();
+                let entry = self
+                    .state
+                    .entries
+                    .iter()
+                    .filter(|e| self.state.filter.fits(e))
+                    .nth(idx)
+                    .unwrap();
+                self.state.edit_value = entry.description.clone();
                 self.state.clear_all_edit();
                 self.state.toggle_edit(idx);
             }


### PR DESCRIPTION
### How to repro the bug ?

![企业微信截图_540b9c0b-0678-45b0-b4c2-20e4591a5cf4](https://user-images.githubusercontent.com/4383967/193229821-a333d080-7363-4c51-b4e0-bd9a1857244b.png)

![企业微信截图_4bf19020-bdb1-42c2-811b-5362ed5dc7ae](https://user-images.githubusercontent.com/4383967/193229868-c81f01c8-d559-4ed6-97e0-3011298084f6.png)

### Double click on "BBB", then the "BBB" will change to "AAA" ↓

![企业微信截图_c59ca716-f0bc-4f20-90e2-d70c9395f516](https://user-images.githubusercontent.com/4383967/193229914-4ff1ad4a-949c-463e-a2a6-c356c8ee61f3.png)

![企业微信截图_7198fb67-7b34-4aa0-8f43-488031b67590](https://user-images.githubusercontent.com/4383967/193229936-02ae4dc5-85c0-40ab-9650-51cd29edb8bd.png)
