### PR TITLE
node refs example link updated

### DIFF
--- a/examples/node_refs/README.md
+++ b/examples/node_refs/README.md
@@ -6,7 +6,7 @@ This example shows two input fields which are automatically focused when hovered
 
 ## Concepts
 
-The example uses [Refs](https://yew.rs/docs/concepts/components/refs/) to
+The example uses [Refs](https://yew.rs/docs/concepts/function-components/node-refs) to
 manipulate the underlying DOM element directly.
 
 ## Running


### PR DESCRIPTION
#### Description

The NodeRef example has a link in README which does not exist.
Changed it to the actual path.


#### Checklist


- [ x] I have reviewed my own code
- [ ] I have added tests (Not Applicable)
