### PR TITLE
Keep checked attribute for elements without special handling

### DIFF
--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -641,6 +641,9 @@ impl Parse for HtmlElementOpen {
                             if let Some(attr) = props.value.take() {
                                 props.attributes.push(attr);
                             }
+                            if let Some(attr) = props.checked.take() {
+                                props.attributes.push(attr);
+                            }
                         }
                     }
                 }

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -1290,9 +1290,7 @@ mod tests_without_browser {
         match tag {
             VNode::VTag(tag) => {
                 assert_eq!(
-                    tag.attributes
-                        .iter()
-                        .find(|(k, _)| *k == "checked"),
+                    tag.attributes.iter().find(|(k, _)| *k == "checked"),
                     Some(("checked", "true"))
                 );
             }

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -1096,6 +1096,7 @@ mod layout_tests {
 #[cfg(test)]
 mod tests_without_browser {
     use crate::html;
+    use crate::virtual_dom::VNode;
 
     #[test]
     fn html_if_bool() {
@@ -1267,5 +1268,35 @@ mod tests_without_browser {
             },
             html! { <div><></></div> },
         );
+    }
+
+    #[test]
+    fn input_checked_stays_there() {
+        let tag = html! {
+            <input checked={true} />
+        };
+        match tag {
+            VNode::VTag(tag) => {
+                assert_eq!(tag.checked(), Some(true));
+            }
+            _ => unreachable!(),
+        }
+    }
+    #[test]
+    fn non_input_checked_stays_there() {
+        let tag = html! {
+            <my-el checked="true" />
+        };
+        match tag {
+            VNode::VTag(tag) => {
+                assert_eq!(
+                    tag.attributes
+                        .iter()
+                        .find(|(k, _)| *k == "checked"),
+                    Some(("checked", "true"))
+                );
+            }
+            _ => unreachable!(),
+        }
     }
 }


### PR DESCRIPTION
#### Description

Input and textarea elements are handled specially. `html!` macro popped checked attribute for every element but did not return it if the element was one without special handling. This PR fixes that

Fixes #3189 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
