### PR TITLE
Add conversion from `UseStateSetter` & `UseReducerDispatcher` to a `Callback`

### DIFF
--- a/packages/yew/src/functional/hooks/use_state.rs
+++ b/packages/yew/src/functional/hooks/use_state.rs
@@ -4,6 +4,8 @@ use std::rc::Rc;
 
 use super::{use_reducer, use_reducer_eq, Reducible, UseReducerDispatcher, UseReducerHandle};
 use crate::functional::hook;
+use crate::html::IntoPropValue;
+use crate::Callback;
 
 struct UseStateReducer<T> {
     value: T,
@@ -171,6 +173,18 @@ where
     }
 }
 
+impl<T> From<UseStateSetter<T>> for Callback<T> {
+    fn from(value: UseStateSetter<T>) -> Self {
+        Self::from(value.inner)
+    }
+}
+
+impl<T> IntoPropValue<Callback<T>> for UseStateSetter<T> {
+    fn into_prop_value(self) -> Callback<T> {
+        self.inner.into_prop_value()
+    }
+}
+
 impl<T> PartialEq for UseStateSetter<T> {
     fn eq(&self, rhs: &Self) -> bool {
         self.inner == rhs.inner
@@ -181,5 +195,11 @@ impl<T> UseStateSetter<T> {
     /// Replaces the value
     pub fn set(&self, value: T) {
         self.inner.dispatch(value)
+    }
+
+    /// Get a callback, invoking which is equivalent to calling `set()`
+    /// on this same setter.
+    pub fn to_callback(&self) -> Callback<T> {
+        self.inner.to_callback()
     }
 }


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Implements #3510 by adding `UseStateSetter::to_callback` & `UseReducerDispatcher::to_callback` methods and `From`/`IntoPropValue` implementations to do the same thing as the methods but without cloning.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
