### PR TITLE
Draft: `use_ref_state`, `use_ref_state_eq()`

### DIFF
--- a/packages/yew/src/functional/hooks/mod.rs
+++ b/packages/yew/src/functional/hooks/mod.rs
@@ -6,6 +6,7 @@ mod use_memo;
 mod use_prepared_state;
 mod use_reducer;
 mod use_ref;
+mod use_ref_state;
 mod use_state;
 mod use_transitive_state;
 
@@ -17,6 +18,7 @@ pub use use_memo::*;
 pub use use_prepared_state::*;
 pub use use_reducer::*;
 pub use use_ref::*;
+pub use use_ref_state::*;
 pub use use_state::*;
 pub use use_transitive_state::*;
 

--- a/packages/yew/src/functional/hooks/use_ref_state.rs
+++ b/packages/yew/src/functional/hooks/use_ref_state.rs
@@ -1,0 +1,155 @@
+use std::cell::RefCell;
+use std::fmt;
+use std::ops::Deref;
+use std::rc::Rc;
+
+use super::{use_reducer, use_reducer_eq, Reducible, UseReducerDispatcher, UseReducerHandle};
+use crate::functional::hook;
+use crate::use_force_update;
+use crate::UseForceUpdateHandle;
+
+struct UseRefStateReducer<T> {
+    value: Rc<RefCell<T>>,
+}
+
+impl<T> Reducible for UseRefStateReducer<T> {
+    type Action = T;
+
+    fn reduce(self: Rc<Self>, _: Self::Action) -> Rc<Self> {
+        Rc::new(Self {
+            value: self.value.clone(),
+        })
+    }
+}
+
+impl<T> PartialEq for UseRefStateReducer<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, rhs: &Self) -> bool {
+        *(self.value).borrow() == *(rhs.value).borrow()
+    }
+}
+
+#[hook]
+pub fn use_ref_state<T, F>(init_fn: F) -> UseRefStateHandle<T>
+where
+    T: 'static,
+    F: FnOnce() -> T,
+{
+    let update_handle = use_force_update();
+    let inner = use_reducer(move || UseRefStateReducer {
+        value: Rc::new(RefCell::new(init_fn())),
+    });
+
+    UseRefStateHandle {
+        update_handle,
+        inner,
+    }
+}
+
+/// [`use_ref_state`] but only re-renders when `prev_state != next_state`.
+///
+/// This hook requires the state to implement [`PartialEq`].
+#[hook]
+pub fn use_ref_state_eq<T, F>(init_fn: F) -> UseRefStateHandle<T>
+where
+    T: PartialEq + 'static,
+    F: FnOnce() -> T,
+{
+    let update_handle = use_force_update();
+    let inner = use_reducer_eq(move || UseRefStateReducer {
+        value: Rc::new(RefCell::new(init_fn())),
+    });
+
+    UseRefStateHandle {
+        update_handle,
+        inner,
+    }
+}
+
+/// State handle for the [`use_ref_state`] hook.
+pub struct UseRefStateHandle<T> {
+    update_handle: UseForceUpdateHandle,
+    inner: UseReducerHandle<UseRefStateReducer<T>>,
+}
+
+impl<T: fmt::Debug> fmt::Debug for UseRefStateHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UseRefStateHandle")
+            .field("value", &format!("{:?}", *(*self.inner.value).borrow()))
+            .finish()
+    }
+}
+
+impl<T> UseRefStateHandle<T> {
+    /// Mutate the value
+    pub fn mutate<F>(&self, mut mutator: F)
+    where
+        F: FnMut(&mut T),
+    {
+        mutator(&mut (*self.inner.value).borrow_mut());
+        self.update_handle.force_update();
+    }
+}
+
+impl<T> Deref for UseRefStateHandle<T> {
+    type Target = Rc<RefCell<T>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.value
+    }
+}
+
+impl<T> Clone for UseRefStateHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            update_handle: self.update_handle.clone(),
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> PartialEq for UseRefStateHandle<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, rhs: &Self) -> bool {
+        *self.inner == *rhs.inner
+    }
+}
+
+/// Setter handle for [`use_ref_state`] and [`use_ref_state_eq`] hook
+pub struct UseRefStateMutator<T: 'static> {
+    inner: UseReducerDispatcher<UseRefStateReducer<T>>,
+}
+
+impl<T> Clone for UseRefStateMutator<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> fmt::Debug for UseRefStateMutator<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UseRefStateSetter").finish()
+    }
+}
+
+impl<T> PartialEq for UseRefStateMutator<T> {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.inner == rhs.inner
+    }
+}
+
+impl<T> UseRefStateMutator<T> {
+    /// Replaces the value
+    pub fn set(&self, value: T) {
+        self.inner.dispatch(value)
+    }
+}

--- a/packages/yew/src/functional/hooks/use_ref_state.rs
+++ b/packages/yew/src/functional/hooks/use_ref_state.rs
@@ -5,8 +5,7 @@ use std::rc::Rc;
 
 use super::{use_reducer, use_reducer_eq, Reducible, UseReducerDispatcher, UseReducerHandle};
 use crate::functional::hook;
-use crate::use_force_update;
-use crate::UseForceUpdateHandle;
+use crate::{use_force_update, UseForceUpdateHandle};
 
 struct UseRefStateReducer<T> {
     value: Rc<RefCell<T>>,


### PR DESCRIPTION
**This is a draft and one of the first times I've tried to implement something that works functionally. I do want some help with this.**

#### Description

There's a need for a new hook to deal with Rust's *unique* problem of interior mutability. Without a user leveraging a `UseForceUpdateHandle`, there's no way to re-render on a change to an object with interior mutability, e.g. `use_state(Rc::new(RefCell::new(vec![]))) -> UseStateHandle<Rc<RefCell<Vec<f32>>>`.

The current implementations suggest you to create your own `Reducible`, which is a ton of code or `use_force_update()` hooks. Both of those are insufficient, because:
- Reducible components require significant development time and boilerplate. Not ergonomic.
- We should not encourage users to leverage low level force updates.

I'm proposing `use_ref_state`, similar to `use_state`.
Inspired by the backing concepts `RefCell` (Reference types) and `Cell` (Copy types).

The goal would be an API similar to the following:
```rs
let data = use_ref_state(|| Vec<f32>);

// Setting data would be similar to map()
data.mutate(|state: &mut Vec<f32>| state.push(5.0));

// Deref would make this easy
html! {
  data.deref().iter().map(|v| html!(<h1>*v</h2>))
}
```

The features include:
- Easy initialization (no `Rcs`, `RefCells`)
- `Handler.mutate()` takes a mutating closure
- `Deref -> &T`, `DerefMut -> &mut T` are implemented


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
