### PR TITLE
Fix panic because of unwrapping when resuming suspension

### DIFF
--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -302,12 +302,8 @@ impl ComponentState {
         if let Some(m) = self.suspension.take() {
             let comp_scope = self.inner.any_scope();
 
-            if let Some(suspense_scope) = comp_scope.find_parent_scope::<BaseSuspense>() {
-                let component = suspense_scope.get_component();
-                if let Some(suspense) = component {
-                    suspense.resume(m);
-                }
-            }
+            let suspense_scope = comp_scope.find_parent_scope::<BaseSuspense>().unwrap();
+            BaseSuspense::resume(&suspense_scope, m);
         }
     }
 }
@@ -464,7 +460,6 @@ impl ComponentState {
             let suspense_scope = comp_scope
                 .find_parent_scope::<BaseSuspense>()
                 .expect("To suspend rendering, a <Suspense /> component is required.");
-            let suspense = suspense_scope.get_component().unwrap();
 
             let comp_id = self.comp_id;
             let shared_state = shared_state.clone();
@@ -481,12 +476,12 @@ impl ComponentState {
             if let Some(ref last_suspension) = self.suspension {
                 if &suspension != last_suspension {
                     // We remove previous suspension from the suspense.
-                    suspense.resume(last_suspension.clone());
+                    BaseSuspense::resume(&suspense_scope, last_suspension.clone());
                 }
             }
             self.suspension = Some(suspension.clone());
 
-            suspense.suspend(suspension);
+            BaseSuspense::suspend(&suspense_scope, suspension);
         }
     }
 

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -302,10 +302,12 @@ impl ComponentState {
         if let Some(m) = self.suspension.take() {
             let comp_scope = self.inner.any_scope();
 
-            let suspense_scope = comp_scope.find_parent_scope::<BaseSuspense>().unwrap();
-            let suspense = suspense_scope.get_component().unwrap();
-
-            suspense.resume(m);
+            if let Some(suspense_scope) = comp_scope.find_parent_scope::<BaseSuspense>() {
+                let component = suspense_scope.get_component();
+                if let Some(suspense) = component {
+                    suspense.resume(m);
+                }
+            }
         }
     }
 }

--- a/packages/yew/src/suspense/component.rs
+++ b/packages/yew/src/suspense/component.rs
@@ -133,11 +133,11 @@ mod feat_csr_ssr {
     impl BaseSuspense {
         pub(crate) fn suspend(scope: &Scope<Self>, s: Suspension) {
             scope.send_message(BaseSuspenseMsg::Suspend(s));
-        } 
+        }
 
         pub(crate) fn resume(scope: &Scope<Self>, s: Suspension) {
             scope.send_message(BaseSuspenseMsg::Resume(s));
-        } 
+        }
     }
 
     /// Suspend rendering and show a fallback UI until the underlying task completes.

--- a/packages/yew/src/suspense/component.rs
+++ b/packages/yew/src/suspense/component.rs
@@ -36,7 +36,6 @@ mod feat_csr_ssr {
 
     #[derive(Debug)]
     pub(crate) struct BaseSuspense {
-        link: Scope<Self>,
         suspensions: Vec<Suspension>,
         #[cfg(feature = "hydration")]
         hydration_handle: Option<SuspensionHandle>,
@@ -46,7 +45,7 @@ mod feat_csr_ssr {
         type Message = BaseSuspenseMsg;
         type Properties = BaseSuspenseProps;
 
-        fn create(ctx: &Context<Self>) -> Self {
+        fn create(_ctx: &Context<Self>) -> Self {
             #[cfg(not(feature = "hydration"))]
             let suspensions = Vec::new();
 
@@ -56,9 +55,9 @@ mod feat_csr_ssr {
                 use crate::callback::Callback;
                 use crate::html::RenderMode;
 
-                match ctx.creation_mode() {
+                match _ctx.creation_mode() {
                     RenderMode::Hydration => {
-                        let link = ctx.link().clone();
+                        let link = _ctx.link().clone();
                         let (s, handle) = Suspension::new();
                         s.listen(Callback::from(move |s| {
                             link.send_message(BaseSuspenseMsg::Resume(s));
@@ -70,7 +69,6 @@ mod feat_csr_ssr {
             };
 
             Self {
-                link: ctx.link().clone(),
                 suspensions,
                 #[cfg(feature = "hydration")]
                 hydration_handle,
@@ -133,13 +131,13 @@ mod feat_csr_ssr {
     }
 
     impl BaseSuspense {
-        pub(crate) fn suspend(&self, s: Suspension) {
-            self.link.send_message(BaseSuspenseMsg::Suspend(s));
-        }
+        pub(crate) fn suspend(scope: &Scope<Self>, s: Suspension) {
+            scope.send_message(BaseSuspenseMsg::Suspend(s));
+        } 
 
-        pub(crate) fn resume(&self, s: Suspension) {
-            self.link.send_message(BaseSuspenseMsg::Resume(s));
-        }
+        pub(crate) fn resume(scope: &Scope<Self>, s: Suspension) {
+            scope.send_message(BaseSuspenseMsg::Resume(s));
+        } 
     }
 
     /// Suspend rendering and show a fallback UI until the underlying task completes.

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -14,7 +14,7 @@ use yew::platform::spawn_local;
 use yew::platform::time::sleep;
 use yew::prelude::*;
 use yew::suspense::{use_future, use_future_with_deps, Suspension, SuspensionResult};
-use yew::{UseStateHandle};
+use yew::UseStateHandle;
 
 wasm_bindgen_test_configure!(run_in_browser);
 


### PR DESCRIPTION
#### Description

Code would panic with:

> panicked at 'called `Option::unwrap()` on a `None` value', ../yew/src/html/component/lifecycle.rs:306:59

So I turned them in proper `if let Some(..)`

I don't know exactly what caused it, but it had something to do with non existing components because of quick sequential events. 

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests

