### PR TITLE
Update examples/README with correct starter templates link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -61,7 +61,7 @@ As an example, check out the TodoMVC example here: <https://examples.yew.rs/todo
 
 ## Next steps
 
-Have a look at Yew's [starter templates](https://yew.rs/docs/getting-started/starter-templates) when starting a project using Yew – they can significantly simplify things.
+Have a look at Yew's [starter templates](https://yew.rs/docs/getting-started/build-a-sample-app#using-a-starter-template) when starting a project using Yew – they can significantly simplify things.
 
 ## Help out
 


### PR DESCRIPTION
I've noticed that https://yew.rs/docs/getting-started/starter-templates doesn't exist anymore.
Assuming that it should now point to https://yew.rs/docs/getting-started/build-a-sample-app#using-a-starter-template