### PR TITLE
remove "Next loop" - introduction repeating

### DIFF
--- a/website/sidebars/docs.js
+++ b/website/sidebars/docs.js
@@ -117,7 +117,6 @@ module.exports = {
                     },
                     items: [
                         'advanced-topics/struct-components/hoc',
-                        'advanced-topics/struct-components/introduction',
                         'advanced-topics/struct-components/lifecycle',
                         'advanced-topics/struct-components/scope',
                         'advanced-topics/struct-components/callbacks',

--- a/website/versioned_sidebars/version-0.20-sidebars.json
+++ b/website/versioned_sidebars/version-0.20-sidebars.json
@@ -110,7 +110,6 @@
                     },
                     "items": [
                         "advanced-topics/struct-components/hoc",
-                        "advanced-topics/struct-components/introduction",
                         "advanced-topics/struct-components/lifecycle",
                         "advanced-topics/struct-components/scope",
                         "advanced-topics/struct-components/callbacks",


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

On this page
https://yew.rs/docs/advanced-topics/struct-components/hoc
the "Next" link in the footer points back to the introduction rather than the next item under "advanced-topics/struct-components". The problem is that introduction is duplicated - also inserted as an item. This change fixes that.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
