### PR TITLE
Fix links to authors in the changelog generator.

### DIFF
--- a/tools/changelog/src/create_log_line.rs
+++ b/tools/changelog/src/create_log_line.rs
@@ -6,6 +6,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::github_issue_labels_fetcher::GitHubIssueLabelsFetcher;
+use crate::github_user_fetcher::GitHubUsersFetcher;
 use crate::log_line::LogLine;
 
 static REGEX_FOR_ISSUE_ID_CAPTURE: Lazy<Regex> =
@@ -18,6 +19,7 @@ pub fn create_log_line(
     package_labels: &'static [&'static str],
     oid: Result<Oid, Error>,
     token: Option<String>,
+    user_fetcher: &mut GitHubUsersFetcher
 ) -> Result<Option<LogLine>> {
     println!("Commit oid: {oid:?}");
     let oid = oid?;
@@ -31,6 +33,8 @@ pub fn create_log_line(
         .to_string();
     let author = commit.author();
     let author_name = author.name().unwrap_or("Unknown");
+    let author_id = user_fetcher.fetch_user_by_commit_author(author_name, commit.id().to_string(), token.clone())
+        .context("Missing author's GitHub ID")?;
     let email = author.email().context("Missing author's email")?;
 
     if email.contains("dependabot") {
@@ -96,6 +100,7 @@ pub fn create_log_line(
     let log_line = LogLine {
         message,
         user: author_name.to_string(),
+        user_id: author_id.to_string(),
         issue_id,
         is_breaking_change,
     };

--- a/tools/changelog/src/create_log_line.rs
+++ b/tools/changelog/src/create_log_line.rs
@@ -19,7 +19,7 @@ pub fn create_log_line(
     package_labels: &'static [&'static str],
     oid: Result<Oid, Error>,
     token: Option<String>,
-    user_fetcher: &mut GitHubUsersFetcher
+    user_fetcher: &mut GitHubUsersFetcher,
 ) -> Result<Option<LogLine>> {
     println!("Commit oid: {oid:?}");
     let oid = oid?;
@@ -33,7 +33,8 @@ pub fn create_log_line(
         .to_string();
     let author = commit.author();
     let author_name = author.name().unwrap_or("Unknown");
-    let author_id = user_fetcher.fetch_user_by_commit_author(author_name, commit.id().to_string(), token.clone())
+    let author_id = user_fetcher
+        .fetch_user_by_commit_author(author_name, commit.id().to_string(), token.clone())
         .context("Missing author's GitHub ID")?;
     let email = author.email().context("Missing author's email")?;
 

--- a/tools/changelog/src/create_log_lines.rs
+++ b/tools/changelog/src/create_log_lines.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use git2::{Repository, Sort};
 
 use crate::create_log_line::create_log_line;
+use crate::github_user_fetcher::GitHubUsersFetcher;
 use crate::log_line::LogLine;
 
 pub fn create_log_lines(
@@ -12,6 +13,7 @@ pub fn create_log_lines(
 ) -> Result<Vec<LogLine>> {
     let repo = Repository::open_from_env()?;
 
+    let mut user_fetcher = GitHubUsersFetcher::default();
     let from_oid = repo
         .revparse_single(&from)
         .context("Could not find `from` revision")?
@@ -28,6 +30,6 @@ pub fn create_log_lines(
     revwalk.push(to_oid)?;
 
     revwalk
-        .filter_map(|oid| create_log_line(&repo, package_labels, oid, token.clone()).transpose())
+        .filter_map(|oid| create_log_line(&repo, package_labels, oid, token.clone(), &mut user_fetcher).transpose())
         .collect()
 }

--- a/tools/changelog/src/create_log_lines.rs
+++ b/tools/changelog/src/create_log_lines.rs
@@ -30,6 +30,9 @@ pub fn create_log_lines(
     revwalk.push(to_oid)?;
 
     revwalk
-        .filter_map(|oid| create_log_line(&repo, package_labels, oid, token.clone(), &mut user_fetcher).transpose())
+        .filter_map(|oid| {
+            create_log_line(&repo, package_labels, oid, token.clone(), &mut user_fetcher)
+                .transpose()
+        })
         .collect()
 }

--- a/tools/changelog/src/get_latest_version.rs
+++ b/tools/changelog/src/get_latest_version.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use git2::Repository;
 use semver::{Error, Version};
 

--- a/tools/changelog/src/get_latest_version.rs
+++ b/tools/changelog/src/get_latest_version.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, Context};
 use git2::Repository;
 use semver::{Error, Version};
 
@@ -8,7 +8,7 @@ pub fn get_latest_version(package: &YewPackage) -> Result<Version> {
     let common_tag_pattern = format!("{package}-v");
     let search_pattern = format!("{common_tag_pattern}*");
 
-    let mut tags: Vec<Version> = Repository::open_from_env()?
+    let tags: Vec<Version> = Repository::open_from_env()?
         .tag_names(Some(&search_pattern))?
         .iter()
         .filter_map(|mb_tag| {
@@ -19,8 +19,5 @@ pub fn get_latest_version(package: &YewPackage) -> Result<Version> {
         })
         .collect::<Result<Vec<Version>, Error>>()?;
 
-    tags.sort();
-    tags.reverse();
-
-    Ok(tags[0].clone())
+    tags.into_iter().max().context("no version found")
 }

--- a/tools/changelog/src/log_line.rs
+++ b/tools/changelog/src/log_line.rs
@@ -2,6 +2,7 @@
 pub struct LogLine {
     pub message: String,
     pub user: String,
+    pub user_id: String,
     pub issue_id: String,
     pub is_breaking_change: bool,
 }

--- a/tools/changelog/src/write_log_lines.rs
+++ b/tools/changelog/src/write_log_lines.rs
@@ -1,5 +1,7 @@
 use std::io::Write;
+
 use anyhow::Result;
+
 use crate::log_line::LogLine;
 
 pub fn write_log_lines(log_lines: Vec<LogLine>) -> Result<Vec<u8>> {

--- a/tools/changelog/src/write_log_lines.rs
+++ b/tools/changelog/src/write_log_lines.rs
@@ -1,7 +1,5 @@
 use std::io::Write;
-
 use anyhow::Result;
-
 use crate::log_line::LogLine;
 
 pub fn write_log_lines(log_lines: Vec<LogLine>) -> Result<Vec<u8>> {
@@ -10,12 +8,13 @@ pub fn write_log_lines(log_lines: Vec<LogLine>) -> Result<Vec<u8>> {
         message,
         user,
         issue_id,
+        user_id,
         ..
     } in log_lines
     {
         writeln!(
             logs_list,
-            "- {message}. [[@{user}](https://github.com/{user}), [#{issue_id}](https://github.com/yewstack/yew/pull/{issue_id})]",
+            "- {message}. [[@{user}](https://github.com/{user_id}), [#{issue_id}](https://github.com/yewstack/yew/pull/{issue_id})]",
         )?;
     }
     Ok(logs_list)


### PR DESCRIPTION
#### Description

Right now, the changelog generator puts invalid links to Github accounts of the authors of changes, this PR addressess that.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
