### PR TITLE
Migration guide from-0_19_0-to-0_20_0.mdx wrong feature 

### DIFF
--- a/website/docs/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
+++ b/website/docs/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
@@ -48,7 +48,7 @@ The reducer function can see all previous changes at the time they are run.
 
 `start_app*` has been replaced by `yew::Renderer`.
 
-You need to enable feature `render` to use `yew::Renderer`.
+You need to enable feature `csr` to use `yew::Renderer`.
 
 ## `ref` prop for Components
 


### PR DESCRIPTION
Feature `render` does not exist. `csr` should be used.