### PR TITLE
todomvc example: Disallow entering empty items

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -45,9 +45,10 @@ impl Component for App {
     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Add(description) => {
+                let description = description.trim();
                 if !description.is_empty() {
                     let entry = Entry {
-                        description: description.trim().to_string(),
+                        description: description.to_string(),
                         completed: false,
                         editing: false,
                     };


### PR DESCRIPTION
#### Description

It was possible to add an empty entry by typing whitespace into the text field.

To reproduce: Click in the input field. Hit space. Press enter. Notice that an empty entry appears, and the rendering is ugly as the height of that entry is smaller.

This PR fixes that by trimming the string *before* we check whether it's empty. So if you hit space and press enter, nothing will be added to the list.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests

No tests as no examples seem to have them.
