### PR TITLE
Make Classes cheap to clone

### DIFF
--- a/packages/yew-macro/tests/classes_macro/classes-fail.stderr
+++ b/packages/yew-macro/tests/classes_macro/classes-fail.stderr
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 4 others
+           and 5 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
 note: required by a bound in `Classes::push`
   --> $WORKSPACE/packages/yew/src/html/classes.rs
@@ -40,7 +40,7 @@ error[E0277]: the trait bound `Classes: From<{float}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 4 others
+           and 5 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{float}`
 note: required by a bound in `Classes::push`
   --> $WORKSPACE/packages/yew/src/html/classes.rs
@@ -59,7 +59,7 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 4 others
+           and 5 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
    = note: required because of the requirements on the impl of `From<Vec<{integer}>>` for `Classes`
    = note: 1 redundant requirement hidden
@@ -81,7 +81,7 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 4 others
+           and 5 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
    = note: required because of the requirements on the impl of `From<Option<{integer}>>` for `Classes`
    = note: 1 redundant requirement hidden
@@ -103,7 +103,7 @@ error[E0277]: the trait bound `Classes: From<u32>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 4 others
+           and 5 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `u32`
    = note: required because of the requirements on the impl of `From<Option<u32>>` for `Classes`
    = note: 1 redundant requirement hidden
@@ -125,7 +125,7 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 4 others
+           and 5 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
 note: required by a bound in `Classes::push`
   --> $WORKSPACE/packages/yew/src/html/classes.rs

--- a/packages/yew-macro/tests/classes_macro/classes-fail.stderr
+++ b/packages/yew-macro/tests/classes_macro/classes-fail.stderr
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 5 others
+           and 6 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
 note: required by a bound in `Classes::push`
   --> $WORKSPACE/packages/yew/src/html/classes.rs
@@ -40,7 +40,7 @@ error[E0277]: the trait bound `Classes: From<{float}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 5 others
+           and 6 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{float}`
 note: required by a bound in `Classes::push`
   --> $WORKSPACE/packages/yew/src/html/classes.rs
@@ -59,7 +59,7 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 5 others
+           and 6 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
    = note: required because of the requirements on the impl of `From<Vec<{integer}>>` for `Classes`
    = note: 1 redundant requirement hidden
@@ -81,7 +81,7 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 5 others
+           and 6 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
    = note: required because of the requirements on the impl of `From<Option<{integer}>>` for `Classes`
    = note: 1 redundant requirement hidden
@@ -103,7 +103,7 @@ error[E0277]: the trait bound `Classes: From<u32>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 5 others
+           and 6 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `u32`
    = note: required because of the requirements on the impl of `From<Option<u32>>` for `Classes`
    = note: 1 redundant requirement hidden
@@ -125,7 +125,7 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
              <Classes as From<&Option<T>>>
              <Classes as From<&String>>
              <Classes as From<&[T]>>
-           and 5 others
+           and 6 others
    = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
 note: required by a bound in `Classes::push`
   --> $WORKSPACE/packages/yew/src/html/classes.rs

--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::iter::FromIterator;
 use std::rc::Rc;
 
+use implicit_clone::ImplicitClone;
 use indexmap::IndexSet;
 
 use super::IntoPropValue;
@@ -14,6 +15,8 @@ use crate::virtual_dom::AttrValue;
 pub struct Classes {
     set: Rc<IndexSet<AttrValue>>,
 }
+
+impl ImplicitClone for Classes {}
 
 /// helper method to efficiently turn a set of classes into a space-separated
 /// string. Abstracts differences between ToString and IntoPropValue. The

--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -35,7 +35,7 @@ fn build_attr_value(first: AttrValue, rest: impl Iterator<Item = AttrValue> + Cl
     s.push_str(first.as_str());
     // NOTE: this can be improved once Iterator::intersperse() becomes stable
     for class in rest {
-        s.push_str(" ");
+        s.push(' ');
         s.push_str(class.as_str());
     }
     s.into()

--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -212,14 +212,31 @@ impl From<&String> for Classes {
     }
 }
 
-impl From<AttrValue> for Classes {
-    fn from(t: AttrValue) -> Self {
+impl From<&AttrValue> for Classes {
+    fn from(t: &AttrValue) -> Self {
         let set = t
             .split_whitespace()
             .map(ToOwned::to_owned)
             .map(AttrValue::from)
             .collect();
         Self { set: Rc::new(set) }
+    }
+}
+
+impl From<AttrValue> for Classes {
+    fn from(t: AttrValue) -> Self {
+        match t.contains(|c: char| c.is_whitespace()) {
+            // If the string only contains a single class, we can just use it
+            // directly (rather than cloning it into a new string). Need to make
+            // sure it's not empty, though.
+            false => match t.is_empty() {
+                true => Self::new(),
+                false => Self {
+                    set: Rc::new(IndexSet::from_iter([t])),
+                },
+            },
+            true => Self::from(&t),
+        }
     }
 }
 


### PR DESCRIPTION
#### Description

The goal of this PR is to make `Classes` cheap to clone. My motivation is to
improve the use of `Classes` in UI toolkits like
[yewprint](https://yewprint.rm.rs/#button). In Yewprint, the user can pass
classes to a component like this:

```
use yewprint::Button;

// ...

<Button class={classes!("boo!")}>{"Click here to get scared"}</Button>
```

The next thing Yew will do is to render the actual button to a child component
as you can see here:

```
        <button
            class={classes!(
                "bp3-button",
                props.fill.then_some("bp3-fill"),
                props.minimal.then_some("bp3-minimal"),
                props.small.then_some("bp3-small"),
                props.outlined.then_some("bp3-outlined"),
                props.loading.then_some("bp3-loading"),
                props.large.then_some("bp3-large"),
                (props.active && !props.disabled).then_some("bp3-active"),
                props.disabled.then_some("bp3-disabled"),
                props.intent,
                props.class.clone(),             // <----- here
            )}
            style={props.style.clone()}
            onclick={(!props.disabled).then_some(props.onclick.clone())}
        >
```

This is inefficient at the moment because all the class values (can be
`Cow::Owned`) are cloned unnecessarily.

To make it more efficient, I'm proposing 2 major changes to the `Classes`
object:

1.  use AttrValue instead of Cow in Classes

    `Cow` is cheap to clone only when the value is a `&'static str`. Using
    `AttrValue` here (aka IString) will allow owned string to be cloned
    efficiently, thanks to the use of `AttrValue::Rc`.

2.  wrap indexset into Rc

    In most cases, classes will be added to the user classes before being
    passed to the child component. But there are cases where classes are passed
    as is to the child component. In that case, it is unnecessary to clone the
    internal `IndexSet` itself.


#### Checklist

- [x] I have reviewed my own code
- ~I have added tests~ [edit: I have not added test because the API does not
  change at all and the current tests are already covering all the use cases.]
- [x] Benchmark proves these changes are reasonable.
