### PR TITLE
Fix typo in contrib instructions `cargo make tests` -> `cargo make test`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The most important tasks are outlined below.
 To run all tests, use the following command:
 
 ```bash
-cargo make test
+cargo make test-flow
 ```
 
 ### Browser tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,14 +48,6 @@ If you have [Docker](https://www.docker.com/) installed,
 
 Alternatively, you can set the `HTTPBIN_URL` environment variable to the URL you wish to run tests against.
 
-### WebSocket service tests
-
-The tests for the web-socket service require an echo server.
-If you have [Docker](https://www.docker.com/) installed,
-`cargo make test` will automatically run an [echo server](https://hub.docker.com/r/jmalloc/echo-server) in a container for you.
-
-Alternatively, you can set the `ECHO_SERVER_URL` environment variable to the URL you wish to run tests against.
-
 ### Macro tests
 
 When adding or updating tests, please make sure to update the appropriate `stderr` file, which you can find [here](https://github.com/yewstack/yew/tree/master/packages/yew-macro/tests/macro) for the `html!` macro.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,12 +27,12 @@ The most important tasks are outlined below.
 To run all tests, use the following command:
 
 ```bash
-cargo make tests
+cargo make test
 ```
 
 ### Browser tests
 
-`cargo make tests` will automatically download Geckodriver to a temporary location if it isn't in the PATH.
+`cargo make test` will automatically download Geckodriver to a temporary location if it isn't in the PATH.
 
 Because Geckodriver looks for `firefox` in the path, if you use
 FireFox Developer Edition, you may get an error, because Developer Editions
@@ -44,7 +44,7 @@ To fix this, either install the standard version of Firefox or symlink
 
 The tests for the fetch service require a local [httpbin](https://httpbin.org/) server.
 If you have [Docker](https://www.docker.com/) installed,
-`cargo make tests` will automatically run httpbin in a container for you.
+`cargo make test` will automatically run httpbin in a container for you.
 
 Alternatively, you can set the `HTTPBIN_URL` environment variable to the URL you wish to run tests against.
 
@@ -52,7 +52,7 @@ Alternatively, you can set the `HTTPBIN_URL` environment variable to the URL you
 
 The tests for the web-socket service require an echo server.
 If you have [Docker](https://www.docker.com/) installed,
-`cargo make tests` will automatically run an [echo server](https://hub.docker.com/r/jmalloc/echo-server) in a container for you.
+`cargo make test` will automatically run an [echo server](https://hub.docker.com/r/jmalloc/echo-server) in a container for you.
 
 Alternatively, you can set the `ECHO_SERVER_URL` environment variable to the URL you wish to run tests against.
 


### PR DESCRIPTION
#### Description

There is a small typo in CONTRIBUTING.md, `cargo make tests` should be `cargo make test`. 

Fixes #2908  


