### PR TITLE
Dynamic Prop Labels

### DIFF
--- a/packages/yew-macro/src/html_tree/html_list.rs
+++ b/packages/yew-macro/src/html_tree/html_list.rs
@@ -134,7 +134,7 @@ impl Parse for HtmlListProps {
                 return Err(input.error("only a single `key` prop is allowed on a fragment"));
             }
 
-            if prop.label.to_ascii_lowercase_string() != "key" {
+            if !String::try_from(&prop.label).is_ok_and(|label| label.eq_ignore_ascii_case("key")) {
                 return Err(syn::Error::new_spanned(
                     prop.label,
                     "fragments only accept the `key` prop",

--- a/packages/yew-macro/src/html_tree/lint/mod.rs
+++ b/packages/yew-macro/src/html_tree/lint/mod.rs
@@ -45,10 +45,9 @@ where
 ///
 /// Attribute names are lowercased before being compared (so pass "href" for `name` and not "HREF").
 fn get_attribute<'a>(props: &'a ElementProps, name: &str) -> Option<&'a Prop> {
-    props
-        .attributes
-        .iter()
-        .find(|item| item.label.eq_ignore_ascii_case(name))
+    props.attributes.iter().find(|item| {
+        String::try_from(&item.label).is_ok_and(|label| label.eq_ignore_ascii_case(name))
+    })
 }
 
 /// Lints to check if anchor (`<a>`) tags have valid `href` attributes defined.

--- a/packages/yew-macro/src/props/component.rs
+++ b/packages/yew-macro/src/props/component.rs
@@ -7,7 +7,7 @@ use syn::spanned::Spanned;
 use syn::token::DotDot;
 use syn::Expr;
 
-use super::{Prop, Props, SpecialProps, CHILDREN_LABEL};
+use super::{Prop, PropLabel, Props, SpecialProps, CHILDREN_LABEL};
 
 struct BaseExpr {
     pub dot_dot: DotDot,
@@ -190,15 +190,12 @@ impl TryFrom<Props> for ComponentProps {
 
 fn validate(props: Props) -> Result<Props, syn::Error> {
     props.check_no_duplicates()?;
-    props.check_all(|prop| {
-        if !prop.label.extended.is_empty() {
-            Err(syn::Error::new_spanned(
-                &prop.label,
-                "expected a valid Rust identifier",
-            ))
-        } else {
-            Ok(())
-        }
+    props.check_all(|prop| match &prop.label {
+        PropLabel::Static(dashed_name) if dashed_name.extended.is_empty() => Ok(()),
+        _ => Err(syn::Error::new_spanned(
+            &prop.label,
+            "expected a valid Rust identifier",
+        )),
     })?;
 
     Ok(props)

--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -19,14 +19,16 @@ impl Parse for ElementProps {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut props = input.parse::<Props>()?;
 
-        let listeners =
-            props.drain_filter(|prop| LISTENER_SET.contains(prop.label.to_string().as_str()));
+        let listeners = props.drain_filter(|prop| {
+            String::try_from(&prop.label).is_ok_and(|prop| LISTENER_SET.contains(prop.as_str()))
+        });
 
         // Multiple listener attributes are allowed, but no others
         props.check_no_duplicates()?;
 
-        let booleans =
-            props.drain_filter(|prop| BOOLEAN_SET.contains(prop.label.to_string().as_str()));
+        let booleans = props.drain_filter(|prop| {
+            String::try_from(&prop.label).is_ok_and(|prop| BOOLEAN_SET.contains(prop.as_str()))
+        });
 
         let classes = props.pop("class");
         let value = props.pop("value");

--- a/packages/yew-macro/src/props/prop.rs
+++ b/packages/yew-macro/src/props/prop.rs
@@ -335,7 +335,7 @@ impl PropList {
             if let Some(other_prop) = self.get_by_label(key) {
                 return Err(syn::Error::new_spanned(
                     // OK to unwrap since pop/get_by_label can be Some only if PropLabel::Static
-                    &String::try_from(&other_prop.label).unwrap(),
+                    String::try_from(&other_prop.label).unwrap(),
                     format!("`{key}` can only be specified once"),
                 ));
             }
@@ -380,7 +380,7 @@ impl PropList {
         crate::join_errors(self.iter_duplicates().map(|prop| {
             syn::Error::new_spanned(
                 // OK to unwrap since iter_duplicates iterates only over PropLabel::Static
-                &String::try_from(&prop.label).unwrap(),
+                String::try_from(&prop.label).unwrap(),
                 format!(
                     "`{}` can only be specified once but is given here again",
                     String::try_from(&prop.label).unwrap()

--- a/packages/yew-macro/src/props/prop_macro.rs
+++ b/packages/yew-macro/src/props/prop_macro.rs
@@ -8,7 +8,7 @@ use syn::spanned::Spanned;
 use syn::token::Brace;
 use syn::{Expr, Token, TypePath};
 
-use super::{ComponentProps, Prop, PropList, Props};
+use super::{ComponentProps, Prop, PropLabel, PropList, Props};
 use crate::html_tree::HtmlDashedName;
 
 /// Pop from `Punctuated` without leaving it in a state where it has trailing punctuation.
@@ -45,6 +45,7 @@ struct PropValue {
     label: HtmlDashedName,
     value: Expr,
 }
+
 impl Parse for PropValue {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let label = input.parse()?;
@@ -62,7 +63,7 @@ impl From<PropValue> for Prop {
     fn from(prop_value: PropValue) -> Prop {
         let PropValue { label, value } = prop_value;
         Prop {
-            label,
+            label: PropLabel::Static(label),
             value,
             directive: None,
         }
@@ -74,6 +75,7 @@ struct PropsExpr {
     _brace_token: Brace,
     fields: Punctuated<PropValue, Token![,]>,
 }
+
 impl Parse for PropsExpr {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut ty: TypePath = input.parse()?;
@@ -103,6 +105,7 @@ pub struct PropsMacroInput {
     ty: TypePath,
     props: ComponentProps,
 }
+
 impl Parse for PropsMacroInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let PropsExpr { ty, fields, .. } = input.parse()?;
@@ -121,6 +124,7 @@ impl Parse for PropsMacroInput {
         })
     }
 }
+
 impl ToTokens for PropsMacroInput {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Self { ty, props } = self;


### PR DESCRIPTION
#### Description

Partially implements features from discussion #3477. This PR adds Dynamic Prop Labels, so that anyone can write their favorite attributes like [HTMX's `hx-on:click`](https://htmx.org/attributes/hx-on/):
```rust
html! {
    <div { "hx-on:click" }={ "alert('Clicked!')" }>{ "Click" }</div>
}
```

It works by using new `PropLabel` enum everywhere, which can be either a `Static` `HtmlDashedName` like before, or `Dynamic` `Expr`. When parsing, if it meets `=` token after the expression group, it will read a value following it instead of assuming that it is shorthand syntax.

#### Checklist

- [x] I have reviewed my own code - what does that mean? Is this always checked for everyone?
- [ ] I have added tests - I need help with that! I have not tested this at all (besides `cargo make test-flow`, which contains no usages of this feature). I know that my implementation allows for repeating the attribute name, since this can be checked only during runtime, and I have not added checks like this in the runtime code (I only did the macro). SSR is also a concern (since this was added for HTMX, and that obviously needs it), but I believe it should not be different since both CSR and SSR use the same `html!` macro. I also know that dynamic prop labels should not be allowed for components.
