### PR TITLE
Only handle "normal" clicks on <Link>s

### DIFF
--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -55,8 +55,10 @@ where
         let query = query.clone();
 
         Callback::from(move |e: MouseEvent| {
+            if e.meta_key() || e.ctrl_key() {
+               return;
+            }
             e.prevent_default();
-
             match query {
                 None => {
                     navigator.push(&to);

--- a/packages/yew-router/src/components/link.rs
+++ b/packages/yew-router/src/components/link.rs
@@ -55,8 +55,8 @@ where
         let query = query.clone();
 
         Callback::from(move |e: MouseEvent| {
-            if e.meta_key() || e.ctrl_key() {
-               return;
+            if e.meta_key() || e.ctrl_key() || e.shift_key() || e.alt_key() {
+                return;
             }
             e.prevent_default();
             match query {


### PR DESCRIPTION
#### Description

This issue fixes [Issue 2911](https://github.com/yewstack/yew/issues/2911)

It uses the exact same approach as [React Router](https://github.com/remix-run/react-router/blob/11156ac7f3d7c1c557c67cc449ecbf9bd5c6a4ca/packages/react-router-dom/dom.ts#L29)
 
Yew Router's Link's onclick now early returns if any of the following keys are held:
* Control: this allows links to be opened in new tabs on windows machines
* Meta (aka Mac command key): this allows   links to be opened in new tabs on macs
* Alt: This allows users to open a link in the save dialog
* Shift: This allows users to open al in a new window

Fixes #2911<!-- replace with issue number or remove if not applicable -->

#### Checklist
- [x] `cargo make test-flow` passes
- [x] `cargo make lint` passes
- [x] I have reviewed my own code
- [x] I have verified that the examples work as intended
- [ ] I have added tests - The onclick function was entirely untested. I am happy to refactor the logic into a stand-alone function and run a test on that. I am also happy to be introduced to a fancy way of testing the on-click browser behaviours 
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
