### PR TITLE
Mention certain components must be children of Router

### DIFF
--- a/website/docs/concepts/router.mdx
+++ b/website/docs/concepts/router.mdx
@@ -44,9 +44,9 @@ current URL and passes it to the `render` callback. The callback then decides wh
 matched, the router navigates to the path with `not_found` attribute. If no route is specified, nothing is rendered, and
 a message is logged to console stating that no route was matched.
 
-The router components, e.g. `<Link />` and `<Switch />`, must be used in the [context](concepts/contexts.mdx)
-of a Router provider like `<BrowserRouter />`. That means they must be wrapper in a router (children of `<Router/>`).
-This is shown below.
+Most of yew-router's components, in particular <Link /> and <Switch />, must be (grand-)children of one of the Router components
+(e.g. `<BrowserRouter />`). You usually only need a single Router in your app, most often rendered immediately by your most top-level `<App />`
+component. The Router registers a context, which is needed for Links and Switches to function. An example is shown below.
 
 :::caution
 When using `yew-router` in browser environment, `<BrowserRouter />` is highly recommended.
@@ -95,7 +95,7 @@ fn switch(routes: Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={switch} /> // <- depends on <BrowserRouter>
+            <Switch<Route> render={switch} /> // <- must be child of <BrowserRouter>
         </BrowserRouter>
     }
 }

--- a/website/docs/concepts/router.mdx
+++ b/website/docs/concepts/router.mdx
@@ -45,7 +45,9 @@ matched, the router navigates to the path with `not_found` attribute. If no rout
 a message is logged to console stating that no route was matched.
 
 Finally, you need to register one of the Router context provider components like `<BrowserRouter />`.
-It provides location information and navigator to its children.
+It provides location information and navigator to its children. I.e. certain components depend on the
+functionality provided by the Router to work properly e.g. `<Link />` and `<Switch />`. That means
+they must be wrapped in a Router (children of `<Router/>`). This is shown in the code below.
 
 :::caution
 When using `yew-router` in browser environment, `<BrowserRouter />` is highly recommended.
@@ -94,7 +96,7 @@ fn switch(routes: Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={switch} />
+            <Switch<Route> render={switch} /> // <- depends on <BorwserRouter> functionality
         </BrowserRouter>
     }
 }

--- a/website/docs/concepts/router.mdx
+++ b/website/docs/concepts/router.mdx
@@ -95,7 +95,7 @@ fn switch(routes: Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={switch} /> // <- depends on <BorwserRouter>
+            <Switch<Route> render={switch} /> // <- depends on <BrowserRouter>
         </BrowserRouter>
     }
 }

--- a/website/docs/concepts/router.mdx
+++ b/website/docs/concepts/router.mdx
@@ -44,10 +44,9 @@ current URL and passes it to the `render` callback. The callback then decides wh
 matched, the router navigates to the path with `not_found` attribute. If no route is specified, nothing is rendered, and
 a message is logged to console stating that no route was matched.
 
-Finally, you need to register one of the Router context provider components like `<BrowserRouter />`.
-It provides location information and navigator to its children. I.e. certain components depend on the
-functionality provided by the Router to work properly e.g. `<Link />` and `<Switch />`. That means
-they must be wrapped in a Router (children of `<Router/>`). This is shown in the code below.
+The router components, e.g. `<Link />` and `<Switch />`, must be used in the [context](concepts/contexts.mdx)
+of a Router provider like `<BrowserRouter />`. That means they must be wrapper in a router (children of `<Router/>`).
+This is shown below.
 
 :::caution
 When using `yew-router` in browser environment, `<BrowserRouter />` is highly recommended.
@@ -96,7 +95,7 @@ fn switch(routes: Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={switch} /> // <- depends on <BorwserRouter> functionality
+            <Switch<Route> render={switch} /> // <- depends on <BorwserRouter>
         </BrowserRouter>
     }
 }

--- a/website/docs/concepts/router.mdx
+++ b/website/docs/concepts/router.mdx
@@ -44,7 +44,7 @@ current URL and passes it to the `render` callback. The callback then decides wh
 matched, the router navigates to the path with `not_found` attribute. If no route is specified, nothing is rendered, and
 a message is logged to console stating that no route was matched.
 
-Most of yew-router's components, in particular <Link /> and <Switch />, must be (grand-)children of one of the Router components
+Most of yew-router's components, in particular `<Link />` and `<Switch />`, must be (grand-)children of one of the Router components
 (e.g. `<BrowserRouter />`). You usually only need a single Router in your app, most often rendered immediately by your most top-level `<App />`
 component. The Router registers a context, which is needed for Links and Switches to function. An example is shown below.
 

--- a/website/versioned_docs/version-0.19.0/concepts/router.mdx
+++ b/website/versioned_docs/version-0.19.0/concepts/router.mdx
@@ -42,10 +42,9 @@ current URL and passes it to the `render` callback. The callback then decides wh
 matched, the router navigates to the path with `not_found` attribute. If no route is specified, nothing is rendered, and
 a message is logged to console stating that no route was matched.
 
-Finally, you need to register one of the Router context provider components like `<BrowserRouter />`.
-It provides location information and navigator to its children. I.e. certain components depend on the
-functionality provided by the Router to work properly e.g. `<Link />` and `<Switch />`. That means
-they must be wrapped in a Router (children of `<Router/>`). This is shown in the code below.
+The router components, e.g. `<Link />` and `<Switch />`, must be used in the [context](concepts/contexts.mdx)
+of a Router provider like `<BrowserRouter />`. That means they must be wrapper in a router (children of `<Router/>`).
+This is shown below.
 
 When using `yew-router` in browser environment, `<BrowserRouter />` is recommended.
 
@@ -91,7 +90,7 @@ fn switch(routes: &Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={switch} /> // <- depends on <BorwserRouter> functionality
+            <Switch<Route> render={switch} /> // <- depends on <BorwserRouter>
         </BrowserRouter>
     }
 }

--- a/website/versioned_docs/version-0.19.0/concepts/router.mdx
+++ b/website/versioned_docs/version-0.19.0/concepts/router.mdx
@@ -42,8 +42,10 @@ current URL and passes it to the `render` callback. The callback then decides wh
 matched, the router navigates to the path with `not_found` attribute. If no route is specified, nothing is rendered, and
 a message is logged to console stating that no route was matched.
 
-Finally, you need to register the `<Router />` component as a context.
-`<Router />` provides session history information to its children.
+Finally, you need to register one of the Router context provider components like `<BrowserRouter />`.
+It provides location information and navigator to its children. I.e. certain components depend on the
+functionality provided by the Router to work properly e.g. `<Link />` and `<Switch />`. That means
+they must be wrapped in a Router (children of `<Router/>`). This is shown in the code below.
 
 When using `yew-router` in browser environment, `<BrowserRouter />` is recommended.
 
@@ -89,7 +91,7 @@ fn switch(routes: &Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={Switch::render(switch)} />
+            <Switch<Route> render={switch} /> // <- depends on <BorwserRouter> functionality
         </BrowserRouter>
     }
 }

--- a/website/versioned_docs/version-0.19.0/concepts/router.mdx
+++ b/website/versioned_docs/version-0.19.0/concepts/router.mdx
@@ -42,11 +42,14 @@ current URL and passes it to the `render` callback. The callback then decides wh
 matched, the router navigates to the path with `not_found` attribute. If no route is specified, nothing is rendered, and
 a message is logged to console stating that no route was matched.
 
-The router components, e.g. `<Link />` and `<Switch />`, must be used in the [context](concepts/contexts.mdx)
-of a Router provider like `<BrowserRouter />`. That means they must be wrapper in a router (children of `<Router/>`).
-This is shown below.
+Most of yew-router's components, in particular `<Link />` and `<Switch />`, must be (grand-)children of one of the Router components
+(e.g. `<BrowserRouter />`). You usually only need a single Router in your app, most often rendered immediately by your most top-level `<App />`
+component. The Router registers a context, which is needed for Links and Switches to function. An example is shown below.
 
-When using `yew-router` in browser environment, `<BrowserRouter />` is recommended.
+:::caution
+When using `yew-router` in browser environment, `<BrowserRouter />` is highly recommended.
+You can find other router flavours in the [API Reference](https://docs.rs/yew-router/).
+:::
 
 ```rust
 use yew_router::prelude::*;
@@ -90,7 +93,7 @@ fn switch(routes: &Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={Switch::render(switch)} /> // <- depends on <BrowserRouter>
+            <Switch<Route> render={Switch::render(switch)} /> // <- must be child of <BrowserRouter>
         </BrowserRouter>
     }
 }

--- a/website/versioned_docs/version-0.19.0/concepts/router.mdx
+++ b/website/versioned_docs/version-0.19.0/concepts/router.mdx
@@ -90,7 +90,7 @@ fn switch(routes: &Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={switch} /> // <- depends on <BorwserRouter>
+            <Switch<Route> render={Switch::render(switch)} /> // <- depends on <BrowserRouter>
         </BrowserRouter>
     }
 }

--- a/website/versioned_docs/version-0.20/concepts/router.mdx
+++ b/website/versioned_docs/version-0.20/concepts/router.mdx
@@ -44,8 +44,9 @@ current URL and passes it to the `render` callback. The callback then decides wh
 matched, the router navigates to the path with `not_found` attribute. If no route is specified, nothing is rendered, and
 a message is logged to console stating that no route was matched.
 
-Finally, you need to register one of the Router context provider components like `<BrowserRouter />`.
-It provides location information and navigator to its children.
+Most of yew-router's components, in particular `<Link />` and `<Switch />`, must be (grand-)children of one of the Router components
+(e.g. `<BrowserRouter />`). You usually only need a single Router in your app, most often rendered immediately by your most top-level `<App />`
+component. The Router registers a context, which is needed for Links and Switches to function. An example is shown below.
 
 :::caution
 When using `yew-router` in browser environment, `<BrowserRouter />` is highly recommended.
@@ -94,7 +95,7 @@ fn switch(routes: Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={switch} />
+            <Switch<Route> render={switch} /> // <- must be child of <BrowserRouter />
         </BrowserRouter>
     }
 }

--- a/website/versioned_docs/version-0.20/concepts/router.mdx
+++ b/website/versioned_docs/version-0.20/concepts/router.mdx
@@ -95,7 +95,7 @@ fn switch(routes: Route) -> Html {
 fn app() -> Html {
     html! {
         <BrowserRouter>
-            <Switch<Route> render={switch} /> // <- must be child of <BrowserRouter />
+            <Switch<Route> render={switch} /> // <- must be child of <BrowserRouter>
         </BrowserRouter>
     }
 }


### PR DESCRIPTION
#### Description

I've added documentation explaining that certain elements like `<Link />` &  `<Switch />` must be nested inside of a router.

Fixes #2903 


