### PR TITLE
Documentation changes related to context code snippets

### DIFF
--- a/website/versioned_docs/version-0.20/concepts/contexts.mdx
+++ b/website/versioned_docs/version-0.20/concepts/contexts.mdx
@@ -107,7 +107,7 @@ struct Theme {
 
 #[function_component]
 fn NavButton() -> Html {
-    let theme = use_context::<Theme>();
+    let theme = use_context::<Rc<Theme>>().expect("Context not found");
 
     html! {
         // use theme


### PR DESCRIPTION
The way the documentation demonstrates context usage does not work for me (panics on expect).
Its unclear if this is because im running a BrowserRouter in between the context provider and consumers. Either way, adding the Rc makes it work as expected.

This change just concerns the 0.20 version of the docs.