### PR TITLE
Fix incorrect use of Swatinem/rust-cache

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -32,6 +32,8 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: profile-${{ matrix.profile }}
 
       - name: Lint feature soundness
         if: matrix.profile == 'dev'
@@ -73,6 +75,8 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: toolchain-${{ matrix.toolchain }}
 
       - name: Run clippy
         run: |

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -74,6 +74,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: toolchain-${{ matrix.toolchain }}
 
       # for wasm-bindgen-cli, always use stable rust
       - name: Setup toolchain
@@ -131,6 +133,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: toolchain-${{ matrix.toolchain }}
 
       - name: Run native tests
         env:
@@ -159,6 +163,8 @@ jobs:
           toolchain: nightly
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: toolchain-${{ matrix.toolchain }}
 
       - name: Run tests
         env:

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Restore Rust cache for master
         uses: Swatinem/rust-cache@v2
+        with:
+          key: target-${{ matrix.target }}
 
       - name: Setup Trunk
         uses: jetli/trunk-action@v0.4.0


### PR DESCRIPTION
#### Description

I just discovered the other day that the Swatinem/cache action doesn't work
properly when using matrix. Apparently the cache key is the same for all the
different paths of the workflow matrix which makes Rust not re-use the correct
cache.

This should speed up our workflows a bit.

Related to https://github.com/yewstack/yew-autoprops/pull/10#issuecomment-1793690594

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
