### PR TITLE
Updated the docs of `set_event_bubbling`

### DIFF
--- a/packages/yew/src/dom_bundle/subtree_root.rs
+++ b/packages/yew/src/dom_bundle/subtree_root.rs
@@ -286,10 +286,6 @@ static BUBBLE_EVENTS: AtomicBool = AtomicBool::new(true);
 /// Bubbling is enabled by default. Disabling bubbling can lead to substantial improvements in event
 /// handling performance.
 ///
-/// Note that yew uses event delegation and implements internal even bubbling for performance
-/// reasons. Calling `Event.stopPropagation()` or `Event.stopImmediatePropagation()` in the event
-/// handler has no effect.
-///
 /// This function should be called before any component is mounted.
 #[cfg(feature = "csr")]
 pub fn set_event_bubbling(bubble: bool) {


### PR DESCRIPTION

#### Description
Removed a paragraph from the docs of [`set_event_bubbling`](https://docs.rs/yew/0.20.0/yew/events/fn.set_event_bubbling.html) which describes a caveat of the framework which is no longer true



#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
