### PR TITLE
Separate PR and master size collection

### DIFF
--- a/.github/workflows/post-size-cmp.yml
+++ b/.github/workflows/post-size-cmp.yml
@@ -17,14 +17,24 @@ jobs:
         uses: actions/checkout@v2
 
       - if: github.event.workflow_run.event == 'pull_request'
-        name: Download Artifact
+        name: Download Artifact (master)
         uses: Legit-Labs/action-download-artifact@v2
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           workflow: size-cmp.yml
           run_id: ${{ github.event.workflow_run.id }}
-          name: size-cmp-info
-          path: "size-cmp-info/"
+          name: size-cmp-master-info
+          path: "size-cmp-master-info/"
+
+      - if: github.event.workflow_run.event == 'pull_request'
+        name: Download Artifact (PR)
+        uses: Legit-Labs/action-download-artifact@v2
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          workflow: size-cmp.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: size-cmp-pr-info
+          path: "size-cmp-pr-info/"
 
       - name: Make pull request comment
         run: python3 ci/make_example_size_cmt.py

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -13,21 +13,23 @@ on:
 
 jobs:
   size-cmp:
-    name: Compare Size between master and current Pull Request
+    name: Collect ${{ matrix.target }} Size
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["master", "pr"]
 
     steps:
       - name: Checkout master
         uses: actions/checkout@v3
+        if: ${{ matrix.target == 'master' }}
         with:
-          repository: 'yewstack/yew'
+          repository: "yewstack/yew"
           ref: master
-          path: yew-master
 
       - name: Checkout pull request
         uses: actions/checkout@v3
-        with:
-          path: current-pr
+        if: ${{ matrix.target == 'pr' }}
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
@@ -38,42 +40,27 @@ jobs:
 
       - name: Restore Rust cache for master
         uses: Swatinem/rust-cache@v2
-        with:
-          working-directory: yew-master
-          key: master
-
-      - name: Restore Rust cache for current pull request
-        uses: Swatinem/rust-cache@v2
-        with:
-          working-directory: current-pr
-          key: pr
 
       - name: Setup Trunk
         uses: jetli/trunk-action@v0.2.0
         with:
-          version: 'latest'
+          version: "latest"
 
-      - name: Build master examples
+      - name: Build examples
         run: find ./*/index.html | xargs -I '{}' trunk build --release '{}' || exit 0
-        working-directory: yew-master/examples
-        env:
-          RUSTUP_TOOLCHAIN: nightly
-
-      - name: Build pull request examples
-        run: find ./*/index.html | xargs -I '{}' trunk build --release '{}' || exit 0
-        working-directory: current-pr/examples
+        working-directory: examples
         env:
           RUSTUP_TOOLCHAIN: nightly
           RUSTFLAGS: --cfg nightly_yew
 
       - name: Collect size information
-        run: python3 current-pr/ci/collect_sizes.py
+        run: python3 ci/collect_sizes.py
         env:
           ISSUE_NUMBER: ${{ github.event.number }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: size-cmp-info
+          name: size-cmp-${{ matrix.target }}-info
           path: ".SIZE_CMP_INFO"
           retention-days: 1

--- a/ci/collect_sizes.py
+++ b/ci/collect_sizes.py
@@ -32,15 +32,10 @@ def find_example_sizes(parent_dir: Path) -> Dict[str, int]:
 
 
 def main() -> None:
-    master_sizes = find_example_sizes(Path("yew-master"))
-    pr_sizes = find_example_sizes(Path("current-pr"))
-
-    example_names = sorted(set([*master_sizes.keys(), *pr_sizes.keys()]))
-
-    joined_sizes = [(i, [master_sizes.get(i), pr_sizes.get(i)]) for i in example_names]
+    sizes = find_example_sizes(Path.cwd())
 
     size_cmp_info = {
-        "sizes": joined_sizes,
+        "sizes": sizes,
         "issue_number": os.environ["ISSUE_NUMBER"],
     }
 

--- a/ci/make_example_size_cmt.py
+++ b/ci/make_example_size_cmt.py
@@ -35,11 +35,22 @@ def format_diff_size(
 
 
 def main() -> None:
-    with open("size-cmp-info/.SIZE_CMP_INFO") as f:
-        content = json.loads(f.read())
+    with open("size-cmp-pr-info/.SIZE_CMP_INFO") as f:
+        pr_content = json.loads(f.read())
 
-    joined_sizes = content["sizes"]
-    issue_number = content["issue_number"]
+    with open("size-cmp-master-info/.SIZE_CMP_INFO") as f:
+        master_content = json.loads(f.read())
+
+    master_sizes: dict[str, int] = master_content["sizes"]
+    pr_sizes: dict[str, int] = pr_content["sizes"]
+
+    example_names = sorted(set([*master_sizes.keys(), *pr_sizes.keys()]))
+    joined_sizes = [(i, [master_sizes.get(i), pr_sizes.get(i)]) for i in example_names]
+
+    assert pr_content["issue_number"] == master_content["issue_number"], \
+        "Issue number differs between master and pr?"
+
+    issue_number = pr_content["issue_number"]
 
     lines: List[str] = []
     significant_lines: List[str] = []


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This pull request moves PR and master size collection into their own job, this will hopefully make size comparison run faster.

This pull request is not going to work until it is merged.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
