### PR TITLE
Fix in custom-hooks.mdx

### DIFF
--- a/website/versioned_docs/version-0.20/concepts/function-components/hooks/custom-hooks.mdx
+++ b/website/versioned_docs/version-0.20/concepts/function-components/hooks/custom-hooks.mdx
@@ -40,7 +40,7 @@ instead of copying the code, we can move the logic into a custom hook.
 We'll start by creating a new function called `use_event`.
 The `use_` prefix denotes that a function is a hook.
 This function will take an event target, an event type and a callback.
-All hooks must be marked by `#[hook]` to function as as hook.
+All hooks must be marked by `#[hook]` to function as hook.
 
 ```rust
 use web_sys::{Event, EventTarget};


### PR DESCRIPTION
Removed duplicated `as as`

#### Description

I would like to write my own hook for my project and found out about this typo. Fixed it.

#### Checklist

- [X] I have reviewed my own code
- [ ] I have added tests
