### PR TITLE
Make `key` fall back to `id` for VTags

### DIFF
--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -117,12 +117,17 @@ impl ToTokens for HtmlElement {
             checked,
             listeners,
             special,
+            id
         } = &props;
 
         // attributes with special treatment
 
         let node_ref = special.wrap_node_ref_attr();
         let key = special.wrap_key_attr();
+        let id = id
+            .as_ref()
+            .map(|prop| wrap_attr_value(prop.value.optimize_literals()))
+            .unwrap_or(quote! { ::std::option::Option::None });
         let value = value
             .as_ref()
             .map(|prop| wrap_attr_value(prop.value.optimize_literals()))
@@ -336,6 +341,7 @@ impl ToTokens for HtmlElement {
                                     #checked,
                                     #node_ref,
                                     #key,
+                                    #id,
                                     #attributes,
                                     #listeners,
                                 ),
@@ -349,6 +355,7 @@ impl ToTokens for HtmlElement {
                                     #value,
                                     #node_ref,
                                     #key,
+                                    #id,
                                     #attributes,
                                     #listeners,
                                 ),
@@ -362,6 +369,7 @@ impl ToTokens for HtmlElement {
                                     ::std::borrow::Cow::<'static, ::std::primitive::str>::Borrowed(#name),
                                     #node_ref,
                                     #key,
+                                    #id,
                                     #attributes,
                                     #listeners,
                                     #children,
@@ -432,6 +440,7 @@ impl ToTokens for HtmlElement {
                                 #checked,
                                 #node_ref,
                                 #key,
+                                #id,
                                 #attributes,
                                 #listeners,
                             )
@@ -441,6 +450,7 @@ impl ToTokens for HtmlElement {
                                 #value,
                                 #node_ref,
                                 #key,
+                                #id,
                                 #attributes,
                                 #listeners,
                             )
@@ -450,6 +460,7 @@ impl ToTokens for HtmlElement {
                                 #vtag_name,
                                 #node_ref,
                                 #key,
+                                #id,
                                 #attributes,
                                 #listeners,
                                 #children,

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -117,7 +117,7 @@ impl ToTokens for HtmlElement {
             checked,
             listeners,
             special,
-            id
+            id,
         } = &props;
 
         // attributes with special treatment

--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -26,6 +26,7 @@ pub struct ElementProps {
     pub booleans: Vec<Prop>,
     pub value: Option<Prop>,
     pub checked: Option<Prop>,
+    pub id: Option<Prop>,
     pub special: SpecialProps,
 }
 
@@ -47,6 +48,7 @@ impl Parse for ElementProps {
             .map(|prop| ClassesForm::from_expr(prop.value));
         let value = props.pop("value");
         let checked = props.pop("checked");
+        let id = props.pop("id");
         let special = props.special;
 
         Ok(Self {
@@ -57,6 +59,7 @@ impl Parse for ElementProps {
             booleans: booleans.into_vec(),
             value,
             special,
+            id
         })
     }
 }

--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -59,7 +59,7 @@ impl Parse for ElementProps {
             booleans: booleans.into_vec(),
             value,
             special,
-            id
+            id,
         })
     }
 }

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -19,7 +19,7 @@ use super::{BNode, BSubtree, DomSlot, Reconcilable, ReconcileTarget};
 use crate::html::AnyScope;
 use crate::virtual_dom::vtag::{InputFields, VTagInner, Value, MATHML_NAMESPACE, SVG_NAMESPACE};
 use crate::virtual_dom::{Attributes, Key, VTag};
-use crate::{NodeRef, AttrValue};
+use crate::{AttrValue, NodeRef};
 
 /// Applies contained changes to DOM [web_sys::Element]
 trait Apply {
@@ -207,9 +207,11 @@ impl Reconcilable for VTag {
                 _ = el.remove_attribute("id");
                 tag.id = None;
             }
-            (Some(new), old) => if Some(&new) == old.as_ref() {
-                el.set_id(&new);
-                tag.id = Some(new);
+            (Some(new), old) => {
+                if Some(&new) == old.as_ref() {
+                    el.set_id(&new);
+                    tag.id = Some(new);
+                }
             }
         };
         self.attributes.apply_diff(root, el, &mut tag.attributes);
@@ -355,7 +357,7 @@ mod feat_hydration {
                 attributes,
                 node_ref,
                 key,
-                id
+                id,
             } = self;
 
             // We trim all text nodes as it's likely these are whitespaces.
@@ -420,7 +422,7 @@ mod feat_hydration {
                 reference: el,
                 node_ref,
                 key,
-                id
+                id,
             }
         }
     }

--- a/packages/yew/src/dom_bundle/utils.rs
+++ b/packages/yew/src/dom_bundle/utils.rs
@@ -50,7 +50,6 @@ mod feat_hydration {
 
 #[cfg(feature = "hydration")]
 pub(super) use feat_hydration::*;
-
 #[cfg(test)]
 // this is needed because clippy doesn't like the import not being used
 #[allow(unused_imports)]

--- a/packages/yew/src/dom_bundle/utils.rs
+++ b/packages/yew/src/dom_bundle/utils.rs
@@ -52,6 +52,11 @@ mod feat_hydration {
 pub(super) use feat_hydration::*;
 
 #[cfg(test)]
+// this is needed because clippy doesn't like the import not being used
+#[allow(unused_imports)]
+pub(super) use tests::*;
+
+#[cfg(test)]
 mod tests {
     #![allow(dead_code)]
 
@@ -87,8 +92,3 @@ mod tests {
         (root, scope, parent, sibling)
     }
 }
-
-#[cfg(test)]
-// this is needed because clippy doesn't like the import not being used
-#[allow(unused_imports)]
-pub(super) use tests::*;

--- a/packages/yew/src/virtual_dom/key.rs
+++ b/packages/yew/src/virtual_dom/key.rs
@@ -4,6 +4,7 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::rc::Rc;
 
+use crate::AttrValue;
 use crate::html::ImplicitClone;
 
 /// Represents the (optional) key of Yew's virtual nodes.
@@ -31,6 +32,16 @@ impl Deref for Key {
 impl From<Rc<str>> for Key {
     fn from(key: Rc<str>) -> Self {
         Self { key }
+    }
+}
+
+impl From<AttrValue> for Key {
+    fn from(key: AttrValue) -> Self {
+        let key = match key {
+            AttrValue::Static(x) => Rc::from(x),
+            AttrValue::Rc(x) => x
+        };
+        Self::from(key)
     }
 }
 

--- a/packages/yew/src/virtual_dom/key.rs
+++ b/packages/yew/src/virtual_dom/key.rs
@@ -4,8 +4,8 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::rc::Rc;
 
-use crate::AttrValue;
 use crate::html::ImplicitClone;
+use crate::AttrValue;
 
 /// Represents the (optional) key of Yew's virtual nodes.
 ///
@@ -39,7 +39,7 @@ impl From<AttrValue> for Key {
     fn from(key: AttrValue) -> Self {
         let key = match key {
             AttrValue::Static(x) => Rc::from(x),
-            AttrValue::Rc(x) => x
+            AttrValue::Rc(x) => x,
         };
         Self::from(key)
     }

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -126,7 +126,7 @@ pub struct VTag {
     pub(crate) inner: VTagInner,
     /// List of attached listeners.
     pub(crate) listeners: Listeners,
-    /// HTML element's 
+    /// HTML element's
     /// [id](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)
     pub(crate) id: Option<AttrValue>,
     /// A node reference used for DOM access in Component lifecycle methods
@@ -269,7 +269,7 @@ impl VTag {
             listeners,
             node_ref,
             key: key.or_else(|| id.as_ref().map(|id| id.clone().into())),
-            id
+            id,
         }
     }
 
@@ -697,6 +697,6 @@ mod ssr_tests {
 
     #[test]
     async fn id_is_key_fallback() {
-        assert!(html!{ <div id="yew"/> }.has_key())
+        assert!(html! { <div id="yew"/> }.has_key())
     }
 }


### PR DESCRIPTION
#### Description

Makes an HTML element's `id` attribute a fall-back value for `key`, if the latter's not provided. This will allow users to get potential performance benefits without concering themselves with the peculiarities of the framework.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
