### PR TITLE
docs: fix markdown link

### DIFF
--- a/website/docs/more/debugging.mdx
+++ b/website/docs/more/debugging.mdx
@@ -43,7 +43,7 @@ fn main() {
 
 ### [`tracing-web`](https://crates.io/crates/tracing-web)
 
-`tracing-web` can be used with [`tracing-subscriber`](https://crates.io/crates/tracing-subscriber to output messages to the browser console.
+`tracing-web` can be used with [`tracing-subscriber`](https://crates.io/crates/tracing-subscriber) to output messages to the browser console.
 
 ```rust, ignore
 use tracing_subscriber::{

--- a/website/versioned_docs/version-0.20/more/debugging.mdx
+++ b/website/versioned_docs/version-0.20/more/debugging.mdx
@@ -43,7 +43,7 @@ fn main() {
 
 ### [`tracing-web`](https://crates.io/crates/tracing-web)
 
-`tracing-web` can be used with [`tracing-subscriber`](https://crates.io/crates/tracing-subscriber to output messages to the browser console.
+`tracing-web` can be used with [`tracing-subscriber`](https://crates.io/crates/tracing-subscriber) to output messages to the browser console.
 
 ```rust, ignore
 use tracing_subscriber::{


### PR DESCRIPTION
#### Description
It was missing the closing parenthesis.

#### Checklist
- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
