### PR TITLE
Read for pull_request.user.login when checking for maintainer

### DIFF
--- a/.github/workflows/auto-approve-maintainer-pr.yml
+++ b/.github/workflows/auto-approve-maintainer-pr.yml
@@ -19,7 +19,7 @@ jobs:
         uses: JamesSingleton/is-organization-member@1.0.1
         with:
           organization: "yewstack"
-          username: ${{ github.actor }}
+          username: ${{ github.event.pull_request.user.login }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto approve


### PR DESCRIPTION
#### Description

Read `github.event.pull_request.user.login` instead `github.actor` when checking for maintainer status. This is to prevent PRs authored by non-maintainers from being auto approved when actions (such as requesting reviews or applying requested changes) are taken

See https://github.com/orgs/community/discussions/25502#discussioncomment-3248134

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
