### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,9 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "master"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "master"

--- a/.github/workflows/benchmark-ssr.yml
+++ b/.github/workflows/benchmark-ssr.yml
@@ -32,11 +32,10 @@ jobs:
           path: current-pr
 
       - name: Setup toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: wasm32-unknown-unknown
-          profile: minimal
+          targets: wasm32-unknown-unknown
 
       - name: Restore Rust cache for master
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,12 +65,11 @@ jobs:
           path: "./js-framework-benchmark"
           ref: 678cd09a8e02b9a01bcb9b71dc9248d17a33ff82
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
-          profile: minimal
+          targets: wasm32-unknown-unknown
 
       - uses: jetli/wasm-pack-action@v0.3.0
         with:

--- a/.github/workflows/build-api-docs.yml
+++ b/.github/workflows/build-api-docs.yml
@@ -21,20 +21,26 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
-          profile: minimal
+          targets: wasm32-unknown-unknown
           components: rust-docs
 
       - name: Run cargo doc
-        uses: actions-rs/cargo@v1
         env:
           RUSTDOCFLAGS: --cfg documenting --html-before-content ./api-docs/before-content.html --extend-css ./api-docs/styles.css -Z unstable-options --enable-index-page
-        with:
-          command: doc
-          args: -p yew -p yew-macro -p yew-router -p yew-router-macro -p yew-agent --no-deps --all-features
+        run: |
+          cargo doc \
+            --no-deps \
+            --all-features \
+
+            -p yew \
+            -p yew-macro \
+            -p yew-router \
+            -p yew-router-macro \
+            -p yew-agent
 
       - name: Move files in correct directory
         run: |

--- a/.github/workflows/build-api-docs.yml
+++ b/.github/workflows/build-api-docs.yml
@@ -25,7 +25,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          targets: wasm32-unknown-unknown
           components: rust-docs
 
       - name: Run cargo doc
@@ -35,7 +34,6 @@ jobs:
           cargo doc \
             --no-deps \
             --all-features \
-
             -p yew \
             -p yew-macro \
             -p yew-router \

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -14,16 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
-          profile: minimal
+          targets: wasm32-unknown-unknown
           components: rustfmt
 
       - name: Run fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          toolchain: nightly
-          args: --all -- --check
+        run: cargo +nightly fmt --all -- --check --unstable-features

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -19,7 +19,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          targets: wasm32-unknown-unknown
           components: rustfmt
 
       - name: Run fmt

--- a/.github/workflows/inspect-next-changelogs.yml
+++ b/.github/workflows/inspect-next-changelogs.yml
@@ -16,12 +16,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
 
       - name: Build changelog generator
         run: cargo build --release -p changelog

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -22,20 +22,17 @@ jobs:
           - release
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
           components: clippy
 
       - uses: Swatinem/rust-cache@v1
 
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features --profile ${{ matrix.profile }} -- -D warnings
+        run: cargo clippy --all-targets --all-features --profile ${{ matrix.profile }} -- -D warnings
 
       - name: Lint feature soundness
         if: matrix.profile == 'dev'
@@ -64,48 +61,38 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
 
-      # perhaps extract it into its own little action?
-      - uses: actions-rs/toolchain@v1
-        # for wasm-bindgen-cli, always use stable rust
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          profile: minimal
 
       - name: Install wasm-bindgen-cli
         shell: bash
         run: ./ci/install-wasm-bindgen-cli.sh
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          target: wasm32-unknown-unknown
-          override: true
-          profile: minimal
+          targets: wasm32-unknown-unknown
 
       - uses: browser-actions/setup-geckodriver@latest
       - uses: nanasess/setup-chromedriver@v1
 
       - name: Run doctest
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --workspace --exclude yew --target wasm32-unknown-unknown
+        run: cargo test --doc --workspace --exclude yew --target wasm32-unknown-unknown
 
       - name: Run website code snippet tests
         run: cargo test -p website-test --target wasm32-unknown-unknown
         working-directory: tools
 
       - name: Run doctest - yew with features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p yew --doc --all-features --target wasm32-unknown-unknown
+        run: cargo test -p yew --doc --all-features --target wasm32-unknown-unknown
 
   integration_tests:
     name: Integration Tests on ${{ matrix.toolchain }}
@@ -123,22 +110,21 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/toolchain@v1
-        # for wasm-bindgen-cli, always use stable rust
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          profile: minimal
+          targets: wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-cli
         shell: bash
         run: ./ci/install-wasm-bindgen-cli.sh
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          target: wasm32-unknown-unknown
-          override: true
-          profile: minimal
+          targets: wasm32-unknown-unknown
 
       - uses: browser-actions/setup-geckodriver@latest
       - uses: nanasess/setup-chromedriver@v1
@@ -171,33 +157,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          override: true
-          profile: minimal
 
       - uses: Swatinem/rust-cache@v1
 
       - name: Run native tests
-        uses: actions-rs/cargo@v1
         env:
           # workaround for lack of ternary operator
           # see https://github.com/orgs/community/discussions/25725
           RUSTFLAGS: ${{ matrix.toolchain == 'nightly' && '--cfg nightly_yew' || '' }}
-        with:
-          command: test
-          args: --all-targets --workspace --exclude yew
+        run: cargo test --all-targets --workspace --exclude yew
 
       - name: Run native tests for yew
-        uses: actions-rs/cargo@v1
         env:
           # workaround for lack of ternary operator
           # see https://github.com/orgs/community/discussions/25725
           RUSTFLAGS: ${{ matrix.toolchain == 'nightly' && '--cfg nightly_yew' || '' }}
-        with:
-          command: test
-          args: -p yew --all-features
+        run: cargo test -p yew --all-features
 
   test-lints:
     name: Test lints on nightly
@@ -205,18 +184,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
-          profile: minimal
+          components: clippy
 
       - uses: Swatinem/rust-cache@v1
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: --cfg nightly_yew --cfg yew_lints
-        with:
-          command: test
-          args: -p yew-macro test_html_lints
+        run: cargo test -p yew-macro test_html_lints

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           toolchain: stable
 
+      # for wasm-bindgen-cli, always use stable rust
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -110,11 +111,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
+      # for wasm-bindgen-cli, always use stable rust
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          targets: wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-cli
         shell: bash
@@ -189,7 +190,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          components: clippy
 
       - uses: Swatinem/rust-cache@v1
 

--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           components: rust-src
-          override: true
-          profile: minimal
 
       - uses: Swatinem/rust-cache@v1
 

--- a/.github/workflows/publish-yew-agent.yml
+++ b/.github/workflows/publish-yew-agent.yml
@@ -29,12 +29,10 @@ jobs:
         with:
           token: "${{ secrets.YEWTEMPBOT_TOKEN }}"
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
 
       - name: Install cargo binary dependencies
         uses: baptiste0928/cargo-install@v1

--- a/.github/workflows/publish-yew-only.yml
+++ b/.github/workflows/publish-yew-only.yml
@@ -30,12 +30,10 @@ jobs:
         with:
           token: "${{ secrets.YEWTEMPBOT_TOKEN }}"
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
 
       - name: Install cargo binary dependencies
         uses: baptiste0928/cargo-install@v1

--- a/.github/workflows/publish-yew-router-only.yml
+++ b/.github/workflows/publish-yew-router-only.yml
@@ -29,12 +29,10 @@ jobs:
         with:
           token: "${{ secrets.YEWTEMPBOT_TOKEN }}"
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
 
       - name: Install cargo binary dependencies
         uses: baptiste0928/cargo-install@v1

--- a/.github/workflows/publish-yew-router.yml
+++ b/.github/workflows/publish-yew-router.yml
@@ -29,12 +29,10 @@ jobs:
         with:
           token: "${{ secrets.YEWTEMPBOT_TOKEN }}"
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
 
       - name: Install cargo binary dependencies
         uses: baptiste0928/cargo-install@v1

--- a/.github/workflows/publish-yew.yml
+++ b/.github/workflows/publish-yew.yml
@@ -29,12 +29,10 @@ jobs:
         with:
           token: "${{ secrets.YEWTEMPBOT_TOKEN }}"
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
-          profile: minimal
 
       - name: Install cargo binary dependencies
         uses: baptiste0928/cargo-install@v1

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -30,13 +30,11 @@ jobs:
           path: current-pr
 
       - name: Setup toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          target: wasm32-unknown-unknown
           components: rust-src
-          override: true
-          profile: minimal
+          targets: wasm32-unknown-unknown
 
       - name: Restore Rust cache for master
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/tools-examples.yml
+++ b/.github/workflows/tools-examples.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
           toolchain: ${{ matrix.toolchain }}
           components: ${{ matrix.runs }}
 

--- a/.github/workflows/tools-examples.yml
+++ b/.github/workflows/tools-examples.yml
@@ -31,25 +31,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
           toolchain: ${{ matrix.toolchain }}
-          override: true
-          profile: minimal
           components: ${{ matrix.runs }}
 
       - uses: Swatinem/rust-cache@v1
 
       - name: Run clippy for ${{ matrix.workspace }}
         if: matrix.runs == 'clippy'
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features --manifest-path ${{ matrix.workspace }}/Cargo.toml -- -D warnings
+        run: cargo clippy --all-targets --all-features --manifest-path ${{ matrix.workspace }}/Cargo.toml -- -D warnings
 
       - name: Run fmt for ${{ matrix.workspace }}
         if: matrix.runs == 'rustfmt'
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --manifest-path ${{ matrix.workspace }}/Cargo.toml -- --check
+        run: cargo fmt --all --manifest-path ${{ matrix.workspace }}/Cargo.toml -- --check

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "yew"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "base64ct",
  "bincode",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "yew-agent"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "gloo-worker 0.1.2",
  "yew",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "yew-macro"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "boolinator",
  "once_cell",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "yew-router"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "gloo",
  "js-sys",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "yew-router-macro"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

GitHub Actions will soon deprecate Node.js 12 Actions.
`actions-rs/*` actions are still using Node.js 12 and haven't received any updates for more than a year.

This pull request replaces them with `dtolnay/rust-toolchain` and `run`.

This pull request also enables dependabot for GitHub Actions which should phase out remaining Node.js 12 actions by merging the pull request dependabot creates.

#### Checklist



- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
