### PR TITLE
Improve grammar, typos in introduction.mdx

### DIFF
--- a/website/docs/getting-started/introduction.mdx
+++ b/website/docs/getting-started/introduction.mdx
@@ -2,11 +2,11 @@
 title: 'Getting Started'
 ---
 
-You will need a couple of tools to compile, build, package and debug your Yew application.
-When getting started, we recommend using [Trunk](https://trunkrs.dev/). Trunk is a WASM web application
+You will need a couple of tools to compile, build, package, and debug your Yew application.
+When getting started, we recommend using [Trunk](https://trunkrs.dev/). Trunk is a Wasm web application
 bundler for Rust.
 
-## Installing Rust
+## Install Rust
 
 To install Rust, follow the [official instructions](https://www.rust-lang.org/tools/install).
 
@@ -49,5 +49,5 @@ There are options other than Trunk that may be used for bundling Yew application
 
 ## Next steps
 
-With your development environment setup, you can now either proceed with reading the documentation.
-If you like to learn by getting your hands dirty, we recommend you check out our [tutorial](../tutorial).
+With your development environment set up, you can now either proceed with reading the documentation, or
+if you like to learn by getting your hands dirty, we recommend you check out our [tutorial](../tutorial).


### PR DESCRIPTION
Add Oxford comma; correct misspelled abbreviation ‘Wasm’; change ‘Installing’ in heading to ‘Install’, to be consistent with other headings; correct misspelled past tense of the verb ‘set up’, correct grammar in paragraph under ‘Next steps’.

#### Description

<!-- Please include a summary of the change. -->

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
