### PR TITLE
Fix clippy::let_unit_value lint in propless components

### DIFF
--- a/packages/yew-macro/src/html_tree/html_component.rs
+++ b/packages/yew-macro/src/html_tree/html_component.rs
@@ -145,6 +145,7 @@ impl ToTokens for HtmlComponent {
         tokens.extend(quote_spanned! {ty_span=>
             {
                 #use_close_tag
+                #[allow(clippy::let_unit_value)]
                 let __yew_props = #build_props;
                 ::yew::virtual_dom::VChild::<#ty>::new(__yew_props, #key)
             }


### PR DESCRIPTION
#### Description

Fixes #2931 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests.
I can't figure out how to run clippy lints as part of the try_build macro tests. Any tip is appreciated. Otherwise, we'd have to setup another test rig just for clippy.
