### PR TITLE
added `IntoPropValue` implementation to convert from `Cow`s

### DIFF
--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -435,10 +435,10 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<implici
    |                       required by a bound introduced by this call
    |
    = help: the following implementations were found:
-             <Option<&'a str> as IntoPropValue<Option<String>>>
+             <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
-             <Option<Cow<'a, str>> as IntoPropValue<Option<Rc<str>>>>
-             <Option<Cow<'a, str>> as IntoPropValue<Option<String>>>
+             <Option<Cow<'static, str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
            and $N others
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_clone::unsync::IString>>` is not satisfied
@@ -451,10 +451,10 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_
    |                      required by a bound introduced by this call
    |
    = help: the following implementations were found:
-             <Option<&'a str> as IntoPropValue<Option<String>>>
+             <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
-             <Option<Cow<'a, str>> as IntoPropValue<Option<Rc<str>>>>
-             <Option<Cow<'a, str>> as IntoPropValue<Option<String>>>
+             <Option<Cow<'static, str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
            and $N others
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
@@ -549,10 +549,10 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
    |                         required by a bound introduced by this call
    |
    = help: the following implementations were found:
-             <Option<&'a str> as IntoPropValue<Option<String>>>
+             <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
-             <Option<Cow<'a, str>> as IntoPropValue<Option<Rc<str>>>>
-             <Option<Cow<'a, str>> as IntoPropValue<Option<String>>>
+             <Option<Cow<'static, str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
            and $N others
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -507,7 +507,9 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<implici
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
              <Option<Cow<'static, str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
              <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-           and $N others
+             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<String> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<VChild<T>> as IntoPropValue<Option<ChildrenRenderer<C>>>>
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_clone::unsync::IString>>` is not satisfied
   --> tests/html_macro/element-fail.rs:48:22
@@ -520,7 +522,9 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
              <Option<Cow<'static, str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
              <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-           and $N others
+             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<String> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<VChild<T>> as IntoPropValue<Option<ChildrenRenderer<C>>>>
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
   --> tests/html_macro/element-fail.rs:51:28
@@ -632,7 +636,10 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
              <Option<Cow<'static, str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
              <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-           and $N others
+             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<String> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<VChild<T>> as IntoPropValue<Option<ChildrenRenderer<C>>>>
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
   --> tests/html_macro/element-fail.rs:58:29

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -451,7 +451,7 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_
    |                      required by a bound introduced by this call
    |
    = help: the following implementations were found:
-             <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<&'a str> as IntoPropValue<Option<String>>>
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
              <Option<Cow<'a, str>> as IntoPropValue<Option<Rc<str>>>>
              <Option<Cow<'a, str>> as IntoPropValue<Option<String>>>
@@ -549,7 +549,7 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
    |                         required by a bound introduced by this call
    |
    = help: the following implementations were found:
-             <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<&'a str> as IntoPropValue<Option<String>>>
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
              <Option<Cow<'a, str>> as IntoPropValue<Option<Rc<str>>>>
              <Option<Cow<'a, str>> as IntoPropValue<Option<String>>>

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -435,10 +435,10 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<implici
    |                       required by a bound introduced by this call
    |
    = help: the following implementations were found:
-             <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<&'a str> as IntoPropValue<Option<String>>>
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
-             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<Cow<'a, str>> as IntoPropValue<Option<Rc<str>>>>
+             <Option<Cow<'a, str>> as IntoPropValue<Option<String>>>
            and $N others
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_clone::unsync::IString>>` is not satisfied
@@ -453,8 +453,8 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_
    = help: the following implementations were found:
              <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
-             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<Cow<'a, str>> as IntoPropValue<Option<Rc<str>>>>
+             <Option<Cow<'a, str>> as IntoPropValue<Option<String>>>
            and $N others
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
@@ -551,8 +551,8 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
    = help: the following implementations were found:
              <Option<&'static str> as IntoPropValue<Option<String>>>
              <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
-             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::IString>>>
+             <Option<Cow<'a, str>> as IntoPropValue<Option<Rc<str>>>>
+             <Option<Cow<'a, str>> as IntoPropValue<Option<String>>>
            and $N others
 
 error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`

--- a/packages/yew/src/html/conversion/into_prop_value.rs
+++ b/packages/yew/src/html/conversion/into_prop_value.rs
@@ -155,9 +155,9 @@ impl IntoPropValue<ChildrenRenderer<VNode>> for VText {
 }
 
 macro_rules! impl_into_prop {
-    ($(<$args:tt>)? |$value:ident: $from_ty:ty| -> $to_ty:ty { $conversion:expr }) => {
+    (|$value:ident: $from_ty:ty| -> $to_ty:ty { $conversion:expr }) => {
         // implement V -> T
-        impl $(<$args>)? IntoPropValue<$to_ty> for $from_ty {
+        impl IntoPropValue<$to_ty> for $from_ty {
             #[inline]
             fn into_prop_value(self) -> $to_ty {
                 let $value = self;
@@ -165,7 +165,7 @@ macro_rules! impl_into_prop {
             }
         }
         // implement V -> Option<T>
-        impl $(<$args>)? IntoPropValue<Option<$to_ty>> for $from_ty {
+        impl IntoPropValue<Option<$to_ty>> for $from_ty {
             #[inline]
             fn into_prop_value(self) -> Option<$to_ty> {
                 let $value = self;
@@ -173,7 +173,7 @@ macro_rules! impl_into_prop {
             }
         }
         // implement Option<V> -> Option<T>
-        impl $(<$args>)? IntoPropValue<Option<$to_ty>> for Option<$from_ty> {
+        impl IntoPropValue<Option<$to_ty>> for Option<$from_ty> {
             #[inline]
             fn into_prop_value(self) -> Option<$to_ty> {
                 self.map(IntoPropValue::into_prop_value)
@@ -183,13 +183,11 @@ macro_rules! impl_into_prop {
 }
 
 // implemented with literals in mind
-impl_into_prop!(<'a> |value: &'a str| -> String { value.to_owned() });
+impl_into_prop!(|value: &'static str| -> String { value.to_owned() });
 impl_into_prop!(|value: &'static str| -> AttrValue { AttrValue::Static(value) });
 impl_into_prop!(|value: String| -> AttrValue { AttrValue::Rc(Rc::from(value)) });
 impl_into_prop!(|value: Rc<str>| -> AttrValue { AttrValue::Rc(value) });
 impl_into_prop!(|value: Cow<'static, str>| -> AttrValue { AttrValue::from(value) });
-impl_into_prop!(<'a> |value: Cow<'a, str>| -> String { Cow::into_owned(value) });
-impl_into_prop!(<'a> |value: Cow<'a, str>| -> Rc<str> { Rc::from(value) });
 
 impl<T: ImplicitClone + 'static> IntoPropValue<IArray<T>> for &'static [T] {
     fn into_prop_value(self) -> IArray<T> {
@@ -231,8 +229,6 @@ mod test {
         let _: Option<AttrValue> = "foo".into_prop_value();
         let _: Option<AttrValue> = Rc::<str>::from("foo").into_prop_value();
         let _: Option<AttrValue> = Cow::Borrowed("foo").into_prop_value();
-        let _: String = Cow::Borrowed("foo").into_prop_value();
-        let _: Option<Rc<str>> = Some(Cow::Borrowed("foo")).into_prop_value();
     }
 
     #[test]

--- a/packages/yew/src/html/conversion/into_prop_value.rs
+++ b/packages/yew/src/html/conversion/into_prop_value.rs
@@ -1,4 +1,5 @@
-use std::{borrow::Cow, rc::Rc};
+use std::rc::Rc;
+use std::borrow::Cow;
 
 use implicit_clone::unsync::{IArray, IMap};
 pub use implicit_clone::ImplicitClone;

--- a/packages/yew/src/html/conversion/into_prop_value.rs
+++ b/packages/yew/src/html/conversion/into_prop_value.rs
@@ -1,5 +1,5 @@
-use std::rc::Rc;
 use std::borrow::Cow;
+use std::rc::Rc;
 
 use implicit_clone::unsync::{IArray, IMap};
 pub use implicit_clone::ImplicitClone;


### PR DESCRIPTION
#### Description

- Added implementations for `IntoPropValue` to allow for conversion from `Cow`s
- Turned `impl IntoPropValue<String> for &'static str` into `impl<'a> IntoPropValue<String> for &'a str`, making it more generic

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
