### PR TITLE
Website docs update link in hooks page

### DIFF
--- a/website/docs/concepts/function-components/hooks/introduction.mdx
+++ b/website/docs/concepts/function-components/hooks/introduction.mdx
@@ -38,7 +38,7 @@ Yew comes with the following predefined Hooks:
 -   `use_context`
 -   `use_force_update`
 
-The documentation for these hooks can be found in the [Yew API docs](https://yew-rs-api.web.app/next/yew/functional/)
+The documentation for these hooks can be found in the [Yew API docs](https://docs.rs/yew/latest/yew/functional/index.html)
 
 ### Custom Hooks
 

--- a/website/docs/concepts/function-components/hooks/introduction.mdx
+++ b/website/docs/concepts/function-components/hooks/introduction.mdx
@@ -38,7 +38,7 @@ Yew comes with the following predefined Hooks:
 -   `use_context`
 -   `use_force_update`
 
-The documentation for these hooks can be found in the [Yew API docs](https://docs.rs/yew/latest/yew/functional/index.html)
+The documentation for these hooks can be found in the [Yew API docs](https://docs.rs/yew/0.20.0/yew/functional/index.html)
 
 ### Custom Hooks
 


### PR DESCRIPTION
#### Description
Update link to remove nag
![image](https://user-images.githubusercontent.com/26617779/204533536-0fcfc945-2606-4975-8cca-d2d11509e475.png)
![image](https://user-images.githubusercontent.com/26617779/204534472-41825cb2-b4ae-477a-a519-2f7a62493aed.png)


This nag is really annoying because when you click go to the latest version it goes to the home page.

It will go to this page now: https://docs.rs/yew/0.20.0/yew/functional/index.html

