### PR TITLE
Deduplicate suspensions when considering subsequent renders for suspensions

### DIFF
--- a/packages/yew/src/suspense/component.rs
+++ b/packages/yew/src/suspense/component.rs
@@ -87,6 +87,11 @@ mod feat_csr_ssr {
                         return false;
                     }
 
+                    // If a suspension already exists, ignore it.
+                    if self.suspensions.iter().any(|n| n == &m) {
+                        return false;
+                    }
+
                     self.suspensions.push(m);
 
                     true

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -786,3 +786,40 @@ async fn resume_after_unmount() {
     let result = obtain_result();
     assert_eq!(result.as_str(), "<div>Content replacement</div>");
 }
+
+#[wasm_bindgen_test]
+async fn test_duplicate_suspension() {
+    use yew::html::ChildrenProps;
+
+    #[function_component]
+    fn FetchingProvider(_props: &ChildrenProps) -> HtmlResult {
+        use_future(|| async {
+            sleep(Duration::from_secs(10)).await;
+        })?;
+        Ok(Html::default())
+    }
+
+    #[function_component]
+    fn Comp() -> Html {
+        html! {<div>{"hello!"}</div>}
+    }
+
+    #[function_component]
+    fn App() -> Html {
+        let fallback = Html::default();
+        html! {
+           <Suspense {fallback}>
+               <FetchingProvider>
+                   <Home />
+               </FetchingProvider>
+           </Suspense>
+        }
+    }
+
+    yew::Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
+        .render();
+
+    sleep(Duration::from_millis(50)).await;
+    let result = obtain_result();
+    assert_eq!(result.as_str(), "<div>htllo!</div>");
+}

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -800,7 +800,7 @@ async fn test_duplicate_suspension() {
     }
 
     #[function_component]
-    fn Comp() -> Html {
+    fn Child() -> Html {
         html! {<div>{"hello!"}</div>}
     }
 
@@ -810,7 +810,7 @@ async fn test_duplicate_suspension() {
         html! {
            <Suspense {fallback}>
                <FetchingProvider>
-                   <Home />
+                   <Child />
                </FetchingProvider>
            </Suspense>
         }


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Fixes #3083 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
