### PR TITLE
Make signature of use_future_with consistent

### DIFF
--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -72,7 +72,7 @@ where
     T: Future<Output = O> + 'static,
     O: 'static,
 {
-    use_future_with_deps(move |_| init_f(), ())
+    use_future_with((), move |_| init_f())
 }
 
 /// Use the result of an async computation with dependencies, suspending while waiting.
@@ -84,7 +84,7 @@ where
 ///
 /// [ready]: std::task::Poll::Ready
 #[hook]
-pub fn use_future_with_deps<F, D, T, O>(f: F, deps: D) -> SuspensionResult<UseFutureHandle<O>>
+pub fn use_future_with<F, D, T, O>(deps: D, f: F) -> SuspensionResult<UseFutureHandle<O>>
 where
     F: FnOnce(Rc<D>) -> T,
     T: Future<Output = O> + 'static,

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -13,7 +13,7 @@ use web_sys::{HtmlElement, HtmlTextAreaElement};
 use yew::platform::spawn_local;
 use yew::platform::time::sleep;
 use yew::prelude::*;
-use yew::suspense::{use_future, use_future_with_deps, Suspension, SuspensionResult};
+use yew::suspense::{use_future, use_future_with, Suspension, SuspensionResult};
 use yew::UseStateHandle;
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -645,13 +645,10 @@ async fn use_suspending_future_with_deps_works() {
 
     #[function_component(Content)]
     fn content(ContentProps { delay_millis }: &ContentProps) -> HtmlResult {
-        let delayed_result = use_future_with_deps(
-            |delay_millis| async move {
-                sleep(Duration::from_millis(*delay_millis)).await;
-                42
-            },
-            *delay_millis,
-        )?;
+        let delayed_result = use_future_with(*delay_millis, |delay_millis| async move {
+            sleep(Duration::from_millis(*delay_millis)).await;
+            42
+        })?;
 
         Ok(html! {
             <div>

--- a/website/docs/migration-guides/yew/from-0_20_0-to-next.mdx
+++ b/website/docs/migration-guides/yew/from-0_20_0-to-next.mdx
@@ -24,6 +24,9 @@ sg --pattern 'use_callback($DEPENDENCIES,,$$$CALLBACK)' --rewrite 'use_callback(
 
 sg --pattern 'use_memo($CALLBACK,$$$DEPENDENCIES)' --rewrite 'use_memo($$$DEPENDENCIES, $CALLBACK)' -l rs -i
 sg --pattern 'use_memo($DEPENDENCIES,,$$$CALLBACK)' --rewrite 'use_memo($DEPENDENCIES,$$$CALLBACK)' -l rs -i
+
+sg --pattern 'use_future_with_deps($CALLBACK,$$$DEPENDENCIES)' --rewrite 'use_effect_with($$$DEPENDENCIES, $CALLBACK)' -l rs -i
+sg --pattern 'use_future_with($DEPENDENCIES,,$$$CALLBACK)' --rewrite 'use_effect_with($DEPENDENCIES,$$$CALLBACK)' -l rs -i
 ```
 
 ### Reasoning


### PR DESCRIPTION
#### Description

Rename `use_future_with_deps` to `use_future_with` and change it's signature to bring it in line with other hooks that dependencies

See #3371 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [-] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
