### PR TITLE
Point links in docs for 0.20 to stable versions

### DIFF
--- a/website/versioned_docs/version-0.20/advanced-topics/immutable.mdx
+++ b/website/versioned_docs/version-0.20/advanced-topics/immutable.mdx
@@ -20,5 +20,5 @@ be cheaply cloned when passed from component to component.
 
 ## Further reading
 
--   [Immutable example](https://github.com/yewstack/yew/tree/master/examples/immutable)
+-   [Immutable example](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/immutable)
 -   [Crate `implicit-clone`](https://docs.rs/implicit-clone/)

--- a/website/versioned_docs/version-0.20/advanced-topics/portals.mdx
+++ b/website/versioned_docs/version-0.20/advanced-topics/portals.mdx
@@ -61,4 +61,4 @@ about it.
 
 ## Further reading
 
--   [Portals example](https://github.com/yewstack/yew/tree/master/examples/portals)
+-   [Portals example](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/portals)

--- a/website/versioned_docs/version-0.20/advanced-topics/server-side-rendering.md
+++ b/website/versioned_docs/version-0.20/advanced-topics/server-side-rendering.md
@@ -185,8 +185,8 @@ fn main() {
 }
 ```
 
-Example: [simple_ssr](https://github.com/yewstack/yew/tree/master/examples/simple_ssr)
-Example: [ssr_router](https://github.com/yewstack/yew/tree/master/examples/ssr_router)
+Example: [simple_ssr](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/simple_ssr)
+Example: [ssr_router](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/ssr_router)
 
 :::caution
 

--- a/website/versioned_docs/version-0.20/advanced-topics/struct-components/callbacks.mdx
+++ b/website/versioned_docs/version-0.20/advanced-topics/struct-components/callbacks.mdx
@@ -82,5 +82,5 @@ impl Component for Comp {
 
 ## Relevant examples
 
--   [Counter](https://github.com/yewstack/yew/tree/master/examples/counter)
--   [Timer](https://github.com/yewstack/yew/tree/master/examples/timer)
+-   [Counter](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/counter)
+-   [Timer](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/timer)

--- a/website/versioned_docs/version-0.20/advanced-topics/struct-components/refs.mdx
+++ b/website/versioned_docs/version-0.20/advanced-topics/struct-components/refs.mdx
@@ -52,4 +52,4 @@ impl Component for Comp {
 
 ## Relevant examples
 
--   [Node Refs](https://github.com/yewstack/yew/tree/master/examples/node_refs)
+-   [Node Refs](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/node_refs)

--- a/website/versioned_docs/version-0.20/concepts/agents.mdx
+++ b/website/versioned_docs/version-0.20/concepts/agents.mdx
@@ -60,5 +60,5 @@ with other threads, so the cost is substantially higher than just calling a func
 
 ## Further reading
 
--   The [web_worker_fib](https://github.com/yewstack/yew/tree/master/examples/web_worker_fib) example shows how
+-   The [web_worker_fib](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/web_worker_fib) example shows how
     components can send message to and receive message from agents.

--- a/website/versioned_docs/version-0.20/concepts/contexts.mdx
+++ b/website/versioned_docs/version-0.20/concepts/contexts.mdx
@@ -141,7 +141,7 @@ See [docs for use_context](https://yew-rs-api.web.app/next/yew/functional/fn.use
 We have 2 options to consume contexts in struct components:
 
 -   [Higher Order Components](../advanced-topics/struct-components/hoc.mdx): A higher order function component will consume the context and pass the data to the struct component which requires it.
--   Consume context directly in struct component. See [example of struct component as a consumer](https://github.com/yewstack/yew/tree/master/examples/contexts/src/struct_component_subscriber.rs)
+-   Consume context directly in struct component. See [example of struct component as a consumer](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/contexts/src/struct_component_subscriber.rs)
 
 ## Use cases
 
@@ -166,9 +166,9 @@ Because of Rust's ownership rules, a context cannot have a method that takes `&m
 In order to mutate a context's value, we must combine it with a reducer. This is done by using the
 [`use_reducer`](https://yew-rs-api.web.app/next/yew/functional/fn.use_reducer.html) hook.
 
-The [contexts example](https://github.com/yewstack/yew/tree/master/examples/contexts) demonstrates mutable contexts
+The [contexts example](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/contexts) demonstrates mutable contexts
 with the help of contexts
 
 ## Further reading
 
--   The [contexts example](https://github.com/yewstack/yew/tree/master/examples/contexts)
+-   The [contexts example](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/contexts)

--- a/website/versioned_docs/version-0.20/concepts/function-components/node-refs.mdx
+++ b/website/versioned_docs/version-0.20/concepts/function-components/node-refs.mdx
@@ -18,4 +18,4 @@ access, if you are unsure.
 ## Further Reading
 
 -   [use_node_ref hook](https://yew-rs-api.web.app/next/yew/functional/fn.use_node_ref.html)
--   [`node_refs` example](https://github.com/yewstack/yew/tree/master/examples/node_refs)
+-   [`node_refs` example](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/node_refs)

--- a/website/versioned_docs/version-0.20/concepts/html/components.mdx
+++ b/website/versioned_docs/version-0.20/concepts/html/components.mdx
@@ -168,5 +168,5 @@ html! {
 
 ## Relevant examples
 
--   [Function Todo MVC](https://github.com/yewstack/yew/tree/master/examples/function_todomvc)
--   [Function Router](https://github.com/yewstack/yew/tree/master/examples/function_router)
+-   [Function Todo MVC](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/function_todomvc)
+-   [Function Router](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/function_router)

--- a/website/versioned_docs/version-0.20/concepts/html/elements.mdx
+++ b/website/versioned_docs/version-0.20/concepts/html/elements.mdx
@@ -142,4 +142,4 @@ If the attribute is set to `None`, the attribute won't be set in the DOM.
 
 ## Relevant examples
 
--   [Inner HTML](https://github.com/yewstack/yew/tree/master/examples/inner_html)
+-   [Inner HTML](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/inner_html)

--- a/website/versioned_docs/version-0.20/concepts/html/lists.mdx
+++ b/website/versioned_docs/version-0.20/concepts/html/lists.mdx
@@ -81,9 +81,9 @@ html! {
 
 ### Performance increases
 
-We have [Keyed list](https://github.com/yewstack/yew/tree/master/examples/keyed_list) example that lets you test the performance improvements, but here is rough rundown:
+We have [Keyed list](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/keyed_list) example that lets you test the performance improvements, but here is rough rundown:
 
-1. Go to [Keyed list](https://github.com/yewstack/yew/tree/master/examples/keyed_list) hosted demo
+1. Go to [Keyed list](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/keyed_list) hosted demo
 2. Add 500 elements.
 3. Disable keys.
 4. Reverse the list.
@@ -120,6 +120,6 @@ If you need that div to be recreated instead of reused, then you can add differe
 
 ## Further reading
 
--   [TodoMVC](https://github.com/yewstack/yew/tree/master/examples/todomvc)
--   [Keyed list](https://github.com/yewstack/yew/tree/master/examples/keyed_list)
--   [Router](https://github.com/yewstack/yew/tree/master/examples/router)
+-   [TodoMVC](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/todomvc)
+-   [Keyed list](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/keyed_list)
+-   [Router](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/router)

--- a/website/versioned_docs/version-0.20/concepts/router.mdx
+++ b/website/versioned_docs/version-0.20/concepts/router.mdx
@@ -13,7 +13,7 @@ Yew provides router support in the `yew-router` crate. To start using it, add th
 <!-- Reminder: fix this when we release a new version of yew -->
 
 ```toml
-yew-router = { git = "https://github.com/yewstack/yew.git" }
+yew-router = "0.17"
 ```
 
 The utilities needed are provided under `yew_router::prelude`,
@@ -498,7 +498,7 @@ fallback to `/` if no `<base />` presents in the html file.
 
 ## Relevant examples
 
--   [Router](https://github.com/yewstack/yew/tree/master/examples/router)
+-   [Router](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/router)
 
 ## API Reference
 

--- a/website/versioned_docs/version-0.20/concepts/suspense.mdx
+++ b/website/versioned_docs/version-0.20/concepts/suspense.mdx
@@ -178,4 +178,4 @@ pub type UserContent = WithUser<BaseUserContent>;
 
 ## Relevant examples
 
--   [Suspense](https://github.com/yewstack/yew/tree/master/examples/suspense)
+-   [Suspense](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/suspense)

--- a/website/versioned_docs/version-0.20/getting-started/examples.mdx
+++ b/website/versioned_docs/version-0.20/getting-started/examples.mdx
@@ -13,5 +13,5 @@ Most of the examples have a live deployment that can be found at https://example
 Click the shield on their individual README page in their respective sub-folder to navigate to the live demo.
 :::
 
-[examples]: https://github.com/yewstack/yew/tree/master/examples
-[readme]: https://github.com/yewstack/yew/tree/master/examples#yew-examples
+[examples]: https://github.com/yewstack/yew/tree/yew-v0.20.0/examples
+[readme]: https://github.com/yewstack/yew/tree/yew-v0.20.0/examples#yew-examples

--- a/website/versioned_docs/version-0.20/migration-guides/yew-agent/from-0_1_0-to-0_2_0.mdx
+++ b/website/versioned_docs/version-0.20/migration-guides/yew-agent/from-0_1_0-to-0_2_0.mdx
@@ -6,7 +6,7 @@ title: 'From 0.1.0 to 0.2.0'
 
 The `Context` and `Job` Agents have been removed in favour of Yew's Context API.
 
-You can see the updated [`contexts`](https://github.com/yewstack/yew/tree/master/examples/contexts)
+You can see the updated [`contexts`](https://github.com/yewstack/yew/tree/yew-v0.20.0/examples/contexts)
 which demonstrate how to use the context API.
 
 For users of `yew_agent::utils::store`, you may switch to third party solutions like: [Yewdux](https://github.com/intendednull/yewdux) or [Bounce](https://github.com/futursolo/bounce).

--- a/website/versioned_docs/version-0.20/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.20/tutorial/index.mdx
@@ -71,7 +71,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-yew = { git = "https://github.com/yewstack/yew/", features = ["csr"] }
+yew = { version = "0.20", features = ["csr"] }
 ```
 
 :::info


### PR DESCRIPTION
Fixes #3015 and other issues with links

#### Description

Use stable links in `versioned_docs/version-0.20`, and stable crate versions, pointing to the branch for the release instead of `master`.

#### Checklist

- [x] I have reviewed my own code
