### PR TITLE
Backport portal fix to yew v0.19

### DIFF
--- a/packages/yew/src/virtual_dom/vportal.rs
+++ b/packages/yew/src/virtual_dom/vportal.rs
@@ -41,7 +41,7 @@ impl VDiff for VPortal {
                     // Remount the inner node somewhere else instead of diffing
                     node.detach(&old_host);
                     None
-                } else if old_sibling != self.next_sibling {
+                } else if old_sibling.get() != self.next_sibling.get() {
                     // Move the node, but keep the state
                     node.move_before(&self.host, &self.next_sibling.get());
                     Some(*node)


### PR DESCRIPTION
#### Description

Backport a fix of #2890 from #2891

As far as I understand the core of the issue was from comparing `NodeRef`'s instead of comparing `Node`'s directly because you were never intended to be able to pass `NodeRef`'s there. While breaking API is not an option for a backport I _think_ comparing the `NodeRef::get()` results accomplishes the same end goal

#### Checklist

- [x] I have reviewed my own code
- [ ] I have NOT added tests (I have manually tested that the issue goes away, but I am having trouble running tests on v0.19 branch, so I would like some guidance setting them up...)