### PR TITLE
Make UseFutureHandle Clone

### DIFF
--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -15,6 +15,14 @@ pub struct UseFutureHandle<O> {
     inner: UseStateHandle<Option<O>>,
 }
 
+impl<O> Clone for UseFutureHandle<O> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
 impl<O> Deref for UseFutureHandle<O> {
     type Target = O;
 


### PR DESCRIPTION
#### Description

This change makes `UseFutureHandle` implement `Clone`. All other `UseXHandle` structs have a cheap clone that calls `Rc::clone` internally, so I think `UseFutureHandle` should also have this functionality. 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
