### PR TITLE
Added Convenience method to Scope<impl BaseComponent>

### DIFF
--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -289,10 +289,7 @@ impl<COMP: BaseComponent> Scope<COMP> {
     }
 }
 
-impl<COMP: BaseComponent> Scope<COMP> 
-where
-    COMP::Message: Clone,
-{
+impl<COMP: BaseComponent> Scope<COMP> {
     /// Creates a `Callback` which will send a message to the linked
     /// component's update method when invoked, AND calls `.prevent_default()`
     /// on the [web_sys::Event] that is passed to the callback. 
@@ -300,9 +297,12 @@ where
     /// This is helpful for making more terse callback definitions for `onclick`
     /// events on `<a>` elements, which alter the URL by default.
     /// 
+    /// If your app scrolls to the top of the page when a link or button with
+    /// a callback is clicked, this will prevent that.
+    /// 
     /// ### Short Example
     /// ```rust,ignore
-    /// let onclick = ctx.link().callback_event( |e| RBMessage::Refresh );
+    /// let onclick = ctx.link().callback_event(|e| RBMessage::Refresh);
     ///
     /// html! {
     ///     <a href="#" {onclick}>{ "Refresh" }</a>
@@ -314,7 +314,6 @@ where
     /// # use web_sys::*;
     /// pub struct RefreshButton;
     /// 
-    /// #[derive(Clone)]
     /// pub enum RBMessage {
     ///     Refresh
     /// }
@@ -338,6 +337,7 @@ where
     ///             }
     ///         }
     ///     }
+    /// 
     ///     fn view<'a>( &self, ctx: &'a Context<Self> ) -> Html {
     ///         let onclick = ctx.link().callback_event( |e| RBMessage::Refresh );
     ///

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -290,14 +290,14 @@ impl<COMP: BaseComponent> Scope<COMP> {
 
     /// Creates a `Callback` which will send a message to the linked
     /// component's update method when invoked, AND calls `.prevent_default()`
-    /// on the [web_sys::Event] that is passed to the callback. 
+    /// on the [web_sys::Event] that is passed to the callback.
     ///
     /// This is helpful for making more terse callback definitions for `onclick`
     /// events on `<a>` elements, which alter the URL by default.
-    /// 
+    ///
     /// If your app scrolls to the top of the page when a link or button with
     /// a callback is clicked, this will prevent that.
-    /// 
+    ///
     /// ### Short Example
     /// ```rust,ignore
     /// let onclick = ctx.link().callback_event(|e| RBMessage::Refresh);
@@ -311,19 +311,19 @@ impl<COMP: BaseComponent> Scope<COMP> {
     /// # use yew::prelude::*;
     /// # use web_sys::*;
     /// pub struct RefreshButton;
-    /// 
+    ///
     /// pub enum RBMessage {
-    ///     Refresh
+    ///     Refresh,
     /// }
-    /// 
+    ///
     /// impl Component for RefreshButton {
     ///     type Message = RBMessage;
     ///     type Properties = ();
-    /// 
+    ///
     ///     fn create(ctx: &Context<Self>) -> Self {
     ///         Self
     ///     }
-    /// 
+    ///
     ///     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
     ///         match msg {
     ///             RBMessage::Refresh => {
@@ -335,9 +335,9 @@ impl<COMP: BaseComponent> Scope<COMP> {
     ///             }
     ///         }
     ///     }
-    /// 
-    ///     fn view<'a>( &self, ctx: &'a Context<Self> ) -> Html {
-    ///         let onclick = ctx.link().callback_event( |e| RBMessage::Refresh );
+    ///
+    ///     fn view<'a>(&self, ctx: &'a Context<Self>) -> Html {
+    ///         let onclick = ctx.link().callback_event(|e| RBMessage::Refresh);
     ///
     ///         html! {
     ///             <a href="#" {onclick}>{ "Refresh" }</a>
@@ -345,13 +345,13 @@ impl<COMP: BaseComponent> Scope<COMP> {
     ///     }
     /// }
     /// ```
-    pub fn callback_event<EVT, F>( &self, function: F ) -> Callback<EVT> 
+    pub fn callback_event<EVT, F>(&self, function: F) -> Callback<EVT>
     where
-        F: Fn( &EVT ) -> COMP::Message + 'static,
-        EVT: Into<web_sys::Event>
+        F: Fn(&EVT) -> COMP::Message + 'static,
+        EVT: Into<web_sys::Event>,
     {
-        self.callback( move | event: EVT | {
-            let msg = function( &event );
+        self.callback(move |event: EVT| {
+            let msg = function(&event);
             let evt: web_sys::Event = event.into();
             evt.prevent_default();
             msg

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -287,9 +287,7 @@ impl<COMP: BaseComponent> Scope<COMP> {
     pub fn send_message_batch(&self, messages: Vec<COMP::Message>) {
         self.arch_send_message_batch(messages)
     }
-}
 
-impl<COMP: BaseComponent> Scope<COMP> {
     /// Creates a `Callback` which will send a message to the linked
     /// component's update method when invoked, AND calls `.prevent_default()`
     /// on the [web_sys::Event] that is passed to the callback. 

--- a/packages/yew/tests/raw_html.rs
+++ b/packages/yew/tests/raw_html.rs
@@ -4,10 +4,11 @@ mod common;
 use wasm_bindgen::JsCast;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;
+#[cfg(feature = "ssr")]
 use yew::prelude::*;
 #[cfg(target_arch = "wasm32")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "ssr", not(target_arch = "wasm32")))]
 use tokio::test;
 
 macro_rules! create_test {
@@ -16,6 +17,7 @@ macro_rules! create_test {
     };
     ($name:ident, $raw:expr, $expected:expr) => {
         #[test]
+        #[cfg(feature = "ssr")]
         async fn $name() {
             #[function_component]
             fn App() -> Html {


### PR DESCRIPTION
#### Description

I added a method called `callback_event( )` to `Scope<impl BaseComponent>`.
It does the same thing as `callback( )`, but with the added benefit of calling `prevent_default()` on the `web_sys::Event` (or a subclass of that) that is passed to the callback. 

I was motivated to add this method after several hours of struggling to figure out why my page scrolled to the top every time an Message was sent. This method prevents that in a predictable way.

If this pull is accepted, I plan to submit another pull request with an update to the website documentation explaining where and why this method is useful, and what problem it addresses.

#### Checklist

- [ x ] I have reviewed my own code
- [ x ] I have added tests
- [ x ] Ran all of the commands in [CONTRIBUTING.md](https://github.com/yewstack/yew/blob/master/CONTRIBUTING.md) 

Thank you for your time.