### PR TITLE
Fix js-benchmark action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,9 +48,6 @@ jobs:
           cache: "npm"
           cache-dependency-path: js-framework-benchmark/package-lock.json
 
-      - name: Install ts-node
-        run: npm install -g ts-node
-
       - uses: Swatinem/rust-cache@v2
         with:
           working-directory: yew
@@ -119,7 +116,7 @@ jobs:
       - name: transform results to be fit for display benchmark-action/github-action-benchmark@v1
         run: |
           mkdir artifacts/
-          jq -s . js-framework-benchmark/webdriver-ts/results/*.json | cargo run --manifest-path yew/tools/Cargo.toml --release -p process-benchmark-results > artifacts/results.json
+          jq -s . js-framework-benchmark/webdriver-ts/results/*.json | cargo run --release -p process-benchmark-results > artifacts/results.json
           echo "$EVENT_INFO" > artifacts/PR_INFO
         env:
           EVENT_INFO: ${{ toJSON(github.event) }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: js-framework-benchmark/webdriver-ts npm run bench
         working-directory: js-framework-benchmark/webdriver-ts
-        run: xvfb-run npm run tsbench -- --framework keyed/yew keyed/yew-hooks --runner playwright
+        run: xvfb-run npm run bench -- --framework keyed/yew keyed/yew-hooks --runner playwright
 
       - name: transform results to be fit for display benchmark-action/github-action-benchmark@v1
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,8 +49,6 @@ jobs:
           cache-dependency-path: js-framework-benchmark/package-lock.json
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          working-directory: yew
 
       - name: setup js-framework-benchmark
         working-directory: js-framework-benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -116,7 +116,7 @@ jobs:
       - name: transform results to be fit for display benchmark-action/github-action-benchmark@v1
         run: |
           mkdir artifacts/
-          jq -s . js-framework-benchmark/webdriver-ts/results/*.json | cargo run --release -p process-benchmark-results > artifacts/results.json
+          jq -s . js-framework-benchmark/webdriver-ts/results/*.json | cargo run --manifest-path yew/Cargo.toml --release -p process-benchmark-results > artifacts/results.json
           echo "$EVENT_INFO" > artifacts/PR_INFO
         env:
           EVENT_INFO: ${{ toJSON(github.event) }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -111,7 +111,8 @@ jobs:
 
       - name: js-framework-benchmark/webdriver-ts npm run bench
         working-directory: js-framework-benchmark/webdriver-ts
-        run: xvfb-run npm run tsbench -- --framework keyed/yew keyed/yew-hooks --runner playwright
+        shell: bash
+        run: xvfb-run npm run tsbench -- --framework keyed/yew keyed/yew-hooks --runner playwright --headless
 
       - name: transform results to be fit for display benchmark-action/github-action-benchmark@v1
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: js-framework-benchmark/webdriver-ts npm run bench
         working-directory: js-framework-benchmark/webdriver-ts
-        run: xvfb-run npm run tsbench -- --framework keyed/yew keyed/yew-hooks --runner playwright --headless
+        run: xvfb-run npm run tsbench -- --framework keyed/yew keyed/yew-hooks --runner playwright
 
       - name: transform results to be fit for display benchmark-action/github-action-benchmark@v1
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,6 +48,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: js-framework-benchmark/package-lock.json
 
+      - name: Install ts-node
+        run: npm install -g ts-node
+
       - uses: Swatinem/rust-cache@v2
         with:
           working-directory: yew
@@ -111,7 +114,6 @@ jobs:
 
       - name: js-framework-benchmark/webdriver-ts npm run bench
         working-directory: js-framework-benchmark/webdriver-ts
-        shell: bash
         run: xvfb-run npm run tsbench -- --framework keyed/yew keyed/yew-hooks --runner playwright --headless
 
       - name: transform results to be fit for display benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
#### Description

One reason for failing benchmarks seem to be related to the change https://github.com/krausest/js-framework-benchmark/issues/1201 , though i haven't dove deep to figure out details.
But in the end we don't need typescript support when running benchmarks and the proposed solution I think will last us long.

Also fixed how result processing is called.


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
