### PR TITLE
Incremental performance improvements to element creation

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -22,7 +22,7 @@ gloo = "0.8"
 indexmap = { version = "1", features = ["std"] }
 js-sys = "0.3"
 slab = "0.4"
-wasm-bindgen = "0.2"
+wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
 yew-macro = { version = "^0.20.0", path = "../yew-macro" }
 thiserror = "1.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
@@ -75,7 +75,7 @@ features = [
   "WheelEvent",
   "Window",
   "HtmlScriptElement",
-  "SubmitEvent"
+  "SubmitEvent",
 ]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
@@ -89,11 +89,7 @@ trybuild = "1"
 
 [dev-dependencies.web-sys]
 version = "0.3"
-features = [
-  "ShadowRootInit",
-  "ShadowRootMode",
-  "HtmlButtonElement"
-]
+features = ["ShadowRootInit", "ShadowRootMode", "HtmlButtonElement"]
 
 [features]
 ssr = ["dep:html-escape", "dep:base64ct", "dep:bincode"]

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -95,7 +95,6 @@ features = ["ShadowRootInit", "ShadowRootMode", "HtmlButtonElement"]
 ssr = ["dep:html-escape", "dep:base64ct", "dep:bincode"]
 csr = []
 hydration = ["csr", "dep:bincode"]
-enable-interning = ["wasm-bindgen/enable-interning"]
 default = []
 
 [package.metadata.docs.rs]

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -22,7 +22,7 @@ gloo = "0.8"
 indexmap = { version = "1", features = ["std"] }
 js-sys = "0.3"
 slab = "0.4"
-wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
+wasm-bindgen = "0.2"
 yew-macro = { version = "^0.20.0", path = "../yew-macro" }
 thiserror = "1.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
@@ -95,6 +95,7 @@ features = ["ShadowRootInit", "ShadowRootMode", "HtmlButtonElement"]
 ssr = ["dep:html-escape", "dep:base64ct", "dep:bincode"]
 csr = []
 hydration = ["csr", "dep:bincode"]
+enable-interning = ["wasm-bindgen/enable-interning"]
 default = []
 
 [package.metadata.docs.rs]

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::ops::Deref;
 
 use indexmap::IndexMap;
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{intern, JsValue};
 use web_sys::{Element, HtmlInputElement as InputElement, HtmlTextAreaElement as TextAreaElement};
 use yew::AttrValue;
 
@@ -163,9 +163,9 @@ impl Attributes {
 
     fn set(el: &Element, key: &str, value: &str, apply_as: ApplyAttributeAs) {
         match apply_as {
-            ApplyAttributeAs::Attribute => {
-                el.set_attribute(key, value).expect("invalid attribute key")
-            }
+            ApplyAttributeAs::Attribute => el
+                .set_attribute(intern(key), value)
+                .expect("invalid attribute key"),
             ApplyAttributeAs::Property => {
                 let key = JsValue::from_str(key);
                 let value = JsValue::from_str(value);
@@ -177,7 +177,7 @@ impl Attributes {
     fn remove(el: &Element, key: &str, apply_as: ApplyAttributeAs) {
         match apply_as {
             ApplyAttributeAs::Attribute => el
-                .remove_attribute(key)
+                .remove_attribute(intern(key))
                 .expect("could not remove attribute"),
             ApplyAttributeAs::Property => {
                 let key = JsValue::from_str(key);

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -164,7 +164,7 @@ impl Attributes {
     fn set(el: &Element, key: &str, value: &str, apply_as: ApplyAttributeAs) {
         match apply_as {
             ApplyAttributeAs::Attribute => el
-                .set_attribute(intern(key), intern(value))
+                .set_attribute(intern(key), value)
                 .expect("invalid attribute key"),
             ApplyAttributeAs::Property => {
                 let key = JsValue::from_str(key);

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -164,7 +164,7 @@ impl Attributes {
     fn set(el: &Element, key: &str, value: &str, apply_as: ApplyAttributeAs) {
         match apply_as {
             ApplyAttributeAs::Attribute => el
-                .set_attribute(intern(key), value)
+                .set_attribute(intern(key), intern(value))
                 .expect("invalid attribute key"),
             ApplyAttributeAs::Property => {
                 let key = JsValue::from_str(key);

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -10,7 +10,7 @@ use std::ops::DerefMut;
 use gloo::utils::document;
 use listeners::ListenerRegistration;
 pub use listeners::Registry;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{intern, JsCast};
 use web_sys::{Element, HtmlTextAreaElement as TextAreaElement};
 
 use super::{BList, BNode, BSubtree, DomSlot, Reconcilable, ReconcileTarget};
@@ -253,7 +253,7 @@ impl VTag {
                 .expect("can't create namespaced element for vtag")
         } else {
             document()
-                .create_element(tag)
+                .create_element(intern(tag))
                 .expect("can't create element for vtag")
         }
     }

--- a/packages/yew/src/dom_bundle/subtree_root.rs
+++ b/packages/yew/src/dom_bundle/subtree_root.rs
@@ -8,7 +8,7 @@ use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use wasm_bindgen::prelude::{wasm_bindgen, Closure};
-use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use wasm_bindgen::{intern, JsCast, UnwrapThrowExt};
 use web_sys::{
     AddEventListenerOptions, Element, Event, EventTarget as HtmlEventTarget, ShadowRoot,
 };
@@ -157,7 +157,7 @@ impl EventListener {
 
         target
             .add_event_listener_with_callback_and_add_event_listener_options(
-                &event_type,
+                intern(&event_type),
                 callback.as_ref().unchecked_ref(),
                 &options,
             )


### PR DESCRIPTION
#### Description

This PR includes a series of incremental improvements to element creation speed. It is a smaller effect than I'd anticipated overall, but measurable for each step. There are two general performance approaches used:
1. Enabling `wasm-bindgen` [string interning](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/fn.intern.html), which reduces the cost of copying frequently-used strings across the WASM-JS boundary
2. Using `element.cloneNode()` instead of `document.createElement()`, which is [significantly faster on the browsers I've tested](https://www.measurethat.net/Benchmarks/Show/265/0/createelement-vs-clonenode). (I implemented this with a very simple O(n) linear search, where n is the number of distinct elements used in an app, as I'm assuming the number of HTML elements used in any app is small enough for hashing the element names and using a HashMap not to be worth it, but I didn't benchmark a HashMap approach.)

Trade-offs: 
- String interning costs a constant amount for each distinct string used, in exchange for faster speed when reusing strings. This means that for applications that involve creating the same elements or setting the same attributes multiple times, it is a net win.
- The node cloning approach adds some significant complexity over the more intuitive `document().create_element()` approach
- Each level of increased runtime speed tends to come with a slight increase in binary size

I've made this in a series of commits with increasing levels of performance, each building on top of the last, so you can decide which, if any, you want to adopt.
- intern element tag names
- intern attribute and event listener names
- intern attribute values
- use cached node cloning instead of element creation 

Here are local results for js-framework-benchmark for each approach:
<img width="466" alt="Screenshot 2023-03-18 at 3 30 55 PM" src="https://user-images.githubusercontent.com/286622/226133858-aafe2196-e708-4384-815a-e83ec9d1013b.png">
<img width="468" alt="Screenshot 2023-03-18 at 3 30 47 PM" src="https://user-images.githubusercontent.com/286622/226133859-2e07ffe3-3ddd-4cc0-9607-1128432ee2d8.png">

I'd note there seems to be an exponential slowdown somewhere with element creation, such that current Yew scores 1.58 on "create 1000 rows" but 2.20 on "create 10,000 rows," and the node cloning approach is 1.41 on "create 1000" and 1.80 on "create 10,000."

I won't be sad if you decide none of this is worth it, given the magnitude of the improvements is not that big. Just wanted to offer it!


#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
