### PR TITLE
Implement an internal DomPosition

### DIFF
--- a/packages/yew/src/app_handle.rs
+++ b/packages/yew/src/app_handle.rs
@@ -6,10 +6,9 @@ use std::rc::Rc;
 use web_sys::Element;
 
 use crate::dom_bundle::BSubtree;
-use crate::html::{BaseComponent, NodeRef, Scope, Scoped};
+use crate::html::{BaseComponent, DomPosition, RetargetableDomPosition, Scope, Scoped};
 
 /// An instance of an application.
-#[cfg(feature = "csr")]
 #[derive(Debug)]
 pub struct AppHandle<COMP: BaseComponent> {
     /// `Scope` holder
@@ -38,8 +37,8 @@ where
         app.scope.mount_in_place(
             hosting_root,
             host,
-            NodeRef::default(),
-            NodeRef::default(),
+            DomPosition::at_end(),
+            RetargetableDomPosition::new_debug_trapped(),
             props,
         );
 
@@ -58,7 +57,7 @@ where
         skip_all,
     )]
     pub fn update(&mut self, new_props: COMP::Properties) {
-        self.scope.reuse(Rc::new(new_props), NodeRef::default())
+        self.scope.reuse(Rc::new(new_props), DomPosition::at_end())
     }
 
     /// Schedule the app for destruction
@@ -115,11 +114,11 @@ mod feat_hydration {
                 hosting_root,
                 host.clone(),
                 &mut fragment,
-                NodeRef::default(),
+                RetargetableDomPosition::new_debug_trapped(),
                 Rc::clone(&props),
             );
             #[cfg(debug_assertions)] // Fix trapped next_sibling at the root
-            app.scope.reuse(props, NodeRef::default());
+            app.scope.reuse(props, DomPosition::at_end());
 
             // We remove all remaining nodes, this mimics the clear_element behaviour in
             // mount_with_props.

--- a/packages/yew/src/dom_bundle/blist.rs
+++ b/packages/yew/src/dom_bundle/blist.rs
@@ -9,7 +9,7 @@ use web_sys::Element;
 
 use super::{test_log, BNode, BSubtree};
 use crate::dom_bundle::{Reconcilable, ReconcileTarget};
-use crate::html::{AnyScope, NodeRef};
+use crate::html::{AnyScope, DomPosition};
 use crate::virtual_dom::{Key, VList, VNode, VText};
 
 /// This struct represents a mounted [VList]
@@ -36,7 +36,7 @@ struct NodeWriter<'s> {
     root: &'s BSubtree,
     parent_scope: &'s AnyScope,
     parent: &'s Element,
-    next_sibling: NodeRef,
+    next_sibling: DomPosition,
 }
 
 impl<'s> NodeWriter<'s> {
@@ -148,10 +148,10 @@ impl BList {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         lefts: Vec<VNode>,
         rights: &mut Vec<BNode>,
-    ) -> NodeRef {
+    ) -> DomPosition {
         let mut writer = NodeWriter {
             root,
             parent_scope,
@@ -189,10 +189,10 @@ impl BList {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         left_vdoms: Vec<VNode>,
         rev_bundles: &mut Vec<BNode>,
-    ) -> NodeRef {
+    ) -> DomPosition {
         macro_rules! key {
             ($v:expr) => {
                 $v.key().expect("unkeyed child in fully keyed list")
@@ -380,7 +380,7 @@ impl ReconcileTarget for BList {
         }
     }
 
-    fn shift(&self, next_parent: &Element, next_sibling: NodeRef) -> NodeRef {
+    fn shift(&self, next_parent: &Element, next_sibling: DomPosition) -> DomPosition {
         let mut next_sibling = next_sibling;
 
         for node in self.rev_children.iter() {
@@ -399,8 +399,8 @@ impl Reconcilable for VList {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
-    ) -> (NodeRef, Self::Bundle) {
+        next_sibling: DomPosition,
+    ) -> (DomPosition, Self::Bundle) {
         let mut self_ = BList::new();
         let node_ref = self.reconcile(root, parent_scope, parent, next_sibling, &mut self_);
         (node_ref, self_)
@@ -411,9 +411,9 @@ impl Reconcilable for VList {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         bundle: &mut BNode,
-    ) -> NodeRef {
+    ) -> DomPosition {
         // 'Forcefully' pretend the existing node is a list. Creates a
         // singleton list if it isn't already.
         let blist = bundle.make_list();
@@ -425,9 +425,9 @@ impl Reconcilable for VList {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         blist: &mut BList,
-    ) -> NodeRef {
+    ) -> DomPosition {
         // Here, we will try to diff the previous list elements with the new
         // ones we want to insert. For that, we will use two lists:
         //  - lefts: new elements to render in the DOM
@@ -477,32 +477,24 @@ mod feat_hydration {
             parent_scope: &AnyScope,
             parent: &Element,
             fragment: &mut Fragment,
-        ) -> (NodeRef, Self::Bundle) {
-            let node_ref = NodeRef::default();
+        ) -> Self::Bundle {
             let fully_keyed = self.fully_keyed();
             let vchildren = self.children;
             let mut children = Vec::with_capacity(vchildren.len());
 
-            for (index, child) in vchildren.into_iter().enumerate() {
-                let (child_node_ref, child) = child.hydrate(root, parent_scope, parent, fragment);
-
-                if index == 0 {
-                    node_ref.link(child_node_ref);
-                }
+            for child in vchildren.into_iter() {
+                let child = child.hydrate(root, parent_scope, parent, fragment);
 
                 children.push(child);
             }
 
             children.reverse();
 
-            (
-                node_ref,
-                BList {
-                    rev_children: children,
-                    fully_keyed,
-                    key: self.key,
-                },
-            )
+            BList {
+                rev_children: children,
+                fully_keyed,
+                key: self.key,
+            }
         }
     }
 }

--- a/packages/yew/src/dom_bundle/bportal.rs
+++ b/packages/yew/src/dom_bundle/bportal.rs
@@ -1,10 +1,10 @@
 //! This module contains the bundle implementation of a portal [BPortal].
 
-use web_sys::Element;
+use web_sys::{Element, Node};
 
 use super::{test_log, BNode, BSubtree};
 use crate::dom_bundle::{Reconcilable, ReconcileTarget};
-use crate::html::{AnyScope, NodeRef};
+use crate::html::{AnyScope, DomPosition};
 use crate::virtual_dom::{Key, VPortal};
 
 /// The bundle implementation to [VPortal].
@@ -15,7 +15,7 @@ pub struct BPortal {
     /// The element under which the content is inserted.
     host: Element,
     /// The next sibling after the inserted content
-    inner_sibling: NodeRef,
+    inner_sibling: Option<Node>,
     /// The inserted node
     node: Box<BNode>,
 }
@@ -26,7 +26,7 @@ impl ReconcileTarget for BPortal {
         self.node.detach(&self.inner_root, &self.host, false);
     }
 
-    fn shift(&self, _next_parent: &Element, next_sibling: NodeRef) -> NodeRef {
+    fn shift(&self, _next_parent: &Element, next_sibling: DomPosition) -> DomPosition {
         // portals have nothing in it's original place of DOM, we also do nothing.
 
         next_sibling
@@ -41,20 +41,16 @@ impl Reconcilable for VPortal {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        host_next_sibling: NodeRef,
-    ) -> (NodeRef, Self::Bundle) {
+        host_next_sibling: DomPosition,
+    ) -> (DomPosition, Self::Bundle) {
         let Self {
             host,
             inner_sibling,
             node,
         } = self;
-        let inner_sibling = {
-            let sib_ref = NodeRef::default();
-            sib_ref.set(inner_sibling);
-            sib_ref
-        };
+        let inner_pos = DomPosition::create(inner_sibling.clone());
         let inner_root = root.create_subroot(parent.clone(), &host);
-        let (_, inner) = node.attach(&inner_root, parent_scope, &host, inner_sibling.clone());
+        let (_, inner) = node.attach(&inner_root, parent_scope, &host, inner_pos);
         (
             host_next_sibling,
             BPortal {
@@ -71,9 +67,9 @@ impl Reconcilable for VPortal {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         bundle: &mut BNode,
-    ) -> NodeRef {
+    ) -> DomPosition {
         match bundle {
             BNode::Portal(portal) => {
                 self.reconcile(root, parent_scope, parent, next_sibling, portal)
@@ -87,9 +83,9 @@ impl Reconcilable for VPortal {
         _root: &BSubtree,
         parent_scope: &AnyScope,
         _parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         portal: &mut Self::Bundle,
-    ) -> NodeRef {
+    ) -> DomPosition {
         let Self {
             host,
             inner_sibling,
@@ -98,20 +94,20 @@ impl Reconcilable for VPortal {
 
         let old_host = std::mem::replace(&mut portal.host, host);
 
-        let should_shift = old_host != portal.host || portal.inner_sibling.get() != inner_sibling;
-        portal.inner_sibling.set(inner_sibling);
+        let should_shift = old_host != portal.host || portal.inner_sibling != inner_sibling;
+        portal.inner_sibling = inner_sibling;
+        let inner_sibling = DomPosition::create(portal.inner_sibling.clone());
 
         if should_shift {
             // Remount the inner node somewhere else instead of diffing
             // Move the node, but keep the state
-            let inner_sibling = portal.inner_sibling.clone();
-            portal.node.shift(&portal.host, inner_sibling);
+            portal.node.shift(&portal.host, inner_sibling.clone());
         }
         node.reconcile_node(
             &portal.inner_root,
             parent_scope,
             &portal.host,
-            portal.inner_sibling.clone(),
+            inner_sibling,
             &mut portal.node,
         );
         next_sibling
@@ -136,6 +132,7 @@ mod layout_tests {
     use yew::virtual_dom::VPortal;
 
     use super::*;
+    use crate::html::NodeRef;
     use crate::tests::layout_tests::{diff_layouts, TestLayout};
     use crate::virtual_dom::VNode;
     use crate::{create_portal, html};
@@ -252,13 +249,13 @@ mod layout_tests {
         );
         let (_, mut bundle) = portal
             .clone()
-            .attach(&root, &scope, &parent, NodeRef::default());
+            .attach(&root, &scope, &parent, DomPosition::at_end());
 
         // Focus the input, then reconcile again
         let input_el = input_ref.cast::<HtmlInputElement>().unwrap();
         input_el.focus().unwrap();
 
-        let _ = portal.reconcile_node(&root, &scope, &parent, NodeRef::default(), &mut bundle);
+        let _ = portal.reconcile_node(&root, &scope, &parent, DomPosition::at_end(), &mut bundle);
 
         let new_input_el = input_ref.cast::<HtmlInputElement>().unwrap();
         assert_eq!(input_el, new_input_el);

--- a/packages/yew/src/dom_bundle/bsuspense.rs
+++ b/packages/yew/src/dom_bundle/bsuspense.rs
@@ -6,9 +6,8 @@ use web_sys::Element;
 #[cfg(feature = "hydration")]
 use super::Fragment;
 use super::{BNode, BSubtree, Reconcilable, ReconcileTarget};
-use crate::html::AnyScope;
+use crate::html::{AnyScope, DomPosition};
 use crate::virtual_dom::{Key, VSuspense};
-use crate::NodeRef;
 
 #[derive(Debug)]
 enum Fallback {
@@ -60,7 +59,7 @@ impl ReconcileTarget for BSuspense {
         }
     }
 
-    fn shift(&self, next_parent: &Element, next_sibling: NodeRef) -> NodeRef {
+    fn shift(&self, next_parent: &Element, next_sibling: DomPosition) -> DomPosition {
         match self.fallback.as_ref() {
             Some(Fallback::Bundle(bundle)) => bundle.shift(next_parent, next_sibling),
             #[cfg(feature = "hydration")]
@@ -78,8 +77,8 @@ impl Reconcilable for VSuspense {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
-    ) -> (NodeRef, Self::Bundle) {
+        next_sibling: DomPosition,
+    ) -> (DomPosition, Self::Bundle) {
         let VSuspense {
             children,
             fallback,
@@ -94,7 +93,7 @@ impl Reconcilable for VSuspense {
         // tree while rendering fallback UI into the original place where children resides in.
         if suspended {
             let (_child_ref, children_bundle) =
-                children.attach(root, parent_scope, &detached_parent, NodeRef::default());
+                children.attach(root, parent_scope, &detached_parent, DomPosition::at_end());
             let (fallback_ref, fallback) =
                 fallback.attach(root, parent_scope, parent, next_sibling);
             (
@@ -126,9 +125,9 @@ impl Reconcilable for VSuspense {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         bundle: &mut BNode,
-    ) -> NodeRef {
+    ) -> DomPosition {
         match bundle {
             // We only preserve the child state if they are the same suspense.
             BNode::Suspense(m) if m.key == self.key => {
@@ -143,9 +142,9 @@ impl Reconcilable for VSuspense {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         suspense: &mut Self::Bundle,
-    ) -> NodeRef {
+    ) -> DomPosition {
         let VSuspense {
             children,
             fallback: vfallback,
@@ -165,7 +164,7 @@ impl Reconcilable for VSuspense {
                     root,
                     parent_scope,
                     &suspense.detached_parent,
-                    NodeRef::default(),
+                    DomPosition::at_end(),
                     children_bundle,
                 );
 
@@ -175,7 +174,7 @@ impl Reconcilable for VSuspense {
                     }
                     #[cfg(feature = "hydration")]
                     Fallback::Fragment(fragment) => match fragment.front().cloned() {
-                        Some(m) => NodeRef::new(m),
+                        Some(m) => DomPosition::new(m),
                         None => next_sibling,
                     },
                 }
@@ -187,13 +186,13 @@ impl Reconcilable for VSuspense {
             // Freshly suspended. Shift children into the detached parent, then add fallback to the
             // DOM
             (true, None) => {
-                children_bundle.shift(&suspense.detached_parent, NodeRef::default());
+                children_bundle.shift(&suspense.detached_parent, DomPosition::at_end());
 
                 children.reconcile_node(
                     root,
                     parent_scope,
                     &suspense.detached_parent,
-                    NodeRef::default(),
+                    DomPosition::at_end(),
                     children_bundle,
                 );
                 // first render of fallback
@@ -238,7 +237,7 @@ mod feat_hydration {
             parent_scope: &AnyScope,
             parent: &Element,
             fragment: &mut Fragment,
-        ) -> (NodeRef, Self::Bundle) {
+        ) -> Self::Bundle {
             let detached_parent = document()
                 .create_element("div")
                 .expect("failed to create detached element");
@@ -254,33 +253,24 @@ mod feat_hydration {
 
             // Even if initially suspended, these children correspond to the first non-suspended
             // content Refer to VSuspense::render_to_string
-            let (_, children_bundle) =
+            let children_bundle =
                 self.children
                     .hydrate(root, parent_scope, &detached_parent, &mut nodes);
 
             // We trim all leading text nodes before checking as it's likely these are whitespaces.
-            nodes.trim_start_text_nodes(&detached_parent);
+            nodes.trim_start_text_nodes();
 
             assert!(nodes.is_empty(), "expected end of suspense, found node.");
 
-            let node_ref = fallback_fragment
-                .front()
-                .cloned()
-                .map(NodeRef::new)
-                .unwrap_or_default();
+            BSuspense {
+                children_bundle,
+                detached_parent,
+                key: self.key,
 
-            (
-                node_ref,
-                BSuspense {
-                    children_bundle,
-                    detached_parent,
-                    key: self.key,
-
-                    // We start hydration with the BSuspense being suspended.
-                    // A subsequent render will resume the BSuspense if not needed to be suspended.
-                    fallback: Some(Fallback::Fragment(fallback_fragment)),
-                },
-            )
+                // We start hydration with the BSuspense being suspended.
+                // A subsequent render will resume the BSuspense if not needed to be suspended.
+                fallback: Some(Fallback::Fragment(fallback_fragment)),
+            }
         }
     }
 }

--- a/packages/yew/src/dom_bundle/btext.rs
+++ b/packages/yew/src/dom_bundle/btext.rs
@@ -4,9 +4,8 @@ use gloo::utils::document;
 use web_sys::{Element, Text as TextNode};
 
 use super::{insert_node, BNode, BSubtree, Reconcilable, ReconcileTarget};
-use crate::html::AnyScope;
+use crate::html::{AnyScope, DomPosition};
 use crate::virtual_dom::{AttrValue, VText};
-use crate::NodeRef;
 
 /// The bundle implementation to [VText]
 pub(super) struct BText {
@@ -25,14 +24,10 @@ impl ReconcileTarget for BText {
         }
     }
 
-    fn shift(&self, next_parent: &Element, next_sibling: NodeRef) -> NodeRef {
-        let node = &self.text_node;
+    fn shift(&self, next_parent: &Element, next_sibling: DomPosition) -> DomPosition {
+        insert_node(&self.text_node, next_parent, &next_sibling);
 
-        next_parent
-            .insert_before(node, next_sibling.get().as_ref())
-            .unwrap();
-
-        NodeRef::new(self.text_node.clone().into())
+        DomPosition::new(self.text_node.clone().into())
     }
 }
 
@@ -44,12 +39,12 @@ impl Reconcilable for VText {
         _root: &BSubtree,
         _parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
-    ) -> (NodeRef, Self::Bundle) {
+        next_sibling: DomPosition,
+    ) -> (DomPosition, Self::Bundle) {
         let Self { text } = self;
         let text_node = document().create_text_node(&text);
-        insert_node(&text_node, parent, next_sibling.get().as_ref());
-        let node_ref = NodeRef::new(text_node.clone().into());
+        insert_node(&text_node, parent, &next_sibling);
+        let node_ref = DomPosition::new(text_node.clone().into());
         (node_ref, BText { text, text_node })
     }
 
@@ -59,9 +54,9 @@ impl Reconcilable for VText {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         bundle: &mut BNode,
-    ) -> NodeRef {
+    ) -> DomPosition {
         match bundle {
             BNode::Text(btext) => self.reconcile(root, parent_scope, parent, next_sibling, btext),
             _ => self.replace(root, parent_scope, parent, next_sibling, bundle),
@@ -73,15 +68,15 @@ impl Reconcilable for VText {
         _root: &BSubtree,
         _parent_scope: &AnyScope,
         _parent: &Element,
-        _next_sibling: NodeRef,
+        _next_sibling: DomPosition,
         btext: &mut Self::Bundle,
-    ) -> NodeRef {
+    ) -> DomPosition {
         let Self { text } = self;
         let ancestor_text = std::mem::replace(&mut btext.text, text);
         if btext.text != ancestor_text {
             btext.text_node.set_node_value(Some(&btext.text));
         }
-        NodeRef::new(btext.text_node.clone().into())
+        DomPosition::new(btext.text_node.clone().into())
     }
 }
 
@@ -102,52 +97,49 @@ mod feat_hydration {
     impl Hydratable for VText {
         fn hydrate(
             self,
-            root: &BSubtree,
-            parent_scope: &AnyScope,
+            _root: &BSubtree,
+            _parent_scope: &AnyScope,
             parent: &Element,
             fragment: &mut Fragment,
-        ) -> (NodeRef, Self::Bundle) {
-            if let Some(m) = fragment.front().cloned() {
+        ) -> Self::Bundle {
+            let next_sibling = if let Some(m) = fragment.front().cloned() {
                 // better safe than sorry.
                 if m.node_type() == Node::TEXT_NODE {
-                    if let Ok(m) = m.dyn_into::<TextNode>() {
-                        // pop current node.
-                        fragment.pop_front();
+                    let m = m.unchecked_into::<TextNode>();
+                    // pop current node.
+                    fragment.pop_front();
 
-                        // TODO: It may make sense to assert the text content in the text node
-                        // against the VText when #[cfg(debug_assertions)]
-                        // is true, but this may be complicated.
-                        // We always replace the text value for now.
-                        //
-                        // Please see the next comment for a detailed explanation.
-                        m.set_node_value(Some(self.text.as_ref()));
+                    // TODO: It may make sense to assert the text content in the text node
+                    // against the VText when #[cfg(debug_assertions)]
+                    // is true, but this may be complicated.
+                    // We always replace the text value for now.
+                    //
+                    // Please see the next comment for a detailed explanation.
+                    m.set_node_value(Some(self.text.as_ref()));
 
-                        return (
-                            NodeRef::new(m.clone().into()),
-                            BText {
-                                text: self.text,
-                                text_node: m,
-                            },
-                        );
-                    }
+                    return BText {
+                        text: self.text,
+                        text_node: m,
+                    };
                 }
-            }
+                Some(m)
+            } else {
+                fragment.sibling_at_end().cloned()
+            };
 
             // If there are multiple text nodes placed back-to-back in SSR, it may be parsed as a
             // single text node by browser, hence we need to add extra text nodes here
             // if the next node is not a text node. Similarly, the value of the text
             // node may be a combination of multiple VText vnodes. So we always need to
             // override their values.
-            self.attach(
-                root,
-                parent_scope,
-                parent,
-                fragment
-                    .front()
-                    .cloned()
-                    .map(NodeRef::new)
-                    .unwrap_or_default(),
-            )
+            let text_node = document().create_text_node("");
+            parent
+                .insert_before(&text_node, next_sibling.as_ref())
+                .unwrap();
+            BText {
+                text: "".into(),
+                text_node,
+            }
         }
     }
 }

--- a/packages/yew/src/dom_bundle/fragment.rs
+++ b/packages/yew/src/dom_bundle/fragment.rs
@@ -1,15 +1,17 @@
 use std::collections::VecDeque;
 use std::ops::{Deref, DerefMut};
 
+use wasm_bindgen::JsCast;
 use web_sys::{Element, Node};
 
+use crate::dom_bundle::utils::insert_node;
 use crate::dom_bundle::BSubtree;
-use crate::html::NodeRef;
+use crate::html::DomPosition;
 use crate::virtual_dom::Collectable;
 
 /// A Hydration Fragment
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub struct Fragment(VecDeque<Node>);
+pub struct Fragment(VecDeque<Node>, Option<Node>);
 
 impl Deref for Fragment {
     type Target = VecDeque<Node>;
@@ -39,7 +41,7 @@ impl Fragment {
             fragment.push_back(m);
         }
 
-        Self(fragment)
+        Self(fragment, None)
     }
 
     /// Collects nodes for a Component Bundle or a BSuspense.
@@ -63,7 +65,7 @@ impl Fragment {
         };
 
         // We trim all leading text nodes as it's likely these are whitespaces.
-        collect_from.trim_start_text_nodes(parent);
+        collect_from.trim_start_text_nodes();
 
         let first_node = collect_from
             .pop_front()
@@ -115,19 +117,20 @@ impl Fragment {
                 }
             }
 
-            nodes.push_back(current_node.clone());
+            nodes.push_back(current_node);
         }
 
-        Self(nodes)
+        let next_child = collect_from.0.front().cloned();
+        Self(nodes, next_child)
     }
 
     /// Remove child nodes until first non-text node.
-    pub fn trim_start_text_nodes(&mut self, parent: &Element) {
+    pub fn trim_start_text_nodes(&mut self) {
         while let Some(ref m) = self.front().cloned() {
             if m.node_type() == Node::TEXT_NODE {
                 self.pop_front();
 
-                parent.remove_child(m).unwrap();
+                m.unchecked_ref::<web_sys::Text>().remove();
             } else {
                 break;
             }
@@ -141,7 +144,8 @@ impl Fragment {
             .map(|m| m.clone_node_with_deep(true).expect("failed to clone node."))
             .collect::<VecDeque<_>>();
 
-        Self(nodes)
+        // the cloned nodes are disconnected from the real dom, so next_child is `None`
+        Self(nodes, None)
     }
 
     // detaches current fragment.
@@ -156,16 +160,19 @@ impl Fragment {
     }
 
     /// Shift current Fragment into a different position in the dom.
-    pub fn shift(&self, next_parent: &Element, next_sibling: NodeRef) -> NodeRef {
+    pub(crate) fn shift(&self, next_parent: &Element, next_sibling: DomPosition) -> DomPosition {
         for node in self.iter() {
-            next_parent
-                .insert_before(node, next_sibling.get().as_ref())
-                .unwrap();
+            insert_node(node, next_parent, &next_sibling);
         }
 
         self.front()
             .cloned()
-            .map(NodeRef::new)
+            .map(DomPosition::new)
             .unwrap_or(next_sibling)
+    }
+
+    /// Return the node that comes after all the nodes in this fragment
+    pub fn sibling_at_end(&self) -> Option<&Node> {
+        self.1.as_ref()
     }
 }

--- a/packages/yew/src/dom_bundle/mod.rs
+++ b/packages/yew/src/dom_bundle/mod.rs
@@ -7,7 +7,7 @@
 
 use web_sys::Element;
 
-use crate::html::{AnyScope, NodeRef};
+use crate::html::{AnyScope, DomPosition};
 use crate::virtual_dom::VNode;
 
 mod bcomp;
@@ -53,7 +53,7 @@ impl Bundle {
     }
 
     /// Shifts the bundle into a different position.
-    pub fn shift(&self, next_parent: &Element, next_sibling: NodeRef) {
+    pub fn shift(&self, next_parent: &Element, next_sibling: DomPosition) {
         self.0.shift(next_parent, next_sibling);
     }
 
@@ -63,9 +63,9 @@ impl Bundle {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         next_node: VNode,
-    ) -> NodeRef {
+    ) -> DomPosition {
         next_node.reconcile_node(root, parent_scope, parent, next_sibling, &mut self.0)
     }
 
@@ -93,9 +93,9 @@ mod feat_hydration {
             parent: &Element,
             fragment: &mut Fragment,
             node: VNode,
-        ) -> (NodeRef, Self) {
-            let (node_ref, bundle) = node.hydrate(root, parent_scope, parent, fragment);
-            (node_ref, Self(bundle))
+        ) -> Self {
+            let bundle = node.hydrate(root, parent_scope, parent, fragment);
+            Self(bundle)
         }
     }
 }

--- a/packages/yew/src/dom_bundle/traits.rs
+++ b/packages/yew/src/dom_bundle/traits.rs
@@ -1,7 +1,7 @@
 use web_sys::Element;
 
 use super::{BNode, BSubtree};
-use crate::html::{AnyScope, NodeRef};
+use crate::html::{AnyScope, DomPosition};
 
 /// A Reconcile Target.
 ///
@@ -16,7 +16,7 @@ pub(super) trait ReconcileTarget {
     /// Move elements from one parent to another parent.
     /// This is for example used by `VSuspense` to preserve component state without detaching
     /// (which destroys component state).
-    fn shift(&self, next_parent: &Element, next_sibling: NodeRef) -> NodeRef;
+    fn shift(&self, next_parent: &Element, next_sibling: DomPosition) -> DomPosition;
 }
 
 /// This trait provides features to update a tree by calculating a difference against another tree.
@@ -32,7 +32,7 @@ pub(super) trait Reconcilable {
     /// - `next_sibling`: to find where to put the node.
     ///
     /// Returns a reference to the newly inserted element.
-    /// The [`NodeRef`] points the first element (if there are multiple nodes created),
+    /// The [`DomPosition`] points the first element (if there are multiple nodes created),
     /// or is the passed in next_sibling if there are no element is created.
     fn attach(
         self,
@@ -40,8 +40,8 @@ pub(super) trait Reconcilable {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
-    ) -> (NodeRef, Self::Bundle);
+        next_sibling: DomPosition,
+    ) -> (DomPosition, Self::Bundle);
 
     /// Scoped diff apply to other tree.
     ///
@@ -63,18 +63,18 @@ pub(super) trait Reconcilable {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         bundle: &mut BNode,
-    ) -> NodeRef;
+    ) -> DomPosition;
 
     fn reconcile(
         self,
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         bundle: &mut Self::Bundle,
-    ) -> NodeRef;
+    ) -> DomPosition;
 
     /// Replace an existing bundle by attaching self and detaching the existing one
     fn replace(
@@ -83,9 +83,9 @@ pub(super) trait Reconcilable {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: &Element,
-        next_sibling: NodeRef,
+        next_sibling: DomPosition,
         bundle: &mut BNode,
-    ) -> NodeRef
+    ) -> DomPosition
     where
         Self: Sized,
         Self::Bundle: Into<BNode>,
@@ -116,7 +116,7 @@ mod feat_hydration {
             parent_scope: &AnyScope,
             parent: &Element,
             fragment: &mut Fragment,
-        ) -> (NodeRef, Self::Bundle);
+        ) -> Self::Bundle;
     }
 }
 

--- a/packages/yew/src/html/mod.rs
+++ b/packages/yew/src/html/mod.rs
@@ -92,7 +92,7 @@ pub struct NodeRef(Rc<RefCell<NodeRefInner>>);
 
 impl PartialEq for NodeRef {
     fn eq(&self, other: &Self) -> bool {
-        self.0.as_ptr() == other.0.as_ptr() || Some(self) == other.0.borrow().link.as_ref()
+        self.0.as_ptr() == other.0.as_ptr()
     }
 }
 
@@ -109,14 +109,13 @@ impl std::fmt::Debug for NodeRef {
 #[derive(PartialEq, Debug, Default, Clone)]
 struct NodeRefInner {
     node: Option<Node>,
-    link: Option<NodeRef>,
 }
 
 impl NodeRef {
     /// Get the wrapped Node reference if it exists
     pub fn get(&self) -> Option<Node> {
         let inner = self.0.borrow();
-        inner.node.clone().or_else(|| inner.link.as_ref()?.get())
+        inner.node.clone()
     }
 
     /// Try converting the node reference into another form
@@ -126,51 +125,102 @@ impl NodeRef {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct RetargetableDomPosition {
+    target: Rc<RefCell<DomPosition>>,
+}
+
+#[derive(Clone)]
+enum DomPositionVariant {
+    Node(Option<Node>),
+    Chained(RetargetableDomPosition),
+}
+
+#[derive(Clone)]
+pub(crate) struct DomPosition {
+    variant: DomPositionVariant,
+}
+
+impl std::fmt::Debug for DomPosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DomPosition {{ next_sibling: {:?} }}",
+            self.get().map(|n| crate::utils::print_node(&n))
+        )
+    }
+}
+
+impl std::fmt::Debug for RetargetableDomPosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:#?}", *self.target.borrow())
+    }
+}
+
+impl DomPosition {
+    pub(crate) fn get(&self) -> Option<Node> {
+        // we use an iterative approach to traverse a possible long chain for references
+        // see for example issue #3043 why a recursive call is impossible for large lists in vdom
+
+        // TODO: there could be some data structure that performs better here. E.g. a balanced tree
+        // with parent pointers come to mind, but they are a bit fiddly to implement in rust
+        let node = match &self.variant {
+            DomPositionVariant::Node(ref n) => n.clone(),
+            DomPositionVariant::Chained(ref chain) => {
+                let mut this = chain.target.clone();
+                loop {
+                    //                          v------- borrow lives for this match expression
+                    let next_this = match &this.borrow().variant {
+                        DomPositionVariant::Node(ref n) => break n.clone(),
+                        // We clone an Rc here temporarily, so that we don't have to consume stack
+                        // space. The alternative would be to keep the
+                        // `Ref<'_, DomPosition>` above in some temporary buffer
+                        DomPositionVariant::Chained(ref chain) => chain.target.clone(),
+                    };
+                    this = next_this;
+                }
+            }
+        };
+
+        #[cfg(feature = "csr")]
+        feat_csr::TRAP.with(|trap| {
+            assert!(
+                node.as_ref() != Some(trap),
+                "should not use a trapped node ref"
+            )
+        });
+        node
+    }
+}
+
 #[cfg(feature = "csr")]
 mod feat_csr {
     use super::*;
 
     impl NodeRef {
-        /// Link a downstream `NodeRef`
-        pub(crate) fn link(&self, node_ref: Self) {
-            // Avoid circular references
-            debug_assert!(
-                self != &node_ref,
-                "no circular references allowed! Report this as a bug in yew"
-            );
-
-            let mut this = self.0.borrow_mut();
-            this.node = None;
-            this.link = Some(node_ref);
+        pub(crate) fn set(&self, new_ref: Option<Node>) {
+            let mut inner = self.0.borrow_mut();
+            inner.node = new_ref;
         }
+    }
 
-        /// Wrap an existing `Node` in a `NodeRef`
+    impl DomPosition {
         pub(crate) fn new(node: Node) -> Self {
-            let node_ref = NodeRef::default();
-            node_ref.set(Some(node));
-            node_ref
+            Self::create(Some(node))
         }
 
-        /// Place a Node in a reference for later use
-        pub(crate) fn set(&self, node: Option<Node>) {
-            let mut this = self.0.borrow_mut();
-            this.node = node;
-            this.link = None;
+        pub(crate) fn create(node: Option<Node>) -> Self {
+            Self {
+                variant: DomPositionVariant::Node(node),
+            }
         }
-    }
-}
 
-#[cfg(feature = "hydration")]
-mod feat_hydration {
-    use super::*;
+        pub(crate) fn at_end() -> Self {
+            Self {
+                variant: DomPositionVariant::Node(None),
+            }
+        }
 
-    #[cfg(debug_assertions)]
-    thread_local! {
-        // A special marker element that should not be referenced
-        static TRAP: Node = gloo::utils::document().create_element("div").unwrap().into();
-    }
-
-    impl NodeRef {
         // A new "placeholder" node ref that should not be accessed
         #[inline]
         pub(crate) fn new_debug_trapped() -> Self {
@@ -180,19 +230,36 @@ mod feat_hydration {
             }
             #[cfg(not(debug_assertions))]
             {
-                Self::default()
+                Self::at_end()
+            }
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    thread_local! {
+        // A special marker element that should not be referenced
+        pub(super) static TRAP: Node = gloo::utils::document().create_element("div").unwrap().into();
+    }
+
+    impl RetargetableDomPosition {
+        pub(crate) fn new(initial_position: DomPosition) -> Self {
+            Self {
+                target: Rc::new(RefCell::new(initial_position)),
             }
         }
 
-        #[inline]
-        pub(crate) fn debug_assert_not_trapped(&self) {
-            #[cfg(debug_assertions)]
-            TRAP.with(|trap| {
-                assert!(
-                    self.get().as_ref() != Some(trap),
-                    "should not use a trapped node ref"
-                )
-            })
+        pub(crate) fn new_debug_trapped() -> Self {
+            Self::new(DomPosition::new_debug_trapped())
+        }
+
+        pub(crate) fn retarget(&self, next_position: DomPosition) {
+            *self.target.borrow_mut() = next_position;
+        }
+
+        pub(crate) fn as_position(&self) -> DomPosition {
+            DomPosition {
+                variant: DomPositionVariant::Chained(self.clone()),
+            }
         }
     }
 }

--- a/packages/yew/src/tests/layout_tests.rs
+++ b/packages/yew/src/tests/layout_tests.rs
@@ -2,10 +2,9 @@
 //!
 //! This tests must be run in browser and thus require the `csr` feature to be enabled
 use gloo::console::log;
-use yew::NodeRef;
 
 use crate::dom_bundle::{BSubtree, Bundle};
-use crate::html::AnyScope;
+use crate::html::{AnyScope, DomPosition};
 use crate::virtual_dom::VNode;
 use crate::{scheduler, Component, Context, Html};
 
@@ -48,7 +47,7 @@ pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
     parent_element.append_child(&end_node).unwrap();
 
     // Tests each layout independently
-    let next_sibling = NodeRef::new(end_node.into());
+    let next_sibling = DomPosition::new(end_node.into());
     for layout in layouts.iter() {
         // Apply the layout
         let vnode = layout.node.clone();

--- a/packages/yew/src/virtual_dom/vcomp.rs
+++ b/packages/yew/src/virtual_dom/vcomp.rs
@@ -18,7 +18,7 @@ use crate::html::BaseComponent;
 #[cfg(any(feature = "ssr", feature = "csr"))]
 use crate::html::{AnyScope, Scope};
 #[cfg(feature = "csr")]
-use crate::html::{NodeRef, Scoped};
+use crate::html::{DomPosition, RetargetableDomPosition, Scoped};
 #[cfg(feature = "ssr")]
 use crate::platform::fmt::BufWriter;
 
@@ -61,12 +61,12 @@ pub(crate) trait Mountable {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: Element,
-        internal_ref: NodeRef,
-        next_sibling: NodeRef,
+        internal_ref: RetargetableDomPosition,
+        next_sibling: DomPosition,
     ) -> Box<dyn Scoped>;
 
     #[cfg(feature = "csr")]
-    fn reuse(self: Box<Self>, scope: &dyn Scoped, next_sibling: NodeRef);
+    fn reuse(self: Box<Self>, scope: &dyn Scoped, next_sibling: DomPosition);
 
     #[cfg(feature = "ssr")]
     fn render_into_stream<'a>(
@@ -82,7 +82,7 @@ pub(crate) trait Mountable {
         root: BSubtree,
         parent_scope: &AnyScope,
         parent: Element,
-        internal_ref: NodeRef,
+        internal_ref: RetargetableDomPosition,
         fragment: &mut Fragment,
     ) -> Box<dyn Scoped>;
 }
@@ -111,8 +111,8 @@ impl<COMP: BaseComponent> Mountable for PropsWrapper<COMP> {
         root: &BSubtree,
         parent_scope: &AnyScope,
         parent: Element,
-        internal_ref: NodeRef,
-        next_sibling: NodeRef,
+        internal_ref: RetargetableDomPosition,
+        next_sibling: DomPosition,
     ) -> Box<dyn Scoped> {
         let scope: Scope<COMP> = Scope::new(Some(parent_scope.clone()));
         scope.mount_in_place(root.clone(), parent, next_sibling, internal_ref, self.props);
@@ -121,7 +121,7 @@ impl<COMP: BaseComponent> Mountable for PropsWrapper<COMP> {
     }
 
     #[cfg(feature = "csr")]
-    fn reuse(self: Box<Self>, scope: &dyn Scoped, next_sibling: NodeRef) {
+    fn reuse(self: Box<Self>, scope: &dyn Scoped, next_sibling: DomPosition) {
         let scope: Scope<COMP> = scope.to_any().downcast::<COMP>();
         scope.reuse(self.props, next_sibling);
     }
@@ -149,7 +149,7 @@ impl<COMP: BaseComponent> Mountable for PropsWrapper<COMP> {
         root: BSubtree,
         parent_scope: &AnyScope,
         parent: Element,
-        internal_ref: NodeRef,
+        internal_ref: RetargetableDomPosition,
         fragment: &mut Fragment,
     ) -> Box<dyn Scoped> {
         let scope: Scope<COMP> = Scope::new(Some(parent_scope.clone()));


### PR DESCRIPTION
#### Description

A new for-internal-use data structure, `DomPosition`, is introduced to replace the uses of `NodeRef`s. This means the user-facing `NodeRef` does no longer have a `link` to a potentially long chain to follow.

TODO: explain the internal structure and crate internal docs. I want to see some performance comparisons though, hence the early PR

Fixes #3043

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
