### PR TITLE
Add wasm-bindgen-cli dependency to tutorial

### DIFF
--- a/website/docs/tutorial/index.mdx
+++ b/website/docs/tutorial/index.mdx
@@ -43,6 +43,12 @@ We will also need to add the WASM build target by running:
 rustup target add wasm32-unknown-unknown
 ```
 
+The tool `wasm-bindgen-cli` is required by trunk:
+
+```bash
+cargo install wasm-bindgen-cli
+```
+
 ### Setting up the project
 
 First, create a new cargo project:


### PR DESCRIPTION
#### Description

In the tutorial I've added a description on how to install `wasm-bindgen-cli` when setting up the initial environment for yew.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
