### PR TITLE
Fix spelling in guides

### DIFF
--- a/website/versioned_docs/version-0.18.0/concepts/wasm-bindgen/wasm-bindgen.mdx
+++ b/website/versioned_docs/version-0.18.0/concepts/wasm-bindgen/wasm-bindgen.mdx
@@ -169,7 +169,7 @@ _[`JsCast` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindg
 
 ### [`Closure`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html)
 
-The `Closure` type provides a way to transfer Rust closures to JavaScript, the closures past to
+The `Closure` type provides a way to transfer Rust closures to JavaScript, the closures passed to
 JavaScript must have a `'static` lifetime for soundness reasons.
 
 This type is a "handle" in the sense that whenever it is dropped it will invalidate the JS

--- a/website/versioned_docs/version-0.19.0/concepts/wasm-bindgen/introduction.mdx
+++ b/website/versioned_docs/version-0.19.0/concepts/wasm-bindgen/introduction.mdx
@@ -171,7 +171,7 @@ _[`JsCast` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindg
 
 ### [`Closure`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html)
 
-The `Closure` type provides a way to transfer Rust closures to JavaScript, the closures past to
+The `Closure` type provides a way to transfer Rust closures to JavaScript, the closures passed to
 JavaScript must have a `'static` lifetime for soundness reasons.
 
 This type is a "handle" in the sense that whenever it is dropped it will invalidate the JS

--- a/website/versioned_docs/version-0.19.0/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.19.0/tutorial/index.mdx
@@ -453,7 +453,7 @@ element returned by the `Iterator` with the `{ for ... }` syntax.
 ### Handling state
 
 Remember the `use_state` used earlier? That is a special function, called a "hook". Hooks are used to "hook" into
-lifecycle of a function component and perform actions. You can learn more about this hook, and others
+the lifecycle of a function component and perform actions. You can learn more about this hook, and others
 [here](concepts/function-components/pre-defined-hooks#use_state).
 
 :::note

--- a/website/versioned_docs/version-0.20/concepts/basic-web-technologies/wasm-bindgen.mdx
+++ b/website/versioned_docs/version-0.20/concepts/basic-web-technologies/wasm-bindgen.mdx
@@ -169,7 +169,7 @@ _[`JsCast` documentation](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindg
 
 ### [`Closure`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html)
 
-The `Closure` type provides a way to transfer Rust closures to JavaScript, the closures past to
+The `Closure` type provides a way to transfer Rust closures to JavaScript, the closures passed to
 JavaScript must have a `'static` lifetime for soundness reasons.
 
 This type is a "handle" in the sense that whenever it is dropped it will invalidate the JS

--- a/website/versioned_docs/version-0.20/tutorial/index.mdx
+++ b/website/versioned_docs/version-0.20/tutorial/index.mdx
@@ -464,7 +464,7 @@ element returned by the `Iterator` with a special `{ for ... }` syntax
 ### Handling state
 
 Remember the `use_state` used earlier? That is a special function, called a "hook". Hooks are used to "hook" into
-lifecycle of a function component and perform actions. You can learn more about this hook, and others
+the lifecycle of a function component and perform actions. You can learn more about this hook, and others
 [here](concepts/function-components/hooks/introduction.mdx#pre-defined-hooks).
 
 :::note


### PR DESCRIPTION
These are a few minor mistakes I noticed while going through the tutorial.
