### PR TITLE
Fix input dynamic text rendered as textarea (#3239)

### DIFF
--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -428,8 +428,9 @@ impl ToTokens for HtmlElement {
                     #[allow(clippy::redundant_clone, unused_braces, clippy::let_and_return)]
                     let mut #vtag = match () {
                         _ if "input".eq_ignore_ascii_case(::std::convert::AsRef::<::std::primitive::str>::as_ref(&#vtag_name)) => {
-                            ::yew::virtual_dom::VTag::__new_textarea(
+                            ::yew::virtual_dom::VTag::__new_input(
                                 #value,
+                                #checked,
                                 #node_ref,
                                 #key,
                                 #attributes,
@@ -465,7 +466,8 @@ impl ToTokens for HtmlElement {
                     // For literal tags this is already done at compile-time.
                     //
                     // check void element
-                    if !::std::matches!(
+                    if ::yew::virtual_dom::VTag::children(&#vtag).is_some() &&
+                       !::std::matches!(
                         ::yew::virtual_dom::VTag::children(&#vtag),
                         ::std::option::Option::Some(::yew::virtual_dom::VNode::VList(ref #void_children)) if ::std::vec::Vec::is_empty(#void_children)
                     ) {

--- a/packages/yew-macro/tests/html_macro/dyn-element-pass.rs
+++ b/packages/yew-macro/tests/html_macro/dyn-element-pass.rs
@@ -60,4 +60,10 @@ fn main() {
             }
         }/>
     };
+
+    let input_tag = "input";
+    let input_dom = ::yew::html! { <@{input_tag} /> };
+    assert!(
+        ::std::matches!(input_dom, ::yew::virtual_dom::VNode::VTag(ref vtag) if vtag.tag() == "input")
+    );
 }


### PR DESCRIPTION
#### Description

"input" dynamic tag was rendered as "textarea"

<!-- Please include a summary of the change. -->

Fixes #3239  <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
