### PR TITLE
Fix +/- marker and highlighting with ignore in the tutorial

### DIFF
--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -490,7 +490,7 @@ wasm-bindgen-futures = "0.4"
 
 Update the `Video` struct to derive the `Deserialize` trait:
 
-```rust ,ignore {1-2}
+```rust ,ignore {1, 3-4}
 + use serde::Deserialize;
 
 - #[derive(Clone, PartialEq)]
@@ -505,7 +505,7 @@ struct Video {
 
 Now as the last step, we need to update our `App` component to make the fetch request instead of using hardcoded data
 
-```rust ,ignore {3-23,32-33}
+```rust ,ignore {1,5-25,34-35}
 + use gloo_net::http::Request;
 
 #[function_component(App)]

--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -370,9 +370,10 @@ struct VideosListProps {
 
 Then we modify the `VideosList` component to pass the "emit" the selected video to the callback.
 
-```rust ,ignore {3,5-11,14-15}
+```rust ,ignore {2-4,6-12,15-16}
 #[function_component(VideosList)]
-fn videos_list(VideosListProps { videos, on_click }: &VideosListProps) -> Html {
+-fn videos_list(VideosListProps { videos }: &VideosListProps) -> Html {
++fn videos_list(VideosListProps { videos, on_click }: &VideosListProps) -> Html {
 +    let on_click = on_click.clone();
     videos.iter().map(|video| {
 +        let on_video_select = {

--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -461,7 +461,7 @@ element returned by the `Iterator` with a special `{ for ... }` syntax
 
 Remember the `use_state` used earlier? That is a special function, called a "hook". Hooks are used to "hook" into
 lifecycle of a function component and perform actions. You can learn more about this hook, and others
-[here](concepts/function-components/hooks/introduction.mdx#pre-defined-hooks)
+[here](concepts/function-components/hooks/introduction.mdx#pre-defined-hooks).
 
 :::note
 Struct components act differently. See [the documentation](advanced-topics/struct-components/introduction.mdx) to learn about those.

--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -483,7 +483,7 @@ wasm-bindgen-futures = "0.4"
 
 Update the `Video` struct to derive the `Deserialize` trait:
 
-```rust ,ignore {1-2, 5-6}
+```rust ,ignore {1, 3-4}
 + use serde::Deserialize;
 
 - #[derive(Clone, PartialEq)]
@@ -498,7 +498,7 @@ struct Video {
 
 Now as the last step, we need to update our `App` component to make the fetch request instead of using hardcoded data
 
-```rust ,ignore {3-23,32-33}
+```rust ,ignore {1,5-25,34-35}
 + use gloo_net::http::Request;
 
 #[function_component(App)]

--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -364,9 +364,10 @@ struct VideosListProps {
 
 Then we modify the `VideosList` component to pass the "emit" the selected video to the callback.
 
-```rust ,ignore {3,5-11,14-15}
+```rust ,ignore {2-4,6-12,15-16}
 #[function_component(VideosList)]
-fn videos_list(VideosListProps { videos, on_click }: &VideosListProps) -> Html {
+-fn videos_list(VideosListProps { videos }: &VideosListProps) -> Html {
++fn videos_list(VideosListProps { videos, on_click }: &VideosListProps) -> Html {
 +    let on_click = on_click.clone();
     videos.iter().map(|video| {
 +        let on_video_select = {

--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -454,7 +454,7 @@ element returned by the `Iterator` with the `{ for ... }` syntax.
 
 Remember the `use_state` used earlier? That is a special function, called a "hook". Hooks are used to "hook" into
 lifecycle of a function component and perform actions. You can learn more about this hook, and others
-[here](concepts/function-components/pre-defined-hooks#use_state)
+[here](concepts/function-components/pre-defined-hooks#use_state).
 
 :::note
 Struct components act differently. See [the documentation](concepts/components/introduction) to learn about those.

--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -483,7 +483,7 @@ wasm-bindgen-futures = "0.4"
 
 Update the `Video` struct to derive the `Deserialize` trait:
 
-```rust ,ignore {1, 3-4}
+```rust ,ignore {1,3-4}
 + use serde::Deserialize;
 
 - #[derive(Clone, PartialEq)]


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->
Minor fixes to +/- markers in tutorial code and their highlighting.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
- [x] I have checked that the output looks fine when building the website locally.
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->

I have done the changes for the next version. Or should I do them for the versioned docs?
