### PR TITLE
Fix clippy for Rust 1.69

### DIFF
--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -74,7 +74,7 @@ mod feat_ssr_hydration {
             use std::marker::PhantomData;
             // This suppresses the clippy lint about unused generic.
             // We inline this function
-            // so the function body is copied to its callee and generics get optimised away.
+            // so the function body is copied to its caller and generics get optimised away.
             let _comp_type: PhantomData<T> = PhantomData;
             Self::Component(PhantomData)
         }

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -71,12 +71,12 @@ mod feat_ssr_hydration {
         #[cfg(not(debug_assertions))]
         #[inline(always)]
         pub fn for_component<T: 'static>() -> Self {
+            use std::marker::PhantomData;
             // This suppresses the clippy lint about unused generic.
             // We inline this function
             // so the function body is copied to its callee and generics get optimised away.
-            let _comp_type: std::marker::PhantomData<T> = std::marker::PhantomData;
-            let comp_name = std::marker::PhantomData;
-            Self::Component(comp_name)
+            let _comp_type: PhantomData<T> = PhantomData;
+            Self::Component(PhantomData)
         }
 
         #[cfg(debug_assertions)]

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -68,11 +68,20 @@ mod feat_ssr_hydration {
     }
 
     impl Collectable {
+        #[cfg(not(debug_assertions))]
+        #[inline(always)]
         pub fn for_component<T: 'static>() -> Self {
-            #[cfg(debug_assertions)]
-            let comp_name = std::any::type_name::<T>();
-            #[cfg(not(debug_assertions))]
+            // This suppresses the clippy lint about unused generic.
+            // We inline this function
+            // so the function body is copied to its callee and generics get optimised away.
+            let _comp_type: std::marker::PhantomData<T> = std::marker::PhantomData;
             let comp_name = std::marker::PhantomData;
+            Self::Component(comp_name)
+        }
+
+        #[cfg(debug_assertions)]
+        pub fn for_component<T: 'static>() -> Self {
+            let comp_name = std::any::type_name::<T>();
             Self::Component(comp_name)
         }
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This pull request fixes Clippy for Rust 1.69.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
