### PR TITLE
Improve ergonomics of UseStateHandle

### DIFF
--- a/packages/yew/src/functional/hooks/use_state.rs
+++ b/packages/yew/src/functional/hooks/use_state.rs
@@ -123,7 +123,9 @@ impl<T> UseStateHandle<T> {
         }
     }
 
-    /// Returns the current value.
+    /// Returns the value at the time [`use_state`] was called.
+    ///
+    /// For more information see the [`use_state`] documentation.
     pub fn get(&self) -> T
     where
         T: Clone,

--- a/packages/yew/src/functional/hooks/use_state.rs
+++ b/packages/yew/src/functional/hooks/use_state.rs
@@ -122,6 +122,14 @@ impl<T> UseStateHandle<T> {
             inner: self.inner.dispatcher(),
         }
     }
+
+    /// Returns the current value.
+    pub fn get(&self) -> T
+    where
+        T: Clone,
+    {
+        self.inner.value.clone()
+    }
 }
 
 impl<T> Deref for UseStateHandle<T> {

--- a/packages/yew/src/functional/hooks/use_state.rs
+++ b/packages/yew/src/functional/hooks/use_state.rs
@@ -149,6 +149,15 @@ where
     }
 }
 
+impl<T> PartialEq<T> for UseStateHandle<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, rhs: &T) -> bool {
+        &self.inner.value == rhs
+    }
+}
+
 /// Setter handle for [`use_state`] and [`use_state_eq`] hook
 pub struct UseStateSetter<T> {
     inner: UseReducerDispatcher<UseStateReducer<T>>,

--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -101,14 +101,14 @@ where
 
         use_memo_base(
             move |deps| {
-                let self_id = latest_id.get().wrapping_add(1);
+                let self_id = (*latest_id).get().wrapping_add(1);
                 // As long as less than 2**32 futures are in flight wrapping_add is fine
                 (*latest_id).set(self_id);
                 let deps = Rc::new(deps);
                 let task = f(deps.clone());
                 let suspension = Suspension::from_future(async move {
                     let result = task.await;
-                    if latest_id.get() == self_id {
+                    if (*latest_id).get() == self_id {
                         output.set(Some(result));
                     }
                 });


### PR DESCRIPTION
#### Description

Implements ``PartialEq<T>`` for ``UseStateHandle<T>``, as well as ``UseStateHandle::get``.

Here is a code snippet from a project I'm working on
```rust
use_callback(
    move |node: NodeRef, (dragged, is_dragging, ondrop)| {
        if **dragged == node && **is_dragging {
            is_dragging.set(false);
            ondrop.emit(*position);
        }
    },
    (dragged.clone(), is_dragging.clone(), props.ondrop.clone()),
)
```
You will quickly notice eyesore that is ``**dragged == node && **is_dragging``, this is a pattern that emerges all over the place. With this pr, the above code could look something like
```rust
use_callback(
    move |node: NodeRef, (dragged, is_dragging, ondrop)| {
        if *dragged == node && is_dragging.get() {
            is_dragging.set(false);
            ondrop.emit(*position);
        }
    },
    (dragged.clone(), is_dragging.clone(), props.ondrop.clone()),
)
```

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests

not sure that tests are needed here