### PR TITLE
Less error prone yew-router instructions

### DIFF
--- a/website/docs/concepts/router.mdx
+++ b/website/docs/concepts/router.mdx
@@ -8,12 +8,10 @@ default behavior of requesting a different remote resource when a link is clicke
 locally to point to a valid route in your application. The router then detects this change and then decides what to
 render.
 
-Yew provides router support in the `yew-router` crate. To start using it, add the dependency to your `Cargo.toml`
+Yew provides router support in the `yew-router` crate. To start using it, add the dependency to your `Cargo.toml`:
 
-<!-- Reminder: fix this when we release a new version of yew -->
-
-```toml
-yew-router = { git = "https://github.com/yewstack/yew.git" }
+```sh
+cargo add yew-router
 ```
 
 The utilities needed are provided under `yew_router::prelude`,


### PR DESCRIPTION
Simply add yew-router via cargo and hope that cargo figures out the correct version. For most users referencing git directly is wrong and might lead to annoying errors when compiling.

Before, there was even a comment to keep the version reference up-to-date which obviously did not work and seems unpractical.

#### Description

<!-- Please include a summary of the change. -->

Fixes #3547