### PR TITLE
doc: use a more friendly link to codemod tool

### DIFF
--- a/website/docs/migration-guides/yew/from-0_20_0-to-next.mdx
+++ b/website/docs/migration-guides/yew/from-0_20_0-to-next.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem'
 
 ### Automated refactor
 
-With the help of https://crates.io/crates/ast-grep
+With the help of [https://ast-grep.github.io](https://ast-grep.github.io/guide/quick-start.html)
 Here are commands that can do the refactoring for you.
 
 ```bash


### PR DESCRIPTION
#### Description

Hi yew team, I’m the author of the ast-grep, the tool you mentioned in migration guide. 

You have done an amazing job with yew! It is one of the most innovative and impressive Rust web frameworks I have ever seen. I’m thrilled to see that ast-grep could help you. It’s my very design goal to make it easier for OSS teams to manage API changes and code migration and I’m glad you find it useful. Really appreciate your support and trust! 🥰 

I noticed that you are linking to the crates.io page of the ast-grep in your README.md file. While this is a valid link, I would like to suggest changing the link to the official website of [ast-grep](https://ast-grep.github.io/). The official website includes a more detailed description of the tool, as well as installation instructions and usage examples. The crates.io page is more suitable for developers who want to install or depend on ast-grep as a library. It also looks less professional and trustworthy than the official website to the end users. 

I hope this PR will help yew users to migrate the framework with fewer concerns. Thank you for your time and consideration!

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
