### PR TITLE
Try fixing the post-comment benchmark action, take 2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -106,13 +106,13 @@ jobs:
         run: npm run tsbench -- --framework keyed/yew keyed/yew-hooks --runner playwright --headless
 
       - name: transform results to be fit for display benchmark-action/github-action-benchmark@v1
-        uses: mathiasvr/command-output@v1
-        id: results
-        with:
-          run: |
-            mkdir artifacts/
-            jq -s . js-framework-benchmark/webdriver-ts/results/*.json | cargo run --manifest-path yew/tools/Cargo.toml --release -p process-benchmark-results > artifacts/results.json
-            echo "${{ toJSON(github.event) }}" > artifacts/PR_INFO
+        shell: bash
+        run: |
+          mkdir artifacts/
+          jq -s . js-framework-benchmark/webdriver-ts/results/*.json | cargo run --manifest-path yew/tools/Cargo.toml --release -p process-benchmark-results > artifacts/results.json
+          echo "$EVENT_INFO" > artifacts/PR_INFO
+        env:
+          EVENT_INFO: ${{ toJSON(github.event) }}
 
       - name: Upload result artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/post-benchmark.yml
+++ b/.github/workflows/post-benchmark.yml
@@ -12,6 +12,9 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
 
     steps:
+      # Checkout repo for the github-action-benchmark action
+      - uses: actions/checkout@v2
+
       - name: Download result artifacts
         uses: Legit-Labs/action-download-artifact@v2
         with:
@@ -19,9 +22,6 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           name: results
           path: ./artifacts
-
-      # Checkout repo for the github-action-benchmark action
-      - uses: actions/checkout@v2
 
       - name: Test for PR
         uses: mathiasvr/command-output@v1

--- a/examples/function_router/src/components/progress_delay.rs
+++ b/examples/function_router/src/components/progress_delay.rs
@@ -84,8 +84,7 @@ pub fn ProgressDelay(props: &Props) -> Html {
         use_effect_with_deps(
             move |_| {
                 let interval = (duration_ms / RESOLUTION).min(MIN_INTERVAL_MS);
-                let interval =
-                    Interval::new(interval as u32, move || value.dispatch(ValueAction::Tick));
+                let interval = Interval::new(interval, move || value.dispatch(ValueAction::Tick));
 
                 || {
                     let _interval = interval;

--- a/tools/website-test/build.rs
+++ b/tools/website-test/build.rs
@@ -40,7 +40,7 @@ fn main() {
 
     let out = format!("{}/website_tests.rs", env::var("OUT_DIR").unwrap());
 
-    fs::write(&out, level.to_contents()).unwrap();
+    fs::write(out, level.to_contents()).unwrap();
 }
 
 impl Level {


### PR DESCRIPTION
#### Description

See actions/runner#1656 why the previous attempt failed. Pass the expression to echo to the file as an environment variable. This is all so needlessly convoluted.

Also fixes 2 clippy issues.

---

If you know a way of running the actions locally without having to setup a couple gigabytes of docker machines that will just lay around, let me know and I'll do it. I kinda just hand-transpile the commands to a local bash session atm.
