### PR TITLE
Fix syntax highlighting for tracing-web documentation

### DIFF
--- a/website/versioned_docs/version-0.20/more/debugging.mdx
+++ b/website/versioned_docs/version-0.20/more/debugging.mdx
@@ -45,7 +45,7 @@ fn main() {
 
 `tracing-web` can be used with [`tracing-subscriber`](https://crates.io/crates/tracing-subscriber) to output messages to the browser console.
 
-```rust, ignore
+```rust ,ignore
 use tracing_subscriber::{
     fmt::{
         format::{FmtSpan, Pretty},


### PR DESCRIPTION
#### Description

Currently, there is no syntax highlighting for [tracing-web](https://yew.rs/docs/more/debugging#tracing-web), but there is syntax highlighting for [gloo-console](https://yew.rs/docs/more/debugging#gloo-console)

Hopefully this MR fixes this.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests

I don't know how to test it, because it already worked on Github, but it didn't work [here](https://yew.rs/docs/more/debugging#gloo-console), and I don't know how to test this.
