### PR TITLE
Emit a deprecation warning on an encounter of a `String` field when deriving `Properties`

### DIFF
--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -32,6 +32,10 @@ pub struct PropField {
 }
 
 impl PropField {
+    pub fn ty(&self) -> &Type {
+        &self.ty
+    }
+
     /// All required property fields are wrapped in an `Option`
     pub fn is_required(&self) -> bool {
         matches!(self.attr, PropAttr::Required { .. })
@@ -323,6 +327,34 @@ fn is_path_an_option(path: &Path) -> bool {
     is_path_segments_an_option(path.segments.iter().take(3).map(|ps| ps.ident.to_string()))
 }
 
+fn is_path_segments_a_string(path_segments: impl Iterator<Item = String>) -> bool {
+    fn is_string_path_seg(seg_index: usize, path: &str) -> u8 {
+        match (seg_index, path) {
+            (0, "alloc") => 0b001,
+            (0, "std") => 0b001,
+            (0, "String") => 0b111,
+            (1, "string") => 0b010,
+            (2, "String") => 0b100,
+            _ => 0,
+        }
+    }
+
+    path_segments
+        .enumerate()
+        .fold(0, |flags, (i, ps)| flags | is_string_path_seg(i, &ps))
+        == 0b111
+}
+
+/// returns true when the [`Path`] seems like a [`String`] type.
+///
+/// This function considers the following paths as Strings:
+/// - std::string::String
+/// - alloc::string::String
+/// - String
+pub(crate) fn is_path_a_string(path: &Path) -> bool {
+    is_path_segments_a_string(path.segments.iter().map(|ps| ps.ident.to_string()))
+}
+
 impl TryFrom<Field> for PropField {
     type Error = Error;
 
@@ -379,7 +411,7 @@ impl PartialEq for PropField {
 
 #[cfg(test)]
 mod tests {
-    use crate::derive_props::field::is_path_segments_an_option;
+    use crate::derive_props::field::{is_path_segments_a_string, is_path_segments_an_option};
 
     #[test]
     fn all_std_and_core_option_path_seg_return_true() {
@@ -395,6 +427,19 @@ mod tests {
         // why OR instead of XOR
         assert!(is_path_segments_an_option(
             vec!["Option".to_owned(), "Vec".to_owned(), "Option".to_owned()].into_iter()
+        ));
+    }
+
+    #[test]
+    fn all_std_and_alloc_string_seg_return_true() {
+        assert!(is_path_segments_a_string(
+            vec!["alloc".to_owned(), "string".to_owned(), "String".to_owned()].into_iter()
+        ));
+        assert!(is_path_segments_a_string(
+            vec!["std".to_owned(), "string".to_owned(), "String".to_owned()].into_iter()
+        ));
+        assert!(is_path_segments_a_string(
+            vec!["String".to_owned()].into_iter()
         ));
     }
 }

--- a/packages/yew-macro/src/lib.rs
+++ b/packages/yew-macro/src/lib.rs
@@ -105,6 +105,7 @@ fn is_ide_completion() -> bool {
     }
 }
 
+#[proc_macro_error::proc_macro_error]
 #[proc_macro_derive(Properties, attributes(prop_or, prop_or_else, prop_or_default))]
 pub fn derive_props(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DerivePropsInput);


### PR DESCRIPTION
#### Description

Makes the `derive(Properties)` macro emit a warning when encountering a field of type `String` in the struct, which suggests to use `AttrValue` instead.

Adsing this warning raises 2 questions:
- Should it also report using other string types in Rust's standard library as deprecated?
- Should we fix the tests which now raise the new warning or should we leave them as they are for them to be the tests for the new warning?

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
