### PR TITLE
Fixes checked property being reset on render

### DIFF
--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -128,9 +128,9 @@ impl ToTokens for HtmlElement {
             .as_ref()
             .map(|attr| {
                 let value = &attr.value;
-                quote_spanned! {value.span()=> #value}
+                quote! { ::std::option::Option::Some( #value ) }
             })
-            .unwrap_or(quote! { false });
+            .unwrap_or(quote! { ::std::option::Option::None });
 
         // other attributes
 

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -67,18 +67,22 @@ impl Apply for InputFields {
     type Element = InputElement;
 
     fn apply(mut self, root: &BSubtree, el: &Self::Element) -> Self {
-        // IMPORTANT! This parameter has to be set every time
+        // IMPORTANT! This parameter has to be set every time it's explicitly given
         // to prevent strange behaviour in the browser when the DOM changes
-        el.set_checked(self.checked);
+        if let Some(checked) = self.checked {
+            el.set_checked(checked);
+        }
 
         self.value = self.value.apply(root, el);
         self
     }
 
     fn apply_diff(self, root: &BSubtree, el: &Self::Element, bundle: &mut Self) {
-        // IMPORTANT! This parameter has to be set every time
+        // IMPORTANT! This parameter has to be set every time it's explicitly given
         // to prevent strange behaviour in the browser when the DOM changes
-        el.set_checked(self.checked);
+        if let Some(checked) = self.checked {
+            el.set_checked(checked);
+        }
 
         self.value.apply_diff(root, el, &mut bundle.value);
     }


### PR DESCRIPTION
If the value is uncontrolled, do not touch it. Only if it is explicitly given (controlled) set it with every render.

A boolean attribute can have two states: it can exist or be omitted (`true` and `false`).
A boolean property can have three states in vdom: it can be explicitly assigned `true`, explicitly assigned `false` or it can be left uncontrolled. The last has been missing and the buggy behaviour assumes the last is synonymous with "explicitly false".

Marked as a breaking change, because the API exposed by vdom changes slightly. This is not technically necessary for the PR, but it should serve as a reminder for anybody using the method that there was something subtly wrong with it, as it also assumed a default-unchecked which is not true.

```diff
- pub fn VTag::checked(&self) -> bool;
+ pub fn VTag::checked(&self) -> Option<bool>;
+ pub fn VTag::preserve_checked(&mut self);
```

#### Description

Fixes #2875. I will add tests when I have time in the coming days.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
