### PR TITLE
Fix div prop name in css.mdx

### DIFF
--- a/website/versioned_docs/version-0.20/concepts/basic-web-technologies/css.mdx
+++ b/website/versioned_docs/version-0.20/concepts/basic-web-technologies/css.mdx
@@ -94,7 +94,7 @@ but you can use it like any other html attribute:
 use yew::{classes, html};
 
 html! {
-  <div styles="color: red;"></div>
+  <div style="color: red;"></div>
 };
 ```
 


### PR DESCRIPTION

#### Description

`styles` is a not existing property in the `div` component. Changed it to `style`

#### Checklist

- [X] I have reviewed my own code
- [ ] I have added tests
