### PR TITLE
update migration docs to be more explicit

### DIFF
--- a/website/versioned_docs/version-0.20/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
+++ b/website/versioned_docs/version-0.20/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
@@ -51,6 +51,7 @@ The reducer function can see all previous changes at the time they are run.
 You need to enable feature `csr` to use `yew::Renderer`.
 
 For example, to use client side rendering to render a typical app component:
+
 ```rust ,ignore
 yew::Renderer::<App>::new().render();
 ```

--- a/website/versioned_docs/version-0.20/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
+++ b/website/versioned_docs/version-0.20/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
@@ -56,7 +56,7 @@ For example, to use client side rendering to render a typical app component:
 yew::Renderer::<App>::new().render();
 ```
 
-For more options, see [the docs](https://docs.rs/yew/latest/yew/struct.Renderer.html).
+For more options, see [the docs](https://docs.rs/yew/0.20/yew/struct.Renderer.html).
 
 ## `ref` prop for Components
 

--- a/website/versioned_docs/version-0.20/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
+++ b/website/versioned_docs/version-0.20/migration-guides/yew/from-0_19_0-to-0_20_0.mdx
@@ -50,6 +50,13 @@ The reducer function can see all previous changes at the time they are run.
 
 You need to enable feature `csr` to use `yew::Renderer`.
 
+For example, to use client side rendering to render a typical app component:
+```rust ,ignore
+yew::Renderer::<App>::new().render();
+```
+
+For more options, see [the docs](https://docs.rs/yew/latest/yew/struct.Renderer.html).
+
 ## `ref` prop for Components
 
 Components no longer have a `ref` prop. Trying to add a node ref to a component


### PR DESCRIPTION
#### Description

Upgrade migration docs to have a link to the Renderer struct, and an example replacement for
what a replacement of `start_app` might look like. 

This caused me some issues when I was migrating, so thought I'd add it to the guide. 

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
