### PR TITLE
Makes the web worker in the `web_worker_fib` example use a relative path for the web worker

### DIFF
--- a/examples/web_worker_fib/src/agent.rs
+++ b/examples/web_worker_fib/src/agent.rs
@@ -52,4 +52,8 @@ impl yew_agent::Worker for Worker {
     fn name_of_resource() -> &'static str {
         "worker.js"
     }
+
+    fn resource_path_is_relative() -> bool {
+        true
+    }
 }


### PR DESCRIPTION
#### Description
Fixes #3030 <!-- replace with issue number or remove if not applicable -->

The path for the webworker was previously set to be absolute, which was causing the [hosted example page](https://examples.yew.rs/web_worker_fib/) to fail to load it. 

After this change the example worth both when running `trunk serve`, as it did before. 

It is now works if you run `trunk build --public-url web_worker_fib/dist` and then statically host the `./examples` path.
I am conifident this will work, as the [`./ci/build-examples`'s trunk build](https://github.com/yewstack/yew/blob/master/ci/build-examples.sh#L36) uses the public url option

I was unable to get the `./ci/build-examples` to run locally

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->
- [x] `cargo make test-flow` passes
- [x] `cargo make lint` passes
- [x] `cargo fmt` has been ran
- [x] I have reviewed my own code
- [x] I have verified that the examples work as intended when statically hosted 
- [x] I have verified that the examples work as intended when dynamically hosted through trunk
- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
