### PR TITLE
Add impl IntoIterator on &Classes

### DIFF
--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -157,6 +157,16 @@ impl IntoIterator for Classes {
     }
 }
 
+impl IntoIterator for &Classes {
+    type IntoIter = indexmap::set::IntoIter<AttrValue>;
+    type Item = AttrValue;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        (*self.set).clone().into_iter()
+    }
+}
+
 impl ToString for Classes {
     fn to_string(&self) -> String {
         let mut iter = self.set.iter().cloned();
@@ -347,6 +357,7 @@ mod tests {
         other.push("foo");
         other.push("bar");
         let mut subject = Classes::new();
+        subject.extend(&other);
         subject.extend(other);
         assert!(subject.contains("foo"));
         assert!(subject.contains("bar"));


### PR DESCRIPTION
#### Description

Since `Classes` is now cheap to clone, it only makes sense to be able to pass a
reference to a `Classes` to an extend method and having it clone all the things
automatically.

This is on par with `&AttrValue` being accepted in components properties.

Real life example:

```
use yew::prelude::*;
use yew::virtual_dom::AttrValue;

#[derive(Clone, PartialEq, Properties)]
pub struct ButtonGroupProps {
    #[prop_or_default]
    pub minimal: bool,
    #[prop_or_default]
    pub vertical: bool,
    #[prop_or_default]
    pub fill: bool,
    #[prop_or_default]
    pub large: bool,
    #[prop_or_default]
    pub style: Option<AttrValue>,
    #[prop_or_default]
    pub children: html::Children,
    #[prop_or_default]
    pub class: Classes,
}

#[function_component(ButtonGroup)]
pub fn button_group(props: &ButtonGroupProps) -> Html {
    let ButtonGroupProps {
        minimal,
        vertical,
        fill,
        large,
        style,
        children,
        class,
    } = props;

    html! {
        <div
            class={classes!(
                "bp3-button-group",
                minimal.then_some("bp3-minimal"),
                fill.then_some("bp3-fill"),
                large.then_some("bp3-large"),
                vertical.then_some("bp3-vertical"),
                class,              // <--- this PR change
            )}
            {style}                 // <-- already supported for AttrValue
        >
            {children.clone()}
        </div>
    }
}
```

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
