### PR TITLE
Remove special handing of struct fields of type `Option` in `derive(Properties)`

### DIFF
--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -5,10 +5,7 @@ use proc_macro2::{Ident, Span};
 use quote::{format_ident, quote, quote_spanned};
 use syn::parse::Result;
 use syn::spanned::Spanned;
-use syn::{
-    parse_quote, Attribute, Error, Expr, Field, GenericParam, Generics, Type,
-    Visibility,
-};
+use syn::{parse_quote, Attribute, Error, Expr, Field, GenericParam, Generics, Type, Visibility};
 
 use super::should_preserve_attr;
 use crate::derive_props::generics::push_type_param;

--- a/packages/yew-macro/tests/derive_props/fail.rs
+++ b/packages/yew-macro/tests/derive_props/fail.rs
@@ -36,6 +36,18 @@ mod t3 {
     }
 }
 
+mod t4 {
+    use super::*;
+    #[derive(Clone, Properties, PartialEq)]
+    pub struct Props {
+        value: Option<String>
+    }
+
+    fn required_option_should_be_provided() {
+        ::yew::props!{ Props { } };
+    }
+}
+
 mod t5 {
     use super::*;
     #[derive(Clone, Properties, PartialEq)]

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -1,7 +1,7 @@
 error: unexpected end of input, expected expression
-  --> tests/derive_props/fail.rs:44:19
+  --> tests/derive_props/fail.rs:56:19
    |
-44 |         #[prop_or()]
+56 |         #[prop_or()]
    |                   ^
 
 error: cannot find attribute `props` in this scope
@@ -11,18 +11,18 @@ error: cannot find attribute `props` in this scope
    |           ^^^^^
 
 error[E0425]: cannot find value `foo` in this scope
-   --> tests/derive_props/fail.rs:74:24
+   --> tests/derive_props/fail.rs:86:24
     |
-74  |         #[prop_or_else(foo)]
+86  |         #[prop_or_else(foo)]
     |                        ^^^ not found in this scope
     |
 note: these functions exist but are inaccessible
-   --> tests/derive_props/fail.rs:88:5
+   --> tests/derive_props/fail.rs:100:5
     |
-88  |     fn foo(bar: i32) -> String {
+100 |     fn foo(bar: i32) -> String {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `crate::t9::foo`: not accessible
 ...
-102 |     fn foo() -> i32 {
+114 |     fn foo() -> i32 {
     |     ^^^^^^^^^^^^^^^ `crate::t10::foo`: not accessible
 
 error[E0277]: the trait bound `Value: Default` is not satisfied
@@ -107,10 +107,39 @@ note: required by a bound in `html::component::properties::__macro::PreBuild::<T
    |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `html::component::properties::__macro::PreBuild::<Token, B>::build`
    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0308]: mismatched types
-  --> tests/derive_props/fail.rs:54:19
+error[E0277]: the trait bound `AssertAllProps: HasProp<t4::_Props::value, _>` is not satisfied
+  --> tests/derive_props/fail.rs:47:24
    |
-54 |         #[prop_or(123)]
+47 |         ::yew::props!{ Props { } };
+   |                        ^^^^^ the trait `HasProp<t4::_Props::value, _>` is not implemented for `AssertAllProps`
+   |
+   = help: the following other types implement trait `HasProp<P, How>`:
+             <CheckChildrenPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <CheckContextProviderPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <HasContextProviderPropschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <HasContextProviderPropschildren<B> as HasProp<children, HasContextProviderPropschildren<B>>>
+             <HasContextProviderPropscontext<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <HasContextProviderPropscontext<B> as HasProp<yew::context::_ContextProviderProps::context, HasContextProviderPropscontext<B>>>
+             <suspense::component::CheckSuspensePropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t10::CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+           and $N others
+note: required because of the requirements on the impl of `HasAllProps<t4::Props, (_,)>` for `t4::CheckPropsAll<AssertAllProps>`
+  --> tests/derive_props/fail.rs:41:21
+   |
+41 |     #[derive(Clone, Properties, PartialEq)]
+   |                     ^^^^^^^^^^
+   = note: required because of the requirements on the impl of `AllPropsFor<t4::PropsBuilder, (_,)>` for `AssertAllProps`
+note: required by a bound in `html::component::properties::__macro::PreBuild::<Token, B>::build`
+  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
+   |
+   |             Token: AllPropsFor<B, How>,
+   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `html::component::properties::__macro::PreBuild::<Token, B>::build`
+   = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/derive_props/fail.rs:66:19
+   |
+66 |         #[prop_or(123)]
    |                   ^^^
    |                   |
    |                   expected struct `String`, found integer
@@ -119,15 +148,15 @@ error[E0308]: mismatched types
 note: associated function defined here
 help: try using a conversion method
    |
-54 |         #[prop_or(123.to_string())]
+66 |         #[prop_or(123.to_string())]
    |                      ++++++++++++
-54 |         #[prop_or(123.to_string())]
+66 |         #[prop_or(123.to_string())]
    |                      ++++++++++++
 
 error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
-  --> tests/derive_props/fail.rs:64:24
+  --> tests/derive_props/fail.rs:76:24
    |
-64 |         #[prop_or_else(123)]
+76 |         #[prop_or_else(123)]
    |                        ^^^ expected an `FnOnce<()>` closure, found `{integer}`
    |
    = help: the trait `FnOnce<()>` is not implemented for `{integer}`
@@ -135,20 +164,20 @@ error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
 note: required by a bound in `Option::<T>::unwrap_or_else`
 
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
-  --> tests/derive_props/fail.rs:84:24
-   |
-84 |         #[prop_or_else(foo)]
-   |                        ^^^ expected function that takes 0 arguments
+   --> tests/derive_props/fail.rs:96:24
+    |
+96  |         #[prop_or_else(foo)]
+    |                        ^^^ expected function that takes 0 arguments
 ...
-88 |     fn foo(bar: i32) -> String {
-   |     -------------------------- takes 1 argument
-   |
+100 |     fn foo(bar: i32) -> String {
+    |     -------------------------- takes 1 argument
+    |
 note: required by a bound in `Option::<T>::unwrap_or_else`
 
 error[E0271]: type mismatch resolving `<fn() -> i32 {t10::foo} as FnOnce<()>>::Output == String`
-  --> tests/derive_props/fail.rs:98:24
-   |
-98 |         #[prop_or_else(foo)]
-   |                        ^^^ expected struct `String`, found `i32`
-   |
+   --> tests/derive_props/fail.rs:110:24
+    |
+110 |         #[prop_or_else(foo)]
+    |                        ^^^ expected struct `String`, found `i32`
+    |
 note: required by a bound in `Option::<T>::unwrap_or_else`

--- a/packages/yew-macro/tests/derive_props/pass.rs
+++ b/packages/yew-macro/tests/derive_props/pass.rs
@@ -227,7 +227,7 @@ mod t12 {
     }
 
     fn optional_prop_generics_should_work() {
-        ::yew::props! { Props::<::std::primitive::bool> { } };
+        ::yew::props! { Props::<::std::primitive::bool> { value: ::std::option::Option::Some(true) } };
         ::yew::props! { Props::<::std::primitive::bool> { value: true } };
     }
 }
@@ -254,9 +254,9 @@ mod raw_field_names {
 mod value_into_some_value_in_props {
     #[derive(::std::cmp::PartialEq, ::yew::Properties)]
     struct Props {
-        field1: ::std::option::Option<usize>,
+        required: ::std::option::Option<usize>,
         #[prop_or_default]
-        field2: ::std::option::Option<usize>
+        optional: ::std::option::Option<usize>
     }
 
     #[::yew::function_component]
@@ -266,7 +266,10 @@ mod value_into_some_value_in_props {
 
     #[::yew::function_component]
     fn Main() -> ::yew::html::Html {
-        ::yew::html! { <Inner field1=3 field2=5/> }
+        ::yew::html! {<>
+            <Inner required=3 optional=5/>
+            <Inner required={::std::option::Option::Some(6)}/>
+        </>}
     }
 }
 

--- a/packages/yew-macro/tests/derive_props/pass.rs
+++ b/packages/yew-macro/tests/derive_props/pass.rs
@@ -237,7 +237,25 @@ mod raw_field_names {
         r#true: u32,
         r#pointless_raw_name: u32,
     }
+}
 
+mod value_into_some_value_in_props {
+    #[derive(::std::cmp::PartialEq, ::yew::Properties)]
+    struct Props {
+        field1: ::std::option::Option<usize>,
+        #[prop_or_default]
+        field2: ::std::option::Option<usize>
+    }
+
+    #[::yew::function_component]
+    fn Inner(_props: &Props) -> ::yew::html::Html {
+        ::yew::html!{}
+    }
+
+    #[::yew::function_component]
+    fn Main() -> ::yew::html::Html {
+        ::yew::html! { <Inner field1=3 field2=5/> }
+    }
 }
 
 fn main() {}

--- a/packages/yew-macro/tests/derive_props/pass.rs
+++ b/packages/yew-macro/tests/derive_props/pass.rs
@@ -220,18 +220,6 @@ mod t11 {
     }
 }
 
-mod t12 {
-    #[derive(::std::clone::Clone, ::yew::Properties, ::std::cmp::PartialEq)]
-    pub struct Props<T: ::std::clone::Clone + ::std::cmp::PartialEq> {
-        value: ::std::option::Option<T>,
-    }
-
-    fn optional_prop_generics_should_work() {
-        ::yew::props! { Props::<::std::primitive::bool> { } };
-        ::yew::props! { Props::<::std::primitive::bool> { value: true } };
-    }
-}
-
 #[deny(non_snake_case, dead_code)]
 mod t13 {
     #[derive(::std::cmp::PartialEq, ::yew::Properties)]

--- a/packages/yew-macro/tests/derive_props/pass.rs
+++ b/packages/yew-macro/tests/derive_props/pass.rs
@@ -220,6 +220,18 @@ mod t11 {
     }
 }
 
+mod t12 {
+    #[derive(::std::clone::Clone, ::yew::Properties, ::std::cmp::PartialEq)]
+    pub struct Props<T: ::std::clone::Clone + ::std::cmp::PartialEq> {
+        value: ::std::option::Option<T>,
+    }
+
+    fn optional_prop_generics_should_work() {
+        ::yew::props! { Props::<::std::primitive::bool> { } };
+        ::yew::props! { Props::<::std::primitive::bool> { value: true } };
+    }
+}
+
 #[deny(non_snake_case, dead_code)]
 mod t13 {
     #[derive(::std::cmp::PartialEq, ::yew::Properties)]

--- a/packages/yew/src/suspense/component.rs
+++ b/packages/yew/src/suspense/component.rs
@@ -25,6 +25,7 @@ mod feat_csr_ssr {
     #[derive(Properties, PartialEq, Debug, Clone)]
     pub(crate) struct BaseSuspenseProps {
         pub children: Html,
+        #[prop_or(None)]
         pub fallback: Option<Html>,
     }
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Fixes #3395

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests (not sure if a new test is needed after removing a feature)
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
