### PR TITLE
Try to use sccache for size comparsion

### DIFF
--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -36,17 +36,12 @@ jobs:
           components: rust-src
           targets: wasm32-unknown-unknown
 
-      - name: Restore Rust cache for master
-        uses: Swatinem/rust-cache@v2
+      - name: Configure sccache
+        uses: visvirial/sccache-action@v1
         with:
-          working-directory: yew-master
-          key: master
-
-      - name: Restore Rust cache for current pull request
-        uses: Swatinem/rust-cache@v2
-        with:
-          working-directory: current-pr
-          key: pr
+          cache-key: sccache-ubuntu-latest
+          release-name: latest
+          arch: x86_64-unknown-linux-musl
 
       - name: Setup Trunk
         uses: jetli/trunk-action@v0.1.0

--- a/examples/async_clock/src/main.rs
+++ b/examples/async_clock/src/main.rs
@@ -59,6 +59,7 @@ impl Component for AsyncComponent {
                 // Update the clock display
                 self.clock = Some(AttrValue::from(current_time.to_rfc2822()));
             }
+
             Msg::ClockInitialized(_) => {
                 // Now that the clock is initialized, we can start the time stream.
                 self.clock = Some(AttrValue::from("Initialized"));
@@ -75,6 +76,7 @@ impl Component for AsyncComponent {
                 let joke_cb = ctx.link().callback(Msg::Joke);
                 emit_jokes(joke_cb);
             }
+
             Msg::Joke(joke) => {
                 // Update the joke
                 self.joke = Some(joke.clone());
@@ -87,6 +89,7 @@ impl Component for AsyncComponent {
                     .send_now(joke)
                     .expect("failed to send joke");
             }
+
             Msg::FunScore(score) => {
                 self.fun_score = Some(score);
             }


### PR DESCRIPTION
#### Description

I have found the size comparison on pull requests takes forever to run even with rust cache.
This pull request switches caching mechanism to sccache to see if it helps.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
