### PR TITLE
Create Dependabot groups for cargo and npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,21 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    groups:
+       cargo-deps:
+          patterns:
+            - "*"
 
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:
       interval: "monthly"
     target-branch: "master"
+    groups:
+       website-deps:
+          patterns:
+            - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
#### Description

Makes use of [dependabot groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) to prevent it from creating too many PRs. There are two groups: NPM dependencies and cargo dependency. There should now be no more than 2 open PRs
#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
