### PR TITLE
Update build-a-sample-app.mdx

### DIFF
--- a/website/docs/getting-started/build-a-sample-app.mdx
+++ b/website/docs/getting-started/build-a-sample-app.mdx
@@ -80,7 +80,7 @@ that updates its value when clicked. Replace the contents of `src/main.rs` with 
 :::note
 The call to `yew::Renderer::<App>::new().render()` inside the `main` function starts your application and mounts
 it to the page's `<body>` tag. If you would like to start your application with any dynamic
-properties, you can instead use `yew::Renderer::<App>::with_props(..).render()`.
+properties, you can instead use `yew::Renderer::<App>::with_root(element).render() where element is of type web_sys::Element`.
 :::
 
 ```rust ,no_run, title=main.rs


### PR DESCRIPTION
Fixed outdated note in getting started guide

#### Description
According to the getting started guide, yew::Renderer::<App>::with_props(..).render() is they way to mount your component, to an element that is not <body>.
However, after some digging i figured out that the current way to do this is using yew::Renderer::<App>::with_root(elem).render() instead.
I have changed the corresponding line in the getting started guide.
