### PR TITLE
Fix Release 1.72

### DIFF
--- a/packages/yew-macro/tests/html_macro_test.rs
+++ b/packages/yew-macro/tests/html_macro_test.rs
@@ -15,7 +15,7 @@ fn html_macro() {
                 element which can't have any children."
 )]
 fn dynamic_tags_catch_void_elements() {
-    html! {
+    let _ = html! {
         <@{"br"}>
             <span>{ "No children allowed" }</span>
         </@>
@@ -25,7 +25,7 @@ fn dynamic_tags_catch_void_elements() {
 #[test]
 #[should_panic(expected = "a dynamic tag returned a tag name containing non ASCII characters: `❤`")]
 fn dynamic_tags_catch_non_ascii() {
-    html! {
+    let _ = html! {
         <@{"❤"}/>
     };
 }

--- a/packages/yew/src/dom_bundle/btext.rs
+++ b/packages/yew/src/dom_bundle/btext.rs
@@ -156,11 +156,11 @@ mod test {
 
     #[test]
     fn text_as_root() {
-        html! {
+        let _ = html! {
             "Text Node As Root"
         };
 
-        html! {
+        let _ = html! {
             { "Text Node As Root" }
         };
     }

--- a/packages/yew/src/virtual_dom/key.rs
+++ b/packages/yew/src/virtual_dom/key.rs
@@ -82,7 +82,7 @@ mod test {
 
     #[test]
     fn all_key_conversions() {
-        html! {
+        let _ = html! {
             <key="string literal">
                 <img key={"String".to_owned()} />
                 <p key={Rc::<str>::from("rc")}></p>


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

This pull request fixes for Rust Release 1.72.
Rust 1.72 makes `From::from` a must use, which effectively makes `html!` a must use.

I have tried various ways to suppress `unused_must_use` for `html!`.
However, it is not effective. So I added `let _ = ` to tests.


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
