### PR TITLE
Enable PartialEq for all virtual dom types

### DIFF
--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -25,15 +25,7 @@ pub struct VList {
 
 impl PartialEq for VList {
     fn eq(&self, other: &Self) -> bool {
-        self.key == other.key
-            && match (self.children.as_ref(), other.children.as_ref()) {
-                // We try to use ptr_eq if both are behind Rc,
-                // Somehow VNode is not Eq?
-                (Some(l), Some(r)) if Rc::ptr_eq(l, r) => true,
-                // We fallback to PartialEq if left and right didn't point to the same memory
-                // address.
-                (l, r) => l == r,
-            }
+        self.key == other.key && self.children == other.children
     }
 }
 

--- a/packages/yew/src/virtual_dom/vnode.rs
+++ b/packages/yew/src/virtual_dom/vnode.rs
@@ -12,7 +12,7 @@ use crate::virtual_dom::VRaw;
 use crate::AttrValue;
 
 /// Bind virtual element to a DOM reference.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum VNode {
     /// A bind between `VTag` and `Element`.
     VTag(Box<VTag>),
@@ -171,21 +171,6 @@ impl fmt::Debug for VNode {
             VNode::VPortal(ref vportal) => vportal.fmt(f),
             VNode::VSuspense(ref vsuspense) => vsuspense.fmt(f),
             VNode::VRaw(ref vraw) => write!(f, "VRaw {{ {} }}", vraw.html),
-        }
-    }
-}
-
-impl PartialEq for VNode {
-    fn eq(&self, other: &VNode) -> bool {
-        match (self, other) {
-            (VNode::VTag(a), VNode::VTag(b)) => a == b,
-            (VNode::VText(a), VNode::VText(b)) => a == b,
-            (VNode::VList(a), VNode::VList(b)) => a == b,
-            (VNode::VRef(a), VNode::VRef(b)) => a == b,
-            // TODO: Need to improve PartialEq for VComp before enabling.
-            (VNode::VComp(_), VNode::VComp(_)) => false,
-            (VNode::VRaw(a), VNode::VRaw(b)) => a.html == b.html,
-            _ => false,
         }
     }
 }

--- a/packages/yew/src/virtual_dom/vportal.rs
+++ b/packages/yew/src/virtual_dom/vportal.rs
@@ -4,7 +4,7 @@ use web_sys::{Element, Node};
 
 use super::VNode;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct VPortal {
     /// The element under which the content is inserted.
     pub host: Element,

--- a/packages/yew/src/virtual_dom/vraw.rs
+++ b/packages/yew/src/virtual_dom/vraw.rs
@@ -1,7 +1,7 @@
 use crate::AttrValue;
 
 /// A raw HTML string to be used in VDOM.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VRaw {
     pub html: AttrValue,
 }

--- a/packages/yew/tests/use_context.rs
+++ b/packages/yew/tests/use_context.rs
@@ -240,8 +240,8 @@ async fn use_context_update_works() {
         html! {
             <MyContextProvider context={Rc::new((*ctx).clone())}>
                 <RenderCounter id="test-0">
-                    <ContextOutlet id="test-1"/>
-                    <ContextOutlet id="test-2" {magic}/>
+                    <ContextOutlet id="test-1" />
+                    <ContextOutlet id="test-2" {magic} />
                 </RenderCounter>
             </MyContextProvider>
         }
@@ -254,8 +254,8 @@ async fn use_context_update_works() {
 
     sleep(Duration::ZERO).await;
 
-    // 1 initial render + 3 update steps
-    assert_eq!(obtain_result_by_id("test-0"), "total: 4");
+    // 1 initial render + 1 magic
+    assert_eq!(obtain_result_by_id("test-0"), "total: 2");
 
     // 1 initial + 2 context update
     assert_eq!(


### PR DESCRIPTION
#### Description

This pull request enables partial eq on all virtual dom types, so re-render can be avoided if VNode matches.
Previously, VNode comparison always evaluate to false when VComp is present and this will result in a re-render for any Html that contains a VComp.
This pull request addresses this issue.
This pull request also fixes a regression introduced in #3050 where PartialEq is wrongly evaluated via pointer comparison.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
