### PR TITLE
Add CallbackRef that takes ref in argument instead of value

### DIFF
--- a/packages/yew/src/callback.rs
+++ b/packages/yew/src/callback.rs
@@ -186,7 +186,7 @@ pub struct CallbackRef<IN, OUT = ()> {
     pub(crate) cb: Rc<dyn Fn(&IN) -> OUT>,
 }
 
-generate_callback_impls!(CallbackRef, &IN, output => &output);
+generate_callback_impls!(CallbackRef, &IN, output => #[allow(clippy::needless_borrow)] &output);
 
 /// Universal callback wrapper with mutable reference in argument.
 ///

--- a/packages/yew/src/callback.rs
+++ b/packages/yew/src/callback.rs
@@ -9,14 +9,6 @@ use std::rc::Rc;
 
 use crate::html::ImplicitClone;
 
-/// Universal callback wrapper.
-///
-/// An `Rc` wrapper is used to make it cloneable.
-pub struct Callback<IN, OUT = ()> {
-    /// A callback which can be called multiple times
-    pub(crate) cb: Rc<dyn Fn(IN) -> OUT>,
-}
-
 macro_rules! generate_callback_impls {
     ($callback:ident, $in_ty:ty, $out_var:ident => $out_val:expr) => {
         impl<IN, OUT, F: Fn($in_ty) -> OUT + 'static> From<F> for $callback<IN, OUT> {
@@ -69,7 +61,8 @@ macro_rules! generate_callback_impls {
         }
 
         impl<IN: 'static, OUT: 'static> $callback<IN, OUT> {
-            /// Creates a new callback from another callback and a function
+            /// Creates a new [`Callback`] from another callback and a function.
+            ///
             /// That when emitted will call that function and will emit the original callback
             pub fn reform<F, T>(&self, func: F) -> Callback<T, OUT>
             where
@@ -84,12 +77,11 @@ macro_rules! generate_callback_impls {
                 func.into()
             }
 
-            /// Creates a new callback from another callback and a function
+            /// Creates a new [`CallbackRef`] from another callback and a function.
+            ///
             /// That when emitted will call that function and will emit the original callback
             pub fn reform_ref<F, T>(&self, func: F) -> CallbackRef<T, OUT>
             where
-                // NOTE: here we return a CallbackRef so there is actually nothing special about it
-                //       it's just a convenient function
                 F: Fn(&T) -> $in_ty + 'static,
             {
                 let this = self.clone();
@@ -101,7 +93,8 @@ macro_rules! generate_callback_impls {
                 func.into()
             }
 
-            /// Creates a new callback from another callback and a function
+            /// Creates a new [`CallbackRefMut`] from another callback and a function.
+            ///
             /// That when emitted will call that function and will emit the original callback
             pub fn reform_ref_mut<F, T>(&self, func: F) -> CallbackRefMut<T, OUT>
             where
@@ -116,7 +109,8 @@ macro_rules! generate_callback_impls {
                 func.into()
             }
 
-            /// Creates a new callback from another callback and a function.
+            /// Creates a new [`Callback`] from another callback and a function.
+            ///
             /// When emitted will call the function and, only if it returns `Some(value)`, will emit
             /// `value` to the original callback.
             pub fn filter_reform<F, T>(&self, func: F) -> Callback<T, Option<OUT>>
@@ -133,7 +127,8 @@ macro_rules! generate_callback_impls {
                 func.into()
             }
 
-            /// Creates a new callback from another callback and a function.
+            /// Creates a new [`CallbackRef`] from another callback and a function.
+            ///
             /// When emitted will call the function and, only if it returns `Some(value)`, will emit
             /// `value` to the original callback.
             pub fn filter_reform_ref<F, T>(&self, func: F) -> CallbackRef<T, Option<OUT>>
@@ -150,7 +145,8 @@ macro_rules! generate_callback_impls {
                 func.into()
             }
 
-            /// Creates a new callback from another callback and a function.
+            /// Creates a new [`CallbackRefMut`] from another callback and a function.
+            ///
             /// When emitted will call the function and, only if it returns `Some(value)`, will emit
             /// `value` to the original callback.
             pub fn filter_reform_ref_mut<F, T>(&self, func: F) -> CallbackRefMut<T, Option<OUT>>
@@ -170,6 +166,14 @@ macro_rules! generate_callback_impls {
 
         impl<IN, OUT> ImplicitClone for $callback<IN, OUT> {}
     };
+}
+
+/// Universal callback wrapper.
+///
+/// An `Rc` wrapper is used to make it cloneable.
+pub struct Callback<IN, OUT = ()> {
+    /// A callback which can be called multiple times
+    pub(crate) cb: Rc<dyn Fn(IN) -> OUT>,
 }
 
 generate_callback_impls!(Callback, IN, output => output);

--- a/packages/yew/src/callback.rs
+++ b/packages/yew/src/callback.rs
@@ -96,6 +96,186 @@ impl<IN: 'static, OUT: 'static> Callback<IN, OUT> {
 
 impl<IN, OUT> ImplicitClone for Callback<IN, OUT> {}
 
+/// Universal callback wrapper with reference in argument.
+///
+/// An `Rc` wrapper is used to make it cloneable.
+pub struct CallbackRef<IN, OUT = ()> {
+    /// A callback which can be called multiple times
+    pub(crate) cb: Rc<dyn Fn(&IN) -> OUT>,
+}
+
+impl<IN, OUT, F: Fn(&IN) -> OUT + 'static> From<F> for CallbackRef<IN, OUT> {
+    fn from(func: F) -> Self {
+        CallbackRef { cb: Rc::new(func) }
+    }
+}
+
+impl<IN, OUT> Clone for CallbackRef<IN, OUT> {
+    fn clone(&self) -> Self {
+        Self {
+            cb: self.cb.clone(),
+        }
+    }
+}
+
+#[allow(clippy::vtable_address_comparisons)]
+impl<IN, OUT> PartialEq for CallbackRef<IN, OUT> {
+    fn eq(&self, other: &CallbackRef<IN, OUT>) -> bool {
+        let (CallbackRef { cb }, CallbackRef { cb: rhs_cb }) = (self, other);
+        Rc::ptr_eq(cb, rhs_cb)
+    }
+}
+
+impl<IN, OUT> fmt::Debug for CallbackRef<IN, OUT> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CallbackRef<_>")
+    }
+}
+
+impl<IN, OUT> CallbackRef<IN, OUT> {
+    /// This method calls the callback's function.
+    pub fn emit(&self, value: &IN) -> OUT {
+        (*self.cb)(value)
+    }
+}
+
+impl<IN> CallbackRef<IN> {
+    /// Creates a "no-op" callback which can be used when it is not suitable to use an
+    /// `Option<CallbackRef>`.
+    pub fn noop() -> Self {
+        Self::from(|_: &_| ())
+    }
+}
+
+impl<IN> Default for CallbackRef<IN> {
+    fn default() -> Self {
+        Self::noop()
+    }
+}
+
+// TODO lifetimes ^_^'
+/*
+impl<IN: 'static, OUT: 'static> CallbackRef<IN, OUT> {
+    /// Creates a new callback from another callback and a function
+    /// That when emitted will call that function and will emit the original callback
+    pub fn reform<F, T>(&self, func: F) -> CallbackRef<T, OUT>
+    where
+        F: Fn(T) -> IN + 'static,
+    {
+        let this = self.clone();
+        let func = move |input| {
+            let output = func(input);
+            this.emit(output)
+        };
+        CallbackRef::from(func)
+    }
+
+    /// Creates a new callback from another callback and a function.
+    /// When emitted will call the function and, only if it returns `Some(value)`, will emit
+    /// `value` to the original callback.
+    pub fn filter_reform<F, T>(&self, func: F) -> CallbackRef<T, Option<OUT>>
+    where
+        F: Fn(T) -> Option<IN> + 'static,
+    {
+        let this = self.clone();
+        let func = move |input| func(input).map(|output| this.emit(output));
+        CallbackRef::from(func)
+    }
+}
+*/
+
+impl<IN, OUT> ImplicitClone for CallbackRef<IN, OUT> {}
+
+/// Universal callback wrapper with mutable reference in argument.
+///
+/// An `Rc` wrapper is used to make it cloneable.
+pub struct CallbackRefMut<IN, OUT = ()> {
+    /// A callback which can be called multiple times
+    pub(crate) cb: Rc<dyn Fn(&mut IN) -> OUT>,
+}
+
+impl<IN, OUT, F: Fn(&mut IN) -> OUT + 'static> From<F> for CallbackRefMut<IN, OUT> {
+    fn from(func: F) -> Self {
+        CallbackRefMut { cb: Rc::new(func) }
+    }
+}
+
+impl<IN, OUT> Clone for CallbackRefMut<IN, OUT> {
+    fn clone(&self) -> Self {
+        Self {
+            cb: self.cb.clone(),
+        }
+    }
+}
+
+#[allow(clippy::vtable_address_comparisons)]
+impl<IN, OUT> PartialEq for CallbackRefMut<IN, OUT> {
+    fn eq(&self, other: &CallbackRefMut<IN, OUT>) -> bool {
+        let (CallbackRefMut { cb }, CallbackRefMut { cb: rhs_cb }) = (self, other);
+        Rc::ptr_eq(cb, rhs_cb)
+    }
+}
+
+impl<IN, OUT> fmt::Debug for CallbackRefMut<IN, OUT> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CallbackRefMut<_>")
+    }
+}
+
+impl<IN, OUT> CallbackRefMut<IN, OUT> {
+    /// This method calls the callback's function.
+    pub fn emit(&self, value: &mut IN) -> OUT {
+        (*self.cb)(value)
+    }
+}
+
+impl<IN> CallbackRefMut<IN> {
+    /// Creates a "no-op" callback which can be used when it is not suitable to use an
+    /// `Option<CallbackRefMut>`.
+    pub fn noop() -> Self {
+        Self::from(|_: &mut _| ())
+    }
+}
+
+impl<IN> Default for CallbackRefMut<IN> {
+    fn default() -> Self {
+        Self::noop()
+    }
+}
+
+// TODO lifetimes ^_^'
+/*
+impl<IN: 'static, OUT: 'static> CallbackRefMut<IN, OUT> {
+    /// Creates a new callback from another callback and a function
+    /// That when emitted will call that function and will emit the original callback
+    pub fn reform<F, T>(&self, func: F) -> CallbackRefMut<T, OUT>
+    where
+        F: Fn(T) -> IN + 'static,
+    {
+        let this = self.clone();
+        let func = move |input| {
+            let output = func(input);
+            this.emit(output)
+        };
+        CallbackRefMut::from(func)
+    }
+
+    /// Creates a new callback from another callback and a function.
+    /// When emitted will call the function and, only if it returns `Some(value)`, will emit
+    /// `value` to the original callback.
+    pub fn filter_reform<F, T>(&self, func: F) -> CallbackRefMut<T, Option<OUT>>
+    where
+        F: Fn(T) -> Option<IN> + 'static,
+    {
+        let this = self.clone();
+        let func = move |input| func(input).map(|output| this.emit(output));
+        CallbackRefMut::from(func)
+    }
+}
+*/
+
+impl<IN, OUT> ImplicitClone for CallbackRefMut<IN, OUT> {}
+
 #[cfg(test)]
 mod test {
     use std::sync::Mutex;

--- a/packages/yew/src/callback.rs
+++ b/packages/yew/src/callback.rs
@@ -153,17 +153,15 @@ impl<IN> Default for CallbackRef<IN> {
     }
 }
 
-// TODO lifetimes ^_^'
-/*
 impl<IN: 'static, OUT: 'static> CallbackRef<IN, OUT> {
     /// Creates a new callback from another callback and a function
     /// That when emitted will call that function and will emit the original callback
     pub fn reform<F, T>(&self, func: F) -> CallbackRef<T, OUT>
     where
-        F: Fn(T) -> IN + 'static,
+        F: Fn(&T) -> &IN + 'static,
     {
         let this = self.clone();
-        let func = move |input| {
+        let func = move |input: &_| {
             let output = func(input);
             this.emit(output)
         };
@@ -175,14 +173,13 @@ impl<IN: 'static, OUT: 'static> CallbackRef<IN, OUT> {
     /// `value` to the original callback.
     pub fn filter_reform<F, T>(&self, func: F) -> CallbackRef<T, Option<OUT>>
     where
-        F: Fn(T) -> Option<IN> + 'static,
+        F: Fn(&T) -> Option<&IN> + 'static,
     {
         let this = self.clone();
-        let func = move |input| func(input).map(|output| this.emit(output));
+        let func = move |input: &_| func(input).map(|output| this.emit(output));
         CallbackRef::from(func)
     }
 }
-*/
 
 impl<IN, OUT> ImplicitClone for CallbackRef<IN, OUT> {}
 
@@ -243,17 +240,15 @@ impl<IN> Default for CallbackRefMut<IN> {
     }
 }
 
-// TODO lifetimes ^_^'
-/*
 impl<IN: 'static, OUT: 'static> CallbackRefMut<IN, OUT> {
     /// Creates a new callback from another callback and a function
     /// That when emitted will call that function and will emit the original callback
     pub fn reform<F, T>(&self, func: F) -> CallbackRefMut<T, OUT>
     where
-        F: Fn(T) -> IN + 'static,
+        F: Fn(&mut T) -> &mut IN + 'static,
     {
         let this = self.clone();
-        let func = move |input| {
+        let func = move |input: &mut _| {
             let output = func(input);
             this.emit(output)
         };
@@ -265,14 +260,13 @@ impl<IN: 'static, OUT: 'static> CallbackRefMut<IN, OUT> {
     /// `value` to the original callback.
     pub fn filter_reform<F, T>(&self, func: F) -> CallbackRefMut<T, Option<OUT>>
     where
-        F: Fn(T) -> Option<IN> + 'static,
+        F: Fn(&mut T) -> Option<&mut IN> + 'static,
     {
         let this = self.clone();
-        let func = move |input| func(input).map(|output| this.emit(output));
+        let func = move |input: &mut _| func(input).map(|output| this.emit(output));
         CallbackRefMut::from(func)
     }
 }
-*/
 
 impl<IN, OUT> ImplicitClone for CallbackRefMut<IN, OUT> {}
 

--- a/packages/yew/src/callback.rs
+++ b/packages/yew/src/callback.rs
@@ -17,100 +17,162 @@ pub struct Callback<IN, OUT = ()> {
     pub(crate) cb: Rc<dyn Fn(IN) -> OUT>,
 }
 
-impl<IN, OUT, F: Fn(IN) -> OUT + 'static> From<F> for Callback<IN, OUT> {
-    fn from(func: F) -> Self {
-        Callback { cb: Rc::new(func) }
-    }
-}
-
-impl<IN, OUT> Clone for Callback<IN, OUT> {
-    fn clone(&self) -> Self {
-        Self {
-            cb: self.cb.clone(),
+macro_rules! generate_callback_impls {
+    ($callback:ident, $in_ty:ty, $out_var:ident => $out_val:expr) => {
+        impl<IN, OUT, F: Fn($in_ty) -> OUT + 'static> From<F> for $callback<IN, OUT> {
+            fn from(func: F) -> Self {
+                $callback { cb: Rc::new(func) }
+            }
         }
-    }
+
+        impl<IN, OUT> Clone for $callback<IN, OUT> {
+            fn clone(&self) -> Self {
+                Self {
+                    cb: self.cb.clone(),
+                }
+            }
+        }
+
+        #[allow(clippy::vtable_address_comparisons)]
+        impl<IN, OUT> PartialEq for $callback<IN, OUT> {
+            fn eq(&self, other: &$callback<IN, OUT>) -> bool {
+                let ($callback { cb }, $callback { cb: rhs_cb }) = (self, other);
+                Rc::ptr_eq(cb, rhs_cb)
+            }
+        }
+
+        impl<IN, OUT> fmt::Debug for $callback<IN, OUT> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "$callback<_>")
+            }
+        }
+
+        impl<IN, OUT> $callback<IN, OUT> {
+            /// This method calls the callback's function.
+            pub fn emit(&self, value: $in_ty) -> OUT {
+                (*self.cb)(value)
+            }
+        }
+
+        impl<IN> $callback<IN> {
+            /// Creates a "no-op" callback which can be used when it is not suitable to use an
+            /// `Option<$callback>`.
+            pub fn noop() -> Self {
+                Self::from(|_: $in_ty| ())
+            }
+        }
+
+        impl<IN> Default for $callback<IN> {
+            fn default() -> Self {
+                Self::noop()
+            }
+        }
+
+        impl<IN: 'static, OUT: 'static> $callback<IN, OUT> {
+            /// Creates a new callback from another callback and a function
+            /// That when emitted will call that function and will emit the original callback
+            pub fn reform<F, T>(&self, func: F) -> Callback<T, OUT>
+            where
+                F: Fn(T) -> IN + 'static,
+            {
+                let this = self.clone();
+                let func = move |input: T| {
+                    #[allow(unused_mut)]
+                    let mut $out_var = func(input);
+                    this.emit($out_val)
+                };
+                func.into()
+            }
+
+            /// Creates a new callback from another callback and a function
+            /// That when emitted will call that function and will emit the original callback
+            pub fn reform_ref<F, T>(&self, func: F) -> CallbackRef<T, OUT>
+            where
+                // NOTE: here we return a CallbackRef so there is actually nothing special about it
+                //       it's just a convenient function
+                F: Fn(&T) -> IN + 'static,
+            {
+                let this = self.clone();
+                let func = move |input: &T| {
+                    #[allow(unused_mut)]
+                    let mut $out_var = func(input);
+                    this.emit($out_val)
+                };
+                func.into()
+            }
+
+            /// Creates a new callback from another callback and a function
+            /// That when emitted will call that function and will emit the original callback
+            pub fn reform_ref_mut<F, T>(&self, func: F) -> CallbackRefMut<T, OUT>
+            where
+                F: Fn(&mut T) -> IN + 'static,
+            {
+                let this = self.clone();
+                let func = move |input: &mut T| {
+                    #[allow(unused_mut)]
+                    let mut $out_var = func(input);
+                    this.emit($out_val)
+                };
+                func.into()
+            }
+
+            /// Creates a new callback from another callback and a function.
+            /// When emitted will call the function and, only if it returns `Some(value)`, will emit
+            /// `value` to the original callback.
+            pub fn filter_reform<F, T>(&self, func: F) -> Callback<T, Option<OUT>>
+            where
+                F: Fn(T) -> Option<IN> + 'static,
+            {
+                let this = self.clone();
+                let func = move |input: T| {
+                    func(input).map(
+                        #[allow(unused_mut)]
+                        |mut $out_var| this.emit($out_val),
+                    )
+                };
+                func.into()
+            }
+
+            /// Creates a new callback from another callback and a function.
+            /// When emitted will call the function and, only if it returns `Some(value)`, will emit
+            /// `value` to the original callback.
+            pub fn filter_reform_ref<F, T>(&self, func: F) -> CallbackRef<T, Option<OUT>>
+            where
+                F: Fn(&T) -> Option<IN> + 'static,
+            {
+                let this = self.clone();
+                let func = move |input: &T| {
+                    func(input).map(
+                        #[allow(unused_mut)]
+                        |mut $out_var| this.emit($out_val),
+                    )
+                };
+                func.into()
+            }
+
+            /// Creates a new callback from another callback and a function.
+            /// When emitted will call the function and, only if it returns `Some(value)`, will emit
+            /// `value` to the original callback.
+            pub fn filter_reform_ref_mut<F, T>(&self, func: F) -> CallbackRefMut<T, Option<OUT>>
+            where
+                F: Fn(&mut T) -> Option<IN> + 'static,
+            {
+                let this = self.clone();
+                let func = move |input: &mut T| {
+                    func(input).map(
+                        #[allow(unused_mut)]
+                        |mut $out_var| this.emit($out_val),
+                    )
+                };
+                func.into()
+            }
+        }
+
+        impl<IN, OUT> ImplicitClone for $callback<IN, OUT> {}
+    };
 }
 
-#[allow(clippy::vtable_address_comparisons)]
-impl<IN, OUT> PartialEq for Callback<IN, OUT> {
-    fn eq(&self, other: &Callback<IN, OUT>) -> bool {
-        let (Callback { cb }, Callback { cb: rhs_cb }) = (self, other);
-        Rc::ptr_eq(cb, rhs_cb)
-    }
-}
-
-impl<IN, OUT> fmt::Debug for Callback<IN, OUT> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Callback<_>")
-    }
-}
-
-impl<IN, OUT> Callback<IN, OUT> {
-    /// This method calls the callback's function.
-    pub fn emit(&self, value: IN) -> OUT {
-        (*self.cb)(value)
-    }
-}
-
-impl<IN> Callback<IN> {
-    /// Creates a "no-op" callback which can be used when it is not suitable to use an
-    /// `Option<Callback>`.
-    pub fn noop() -> Self {
-        Self::from(|_| ())
-    }
-}
-
-impl<IN> Default for Callback<IN> {
-    fn default() -> Self {
-        Self::noop()
-    }
-}
-
-impl<IN: 'static, OUT: 'static> Callback<IN, OUT> {
-    /// Creates a new callback from another callback and a function
-    /// That when emitted will call that function and will emit the original callback
-    pub fn reform<F, T>(&self, func: F) -> Callback<T, OUT>
-    where
-        F: Fn(T) -> IN + 'static,
-    {
-        let this = self.clone();
-        let func = move |input: T| {
-            let output = func(input);
-            this.emit(output)
-        };
-        Callback::from(func)
-    }
-
-    /// Creates a new callback from another callback and a function
-    /// That when emitted will call that function and will emit the original callback
-    pub fn reform_ref<F, T>(&self, func: F) -> CallbackRef<T, OUT>
-    where
-        // NOTE: here we return a CallbackRef so there is actually nothing special about it
-        //       it's just a convenient function
-        F: Fn(&T) -> IN + 'static,
-    {
-        let this = self.clone();
-        let func = move |input: &T| {
-            let output = func(input);
-            this.emit(output)
-        };
-        CallbackRef::from(func)
-    }
-
-    /// Creates a new callback from another callback and a function.
-    /// When emitted will call the function and, only if it returns `Some(value)`, will emit
-    /// `value` to the original callback.
-    pub fn filter_reform<F, T>(&self, func: F) -> Callback<T, Option<OUT>>
-    where
-        F: Fn(T) -> Option<IN> + 'static,
-    {
-        let this = self.clone();
-        let func = move |input| func(input).map(|output| this.emit(output));
-        Callback::from(func)
-    }
-}
-
-impl<IN, OUT> ImplicitClone for Callback<IN, OUT> {}
+generate_callback_impls!(Callback, IN, output => output);
 
 /// Universal callback wrapper with reference in argument.
 ///
@@ -120,102 +182,7 @@ pub struct CallbackRef<IN, OUT = ()> {
     pub(crate) cb: Rc<dyn Fn(&IN) -> OUT>,
 }
 
-impl<IN, OUT, F: Fn(&IN) -> OUT + 'static> From<F> for CallbackRef<IN, OUT> {
-    fn from(func: F) -> Self {
-        CallbackRef { cb: Rc::new(func) }
-    }
-}
-
-impl<IN, OUT> Clone for CallbackRef<IN, OUT> {
-    fn clone(&self) -> Self {
-        Self {
-            cb: self.cb.clone(),
-        }
-    }
-}
-
-#[allow(clippy::vtable_address_comparisons)]
-impl<IN, OUT> PartialEq for CallbackRef<IN, OUT> {
-    fn eq(&self, other: &CallbackRef<IN, OUT>) -> bool {
-        let (CallbackRef { cb }, CallbackRef { cb: rhs_cb }) = (self, other);
-        Rc::ptr_eq(cb, rhs_cb)
-    }
-}
-
-impl<IN, OUT> fmt::Debug for CallbackRef<IN, OUT> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "CallbackRef<_>")
-    }
-}
-
-impl<IN, OUT> CallbackRef<IN, OUT> {
-    /// This method calls the callback's function.
-    pub fn emit(&self, value: &IN) -> OUT {
-        (*self.cb)(value)
-    }
-}
-
-impl<IN> CallbackRef<IN> {
-    /// Creates a "no-op" callback which can be used when it is not suitable to use an
-    /// `Option<CallbackRef>`.
-    pub fn noop() -> Self {
-        Self::from(|_: &_| ())
-    }
-}
-
-impl<IN> Default for CallbackRef<IN> {
-    fn default() -> Self {
-        Self::noop()
-    }
-}
-
-impl<IN: 'static, OUT: 'static> CallbackRef<IN, OUT> {
-    /// Creates a new callback from another callback and a function
-    /// That when emitted will call that function and will emit the original callback
-    pub fn reform<F, T>(&self, func: F) -> Callback<T, OUT>
-    where
-        F: Fn(T) -> IN + 'static,
-    {
-        let this = self.clone();
-        let func = move |input: T| {
-            let output = func(input);
-            this.emit(&output)
-        };
-        Callback::from(func)
-    }
-
-    /// Creates a new callback from another callback and a function
-    /// That when emitted will call that function and will emit the original callback
-    pub fn reform_ref<F, T>(&self, func: F) -> CallbackRef<T, OUT>
-    where
-        // NOTE: I think both lifetimes here are the same, so it should be good
-        // (don't mind the 'static, that's for the function itself)
-        F: Fn(&T) -> &IN + 'static,
-    {
-        let this = self.clone();
-        let func = move |input: &T| {
-            let output = func(input);
-            this.emit(output)
-        };
-        CallbackRef::from(func)
-    }
-
-/*
-    /// Creates a new callback from another callback and a function.
-    /// When emitted will call the function and, only if it returns `Some(value)`, will emit
-    /// `value` to the original callback.
-    pub fn filter_reform<F, T>(&self, func: F) -> CallbackRef<T, Option<OUT>>
-    where
-        F: Fn(&T) -> Option<&IN> + 'static,
-    {
-        let this = self.clone();
-        let func = move |input: &_| func(input).map(|output| this.emit(output));
-        CallbackRef::from(func)
-    }
-*/
-}
-
-impl<IN, OUT> ImplicitClone for CallbackRef<IN, OUT> {}
+generate_callback_impls!(CallbackRef, &IN, output => &output);
 
 /// Universal callback wrapper with mutable reference in argument.
 ///
@@ -225,84 +192,7 @@ pub struct CallbackRefMut<IN, OUT = ()> {
     pub(crate) cb: Rc<dyn Fn(&mut IN) -> OUT>,
 }
 
-impl<IN, OUT, F: Fn(&mut IN) -> OUT + 'static> From<F> for CallbackRefMut<IN, OUT> {
-    fn from(func: F) -> Self {
-        CallbackRefMut { cb: Rc::new(func) }
-    }
-}
-
-impl<IN, OUT> Clone for CallbackRefMut<IN, OUT> {
-    fn clone(&self) -> Self {
-        Self {
-            cb: self.cb.clone(),
-        }
-    }
-}
-
-#[allow(clippy::vtable_address_comparisons)]
-impl<IN, OUT> PartialEq for CallbackRefMut<IN, OUT> {
-    fn eq(&self, other: &CallbackRefMut<IN, OUT>) -> bool {
-        let (CallbackRefMut { cb }, CallbackRefMut { cb: rhs_cb }) = (self, other);
-        Rc::ptr_eq(cb, rhs_cb)
-    }
-}
-
-impl<IN, OUT> fmt::Debug for CallbackRefMut<IN, OUT> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "CallbackRefMut<_>")
-    }
-}
-
-impl<IN, OUT> CallbackRefMut<IN, OUT> {
-    /// This method calls the callback's function.
-    pub fn emit(&self, value: &mut IN) -> OUT {
-        (*self.cb)(value)
-    }
-}
-
-impl<IN> CallbackRefMut<IN> {
-    /// Creates a "no-op" callback which can be used when it is not suitable to use an
-    /// `Option<CallbackRefMut>`.
-    pub fn noop() -> Self {
-        Self::from(|_: &mut _| ())
-    }
-}
-
-impl<IN> Default for CallbackRefMut<IN> {
-    fn default() -> Self {
-        Self::noop()
-    }
-}
-
-impl<IN: 'static, OUT: 'static> CallbackRefMut<IN, OUT> {
-    /// Creates a new callback from another callback and a function
-    /// That when emitted will call that function and will emit the original callback
-    pub fn reform<F, T>(&self, func: F) -> CallbackRefMut<T, OUT>
-    where
-        F: Fn(&mut T) -> &mut IN + 'static,
-    {
-        let this = self.clone();
-        let func = move |input: &mut _| {
-            let output = func(input);
-            this.emit(output)
-        };
-        CallbackRefMut::from(func)
-    }
-
-    /// Creates a new callback from another callback and a function.
-    /// When emitted will call the function and, only if it returns `Some(value)`, will emit
-    /// `value` to the original callback.
-    pub fn filter_reform<F, T>(&self, func: F) -> CallbackRefMut<T, Option<OUT>>
-    where
-        F: Fn(&mut T) -> Option<&mut IN> + 'static,
-    {
-        let this = self.clone();
-        let func = move |input: &mut _| func(input).map(|output| this.emit(output));
-        CallbackRefMut::from(func)
-    }
-}
-
-impl<IN, OUT> ImplicitClone for CallbackRefMut<IN, OUT> {}
+generate_callback_impls!(CallbackRefMut, &mut IN, output => &mut output);
 
 #[cfg(test)]
 mod test {

--- a/packages/yew/src/callback.rs
+++ b/packages/yew/src/callback.rs
@@ -270,9 +270,9 @@ mod test {
 
     #[test]
     fn test_reform_ref_mut() {
-        let callback: CallbackRefMut<usize, ()> = CallbackRefMut::from(|x: &mut usize| *x = *x + 1);
+        let callback: CallbackRefMut<usize, ()> = CallbackRefMut::from(|x: &mut usize| *x += 1);
         let reformed: CallbackRefMut<usize, ()> = callback.reform_ref_mut(|x: &mut usize| {
-            *x = *x + 2;
+            *x += 2;
             x
         });
         let mut value: usize = 42;
@@ -290,10 +290,10 @@ mod test {
 
     #[test]
     fn test_filter_reform_ref_mut() {
-        let callback: CallbackRefMut<usize, ()> = CallbackRefMut::from(|x: &mut usize| *x = *x + 1);
+        let callback: CallbackRefMut<usize, ()> = CallbackRefMut::from(|x: &mut usize| *x += 1);
         let reformed: CallbackRefMut<usize, Option<()>> =
             callback.filter_reform_ref_mut(|x: &mut usize| {
-                *x = *x + 2;
+                *x += 2;
                 Some(x)
             });
         let mut value: usize = 42;

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -330,7 +330,7 @@ pub mod prelude {
 
     #[cfg(feature = "csr")]
     pub use crate::app_handle::AppHandle;
-    pub use crate::callback::Callback;
+    pub use crate::callback::{Callback, CallbackRef, CallbackRefMut};
     pub use crate::context::{ContextHandle, ContextProvider};
     pub use crate::events::*;
     pub use crate::functional::*;


### PR DESCRIPTION
#### Description

It's sometimes useful to pass callback functions to components. The struct
Callback can be used for that but it only accept passing the input argument by
value. It is useful sometimes to pass the input argument by reference instead.

Alternative explanation from @kirillsemyonkin :

Its for doing `Fn(&IN) -> OUT` instead of `Fn(IN) -> OUT` since some rust weirdness.

Doing Callback<&IN, OUT> says that the type should have a 'a which is wrong because its Fn under the hood.

It would've worked if we were able to write `Callback<&IN> -> OUT` or whatever but I think Rust allows that syntax only for `Fn` family.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
