### PR TITLE
Name the correct feature in the `start_app` migration section.

### DIFF
--- a/website/versioned_docs/version-0.20/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
+++ b/website/versioned_docs/version-0.20/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
@@ -48,7 +48,7 @@ The reducer function can see all previous changes at the time they are run.
 
 `start_app*` has been replaced by `yew::Renderer`.
 
-You need to enable feature `render` to use `yew::Renderer`.
+You need to enable feature `csr` to use `yew::Renderer`.
 
 ## `ref` prop for Components
 


### PR DESCRIPTION
#### Description

Corrects a mistakenly named feature in the 0.19 to 0.20 migration guide.

#### Checklist

- [ ] I have reviewed my own code
- [ ] I have added tests

(Both of these feel like they don't really apply here.)