### PR TITLE
Add safe mode to joke api

### DIFF
--- a/examples/async_clock/src/services.rs
+++ b/examples/async_clock/src/services.rs
@@ -28,7 +28,7 @@ pub fn emit_jokes(joke_cb: Callback<AttrValue>) {
     spawn_local(async move {
         loop {
             // Fetch the online joke
-            let fun_fact = Request::get("https://v2.jokeapi.dev/joke/Programming?format=txt")
+            let fun_fact = Request::get("https://v2.jokeapi.dev/joke/Programming?format=txt&safe-mode")
                 .send()
                 .await
                 .unwrap()

--- a/examples/async_clock/src/services.rs
+++ b/examples/async_clock/src/services.rs
@@ -28,13 +28,14 @@ pub fn emit_jokes(joke_cb: Callback<AttrValue>) {
     spawn_local(async move {
         loop {
             // Fetch the online joke
-            let fun_fact = Request::get("https://v2.jokeapi.dev/joke/Programming?format=txt&safe-mode")
-                .send()
-                .await
-                .unwrap()
-                .text()
-                .await
-                .unwrap();
+            let fun_fact =
+                Request::get("https://v2.jokeapi.dev/joke/Programming?format=txt&safe-mode")
+                    .send()
+                    .await
+                    .unwrap()
+                    .text()
+                    .await
+                    .unwrap();
 
             // Emit it to the component
             joke_cb.emit(AttrValue::from(fun_fact));


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Activates a "safe-mode" in the 3rd party example strings for the async_clock example, blocking potentially offensive content from showing up.

See #3428 for the reasoning

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ x] I have reviewed my own code
- [ ] I have added tests # This is configuration, so no tests are helpful, at least in my eyes

