### PR TITLE
Add method map() on Children to wrap easily

### DIFF
--- a/packages/yew/src/html/component/children.rs
+++ b/packages/yew/src/html/component/children.rs
@@ -192,12 +192,13 @@ where
     /// ```
     /// # let children = Children::new(Vec::new());
     /// # use yew::{classes, html, Children};
-    /// children
-    ///     .map(|children| html! {
+    /// children.map(|children| {
+    ///     html! {
     ///         <div class={classes!("container")}>
     ///             {children}
     ///         </div>
-    ///     })
+    ///     }
+    /// })
     /// # ;
     /// ```
     pub fn map<OUT: Default>(&self, closure: impl FnOnce(&Self) -> OUT) -> OUT {

--- a/packages/yew/src/html/component/children.rs
+++ b/packages/yew/src/html/component/children.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 use crate::html::Html;
-use crate::virtual_dom::{VChild, VNode};
+use crate::virtual_dom::VChild;
 use crate::Properties;
 
 /// A type used for accepting children elements in Component::Properties.
@@ -163,7 +163,7 @@ impl<T: PartialEq> PartialEq for ChildrenRenderer<T> {
 
 impl<T> ChildrenRenderer<T>
 where
-    T: Clone + Into<VNode>,
+    T: Clone,
 {
     /// Create children
     pub fn new(children: Vec<T>) -> Self {
@@ -185,6 +185,27 @@ where
         // clone each child lazily.
         // This way `self.iter().next()` only has to clone a single node.
         self.children.iter().cloned()
+    }
+
+    /// Convert the children elements to another object (if there are any).
+    ///
+    /// ```
+    /// # let children = Children::new(Vec::new());
+    /// # use yew::{classes, html, Children};
+    /// children
+    ///     .map(|children| html! {
+    ///         <div class={classes!("container")}>
+    ///             {children}
+    ///         </div>
+    ///     })
+    /// # ;
+    /// ```
+    pub fn map<OUT: Default>(&self, closure: impl FnOnce(&Self) -> OUT) -> OUT {
+        if self.is_empty() {
+            Default::default()
+        } else {
+            closure(self)
+        }
     }
 }
 
@@ -217,4 +238,19 @@ pub struct ChildrenProps {
     /// The Children of a Component.
     #[prop_or_default]
     pub children: Children,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn children_map() {
+        let children = Children::new(vec![]);
+        let res = children.map(|children| Some(children.clone()));
+        assert!(res.is_none());
+        let children = Children::new(vec![Default::default()]);
+        let res = children.map(|children| Some(children.clone()));
+        assert!(res.is_some());
+    }
 }

--- a/packages/yew/src/utils/mod.rs
+++ b/packages/yew/src/utils/mod.rs
@@ -50,6 +50,15 @@ impl<IN: Into<OUT>, OUT> From<ChildrenRenderer<IN>> for NodeSeq<IN, OUT> {
     }
 }
 
+impl<IN: Into<OUT> + Clone, OUT> From<&ChildrenRenderer<IN>> for NodeSeq<IN, OUT> {
+    fn from(val: &ChildrenRenderer<IN>) -> Self {
+        Self(
+            val.iter().map(|x| x.into()).collect(),
+            PhantomData::default(),
+        )
+    }
+}
+
 impl<IN, OUT> IntoIterator for NodeSeq<IN, OUT> {
     type IntoIter = std::vec::IntoIter<Self::Item>;
     type Item = OUT;


### PR DESCRIPTION
#### Description

Add a function `Children::map(&self)` to easily wrap children.

Real life example:

```
use yew::prelude::*;

#[derive(Clone, PartialEq, Properties)]
pub struct ButtonProps {
    #[prop_or_default]
    pub onclick: Callback<MouseEvent>,
    #[prop_or_default]
    pub children: html::Children,
}

#[function_component(Button)]
pub fn button(props: &ButtonProps) -> Html {
    let ButtonProps {
        onclick,
        children,
        // ...
    } = props;

    html! {
        <button
            // ...
            onclick={(!disabled).then_some(onclick.clone())}
        >
            {
                (!children.is_empty())
                    .then(|| html! {
                        <span class="bp3-button-text">
                            {for children.iter()}
                        </span>
                    })
            }
        </button>
    }
}
```

This can be simplified into:

```
{
    (children
        .map(|children| html! {
            <span class="bp3-button-text">
                {for children.iter()}
            </span>
        })
}
```

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
