### PR TITLE
Assert there are no circular references

### DIFF
--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -134,9 +134,10 @@ mod feat_csr {
         /// Link a downstream `NodeRef`
         pub(crate) fn link(&self, node_ref: Self) {
             // Avoid circular references
-            if self == &node_ref {
-                return;
-            }
+            debug_assert!(
+                self != &node_ref,
+                "no circular references allowed! Report this as a bug in yew"
+            );
 
             let mut this = self.0.borrow_mut();
             this.node = None;


### PR DESCRIPTION
#### Description

The check is costly in release builds and should always fail. Note that the current PartialEq impl is *not* symmetric, it's useful only to check for circular dependencies! This should be fixed as well, with an improved design.

Fixes #3024

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
