### PR TITLE
Updated tutorial to indicate wasm32 dependencies compatibility

### DIFF
--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -492,6 +492,11 @@ serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen-futures = "0.4"
 ```
 
+:::note
+When choosing dependencies make sure they are `wasm32` compatible!
+Otherwise you won't be able to run your application.
+:::
+
 Update the `Video` struct to derive the `Deserialize` trait:
 
 ```rust ,ignore {1, 3-4}


### PR DESCRIPTION
#### Description
That might be obvious for some, but it took me a few hours to figure out that `sqlx` is actually not `wasm32` compatible. Funny enough, `cargo build` was working just fine, but `trunk serve` was failing with a very misleading error about `openssl`. Maybe one day that small note will save a few hours to someone else