### PR TITLE
An experiment macro to automatically derive Properties structs from args for Yew components.

### DIFF
--- a/website/community/awesome.md
+++ b/website/community/awesome.md
@@ -82,6 +82,9 @@ description: 'Community projects built using yew'
 -   [Yew Form](https://github.com/jfbilodeau/yew_form) - Components to simplify handling forms with Yew.
 -   [yew-component-size](https://github.com/AircastDev/yew-component-size) - A Yew component that emits events when the parent component changes width/height.
 -   [yew-virtual-scroller](https://github.com/AircastDev/yew-virtual-scroller) - A Yew component for virtual scrolling / scroll windowing.
+-   [yew-autoprops](https://crates.io/crates/yew-autoprops) - proc-macro to automatically derive Properties structs from args for Yew components.
+
+
 
 ### Hooks
 

--- a/website/community/awesome.md
+++ b/website/community/awesome.md
@@ -84,8 +84,6 @@ description: 'Community projects built using yew'
 -   [yew-virtual-scroller](https://github.com/AircastDev/yew-virtual-scroller) - A Yew component for virtual scrolling / scroll windowing.
 -   [yew-autoprops](https://crates.io/crates/yew-autoprops) - proc-macro to automatically derive Properties structs from args for Yew components.
 
-
-
 ### Hooks
 
 -   [yew-hooks](https://github.com/jetli/yew-hooks) - Custom Hooks library for Yew, inspired by [streamich/react-use](https://github.com/streamich/react-use) and [alibaba/hooks](https://github.com/alibaba/hooks).

--- a/website/docs/concepts/function-components/properties.mdx
+++ b/website/docs/concepts/function-components/properties.mdx
@@ -298,7 +298,7 @@ These include, but are not limited to:
    so you may have to manually force a render. Like all things, it has its place. Use it with caution.
 3. You tell us. Did you run into an edge-case you wish you knew about earlier? Feel free to create an issue
    or PR a fix to this documentation.
-   
+
 ## yew-autoprops
 
 [yew-autoprops](https://crates.io/crates/yew-autoprops) is an experimental package that allows one to create the Props struct on the fly out of the arguments of your function. Might be useful, if the properties struct is never reused.

--- a/website/docs/concepts/function-components/properties.mdx
+++ b/website/docs/concepts/function-components/properties.mdx
@@ -298,3 +298,7 @@ These include, but are not limited to:
    so you may have to manually force a render. Like all things, it has its place. Use it with caution.
 3. You tell us. Did you run into an edge-case you wish you knew about earlier? Feel free to create an issue
    or PR a fix to this documentation.
+   
+## yew-autoprops
+
+[yew-autoprops](https://crates.io/crates/yew-autoprops) is an experimental package that allows one to create the Props struct on the fly out of the arguments of your function. Might be useful, if the properties struct is never reused.


### PR DESCRIPTION
#### Description

I want to propose a macro to automatically derive Properties structs from args for Yew components. This helps avoid defining one-off Props structs:

```rust
#[autoprops_component]
fn CoolComponent(#[prop_or_default] test: &i8, another_arg: &usize) -> Html {
```

It's implemented as a prototype in https://github.com/valyagolev/yew-autoprops . I'm not sure there'd be interest to have this function in the `yew` codebase itself, so I put this together as a library for now. Any proposals on how to proceed further are welcome.

In this PR, I've simply added a couple of links into the docs. I'd appreciate if you agree to add both, or one of them, so that interested users could try out the macro.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [X] I have reviewed my own code
- [X] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
