### PR TITLE
Add useful methods to `UseStateHandle` & `UseReducerHandle`

### DIFF
--- a/packages/yew/src/functional/hooks/use_reducer.rs
+++ b/packages/yew/src/functional/hooks/use_reducer.rs
@@ -39,6 +39,11 @@ impl<T> UseReducerHandle<T>
 where
     T: Reducible,
 {
+    /// Returns the inner value of the handle in an `Rc`.
+    pub fn get(&self) -> Rc<T> {
+        self.value.clone()
+    }
+
     /// Dispatch the given action to the reducer.
     pub fn dispatch(&self, value: T::Action) {
         (self.dispatch)(value)
@@ -49,6 +54,18 @@ where
         UseReducerDispatcher {
             dispatch: self.dispatch.clone(),
         }
+    }
+
+    /// Destrctures the handle into its 2 parts:
+    /// 0: the current data associated with the reducer;
+    /// 1: the dispatcher responsible for applying an action to the value.
+    pub fn into_inner(self) -> (Rc<T>, UseReducerDispatcher<T>) {
+        (
+            self.value,
+            UseReducerDispatcher {
+                dispatch: self.dispatch,
+            },
+        )
     }
 }
 

--- a/packages/yew/src/functional/hooks/use_state.rs
+++ b/packages/yew/src/functional/hooks/use_state.rs
@@ -1,10 +1,12 @@
 use std::fmt;
+use std::mem::transmute;
 use std::ops::Deref;
 use std::rc::Rc;
 
 use super::{use_reducer, use_reducer_eq, Reducible, UseReducerDispatcher, UseReducerHandle};
 use crate::functional::hook;
 
+#[repr(transparent)]
 struct UseStateReducer<T> {
     value: T,
 }
@@ -111,6 +113,12 @@ impl<T: fmt::Debug> fmt::Debug for UseStateHandle<T> {
 }
 
 impl<T> UseStateHandle<T> {
+    /// Returns the inner value of the handle.
+    pub fn get(&self) -> Rc<T> {
+        // Safety: `UseStateReducer<T>` is `repr(transparent)` and only contains `T`
+        unsafe { transmute(self.inner.get()) }
+    }
+
     /// Replaces the value
     pub fn set(&self, value: T) {
         self.inner.dispatch(value)
@@ -121,6 +129,15 @@ impl<T> UseStateHandle<T> {
         UseStateSetter {
             inner: self.inner.dispatcher(),
         }
+    }
+
+    /// Destructures the handle into its 2 parts:
+    /// 0: The current associated state;
+    /// 1: The setter responsible for changing the state on demand.
+    pub fn into_inner(self) -> (Rc<T>, UseStateSetter<T>) {
+        let (data, inner) = self.inner.into_inner();
+        // Safety: check the `get` method above
+        (unsafe { transmute(data) }, UseStateSetter { inner })
     }
 }
 

--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -101,14 +101,14 @@ where
 
         use_memo_base(
             move |deps| {
-                let self_id = latest_id.get().wrapping_add(1);
+                let self_id = (*latest_id).get().wrapping_add(1);
                 // As long as less than 2**32 futures are in flight wrapping_add is fine
                 (*latest_id).set(self_id);
                 let deps = Rc::new(deps);
                 let task = f(deps.clone());
                 let suspension = Suspension::from_future(async move {
                     let result = task.await;
-                    if latest_id.get() == self_id {
+                    if (*latest_id).get() == self_id {
                         output.set(Some(result));
                     }
                 });

--- a/packages/yew/tests/use_state.rs
+++ b/packages/yew/tests/use_state.rs
@@ -2,6 +2,7 @@
 
 mod common;
 
+use std::rc::Rc;
 use std::time::Duration;
 
 use common::obtain_result;
@@ -16,6 +17,7 @@ async fn use_state_works() {
     #[function_component(UseComponent)]
     fn use_state_comp() -> Html {
         let counter = use_state(|| 0);
+        assert_eq!(counter.get(), Rc::new(0));
         if *counter < 5 {
             counter.set(*counter + 1)
         }


### PR DESCRIPTION
#### Description

This PR adds:
- `UseStateHandle::get` & `UseReducerHandle::get` that return the contained value of the handle in the form in which it's stored internally: in an Rc;
- `UseStateHandle::into_inner` & `UseReducerHandle::into_inner` that consume the handle and return its 2 main parts: the inner value and the setter/dispatcher associated with the handle.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
