### PR TITLE
docs(migration): Fix 0.20 to 0.21 migration guide

### DIFF
--- a/website/docs/migration-guides/yew/from-0_20_0-to-0_21_0.mdx
+++ b/website/docs/migration-guides/yew/from-0_20_0-to-0_21_0.mdx
@@ -25,8 +25,8 @@ sg --pattern 'use_callback($DEPENDENCIES,,$$$CALLBACK)' --rewrite 'use_callback(
 sg --pattern 'use_memo($CALLBACK,$$$DEPENDENCIES)' --rewrite 'use_memo($$$DEPENDENCIES, $CALLBACK)' -l rs -i
 sg --pattern 'use_memo($DEPENDENCIES,,$$$CALLBACK)' --rewrite 'use_memo($DEPENDENCIES,$$$CALLBACK)' -l rs -i
 
-sg --pattern 'use_future_with_deps($CALLBACK,$$$DEPENDENCIES)' --rewrite 'use_effect_with($$$DEPENDENCIES, $CALLBACK)' -l rs -i
-sg --pattern 'use_future_with($DEPENDENCIES,,$$$CALLBACK)' --rewrite 'use_effect_with($DEPENDENCIES,$$$CALLBACK)' -l rs -i
+sg --pattern 'use_future_with_deps($CALLBACK,$$$DEPENDENCIES)' --rewrite 'use_future_with($$$DEPENDENCIES, $CALLBACK)' -l rs -i
+sg --pattern 'use_future_with($DEPENDENCIES,,$$$CALLBACK)' --rewrite 'use_future_with($DEPENDENCIES,$$$CALLBACK)' -l rs -i
 
 sg --pattern 'use_transitive_state!($DEPENDENCIES,,$$$CALLBACK)' --rewrite 'use_transitive_state!($DEPENDENCIES,$$$CALLBACK)' -l rs -i
 sg --pattern 'use_transitive_state!($DEPENDENCIES,,$$$CALLBACK)' --rewrite 'use_transitive_state!($DEPENDENCIES,$$$CALLBACK)' -l rs -i


### PR DESCRIPTION
#### Description

The instructions to help migrate from 0.20 to 0.21 using `ast-grep` erroneously turned `use_future` into `use_effect`.