### PR TITLE
Fix typo in wasm-bindgen doc page

### DIFF
--- a/website/docs/concepts/basic-web-technologies/wasm-bindgen.mdx
+++ b/website/docs/concepts/basic-web-technologies/wasm-bindgen.mdx
@@ -169,7 +169,7 @@ _[`JsCast` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindg
 
 ### [`Closure`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html)
 
-The `Closure` type provides a way to transfer Rust closures to JavaScript, the closures past to
+The `Closure` type provides a way to transfer Rust closures to JavaScript, the closures passed to
 JavaScript must have a `'static` lifetime for soundness reasons.
 
 This type is a "handle" in the sense that whenever it is dropped it will invalidate the JS


### PR DESCRIPTION
#### Description

Fix a typo in the wasm-bindgen docs. 

I believe this is correct.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests

