### PR TITLE
Prefer pop_first if it is available

### DIFF
--- a/packages/yew/src/scheduler.rs
+++ b/packages/yew/src/scheduler.rs
@@ -46,10 +46,18 @@ impl TopologicalQueue {
     }
 
     /// Take a single entry, preferring parents over children
+    #[rustversion::before(1.66)]
     fn pop_topmost(&mut self) -> Option<QueueEntry> {
-        // To be replaced with BTreeMap::pop_first once it is stable.
+        // BTreeMap::pop_first is available after 1.66.
         let key = *self.inner.keys().next()?;
         self.inner.remove(&key)
+    }
+
+    /// Take a single entry, preferring parents over children
+    #[rustversion::since(1.66)]
+    #[inline]
+    fn pop_topmost(&mut self) -> Option<QueueEntry> {
+        self.inner.pop_first().map(|(_, v)| v)
     }
 
     /// Drain all entries, such that children are queued before parents


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This pull request prefers `BTreeMap::pop_first` if it is available.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
