### PR TITLE
Remove compatibility code before 1.64

### DIFF
--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -452,25 +452,9 @@ mod feat_csr_ssr {
             }
         }
 
-        #[rustversion::before(1.63)]
         #[inline]
         pub(super) fn arch_get_component(&self) -> Option<impl Deref<Target = COMP> + '_> {
             self.state.try_borrow().ok().and_then(|state_ref| {
-                state_ref.as_ref()?;
-                Some(Ref::map(state_ref, |state| {
-                    state
-                        .as_ref()
-                        .and_then(|m| m.downcast_comp_ref::<COMP>())
-                        .unwrap()
-                }))
-            })
-        }
-
-        #[rustversion::since(1.63)]
-        #[inline]
-        pub(super) fn arch_get_component(&self) -> Option<impl Deref<Target = COMP> + '_> {
-            self.state.try_borrow().ok().and_then(|state_ref| {
-                // Ref::filter_map is only available since 1.63
                 Ref::filter_map(state_ref, |state| {
                     state.as_ref().and_then(|m| m.downcast_comp_ref::<COMP>())
                 })


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

This pull request removes compatibility code that aimed for versions before 1.64.
Since the MSRV of Yew is now 1.64, these compatibility code are no longer needed.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [N/A] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
