### PR TITLE
Add MathML support + test.

### DIFF
--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -15,6 +15,9 @@ use crate::html::{IntoPropValue, NodeRef};
 /// SVG namespace string used for creating svg elements
 pub const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
 
+/// MathML namespace string used for creating MathML elements
+pub const MATHML_NAMESPACE: &str = "http://www.w3.org/1998/Math/MathML";
+
 /// Default namespace for html elements
 pub const HTML_NAMESPACE: &str = "http://www.w3.org/1999/xhtml";
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->
MathML tags now are assigned the correct namespace, so that the browser can correctly render them. We follow the same procedure already used for SVGs that require a non-default namespace also.

 - Added a unit test to ensure the namespace is correctly applied to child tags.
 - Tested locally (firefox, safari, chrome) that MathML is now correctly rendered.

Fixes #3120 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
