### PR TITLE
Add new line indicator to tutorial/index.mdx

### DIFF
--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -370,10 +370,10 @@ struct VideosListProps {
 
 Then we modify the `VideosList` component to pass the "emit" the selected video to the callback.
 
-```rust ,ignore {5-11,14-15}
+```rust ,ignore {3,5-11,14-15}
 #[function_component(VideosList)]
 fn videos_list(VideosListProps { videos, on_click }: &VideosListProps) -> Html {
-    let on_click = on_click.clone();
++    let on_click = on_click.clone();
     videos.iter().map(|video| {
 +        let on_video_select = {
 +            let on_click = on_click.clone();

--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -367,7 +367,7 @@ Then we modify the `VideosList` component to pass the "emit" the selected video 
 ```rust ,ignore {5-11,14-15}
 #[function_component(VideosList)]
 fn videos_list(VideosListProps { videos, on_click }: &VideosListProps) -> Html {
-    let on_click = on_click.clone();
++    let on_click = on_click.clone();
     videos.iter().map(|video| {
 +        let on_video_select = {
 +            let on_click = on_click.clone();

--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -364,7 +364,7 @@ struct VideosListProps {
 
 Then we modify the `VideosList` component to pass the "emit" the selected video to the callback.
 
-```rust ,ignore {5-11,14-15}
+```rust ,ignore {3,5-11,14-15}
 #[function_component(VideosList)]
 fn videos_list(VideosListProps { videos, on_click }: &VideosListProps) -> Html {
 +    let on_click = on_click.clone();


### PR DESCRIPTION
I noticed a missing new line indicator for the on_click variable in the
video_list function component so I wanted to add it so it doesn't
throw anyone off when reading. 

Thanks



#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [N/A] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
