### PR TITLE
Use Ref::filter_map if rustc is later than 1.63

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -33,6 +33,7 @@ bincode = { version = "1.3.3", optional = true }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1.36"
 pin-project = "1.0.11"
+rustversion = "1"
 
 [dependencies.web-sys]
 version = "^0.3.59"
@@ -84,7 +85,6 @@ tokio-stream = { version = "0.1", features = ["time"], optional = true }
 wasm-bindgen-test = "0.3"
 gloo = { version = "0.8", features = ["futures"] }
 wasm-bindgen-futures = "0.4"
-rustversion = "1"
 trybuild = "1"
 
 [dev-dependencies.web-sys]

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -452,17 +452,29 @@ mod feat_csr_ssr {
             }
         }
 
+        #[rustversion::before(1.63)]
         #[inline]
         pub(super) fn arch_get_component(&self) -> Option<impl Deref<Target = COMP> + '_> {
             self.state.try_borrow().ok().and_then(|state_ref| {
                 state_ref.as_ref()?;
-                // TODO: Replace unwrap with Ref::filter_map once it becomes stable.
                 Some(Ref::map(state_ref, |state| {
                     state
                         .as_ref()
                         .and_then(|m| m.downcast_comp_ref::<COMP>())
                         .unwrap()
                 }))
+            })
+        }
+
+        #[rustversion::since(1.63)]
+        #[inline]
+        pub(super) fn arch_get_component(&self) -> Option<impl Deref<Target = COMP> + '_> {
+            self.state.try_borrow().ok().and_then(|state_ref| {
+                // Ref::filter_map is only available since 1.63
+                Ref::filter_map(state_ref, |state| {
+                    state.as_ref().and_then(|m| m.downcast_comp_ref::<COMP>())
+                })
+                .ok()
             })
         }
 


### PR DESCRIPTION
#### Description

Use `Ref::filter_map` Instead of test and unwrapping if compiler is later than 1.63.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
