### PR TITLE
Remove unneded package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "yew",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
#### Description

Remove unneded package-lock.json. It was added in 954b0ec7b92b2a34b5d45d14e4837d87092e40b7

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
