### PR TITLE
fix rust-analyzer non_camel_case_types warning

### DIFF
--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -279,6 +279,7 @@ impl<'a> PropFieldCheck<'a> {
 
         quote! {
             #[doc(hidden)]
+            #[allow(non_camel_case_types)]
             #vis struct #check_struct<How>(::std::marker::PhantomData<How>);
 
             #[automatically_derived]


### PR DESCRIPTION
#### Description

rust-analyzer currently complains with `rust-analyzer(non_camel_case_types)` warnings on all structs annotated with `#[derive(Properites)]`. This appears to have regressed from #2007. This PR resolves the warnings by annotating the generated struct with `#[allow(non_camel_case_types)]`.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests (does not seem applicable)
