### PR TITLE
Add for-loops to `html!`

### DIFF
--- a/examples/function_router/src/components/pagination.rs
+++ b/examples/function_router/src/components/pagination.rs
@@ -84,7 +84,11 @@ pub fn RenderLinks(props: &RenderLinksProps) -> Html {
             </>
         }
     } else {
-        html! { for range.map(|page| html! {<RenderLink to_page={page} props={props.clone()} />}) }
+        html! {
+            for page in range {
+                <RenderLink to_page={page} props={props.clone()} />
+            }
+        }
     }
 }
 

--- a/examples/function_router/src/pages/post.rs
+++ b/examples/function_router/src/pages/post.rs
@@ -118,7 +118,7 @@ pub fn Post(props: &Props) -> Html {
                 render_quote(quote)
             }
         });
-        html! { for parts }
+        html! {{for parts}}
     };
 
     let keywords = post

--- a/examples/router/src/components/pagination.rs
+++ b/examples/router/src/components/pagination.rs
@@ -80,7 +80,11 @@ impl Pagination {
                 </>
             }
         } else {
-            html! { for pages.map(|page| self.render_link(page, props)) }
+            html! {
+                for page in pages {
+                    {self.render_link(page, props)}
+                }
+            }
         }
     }
 

--- a/examples/router/src/pages/post.rs
+++ b/examples/router/src/pages/post.rs
@@ -137,6 +137,6 @@ impl Post {
                 self.render_quote(quote)
             }
         });
-        html! { for parts }
+        html! {{for parts}}
     }
 }

--- a/packages/yew-macro/src/html_tree/html_block.rs
+++ b/packages/yew-macro/src/html_tree/html_block.rs
@@ -59,4 +59,11 @@ impl ToNodeIterator for HtmlBlock {
 
         Some(quote_spanned! {brace.span=> #new_tokens})
     }
+
+    fn is_singular(&self) -> bool {
+        match &self.content {
+            BlockContent::Node(node) => node.is_singular(),
+            BlockContent::Iterable(_) => false
+        }
+    }
 }

--- a/packages/yew-macro/src/html_tree/html_block.rs
+++ b/packages/yew-macro/src/html_tree/html_block.rs
@@ -63,7 +63,7 @@ impl ToNodeIterator for HtmlBlock {
     fn is_singular(&self) -> bool {
         match &self.content {
             BlockContent::Node(node) => node.is_singular(),
-            BlockContent::Iterable(_) => false
+            BlockContent::Iterable(_) => false,
         }
     }
 }

--- a/packages/yew-macro/src/html_tree/html_component.rs
+++ b/packages/yew-macro/src/html_tree/html_component.rs
@@ -11,7 +11,7 @@ use crate::props::ComponentProps;
 
 pub struct HtmlComponent {
     ty: Type,
-    props: ComponentProps,
+    pub props: ComponentProps,
     children: HtmlChildrenTree,
     close: Option<HtmlComponentClose>,
 }

--- a/packages/yew-macro/src/html_tree/html_for.rs
+++ b/packages/yew-macro/src/html_tree/html_for.rs
@@ -1,0 +1,83 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote, ToTokens};
+use syn::buffer::Cursor;
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
+use syn::{braced, Expr, Pat, Token};
+
+use super::{HtmlChildrenTree, ToNodeIterator};
+use crate::PeekValue;
+
+pub struct HtmlFor {
+    for_token: Token![for],
+    pat: Pat,
+    in_token: Token![in],
+    iter: Expr,
+    body: HtmlChildrenTree,
+}
+
+impl PeekValue<()> for HtmlFor {
+    fn peek(cursor: Cursor) -> Option<()> {
+        let (ident, _) = cursor.ident()?;
+        (ident == "for").then_some(())
+    }
+}
+
+impl Parse for HtmlFor {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let for_token = input.parse()?;
+        let pat = Pat::parse_single(input)?;
+        let in_token = input.parse()?;
+        let iter = Expr::parse_without_eager_brace(input)?;
+
+        let body_stream;
+        braced!(body_stream in input);
+        let body = HtmlChildrenTree::parse_delimited(&body_stream)?;
+        Ok(Self {
+            for_token,
+            pat,
+            in_token,
+            iter,
+            body,
+        })
+    }
+}
+
+impl ToTokens for HtmlFor {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self {
+            for_token,
+            pat,
+            in_token,
+            iter,
+            body,
+        } = self;
+        // TODO: call `__yew_v.reserve` if the amount of elements added per iteration can be
+        // pre-determined
+        let acc = Ident::new("__yew_v", iter.span());
+        let optimisation = body.size_hint().map(|size| {
+            quote!(
+                #acc.reserve(#size);
+            )
+        });
+        let body = body.0.iter().map(|child| {
+            if let Some(child) = child.to_node_iterator_stream() {
+                quote!(
+                    #acc.extend(#child);
+                )
+            } else {
+                quote!(
+                    #acc.push(::std::convert::Into::into(#child));
+                )
+            }
+        });
+        tokens.extend(quote!({
+            let mut #acc = ::std::vec::Vec::<::yew::virtual_dom::VNode>::new();
+            #for_token #pat #in_token #iter {
+                #optimisation
+                #(#body)*
+            }
+            ::yew::virtual_dom::VList::with_children(#acc, ::std::option::Option::None)
+        }))
+    }
+}

--- a/packages/yew-macro/src/html_tree/html_for.rs
+++ b/packages/yew-macro/src/html_tree/html_for.rs
@@ -1,6 +1,4 @@
-use std::iter::successors;
-
-use proc_macro2::{Delimiter, Ident, Span, TokenStream, TokenTree};
+use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream};
@@ -9,40 +7,16 @@ use syn::token::{For, In};
 use syn::{braced, Expr, Pat};
 
 use super::{HtmlChildrenTree, ToNodeIterator};
+use crate::html_tree::HtmlTree;
 use crate::PeekValue;
 
-/// Returns the location of a `break` or `continue` token, if found
-fn find_divergence(cursor: Cursor) -> Option<Span> {
-    fn inner(stream: TokenStream) -> Option<Span> {
-        for token in stream {
-            match token {
-                TokenTree::Group(group) => {
-                    if let res @ Some(_) = inner(group.stream()) {
-                        return res;
-                    }
-                }
-                TokenTree::Ident(ident) => {
-                    if ident == "break" || ident == "continue" {
-                        return Some(ident.span());
-                    }
-                }
-                TokenTree::Punct(_) | TokenTree::Literal(_) => (),
-            }
-        }
-        None
+/// Determines if an expression is guaranteed to always return the same value anywhere.
+fn is_contextless_pure(expr: &Expr) -> bool {
+    match expr {
+        Expr::Lit(_) => true,
+        Expr::Path(path) => path.path.get_ident().is_none(),
+        _ => false,
     }
-
-    for (token, _) in successors(cursor.token_tree(), |(_, cursor)| cursor.token_tree()) {
-        if let TokenTree::Group(group) = token {
-            if group.delimiter() == Delimiter::Brace {
-                if let res @ Some(_) = inner(group.stream()) {
-                    return res;
-                }
-            }
-        }
-    }
-
-    None
 }
 
 pub struct HtmlFor {
@@ -68,15 +42,21 @@ impl Parse for HtmlFor {
         let body_stream;
         braced!(body_stream in input);
 
-        if let Some(span) = find_divergence(body_stream.cursor()) {
-            return Err(syn::Error::new(
-                span,
-                "diverging expression in the body of a for loop\n`break` or `continue` are not \
-                 allowed in `html!` for loops",
-            ));
-        }
-
         let body = HtmlChildrenTree::parse_delimited(&body_stream)?;
+        // TODO: reduce nesting by using if-let guards / let-else statements once MSRV is raised
+        for child in body.0.iter() {
+            if let HtmlTree::Element(element) = child {
+                if let Some(key) = &element.props.special.key {
+                    if is_contextless_pure(&key.value) {
+                        return Err(syn::Error::new(
+                            key.value.span(),
+                            "duplicate key for a node in a `for`-loop\nthis will create elements \
+                             with duplicate keys if the loop iterates more than once",
+                        ));
+                    }
+                }
+            }
+        }
         Ok(Self { pat, iter, body })
     }
 }
@@ -85,29 +65,48 @@ impl ToTokens for HtmlFor {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Self { pat, iter, body } = self;
         let acc = Ident::new("__yew_v", iter.span());
-        let optimisation = body.size_hint().map(|size| {
+
+        let alloc_opt = body.size_hint().map(|size| {
             quote!(
                 #acc.reserve(#size);
             )
         });
+
+        let vlist_gen = match body.fully_keyed() {
+            Some(true) => quote! {
+                ::yew::virtual_dom::VList::__macro_new(
+                    #acc,
+                    ::std::option::Option::None,
+                    ::yew::virtual_dom::FullyKeyedState::KnownFullyKeyed
+                )
+            },
+            Some(false) => quote! {
+                ::yew::virtual_dom::VList::__macro_new(
+                    #acc,
+                    ::std::option::Option::None,
+                    ::yew::virtual_dom::FullyKeyedState::KnownFullyKeyed
+                )
+            },
+            None => quote! {
+                ::yew::virtual_dom::VList::with_children(#acc, ::std::option::Option::None)
+            },
+        };
+
         let body = body.0.iter().map(|child| {
             if let Some(child) = child.to_node_iterator_stream() {
-                quote!(
-                    #acc.extend(#child);
-                )
+                quote!( #acc.extend(#child) )
             } else {
-                quote!(
-                    #acc.push(::std::convert::Into::into(#child));
-                )
+                quote!( #acc.push(::std::convert::Into::into(#child)) )
             }
         });
+
         tokens.extend(quote!({
             let mut #acc = ::std::vec::Vec::<::yew::virtual_dom::VNode>::new();
-            for #pat in #iter {
-                #optimisation
-                #(#body)*
-            }
-            ::yew::virtual_dom::VList::with_children(#acc, ::std::option::Option::None)
+            ::std::iter::Iterator::for_each(
+                ::std::iter::IntoIterator::into_iter(#iter),
+                |#pat| { #alloc_opt; #(#body);* }
+            );
+            #vlist_gen
         }))
     }
 }

--- a/packages/yew-macro/src/html_tree/html_for.rs
+++ b/packages/yew-macro/src/html_tree/html_for.rs
@@ -1,17 +1,52 @@
-use proc_macro2::{Ident, TokenStream};
+use std::iter::successors;
+
+use proc_macro2::{Delimiter, Ident, Span, TokenStream, TokenTree};
 use quote::{quote, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{braced, Expr, Pat, Token};
+use syn::token::{For, In};
+use syn::{braced, Expr, Pat};
 
 use super::{HtmlChildrenTree, ToNodeIterator};
 use crate::PeekValue;
 
+/// Returns the location of a `break` or `continue` token, if found
+fn find_divergence(cursor: Cursor) -> Option<Span> {
+    fn inner(stream: TokenStream) -> Option<Span> {
+        for token in stream {
+            match token {
+                TokenTree::Group(group) => {
+                    if let res @ Some(_) = inner(group.stream()) {
+                        return res;
+                    }
+                }
+                TokenTree::Ident(ident) => {
+                    if ident == "break" || ident == "continue" {
+                        return Some(ident.span());
+                    }
+                }
+                TokenTree::Punct(_) | TokenTree::Literal(_) => (),
+            }
+        }
+        None
+    }
+
+    for (token, _) in successors(cursor.token_tree(), |(_, cursor)| cursor.token_tree()) {
+        if let TokenTree::Group(group) = token {
+            if group.delimiter() == Delimiter::Brace {
+                if let res @ Some(_) = inner(group.stream()) {
+                    return res;
+                }
+            }
+        }
+    }
+
+    None
+}
+
 pub struct HtmlFor {
-    for_token: Token![for],
     pat: Pat,
-    in_token: Token![in],
     iter: Expr,
     body: HtmlChildrenTree,
 }
@@ -25,35 +60,30 @@ impl PeekValue<()> for HtmlFor {
 
 impl Parse for HtmlFor {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let for_token = input.parse()?;
+        For::parse(input)?;
         let pat = Pat::parse_single(input)?;
-        let in_token = input.parse()?;
+        In::parse(input)?;
         let iter = Expr::parse_without_eager_brace(input)?;
 
         let body_stream;
         braced!(body_stream in input);
+
+        if let Some(span) = find_divergence(body_stream.cursor()) {
+            return Err(syn::Error::new(
+                span,
+                "diverging expression in the body of a for loop\n`break` or `continue` are not \
+                 allowed in `html!` for loops",
+            ));
+        }
+
         let body = HtmlChildrenTree::parse_delimited(&body_stream)?;
-        Ok(Self {
-            for_token,
-            pat,
-            in_token,
-            iter,
-            body,
-        })
+        Ok(Self { pat, iter, body })
     }
 }
 
 impl ToTokens for HtmlFor {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let Self {
-            for_token,
-            pat,
-            in_token,
-            iter,
-            body,
-        } = self;
-        // TODO: call `__yew_v.reserve` if the amount of elements added per iteration can be
-        // pre-determined
+        let Self { pat, iter, body } = self;
         let acc = Ident::new("__yew_v", iter.span());
         let optimisation = body.size_hint().map(|size| {
             quote!(
@@ -73,7 +103,7 @@ impl ToTokens for HtmlFor {
         });
         tokens.extend(quote!({
             let mut #acc = ::std::vec::Vec::<::yew::virtual_dom::VNode>::new();
-            #for_token #pat #in_token #iter {
+            for #pat in #iter {
                 #optimisation
                 #(#body)*
             }

--- a/packages/yew-macro/src/html_tree/html_for.rs
+++ b/packages/yew-macro/src/html_tree/html_for.rs
@@ -66,7 +66,9 @@ impl ToTokens for HtmlFor {
         let Self { pat, iter, body } = self;
         let acc = Ident::new("__yew_v", iter.span());
 
-        let alloc_opt = body.size_hint().map(|size| quote!( #acc.reserve(#size) ));
+        let alloc_opt = body.size_hint()
+            .filter(|&size| size > 1) // explicitly reserving space for 1 more element is redundant
+            .map(|size| quote!( #acc.reserve(#size) ));
 
         let vlist_gen = match body.fully_keyed() {
             Some(true) => quote! {

--- a/packages/yew-macro/src/html_tree/html_for.rs
+++ b/packages/yew-macro/src/html_tree/html_for.rs
@@ -66,11 +66,7 @@ impl ToTokens for HtmlFor {
         let Self { pat, iter, body } = self;
         let acc = Ident::new("__yew_v", iter.span());
 
-        let alloc_opt = body.size_hint().map(|size| {
-            quote!(
-                #acc.reserve(#size);
-            )
-        });
+        let alloc_opt = body.size_hint().map(|size| quote!( #acc.reserve(#size) ));
 
         let vlist_gen = match body.fully_keyed() {
             Some(true) => quote! {
@@ -84,7 +80,7 @@ impl ToTokens for HtmlFor {
                 ::yew::virtual_dom::VList::__macro_new(
                     #acc,
                     ::std::option::Option::None,
-                    ::yew::virtual_dom::FullyKeyedState::KnownFullyKeyed
+                    ::yew::virtual_dom::FullyKeyedState::KnownMissingKeys
                 )
             },
             None => quote! {

--- a/packages/yew-macro/src/html_tree/html_for.rs
+++ b/packages/yew-macro/src/html_tree/html_for.rs
@@ -66,7 +66,8 @@ impl ToTokens for HtmlFor {
         let Self { pat, iter, body } = self;
         let acc = Ident::new("__yew_v", iter.span());
 
-        let alloc_opt = body.size_hint()
+        let alloc_opt = body
+            .size_hint()
             .filter(|&size| size > 1) // explicitly reserving space for 1 more element is redundant
             .map(|size| quote!( #acc.reserve(#size) ));
 

--- a/packages/yew-macro/src/html_tree/html_for.rs
+++ b/packages/yew-macro/src/html_tree/html_for.rs
@@ -43,18 +43,22 @@ impl Parse for HtmlFor {
         braced!(body_stream in input);
 
         let body = HtmlChildrenTree::parse_delimited(&body_stream)?;
-        // TODO: reduce nesting by using if-let guards / let-else statements once MSRV is raised
+        // TODO: more concise code by using if-let guards once MSRV is raised
         for child in body.0.iter() {
-            if let HtmlTree::Element(element) = child {
-                if let Some(key) = &element.props.special.key {
-                    if is_contextless_pure(&key.value) {
-                        return Err(syn::Error::new(
-                            key.value.span(),
-                            "duplicate key for a node in a `for`-loop\nthis will create elements \
+            let HtmlTree::Element(element) = child else {
+                continue;
+            };
+
+            let Some(key) = &element.props.special.key else {
+                continue;
+            };
+
+            if is_contextless_pure(&key.value) {
+                return Err(syn::Error::new(
+                    key.value.span(),
+                    "duplicate key for a node in a `for`-loop\nthis will create elements \
                              with duplicate keys if the loop iterates more than once",
-                        ));
-                    }
-                }
+                ));
             }
         }
         Ok(Self { pat, iter, body })

--- a/packages/yew-macro/src/html_tree/html_for.rs
+++ b/packages/yew-macro/src/html_tree/html_for.rs
@@ -56,8 +56,8 @@ impl Parse for HtmlFor {
             if is_contextless_pure(&key.value) {
                 return Err(syn::Error::new(
                     key.value.span(),
-                    "duplicate key for a node in a `for`-loop\nthis will create elements \
-                             with duplicate keys if the loop iterates more than once",
+                    "duplicate key for a node in a `for`-loop\nthis will create elements with \
+                     duplicate keys if the loop iterates more than once",
                 ));
             }
         }

--- a/packages/yew-macro/src/html_tree/html_if.rs
+++ b/packages/yew-macro/src/html_tree/html_if.rs
@@ -3,9 +3,9 @@ use quote::{quote_spanned, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{Expr, Token};
+use syn::{parse_quote, Expr, Token};
 
-use super::{HtmlRootBraced, ToNodeIterator};
+use super::HtmlRootBraced;
 use crate::PeekValue;
 
 pub struct HtmlIf {
@@ -69,13 +69,13 @@ impl Parse for HtmlIf {
 
 impl ToTokens for HtmlIf {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let HtmlIf {
+        let Self {
             if_token,
             cond,
             then_branch,
             else_branch,
         } = self;
-        let default_else_branch = syn::parse_quote! { {} };
+        let default_else_branch = parse_quote! { {} };
         let else_branch = else_branch
             .as_ref()
             .map(|(_, branch)| branch)
@@ -85,27 +85,6 @@ impl ToTokens for HtmlIf {
         };
 
         tokens.extend(new_tokens);
-    }
-}
-
-impl ToNodeIterator for HtmlIf {
-    fn to_node_iterator_stream(&self) -> Option<TokenStream> {
-        let HtmlIf {
-            if_token,
-            cond,
-            then_branch,
-            else_branch,
-        } = self;
-        let default_else_branch = syn::parse_str("{}").unwrap();
-        let else_branch = else_branch
-            .as_ref()
-            .map(|(_, branch)| branch)
-            .unwrap_or(&default_else_branch);
-        let new_tokens = quote_spanned! {if_token.span()=>
-            if #cond #then_branch else #else_branch
-        };
-
-        Some(quote_spanned! {if_token.span=> #new_tokens})
     }
 }
 

--- a/packages/yew-macro/src/html_tree/html_iterable.rs
+++ b/packages/yew-macro/src/html_tree/html_iterable.rs
@@ -58,4 +58,8 @@ impl ToNodeIterator for HtmlIterable {
             ::yew::utils::into_node_iter(#expr)
         })
     }
+
+    fn is_singular(&self) -> bool {
+        false
+    }
 }

--- a/packages/yew-macro/src/html_tree/html_list.rs
+++ b/packages/yew-macro/src/html_tree/html_list.rs
@@ -71,16 +71,23 @@ impl ToTokens for HtmlList {
             quote! { ::std::option::Option::None }
         };
 
-        let spanned = {
+        let span = {
             let open = open.to_spanned();
             let close = close.to_spanned();
             quote! { #open #close }
-        };
+        }
+        .span();
 
-        tokens.extend(quote_spanned! {spanned.span()=>
-            ::yew::virtual_dom::VNode::VList(::std::rc::Rc::new(
+        tokens.extend(match children.fully_keyed() {
+            Some(true) => quote_spanned!{span=>
+                ::yew::virtual_dom::VList::__macro_new(#children, #key, ::yew::virtual_dom::FullyKeyedState::KnownFullyKeyed)
+            },
+            Some(false) => quote_spanned!{span=>
+                ::yew::virtual_dom::VList::__macro_new(#children, #key, ::yew::virtual_dom::FullyKeyedState::KnownMissingKeys)
+            },
+            None => quote_spanned!{span=>
                 ::yew::virtual_dom::VList::with_children(#children, #key)
-            ))
+            }
         });
     }
 }

--- a/packages/yew-macro/src/html_tree/html_list.rs
+++ b/packages/yew-macro/src/html_tree/html_list.rs
@@ -10,7 +10,7 @@ use crate::props::Prop;
 use crate::{Peek, PeekValue};
 
 pub struct HtmlList {
-    open: HtmlListOpen,
+    pub open: HtmlListOpen,
     pub children: HtmlChildrenTree,
     close: HtmlListClose,
 }
@@ -85,9 +85,9 @@ impl ToTokens for HtmlList {
     }
 }
 
-struct HtmlListOpen {
+pub struct HtmlListOpen {
     tag: TagTokens,
-    props: HtmlListProps,
+    pub props: HtmlListProps,
 }
 impl HtmlListOpen {
     fn to_spanned(&self) -> impl ToTokens {
@@ -121,8 +121,8 @@ impl Parse for HtmlListOpen {
     }
 }
 
-struct HtmlListProps {
-    key: Option<Expr>,
+pub struct HtmlListProps {
+    pub key: Option<Expr>,
 }
 impl Parse for HtmlListProps {
     fn parse(input: ParseStream) -> syn::Result<Self> {

--- a/packages/yew-macro/src/html_tree/html_node.rs
+++ b/packages/yew-macro/src/html_tree/html_node.rs
@@ -80,7 +80,7 @@ impl ToNodeIterator for HtmlNode {
     fn is_singular(&self) -> bool {
         match self {
             Self::Literal(_) => true,
-            Self::Expression(_) => false
+            Self::Expression(_) => false,
         }
     }
 }

--- a/packages/yew-macro/src/html_tree/html_node.rs
+++ b/packages/yew-macro/src/html_tree/html_node.rs
@@ -67,13 +67,20 @@ impl ToTokens for HtmlNode {
 impl ToNodeIterator for HtmlNode {
     fn to_node_iterator_stream(&self) -> Option<TokenStream> {
         match self {
-            HtmlNode::Literal(_) => None,
-            HtmlNode::Expression(expr) => {
+            Self::Literal(_) => None,
+            Self::Expression(expr) => {
                 // NodeSeq turns both Into<T> and Vec<Into<T>> into IntoIterator<Item = T>
                 Some(quote_spanned! {expr.span().resolved_at(Span::call_site())=>
                     ::std::convert::Into::<::yew::utils::NodeSeq<_, _>>::into(#expr)
                 })
             }
+        }
+    }
+
+    fn is_singular(&self) -> bool {
+        match self {
+            Self::Literal(_) => true,
+            Self::Expression(_) => false
         }
     }
 }

--- a/packages/yew-macro/src/html_tree/mod.rs
+++ b/packages/yew-macro/src/html_tree/mod.rs
@@ -12,6 +12,7 @@ mod html_block;
 mod html_component;
 mod html_dashed_name;
 mod html_element;
+mod html_for;
 mod html_if;
 mod html_iterable;
 mod html_list;
@@ -30,6 +31,7 @@ use html_node::HtmlNode;
 use tag::TagTokens;
 
 use self::html_block::BlockContent;
+use self::html_for::HtmlFor;
 
 pub enum HtmlType {
     Block,
@@ -37,6 +39,7 @@ pub enum HtmlType {
     List,
     Element,
     If,
+    For,
     Empty,
 }
 
@@ -46,6 +49,7 @@ pub enum HtmlTree {
     List(Box<HtmlList>),
     Element(Box<HtmlElement>),
     If(Box<HtmlIf>),
+    For(Box<HtmlFor>),
     Empty,
 }
 
@@ -53,15 +57,15 @@ impl Parse for HtmlTree {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let html_type = Self::peek_html_type(input)
             .ok_or_else(|| input.error("expected a valid html element"))?;
-        let html_tree = match html_type {
-            HtmlType::Empty => HtmlTree::Empty,
-            HtmlType::Component => HtmlTree::Component(Box::new(input.parse()?)),
-            HtmlType::Element => HtmlTree::Element(Box::new(input.parse()?)),
-            HtmlType::Block => HtmlTree::Block(Box::new(input.parse()?)),
-            HtmlType::List => HtmlTree::List(Box::new(input.parse()?)),
-            HtmlType::If => HtmlTree::If(Box::new(input.parse()?)),
-        };
-        Ok(html_tree)
+        Ok(match html_type {
+            HtmlType::Empty => Self::Empty,
+            HtmlType::Component => Self::Component(Box::new(input.parse()?)),
+            HtmlType::Element => Self::Element(Box::new(input.parse()?)),
+            HtmlType::Block => Self::Block(Box::new(input.parse()?)),
+            HtmlType::List => Self::List(Box::new(input.parse()?)),
+            HtmlType::If => Self::If(Box::new(input.parse()?)),
+            HtmlType::For => Self::For(Box::new(input.parse()?)),
+        })
     }
 }
 
@@ -72,17 +76,16 @@ impl HtmlTree {
     /// returns with the appropriate type. If invalid html tag, returns `None`.
     fn peek_html_type(input: ParseStream) -> Option<HtmlType> {
         let input = input.fork(); // do not modify original ParseStream
+        let cursor = input.cursor();
 
         if input.is_empty() {
             Some(HtmlType::Empty)
-        } else if input
-            .cursor()
-            .group(proc_macro2::Delimiter::Brace)
-            .is_some()
-        {
+        } else if HtmlBlock::peek(cursor).is_some() {
             Some(HtmlType::Block)
-        } else if HtmlIf::peek(input.cursor()).is_some() {
+        } else if HtmlIf::peek(cursor).is_some() {
             Some(HtmlType::If)
+        } else if HtmlFor::peek(cursor).is_some() {
+            Some(HtmlType::For)
         } else if input.peek(Token![<]) {
             let _lt: Token![<] = input.parse().ok()?;
 
@@ -122,21 +125,21 @@ impl ToTokens for HtmlTree {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         lint::lint_all(self);
         match self {
-            HtmlTree::Empty => tokens.extend(quote! {
+            Self::Empty => tokens.extend(quote! {
                 <::yew::virtual_dom::VNode as ::std::default::Default>::default()
             }),
-            HtmlTree::Component(comp) => comp.to_tokens(tokens),
-            HtmlTree::Element(tag) => tag.to_tokens(tokens),
-            HtmlTree::List(list) => list.to_tokens(tokens),
-            HtmlTree::Block(block) => block.to_tokens(tokens),
-            HtmlTree::If(block) => block.to_tokens(tokens),
+            Self::Component(comp) => comp.to_tokens(tokens),
+            Self::Element(tag) => tag.to_tokens(tokens),
+            Self::List(list) => list.to_tokens(tokens),
+            Self::Block(block) => block.to_tokens(tokens),
+            Self::If(block) => block.to_tokens(tokens),
+            Self::For(block) => block.to_tokens(tokens),
         }
     }
 }
 
 pub enum HtmlRoot {
     Tree(HtmlTree),
-    Iterable(Box<HtmlIterable>),
     Node(Box<HtmlNode>),
 }
 
@@ -144,8 +147,6 @@ impl Parse for HtmlRoot {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let html_root = if HtmlTree::peek_html_type(input).is_some() {
             Self::Tree(input.parse()?)
-        } else if HtmlIterable::peek(input.cursor()).is_some() {
-            Self::Iterable(Box::new(input.parse()?))
         } else {
             Self::Node(Box::new(input.parse()?))
         };
@@ -168,7 +169,6 @@ impl ToTokens for HtmlRoot {
         match self {
             Self::Tree(tree) => tree.to_tokens(tokens),
             Self::Node(node) => node.to_tokens(tokens),
-            Self::Iterable(iterable) => iterable.to_tokens(tokens),
         }
     }
 }
@@ -200,14 +200,25 @@ pub trait ToNodeIterator {
     /// each element. If the resulting iterator only ever yields a single item this function
     /// should return None instead.
     fn to_node_iterator_stream(&self) -> Option<TokenStream>;
+    /// Returns a boolean indicating whether the node can only ever unfold into 1 node
+    /// Same as calling `.to_node_iterator_stream().is_none()`,
+    /// but doesn't actually construct any token stream
+    fn is_singular(&self) -> bool;
 }
 
 impl ToNodeIterator for HtmlTree {
     fn to_node_iterator_stream(&self) -> Option<TokenStream> {
         match self {
-            HtmlTree::Block(block) => block.to_node_iterator_stream(),
+            Self::Block(block) => block.to_node_iterator_stream(),
             // everything else is just a single node.
             _ => None,
+        }
+    }
+
+    fn is_singular(&self) -> bool {
+        match self {
+            Self::Block(block) => block.is_singular(),
+            _ => true,
         }
     }
 }
@@ -231,10 +242,7 @@ impl HtmlChildrenTree {
     // Check if each child represents a single node.
     // This is the case when no expressions are used.
     fn only_single_node_children(&self) -> bool {
-        self.0
-            .iter()
-            .map(ToNodeIterator::to_node_iterator_stream)
-            .all(|s| s.is_none())
+        self.0.iter().all(HtmlTree::is_singular)
     }
 
     pub fn to_build_vec_token_stream(&self) -> TokenStream {
@@ -339,6 +347,10 @@ impl HtmlChildrenTree {
                 )
             },
         }
+    }
+
+    pub fn size_hint(&self) -> Option<usize> {
+        self.only_single_node_children().then_some(self.0.len())
     }
 }
 

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -35,7 +35,7 @@ impl ToTokens for BaseExpr {
 }
 
 pub struct ComponentProps {
-    props: Props,
+    pub props: Props,
     base_expr: Option<Expr>,
 }
 impl ComponentProps {

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -688,13 +688,13 @@ note: required by a bound in `ChildContainerPropertiesBuilder::children`
     |         -------- required by a bound in this associated function
     = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `VChild<Child>: From<VNode>` is not satisfied
+error[E0277]: the trait bound `VChild<Child>: From<yew::virtual_dom::VList>` is not satisfied
    --> tests/html_macro/component-fail.rs:118:29
     |
 118 |     html! { <ChildContainer><></></ChildContainer> };
-    |                             ^ the trait `From<VNode>` is not implemented for `VChild<Child>`, which is required by `VNode: Into<_>`
+    |                             ^ the trait `From<yew::virtual_dom::VList>` is not implemented for `VChild<Child>`, which is required by `yew::virtual_dom::VList: Into<_>`
     |
-    = note: required for `VNode` to implement `Into<VChild<Child>>`
+    = note: required for `yew::virtual_dom::VList` to implement `Into<VChild<Child>>`
 
 error[E0277]: the trait bound `VNode: IntoPropValue<ChildrenRenderer<VChild<Child>>>` is not satisfied
    --> tests/html_macro/component-fail.rs:119:30

--- a/packages/yew-macro/tests/html_macro/for-fail.rs
+++ b/packages/yew-macro/tests/html_macro/for-fail.rs
@@ -1,0 +1,8 @@
+fn main() {
+    _ = ::yew::html!{for x};
+    _ = ::yew::html!{for x in};
+    _ = ::yew::html!{for x in 0 .. 10};
+    _ = ::yew::html!{for (x, y) in 0 .. 10 {
+        <span>{x}</span>
+    }};
+}

--- a/packages/yew-macro/tests/html_macro/for-fail.rs
+++ b/packages/yew-macro/tests/html_macro/for-fail.rs
@@ -5,4 +5,7 @@ fn main() {
     _ = ::yew::html!{for (x, y) in 0 .. 10 {
         <span>{x}</span>
     }};
+    _ = ::yew::html!{for x in 0 .. 10 {
+        <span>{break}</span>
+    }};
 }

--- a/packages/yew-macro/tests/html_macro/for-fail.rs
+++ b/packages/yew-macro/tests/html_macro/for-fail.rs
@@ -1,3 +1,7 @@
+mod smth {
+    const KEY: u32 = 42;
+}
+
 fn main() {
     _ = ::yew::html!{for x};
     _ = ::yew::html!{for x in};
@@ -5,7 +9,16 @@ fn main() {
     _ = ::yew::html!{for (x, y) in 0 .. 10 {
         <span>{x}</span>
     }};
-    _ = ::yew::html!{for x in 0 .. 10 {
+
+    _ = ::yew::html!{for _ in 0 .. 10 {
         <span>{break}</span>
+    }};
+
+    _ = ::yew::html!{for _ in 0 .. 10 {
+        <div key="duplicate" />
+    }};
+
+    _ = ::yew::html!{for _ in 0 .. 10 {
+        <div key={smth::KEY} />
     }};
 }

--- a/packages/yew-macro/tests/html_macro/for-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/for-fail.stderr
@@ -1,0 +1,34 @@
+error: unexpected end of input, expected `in`
+ --> tests/html_macro/for-fail.rs:2:9
+  |
+2 |     _ = ::yew::html!{for x};
+  |         ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `::yew::html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, expected an expression
+ --> tests/html_macro/for-fail.rs:3:9
+  |
+3 |     _ = ::yew::html!{for x in};
+  |         ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `::yew::html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, expected curly braces
+ --> tests/html_macro/for-fail.rs:4:9
+  |
+4 |     _ = ::yew::html!{for x in 0 .. 10};
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `::yew::html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> tests/html_macro/for-fail.rs:5:26
+  |
+5 |     _ = ::yew::html!{for (x, y) in 0 .. 10 {
+  |                          ^^^^^^    ------- this is an iterator with items of type `{integer}`
+  |                          |
+  |                          expected integer, found tuple
+  |
+  = note: expected type `{integer}`
+            found tuple `(_, _)`

--- a/packages/yew-macro/tests/html_macro/for-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/for-fail.stderr
@@ -22,6 +22,13 @@ error: unexpected end of input, expected curly braces
   |
   = note: this error originates in the macro `::yew::html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: diverging expression in the body of a for loop
+       `break` or `continue` are not allowed in `html!` for loops
+ --> tests/html_macro/for-fail.rs:9:16
+  |
+9 |         <span>{break}</span>
+  |                ^^^^^
+
 error[E0308]: mismatched types
  --> tests/html_macro/for-fail.rs:5:26
   |

--- a/packages/yew-macro/tests/html_macro/for-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/for-fail.stderr
@@ -1,41 +1,59 @@
 error: unexpected end of input, expected `in`
- --> tests/html_macro/for-fail.rs:2:9
+ --> tests/html_macro/for-fail.rs:6:9
   |
-2 |     _ = ::yew::html!{for x};
+6 |     _ = ::yew::html!{for x};
   |         ^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `::yew::html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of input, expected an expression
- --> tests/html_macro/for-fail.rs:3:9
+ --> tests/html_macro/for-fail.rs:7:9
   |
-3 |     _ = ::yew::html!{for x in};
+7 |     _ = ::yew::html!{for x in};
   |         ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `::yew::html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of input, expected curly braces
- --> tests/html_macro/for-fail.rs:4:9
+ --> tests/html_macro/for-fail.rs:8:9
   |
-4 |     _ = ::yew::html!{for x in 0 .. 10};
+8 |     _ = ::yew::html!{for x in 0 .. 10};
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `::yew::html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: diverging expression in the body of a for loop
-       `break` or `continue` are not allowed in `html!` for loops
- --> tests/html_macro/for-fail.rs:9:16
-  |
-9 |         <span>{break}</span>
-  |                ^^^^^
+error: duplicate key for a node in a `for`-loop
+       this will create elements with duplicate keys if the loop iterates more than once
+  --> tests/html_macro/for-fail.rs:18:18
+   |
+18 |         <div key="duplicate" />
+   |                  ^^^^^^^^^^^
+
+error: duplicate key for a node in a `for`-loop
+       this will create elements with duplicate keys if the loop iterates more than once
+  --> tests/html_macro/for-fail.rs:22:19
+   |
+22 |         <div key={smth::KEY} />
+   |                   ^^^^
+
+error[E0267]: `break` inside of a closure
+  --> tests/html_macro/for-fail.rs:14:16
+   |
+13 |       _ = ::yew::html!{for _ in 0 .. 10 {
+   |  _________-
+14 | |         <span>{break}</span>
+   | |                ^^^^^ cannot `break` inside of a closure
+15 | |     }};
+   | |______- enclosing closure
 
 error[E0308]: mismatched types
- --> tests/html_macro/for-fail.rs:5:26
+ --> tests/html_macro/for-fail.rs:9:26
   |
-5 |     _ = ::yew::html!{for (x, y) in 0 .. 10 {
-  |                          ^^^^^^    ------- this is an iterator with items of type `{integer}`
+9 |     _ = ::yew::html!{for (x, y) in 0 .. 10 {
+  |                          ^^^^^^
   |                          |
   |                          expected integer, found tuple
+  |                          expected due to this
   |
   = note: expected type `{integer}`
             found tuple `(_, _)`

--- a/packages/yew-macro/tests/html_macro/for-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/for-fail.stderr
@@ -52,7 +52,7 @@ error[E0308]: mismatched types
 9 |     _ = ::yew::html!{for (x, y) in 0 .. 10 {
   |                          ^^^^^^
   |                          |
-  |                          expected integer, found tuple
+  |                          expected integer, found `(_, _)`
   |                          expected due to this
   |
   = note: expected type `{integer}`

--- a/packages/yew-macro/tests/html_macro/for-pass.rs
+++ b/packages/yew-macro/tests/html_macro/for-pass.rs
@@ -55,4 +55,22 @@ fn main() {
         }
     };
 
+    fn rand_number() -> ::std::primitive::u32 {
+        4 // chosen by fair dice roll. guaranteed to be random.
+    }
+
+    _ = ::yew::html!{
+        for _ in 0..5 {
+            <div>
+                {{
+                    loop {
+                        let a = rand_number();
+                        if a % 2 == 0 {
+                            break a;
+                        }
+                    }
+                }}
+            </div>
+        }
+    }
 }

--- a/packages/yew-macro/tests/html_macro/for-pass.rs
+++ b/packages/yew-macro/tests/html_macro/for-pass.rs
@@ -36,28 +36,23 @@ pub struct u8;
 #[allow(non_camel_case_types)]
 pub struct usize;
 
-fn empty_vec() -> ::std::vec::Vec<::yew::Html> {
-    ::std::vec::Vec::<::yew::Html>::new()
-}
-
-fn empty_iter() -> impl ::std::iter::Iterator<Item = ::yew::Html> {
-    ::std::iter::empty::<::yew::Html>()
-}
-
 fn main() {
-    _ = ::yew::html! { {for empty_iter()} };
-    _ = ::yew::html! { {for { empty_iter() }} };
+    _ = ::yew::html!{
+        for i in 0 .. 10 {
+            <span>{i}</span>
+        }
+    };
 
-    let empty = empty_vec();
-    _ = ::yew::html! { {for empty} };
+    struct Pair {
+        value1: &'static ::std::primitive::str,
+        value2: ::std::primitive::i32
+    }
 
-    _ = ::yew::html! {<>
-        {for empty_vec()}
-    </>};
-    _ = ::yew::html! {<>
-        {for ::std::iter::IntoIterator::into_iter(empty_vec())}
-    </>};
-    _ = ::yew::html! {<>
-        {for ::std::iter::Iterator::map(0..3, |num| { ::yew::html! { <span>{ num }</span> } })}
-    </>};
+    _ = ::yew::html! {
+        for Pair { value1, value2 } in ::std::iter::Iterator::map(0 .. 10, |value2| Pair { value1: "Yew", value2 }) {
+            <span>{value1}</span>
+            <span>{value2}</span>
+        }
+    };
+
 }

--- a/packages/yew-macro/tests/html_macro/iterable-fail.rs
+++ b/packages/yew-macro/tests/html_macro/iterable-fail.rs
@@ -3,14 +3,14 @@ use yew::prelude::*;
 fn compile_fail() {
     html! { for };
     html! { for () };
-    html! { for {()} };
+    html! { {for ()} };
     html! { for Vec::<()>::new().into_iter() };
 
     let empty = Vec::<()>::new().into_iter();
     html! { for empty };
 
     let empty = Vec::<()>::new();
-    html! { for empty.iter() };
+    html! { {for empty.iter()} };
 
     html! {
         <>

--- a/packages/yew-macro/tests/html_macro/iterable-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/iterable-fail.stderr
@@ -1,67 +1,47 @@
-error: expected an expression after the keyword `for`
- --> tests/html_macro/iterable-fail.rs:4:13
+error: unexpected end of input, expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
+ --> tests/html_macro/iterable-fail.rs:4:5
   |
 4 |     html! { for };
-  |             ^^^
+  |     ^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `()` is not an iterator
- --> tests/html_macro/iterable-fail.rs:5:17
+error: unexpected end of input, expected `in`
+ --> tests/html_macro/iterable-fail.rs:5:5
   |
 5 |     html! { for () };
-  |                 ^^ `()` is not an iterator
+  |     ^^^^^^^^^^^^^^^^
   |
-  = help: the trait `Iterator` is not implemented for `()`, which is required by `(): IntoIterator`
-  = note: required for `()` to implement `IntoIterator`
+  = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `()` is not an iterator
- --> tests/html_macro/iterable-fail.rs:6:17
-  |
-6 |     html! { for {()} };
-  |                 ^--^
-  |                 ||
-  |                 |this tail expression is of type `()`
-  |                 `()` is not an iterator
-  |
-  = help: the trait `Iterator` is not implemented for `()`, which is required by `(): IntoIterator`
-  = note: required for `()` to implement `IntoIterator`
-
-error[E0277]: `()` doesn't implement `std::fmt::Display`
- --> tests/html_macro/iterable-fail.rs:7:17
+error: expected `in`
+ --> tests/html_macro/iterable-fail.rs:7:33
   |
 7 |     html! { for Vec::<()>::new().into_iter() };
-  |                 ^^^ `()` cannot be formatted with the default formatter
-  |
-  = help: the trait `std::fmt::Display` is not implemented for `()`, which is required by `VNode: FromIterator<_>`
-  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = help: the trait `FromIterator<A>` is implemented for `VNode`
-  = note: required for `()` to implement `ToString`
-  = note: required for `VNode` to implement `From<()>`
-  = note: required for `()` to implement `Into<VNode>`
-  = note: required for `VNode` to implement `FromIterator<()>`
-note: required by a bound in `collect`
- --> $RUST/core/src/iter/traits/iterator.rs
+  |                                 ^
 
-error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> tests/html_macro/iterable-fail.rs:10:17
+error: unexpected end of input, expected `in`
+  --> tests/html_macro/iterable-fail.rs:10:5
    |
 10 |     html! { for empty };
-   |                 ^^^^^ `()` cannot be formatted with the default formatter
+   |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: the trait `std::fmt::Display` is not implemented for `()`, which is required by `VNode: FromIterator<_>`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = help: the trait `FromIterator<A>` is implemented for `VNode`
-   = note: required for `()` to implement `ToString`
-   = note: required for `VNode` to implement `From<()>`
-   = note: required for `()` to implement `Into<VNode>`
-   = note: required for `VNode` to implement `FromIterator<()>`
-note: required by a bound in `collect`
-  --> $RUST/core/src/iter/traits/iterator.rs
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `()` is not an iterator
+ --> tests/html_macro/iterable-fail.rs:6:18
+  |
+6 |     html! { {for ()} };
+  |                  ^^ `()` is not an iterator
+  |
+  = help: the trait `Iterator` is not implemented for `()`, which is required by `(): IntoIterator`
+  = note: required for `()` to implement `IntoIterator`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> tests/html_macro/iterable-fail.rs:13:17
+  --> tests/html_macro/iterable-fail.rs:13:18
    |
-13 |     html! { for empty.iter() };
-   |                 ^^^^^ `()` cannot be formatted with the default formatter
+13 |     html! { {for empty.iter()} };
+   |                  ^^^^^ `()` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`, which is required by `VNode: FromIterator<_>`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -35,6 +35,8 @@ pub use self::listeners::*;
 pub use self::vcomp::{VChild, VComp};
 #[doc(inline)]
 pub use self::vlist::VList;
+#[doc(hidden)]
+pub use self::vlist::FullyKeyedState;
 #[doc(inline)]
 pub use self::vnode::VNode;
 #[doc(inline)]

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -33,10 +33,10 @@ pub use self::key::Key;
 pub use self::listeners::*;
 #[doc(inline)]
 pub use self::vcomp::{VChild, VComp};
-#[doc(inline)]
-pub use self::vlist::VList;
 #[doc(hidden)]
 pub use self::vlist::FullyKeyedState;
+#[doc(inline)]
+pub use self::vlist::VList;
 #[doc(inline)]
 pub use self::vnode::VNode;
 #[doc(inline)]

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -5,8 +5,9 @@ use std::rc::Rc;
 use super::{Key, VNode};
 use crate::html::ImplicitClone;
 
+#[doc(hidden)]
 #[derive(Clone, Copy, Debug, PartialEq)]
-enum FullyKeyedState {
+pub enum FullyKeyedState {
     KnownFullyKeyed,
     KnownMissingKeys,
     Unknown,
@@ -79,6 +80,16 @@ impl VList {
         };
         vlist.recheck_fully_keyed();
         vlist
+    }
+
+    #[doc(hidden)]
+    /// Used by `html!` to avoid calling `.recheck_fully_keyed()` when possible.
+    pub fn __macro_new(children: Vec<VNode>, key: Option<Key>, fully_keyed: FullyKeyedState) -> Self {
+        VList {
+            children: Some(Rc::new(children)),
+            fully_keyed,
+            key,
+        }
     }
 
     // Returns a mutable reference to children, allocates the children if it hasn't been done.

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -84,7 +84,11 @@ impl VList {
 
     #[doc(hidden)]
     /// Used by `html!` to avoid calling `.recheck_fully_keyed()` when possible.
-    pub fn __macro_new(children: Vec<VNode>, key: Option<Key>, fully_keyed: FullyKeyedState) -> Self {
+    pub fn __macro_new(
+        children: Vec<VNode>,
+        key: Option<Key>,
+        fully_keyed: FullyKeyedState,
+    ) -> Self {
         VList {
             children: Some(Rc::new(children)),
             fully_keyed,

--- a/packages/yew/tests/suspense.rs
+++ b/packages/yew/tests/suspense.rs
@@ -812,7 +812,6 @@ async fn test_duplicate_suspension() {
 
     yew::Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
         .render();
-
     sleep(Duration::from_millis(50)).await;
     let result = obtain_result();
     assert_eq!(result.as_str(), "hello!");

--- a/website/docs/advanced-topics/children.mdx
+++ b/website/docs/advanced-topics/children.mdx
@@ -137,7 +137,7 @@ fn List(props: &Props) -> Html {
             props.value = format!("item-{}", props.value);
             item
     });
-    html! { modified_children }
+    html! {{for modified_children}}
 }
 
 html! {

--- a/website/docs/advanced-topics/children.mdx
+++ b/website/docs/advanced-topics/children.mdx
@@ -137,7 +137,7 @@ fn List(props: &Props) -> Html {
             props.value = format!("item-{}", props.value);
             item
     });
-    html! { for modified_children }
+    html! { modified_children }
 }
 
 html! {

--- a/website/docs/concepts/html/lists.mdx
+++ b/website/docs/concepts/html/lists.mdx
@@ -22,7 +22,7 @@ html! {
     for i in 0 .. 10 {
         <span>{i}</span>
     }
-}
+};
 ```
 
   </TabItem>

--- a/website/docs/concepts/html/lists.mdx
+++ b/website/docs/concepts/html/lists.mdx
@@ -7,12 +7,47 @@ import TabItem from '@theme/TabItem'
 
 ## Iterators
 
-Yew supports two different syntaxes for building HTML from an iterator.
+There are 3 ways to build HTML from iterators:
 
 <Tabs>
-  <TabItem value="Syntax type 1" label="Syntax type 1">
+  <TabItem value="`for` loops" label="`for` loops">
+The main approach is to use for loops, the same for loops that already exist in Rust, but with 2 key differences:
+1. Unlike standard for loops which can't return anything, for loops in `html!` are converted to a list of nodes;
+2. Diverging expressions, i.e. `break`, `continue` are not allowed in the body of for loops in `html!`.
 
-The first is to call `collect::<Html>()` on the final transform in your iterator, which returns a
+```rust
+use yew::prelude::*;
+
+html! {
+    for i in 0 .. 10 {
+        <span>{i}</span>
+    }
+}
+```
+
+  </TabItem>
+  <TabItem value="`for` block" label="`for` block">
+An alternative is to use the `for` keyword, which is not native Rust syntax and instead is used by
+the HTML macro to output the needed code to display the iterator.
+This approach is better than the first one when the iterator is already computed and the only thing left to do
+is to pass it to the macro.
+
+```rust
+use yew::prelude::*;
+
+let items = (1..=10).collect::<Vec<_>>();
+
+html! {
+    <ul class="item-list">
+        { for items.iter() }
+    </ul>
+};
+```
+
+  </TabItem>
+  <TabItem value="`collect` method" label="`collect` method">
+
+The last is to call `collect::<Html>()` on the final transform in your iterator, which returns a
 list that Yew can display.
 
 ```rust
@@ -23,24 +58,6 @@ let items = (1..=10).collect::<Vec<_>>();
 html! {
     <ul class="item-list">
         { items.iter().collect::<Html>() }
-    </ul>
-};
-```
-
-  </TabItem>
-  <TabItem value="Syntax type 2" label="Syntax type 2">
-
-The alternative is to use the `for` keyword, which is not native Rust syntax and instead is used by
-the HTML macro to output the needed code to display the iterator.
-
-```rust
-use yew::prelude::*;
-
-let items = (1..=10).collect::<Vec<_>>();
-
-html! {
-    <ul class="item-list">
-        { for items.iter() }
     </ul>
 };
 ```

--- a/website/versioned_docs/version-0.20/concepts/html/components.mdx
+++ b/website/versioned_docs/version-0.20/concepts/html/components.mdx
@@ -154,7 +154,7 @@ fn List(props: &Props) -> Html {
             props.value = format!("item-{}", props.value);
             item
     });
-    html! { for modified_children }
+    html! { modified_children }
 }
 
 html! {

--- a/website/versioned_docs/version-0.20/concepts/html/components.mdx
+++ b/website/versioned_docs/version-0.20/concepts/html/components.mdx
@@ -154,7 +154,7 @@ fn List(props: &Props) -> Html {
             props.value = format!("item-{}", props.value);
             item
     });
-    html! { modified_children }
+    html! { for modified_children }
 }
 
 html! {


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

1. Adds the following syntax:
```rs
html! {
  for x in 0 .. 10 {
    <span>{x}</span>
  }
}
```
2. Disallows top-level `{for x}`, i.e. the following is no longer valid:
```rs
html! { for x }
```
To disambiguate it and the new for loops, it'll be required to wrap the expression in braces like so:
```rs
html! { {for x} }
```

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
