### PR TITLE
fix lazy-load of js_callback example

### DIFF
--- a/examples/js_callback/src/bindings.rs
+++ b/examples/js_callback/src/bindings.rs
@@ -1,9 +1,12 @@
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+// https://github.com/rustwasm/wasm-bindgen/issues/3208
+#[wasm_bindgen(inline_js = "export function import2(path) { return import(path); }")]
 extern "C" {
     // this should be in js-sys but is not. see https://github.com/rustwasm/wasm-bindgen/issues/2865
-    pub fn import(s: &str) -> js_sys::Promise;
+    // pub fn import(s: &str) -> js_sys::Promise;
+    #[wasm_bindgen(js_name = "import2")]
+    pub fn import(name: &str) -> js_sys::Promise;
 
     pub type Window;
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

js_callback example's lazy-load is not working because of https://github.com/rustwasm/wasm-bindgen/issues/3208
try to fix this 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
