### PR TITLE
Omit conditional elements without an `else` branch when present in children

### DIFF
--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -1175,7 +1175,6 @@ mod tests_without_browser {
             },
             html! {
                 <div>
-                    <></>
                 </div>
             },
         );
@@ -1265,7 +1264,7 @@ mod tests_without_browser {
                     }
                 </div>
             },
-            html! { <div><></></div> },
+            html! { <div></div> },
         );
     }
 }

--- a/packages/yew/tests/children.rs
+++ b/packages/yew/tests/children.rs
@@ -1,0 +1,89 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use yew::prelude::*;
+
+#[tokio::test]
+async fn conditional_children_are_omitted() {
+    #[derive(Properties, PartialEq)]
+    pub struct Props {
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    #[function_component]
+    pub fn Problem(p: &Props) -> Html {
+        html! {
+            <div class="container">
+                {
+                    for p.children.iter().enumerate().map(|(i, x)| {
+                        html! {
+                            <div>
+                                <span>{x}</span>
+                                <span>{i}</span>
+                            </div>
+                        }
+                    })
+                }
+            </div>
+        }
+    }
+
+    #[function_component]
+    fn App() -> Html {
+        let b = false;
+        html! {
+            <Problem>
+                <span>{ "A" }</span>
+                <span>{ "B" }</span>
+                if b {
+                    <span>{ "C" }</span>
+                }
+                <span>{ "D" }</span>
+            </Problem>
+        }
+    }
+
+    let mut s = String::new();
+    yew::ServerRenderer::<App>::new()
+        .render_to_string(&mut s)
+        .await;
+
+    assert_eq!(
+        s,
+        "<!--<[children::conditional_children_are_omitted::{{closure}}::App]>--><!\
+         --<[children::conditional_children_are_omitted::{{closure}}::Problem]>--><div \
+         class=\"container\"><div><span><span>A</span></span><span>0</span></\
+         div><div><span><span>B</span></span><span>1</span></div><div><span><span>D</span></\
+         span><span>2</span></div></div><!--</\
+         [children::conditional_children_are_omitted::{{closure}}::Problem]>--><!--</\
+         [children::conditional_children_are_omitted::{{closure}}::App]>-->"
+    );
+}
+
+#[tokio::test]
+async fn conditional_children_are_omitted_in_non_only_single_node_children_case() {
+    #[function_component]
+    fn App() -> Html {
+        let b = true;
+        let a = Some(());
+        let chtml = html! {
+            <div></div>
+        };
+        html! {
+            <>
+                { chtml }
+                if a.is_some() || b { <></> }
+            </>
+        }
+    }
+
+    let mut s = String::new();
+    yew::ServerRenderer::<App>::new()
+        .render_to_string(&mut s)
+        .await;
+
+    assert_eq!(
+        s,
+        "<!--<[children::conditional_children_are_omitted_in_non_only_single_node_children_case::{{closure}}::App]>--><div></div><!--</[children::conditional_children_are_omitted_in_non_only_single_node_children_case::{{closure}}::App]>-->"
+    );
+}


### PR DESCRIPTION
#### Description

This PR proposes a method to address the behavior described in #3256. It only changes the behavior of conditional syntax without an `else` block.

To overcome the nature of the abstraction between `HtmlChildrenTree` and `HtmlIf`, I've added a newtype struct `HtmlIfIterItem` which is used to generate tokens for `HtmlIf` in this context. There is also judicious use of safe-by-inspection `.unwrap()` for calls to `. to_node_iterator_stream()` to avoid code duplication for this trait which returns `Option<_>`. There are likely simpler ways to do both of these things, comments welcome.

I've added a test to assert/illustrate the behavior in question.

Fixes #3256

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests

