### PR TITLE
Allow literals without braces in `html!`

### DIFF
--- a/packages/yew-macro/src/html_tree/html_block.rs
+++ b/packages/yew-macro/src/html_tree/html_block.rs
@@ -2,14 +2,15 @@ use proc_macro2::Delimiter;
 use quote::{quote, quote_spanned, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream};
-use syn::{braced, token};
+use syn::token::Brace;
+use syn::braced;
 
 use super::{HtmlIterable, HtmlNode, ToNodeIterator};
 use crate::PeekValue;
 
 pub struct HtmlBlock {
     pub content: BlockContent,
-    brace: token::Brace,
+    brace: Option<Brace>,
 }
 
 pub enum BlockContent {
@@ -19,44 +20,48 @@ pub enum BlockContent {
 
 impl PeekValue<()> for HtmlBlock {
     fn peek(cursor: Cursor) -> Option<()> {
-        cursor.group(Delimiter::Brace).map(|_| ())
+        if cursor.group(Delimiter::Brace).is_some() {return Some(())}
+        cursor.literal().map(drop)
     }
 }
 
 impl Parse for HtmlBlock {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        if let Ok(lit) = input.parse() {
+            return Ok(Self { content: BlockContent::Node(HtmlNode::Literal(lit).into()), brace: None })
+        }
         let content;
-        let brace = braced!(content in input);
+        let brace = Some(braced!(content in input));
         let content = if HtmlIterable::peek(content.cursor()).is_some() {
             BlockContent::Iterable(Box::new(content.parse()?))
         } else {
             BlockContent::Node(Box::new(content.parse()?))
         };
 
-        Ok(HtmlBlock { content, brace })
+        Ok(Self { content, brace })
     }
 }
 
 impl ToTokens for HtmlBlock {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let HtmlBlock { content, .. } = self;
-        let new_tokens = match content {
+        tokens.extend(match &self.content {
             BlockContent::Iterable(html_iterable) => quote! {#html_iterable},
             BlockContent::Node(html_node) => quote! {#html_node},
-        };
-
-        tokens.extend(quote! {#new_tokens});
+        })
     }
 }
 
 impl ToNodeIterator for HtmlBlock {
     fn to_node_iterator_stream(&self) -> Option<proc_macro2::TokenStream> {
-        let HtmlBlock { content, brace } = self;
-        let new_tokens = match content {
+        let new_tokens = match &self.content {
             BlockContent::Iterable(iterable) => iterable.to_node_iterator_stream(),
             BlockContent::Node(node) => node.to_node_iterator_stream(),
         }?;
 
-        Some(quote_spanned! {brace.span=> #new_tokens})
+        Some(if let Some(brace) = self.brace {
+            quote_spanned! {brace.span => #new_tokens}
+        } else {
+            quote! {#new_tokens}
+        })
     }
 }

--- a/packages/yew-macro/src/html_tree/html_block.rs
+++ b/packages/yew-macro/src/html_tree/html_block.rs
@@ -1,9 +1,9 @@
 use proc_macro2::Delimiter;
 use quote::{quote, quote_spanned, ToTokens};
+use syn::braced;
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream};
 use syn::token::Brace;
-use syn::braced;
 
 use super::{HtmlIterable, HtmlNode, ToNodeIterator};
 use crate::PeekValue;
@@ -20,7 +20,9 @@ pub enum BlockContent {
 
 impl PeekValue<()> for HtmlBlock {
     fn peek(cursor: Cursor) -> Option<()> {
-        if cursor.group(Delimiter::Brace).is_some() {return Some(())}
+        if cursor.group(Delimiter::Brace).is_some() {
+            return Some(());
+        }
         cursor.literal().map(drop)
     }
 }
@@ -28,7 +30,10 @@ impl PeekValue<()> for HtmlBlock {
 impl Parse for HtmlBlock {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         if let Ok(lit) = input.parse() {
-            return Ok(Self { content: BlockContent::Node(HtmlNode::Literal(lit).into()), brace: None })
+            return Ok(Self {
+                content: BlockContent::Node(HtmlNode::Literal(lit).into()),
+                brace: None,
+            });
         }
         let content;
         let brace = Some(braced!(content in input));

--- a/packages/yew-macro/src/html_tree/html_node.rs
+++ b/packages/yew-macro/src/html_tree/html_node.rs
@@ -16,14 +16,14 @@ pub enum HtmlNode {
 
 impl Parse for HtmlNode {
     fn parse(input: ParseStream) -> Result<Self> {
-        let node = if HtmlNode::peek(input.cursor()).is_some() {
+        let node = if Self::peek(input.cursor()).is_some() {
             let lit: Lit = input.parse()?;
             if matches!(lit, Lit::ByteStr(_) | Lit::Byte(_) | Lit::Verbatim(_)) {
                 return Err(syn::Error::new(lit.span(), "unsupported type"));
             }
-            HtmlNode::Literal(Box::new(lit))
+            Self::Literal(Box::new(lit))
         } else {
-            HtmlNode::Expression(Box::new(input.parse()?))
+            Self::Expression(Box::new(input.parse()?))
         };
 
         Ok(node)
@@ -45,11 +45,11 @@ impl PeekValue<()> for HtmlNode {
 impl ToTokens for HtmlNode {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(match &self {
-            HtmlNode::Literal(lit) => {
+            Self::Literal(lit) => {
                 let sr = lit.stringify();
                 quote_spanned! {lit.span()=> ::yew::virtual_dom::VText::new(#sr) }
             }
-            HtmlNode::Expression(expr) => quote! {#expr},
+            Self::Expression(expr) => quote! {#expr},
         });
     }
 }
@@ -57,8 +57,8 @@ impl ToTokens for HtmlNode {
 impl ToNodeIterator for HtmlNode {
     fn to_node_iterator_stream(&self) -> Option<TokenStream> {
         match self {
-            HtmlNode::Literal(_) => None,
-            HtmlNode::Expression(expr) => {
+            Self::Literal(_) => None,
+            Self::Expression(expr) => {
                 // NodeSeq turns both Into<T> and Vec<Into<T>> into IntoIterator<Item = T>
                 Some(quote_spanned! {expr.span().resolved_at(Span::call_site())=>
                     ::std::convert::Into::<::yew::utils::NodeSeq<_, _>>::into(#expr)

--- a/packages/yew-macro/src/html_tree/mod.rs
+++ b/packages/yew-macro/src/html_tree/mod.rs
@@ -72,16 +72,13 @@ impl HtmlTree {
     /// returns with the appropriate type. If invalid html tag, returns `None`.
     fn peek_html_type(input: ParseStream) -> Option<HtmlType> {
         let input = input.fork(); // do not modify original ParseStream
+        let cursor = input.cursor();
 
         if input.is_empty() {
             Some(HtmlType::Empty)
-        } else if input
-            .cursor()
-            .group(proc_macro2::Delimiter::Brace)
-            .is_some()
-        {
+        } else if HtmlBlock::peek(cursor).is_some() {
             Some(HtmlType::Block)
-        } else if HtmlIf::peek(input.cursor()).is_some() {
+        } else if HtmlIf::peek(cursor).is_some() {
             Some(HtmlType::If)
         } else if input.peek(Token![<]) {
             let _lt: Token![<] = input.parse().ok()?;

--- a/packages/yew-macro/tests/html_macro/html-node-pass.rs
+++ b/packages/yew-macro/tests/html_macro/html-node-pass.rs
@@ -48,6 +48,7 @@ fn compile_pass() {
     ::yew::html! { <span>{ "hello" }</span> };
     ::yew::html! { <span>{ 42 }</span> };
     ::yew::html! { <span>{ 1.234 }</span> };
+    ::yew::html! { <span> "Yew " 0.21 </span> };
 
     ::yew::html! { ::std::format!("Hello") };
     ::yew::html! { {<::std::string::String as ::std::convert::From<&::std::primitive::str>>::from("Hello") } };

--- a/packages/yew-macro/tests/html_macro/node-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/node-fail.stderr
@@ -11,18 +11,6 @@ error: unexpected token
   |                             ^^^^^^^^^
 
 error: unsupported type
-  --> tests/html_macro/node-fail.rs:10:14
-   |
-10 |     html! {  b'a' };
-   |              ^^^^
-
-error: unsupported type
-  --> tests/html_macro/node-fail.rs:11:14
-   |
-11 |     html! {  b"str" };
-   |              ^^^^^^
-
-error: unsupported type
   --> tests/html_macro/node-fail.rs:12:22
    |
 12 |     html! {  <span>{ b'a' }</span> };
@@ -68,6 +56,34 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: required because of the requirements on the impl of `ToString` for `()`
   = note: required because of the requirements on the impl of `From<()>` for `VNode`
   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `implicit_clone::unsync::IString: From<u8>` is not satisfied
+  --> tests/html_macro/node-fail.rs:10:14
+   |
+10 |     html! {  b'a' };
+   |              ^^^^ the trait `From<u8>` is not implemented for `implicit_clone::unsync::IString`
+   |
+   = help: the following other types implement trait `From<T>`:
+             <implicit_clone::unsync::IString as From<&'static str>>
+             <implicit_clone::unsync::IString as From<Cow<'static, str>>>
+             <implicit_clone::unsync::IString as From<Rc<str>>>
+             <implicit_clone::unsync::IString as From<String>>
+   = note: required because of the requirements on the impl of `Into<implicit_clone::unsync::IString>` for `u8`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `implicit_clone::unsync::IString: From<&[u8; 3]>` is not satisfied
+  --> tests/html_macro/node-fail.rs:11:14
+   |
+11 |     html! {  b"str" };
+   |              ^^^^^^ the trait `From<&[u8; 3]>` is not implemented for `implicit_clone::unsync::IString`
+   |
+   = help: the following other types implement trait `From<T>`:
+             <implicit_clone::unsync::IString as From<&'static str>>
+             <implicit_clone::unsync::IString as From<Cow<'static, str>>>
+             <implicit_clone::unsync::IString as From<Rc<str>>>
+             <implicit_clone::unsync::IString as From<String>>
+   = note: required because of the requirements on the impl of `Into<implicit_clone::unsync::IString>` for `&[u8; 3]`
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> tests/html_macro/node-fail.rs:17:9

--- a/packages/yew-macro/tests/html_macro/node-pass.rs
+++ b/packages/yew-macro/tests/html_macro/node-pass.rs
@@ -47,9 +47,11 @@ fn main() {
     ::yew::html! { <span>{ "" }</span> };
     ::yew::html! { <span>{ 'a' }</span> };
     ::yew::html! { <span>{ "hello" }</span> };
-    ::yew::html! { <span>{ "42" }</span> };
+    ::yew::html! { <span>{ 42 }</span> };
     ::yew::html! { <span>{ "1.234" }</span> };
     ::yew::html! { <span>{ "true" }</span> };
+    ::yew::html! { <span> 3.69 </span> };
+    ::yew::html! { <span>"Yew"</span>};
 
     ::yew::html! { ::std::format!("Hello") };
     ::yew::html! { ::std::string::ToString::to_string("Hello") };

--- a/website/docs/concepts/html/literals-and-expressions.mdx
+++ b/website/docs/concepts/html/literals-and-expressions.mdx
@@ -11,6 +11,7 @@ Literals create `Text` nodes, which are treated as strings by the browser. Hence
 :::
 
 Unlike for other types of expressions, braces around literals are optional.
+
 ```rust
 use yew::prelude::*;
 

--- a/website/docs/concepts/html/literals-and-expressions.mdx
+++ b/website/docs/concepts/html/literals-and-expressions.mdx
@@ -5,13 +5,12 @@ title: 'Literals and Expressions'
 ## Literals
 
 If expressions resolve to types that implement `Display`, they will be converted to strings and inserted into the DOM as a [Text](https://developer.mozilla.org/en-US/docs/Web/API/Text) node.
+Thus, any literals can be passed directly to the macro: integers, floats, strings, characters, etc.
 :::note
-String literals create `Text` nodes, which are treated as strings by the browser. Hence, even if the expression contains a `<script>` tag you can't fall for XSS and such security issues, unless of course you wrap the expression in a `<script>` block.
+Literals create `Text` nodes, which are treated as strings by the browser. Hence, even if the expression contains a `<script>` tag you can't fall for XSS and such security issues, unless of course you wrap the expression in a `<script>` block.
 :::
 
-All display text must be enclosed by `{}` blocks because the text is handled as an expression. This is
-the largest deviation from normal HTML syntax that Yew makes.
-
+Unlike for other types of expressions, braces around literals are optional.
 ```rust
 use yew::prelude::*;
 
@@ -19,8 +18,9 @@ let text = "lorem ipsum";
 html!{
     <>
         <div>{text}</div>
-        <div>{"dolor sit"}</div>
-        <span>{42}</span>
+        <div>"dolor sit"</div>
+        <span>42</span>
+	<span>"Yew " 0.21</span>
     </>
 };
 ```


### PR DESCRIPTION
#### Description

Allows for all kinds of literals to be passed to the `html!` macro without enclosing them in braces as would be required for any other Rust expression, thus, for example, making the following valid:
```rs
html!{<span>"Yew" 0.21</span>}
```
The docs are updated accordingly.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
