### PR TITLE
Fix typo in html! concept docs

### DIFF
--- a/website/versioned_docs/version-0.20/concepts/basic-web-technologies/html.mdx
+++ b/website/versioned_docs/version-0.20/concepts/basic-web-technologies/html.mdx
@@ -39,7 +39,7 @@ let combined_html: Html = html! {
 };
 ```
 
-One rule major rule comes with use of `html!` - you can only return 1 wrapping node.
+One major rule comes with the use of `html!` - you can only return 1 wrapping node.
 To render a list of multiple elements, `html!` allows fragments. Fragments are tags
 without a name, that produce no html element by themselves.
 


### PR DESCRIPTION
I am learning Yew and noticed this small typo in a sentence in the `html!` concepts docs as I was reading through it, so I thought I'd fix it :)

#### Description

<!-- Please include a summary of the change. -->

Fixes a small typo/improves readability of a sentence in the documentation.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
