### PR TITLE
update changelog for 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## ✨ yew **0.20.0** *(2022-11-xx)*
+## ✨ yew **0.20.0** *(2022-11-25)*
 
 #### Changelog
+
+- #### 🚨 Breaking changes
+  - Remove `yew::start_app::<App>()`. (Use
+    `yew::Renderer::<App>::new().render()` instead).
 
 - #### 🛠 Fixes
 


### PR DESCRIPTION
This updates `CHANGELOG.md` with the date version 0.20.0 was released and documents a breaking change which was so far not documented. (Was the breaking change unintentional?)