### PR TITLE
feat: support arrays for Classes/classes!()

### DIFF
--- a/packages/yew-macro/tests/classes_macro/classes-pass.rs
+++ b/packages/yew-macro/tests/classes_macro/classes-pass.rs
@@ -49,6 +49,11 @@ fn compile_pass() {
     // single expression
     ::yew::classes!(::std::vec!["one", "two"]);
 
+    // single array
+    ::yew::classes!(["one", "two"]);
+    // multiple arrays
+    ::yew::classes!(["one"], ["two"]);
+
     // optional classes
     ::yew::classes!(
         ::std::option::Option::Some("one"),
@@ -58,7 +63,7 @@ fn compile_pass() {
     // mixed types
     {
         use ::std::borrow::ToOwned;
-        ::yew::classes!("one".to_owned(), "two", ::std::vec!["three"]);
+        ::yew::classes!("one".to_owned(), "two", ::std::vec!["three"], ["four", "five"]);
     }
 }
 

--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -274,6 +274,12 @@ impl<T: Into<Classes> + Clone> From<&[T]> for Classes {
     }
 }
 
+impl<T: Into<Classes>, const SIZE: usize> From<[T;SIZE]> for Classes {
+    fn from(t: [T;SIZE]) -> Self {
+        t.into_iter().collect()
+    }
+}
+
 impl PartialEq for Classes {
     fn eq(&self, other: &Self) -> bool {
         self.set.len() == other.set.len() && self.set.iter().eq(other.set.iter())

--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -274,8 +274,8 @@ impl<T: Into<Classes> + Clone> From<&[T]> for Classes {
     }
 }
 
-impl<T: Into<Classes>, const SIZE: usize> From<[T;SIZE]> for Classes {
-    fn from(t: [T;SIZE]) -> Self {
+impl<T: Into<Classes>, const SIZE: usize> From<[T; SIZE]> for Classes {
+    fn from(t: [T; SIZE]) -> Self {
         t.into_iter().collect()
     }
 }

--- a/website/docs/concepts/html/classes.mdx
+++ b/website/docs/concepts/html/classes.mdx
@@ -84,10 +84,8 @@ html! {
 ```rust
 use yew::{classes, html};
 
-let my_classes = ["class-1", "class-2"];
-
 html! {
-  <div class={classes!(my_classes.as_ref())}></div>
+  <div class={classes!(["class-1", "class-2"])}></div>
 };
 ```
 


### PR DESCRIPTION
#### support `[Into<Classes>;SIZE]` directly
instead of using `.as_ref()`:
```rust
use yew::{classes, html};

let classes = ["class-1", "class-2"];

html! {
  <div class={classes!(classes.as_ref())}></div>
};
```
now we can do this:
```rust
use yew::{classes, html};

html! {
  <div class={classes!(["class-1", "class-2"])}></div>
};
```


#### Checklist
- [x] I have reviewed my own code
- [x] I have added tests
