### PR TITLE
Add link to the rust-yew vscode plugin to the yew docs

### DIFF
--- a/website/docs/getting-started/editor-setup.mdx
+++ b/website/docs/getting-started/editor-setup.mdx
@@ -124,11 +124,12 @@ Utilities like Rename, Go to Declaration, Find Usages will work inside the macro
 
 ### VS Code
 
-Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more. 
+Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more.
 
 !!!This is a work in progress project so please [see details, direct related bug reports / issues / questions over to the extension's repository](https://github.com/TechTheAwesome/code-yew-server)!!!
 
 Emmet support should work out of the box, if not please fall back to edditing the `settings.json` file:
+
 ```json
 "emmet.includeLanguages": {
     "rust": "html",

--- a/website/docs/getting-started/editor-setup.mdx
+++ b/website/docs/getting-started/editor-setup.mdx
@@ -124,9 +124,11 @@ Utilities like Rename, Go to Declaration, Find Usages will work inside the macro
 
 ### VS Code
 
-Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more.
+#### Rust-Yew extension
 
-!!!This is a work in progress project so please [see details, direct related bug reports / issues / questions over to the extension's repository](https://github.com/TechTheAwesome/code-yew-server)!!!
+> This is a **work in progress**, and **community maintained** project! [Please see details and direct related bug reports / issues / questions over to the extension's repository](https://github.com/TechTheAwesome/code-yew-server)
+
+Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more.
 
 Emmet support should work out of the box, if not please fall back to edditing the `settings.json` file:
 

--- a/website/docs/getting-started/editor-setup.mdx
+++ b/website/docs/getting-started/editor-setup.mdx
@@ -124,8 +124,11 @@ Utilities like Rename, Go to Declaration, Find Usages will work inside the macro
 
 ### VS Code
 
-There isn't support for the specialized syntax of `html!`. However, the default HTML IntelliSense can be used by adding this to your `settings.json` file:
+Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more. 
 
+!!!This is a work in progress project so please [see details, direct related bug reports / issues / questions over to the extension's repository](https://github.com/TechTheAwesome/code-yew-server)!!!
+
+Emmet support should work out of the box, if not please fall back to edditing the `settings.json` file:
 ```json
 "emmet.includeLanguages": {
     "rust": "html",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -56,7 +56,7 @@ const FEATURES = [
     },
 ]
 
-function Feature(props: { feature: typeof FEATURES[number] }) {
+function Feature(props: { feature: (typeof FEATURES)[number] }) {
     return (
         <div className="card-demo">
             <div className="card">

--- a/website/versioned_docs/version-0.20/getting-started/editor-setup.mdx
+++ b/website/versioned_docs/version-0.20/getting-started/editor-setup.mdx
@@ -124,11 +124,12 @@ Utilities like Rename, Go to Declaration, Find Usages will work inside the macro
 
 ### VS Code
 
-Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more. 
+Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more.
 
 !!!This is a work in progress project so please [see details, direct related bug reports / issues / questions over to the extension's repository](https://github.com/TechTheAwesome/code-yew-server)!!!
 
 Emmet support should work out of the box, if not please fall back to edditing the `settings.json` file:
+
 ```json
 "emmet.includeLanguages": {
     "rust": "html",

--- a/website/versioned_docs/version-0.20/getting-started/editor-setup.mdx
+++ b/website/versioned_docs/version-0.20/getting-started/editor-setup.mdx
@@ -124,9 +124,11 @@ Utilities like Rename, Go to Declaration, Find Usages will work inside the macro
 
 ### VS Code
 
-Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more.
+#### Rust-Yew extension
 
-!!!This is a work in progress project so please [see details, direct related bug reports / issues / questions over to the extension's repository](https://github.com/TechTheAwesome/code-yew-server)!!!
+> This is a **work in progress**, and **community maintained** project! [Please see details and direct related bug reports / issues / questions over to the extension's repository](https://github.com/TechTheAwesome/code-yew-server)
+
+Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more.
 
 Emmet support should work out of the box, if not please fall back to edditing the `settings.json` file:
 

--- a/website/versioned_docs/version-0.20/getting-started/editor-setup.mdx
+++ b/website/versioned_docs/version-0.20/getting-started/editor-setup.mdx
@@ -124,8 +124,11 @@ Utilities like Rename, Go to Declaration, Find Usages will work inside the macro
 
 ### VS Code
 
-There isn't support for the specialized syntax of `html!`. However, the default HTML IntelliSense can be used by adding this to your `settings.json` file:
+Rust-Yew extension is [avaliable on VSC Marketplace](https://marketplace.visualstudio.com/items?itemName=TechTheAwesome.rust-yew), providing syntax highlight, renames, hover, and more. 
 
+!!!This is a work in progress project so please [see details, direct related bug reports / issues / questions over to the extension's repository](https://github.com/TechTheAwesome/code-yew-server)!!!
+
+Emmet support should work out of the box, if not please fall back to edditing the `settings.json` file:
 ```json
 "emmet.includeLanguages": {
     "rust": "html",


### PR DESCRIPTION
#### Description
This PR added links to the Rust Yew extension, providing some `html! macro` feature support,  on VSCode marketplace and github repository; Per @WorldSEnder 's request.
Closes https://github.com/TechTheAwesome/code-yew-server/issues/13

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
