### PR TITLE
chore(website): code block typo

### DIFF
--- a/website/docs/more/debugging.mdx
+++ b/website/docs/more/debugging.mdx
@@ -45,7 +45,7 @@ fn main() {
 
 `tracing-web` can be used with [`tracing-subscriber`](https://crates.io/crates/tracing-subscriber) to output messages to the browser console.
 
-```rust, ignore
+```rust ,ignore
 use tracing_subscriber::{
     fmt::{
         format::{FmtSpan, Pretty},


### PR DESCRIPTION
#### Description
just a typo

![image](https://github.com/yewstack/yew/assets/10402091/59e6b34e-2530-4e02-8279-ece982ba2734)


#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x ] I have reviewed my own code
- [x ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
