### PR TITLE
Fix broken edit toggle on examples/function_todomvc

### DIFF
--- a/examples/function_todomvc/src/components/entry.rs
+++ b/examples/function_todomvc/src/components/entry.rs
@@ -48,6 +48,15 @@ pub fn entry(props: &EntryProps) -> Html {
         move |_| onremove.emit(id)
     };
 
+    let onedit = {
+        let onedit = props.onedit.clone();
+        let edit_toggle = edit_toggle.clone();
+        move |value| {
+            edit_toggle.clone().toggle();
+            onedit.emit(value)
+        }
+    };
+
     html! {
         <li {class}>
             <div class="view">
@@ -62,7 +71,7 @@ pub fn entry(props: &EntryProps) -> Html {
                 </label>
                 <button class="destroy" onclick={onremove} />
             </div>
-            <EntryEdit entry={props.entry.clone()} onedit={props.onedit.clone()} editing={is_editing} />
+            <EntryEdit entry={props.entry.clone()} onedit={onedit} editing={is_editing} />
         </li>
     }
 }


### PR DESCRIPTION
#### Description

Fixes broken edit toggle on examples/function_todomvc (#3124)

Adds a wrapper for the `onedit` callback in the `entry` component function so that `edit_toggle`  is toggled when finalizing an edit.

#### Checklist

- [x] I have reviewed my own code
- ~~I have added tests~~ No tests present in the examples
