### PR TITLE
[layout tests] Function for rendering a single node and getting the resulting web_sys::Element

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -96,6 +96,7 @@ ssr = ["dep:html-escape", "dep:base64ct", "dep:bincode"]
 csr = []
 hydration = ["csr", "dep:bincode"]
 default = []
+test = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -513,7 +513,7 @@ mod feat_csr {
     use crate::scheduler;
 
     impl AnyScope {
-        #[cfg(test)]
+        #[cfg(any(test, feature = "test"))]
         pub(crate) fn test() -> Self {
             Self {
                 type_id: TypeId::of::<()>(),

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -295,8 +295,8 @@ mod app_handle;
 #[cfg(feature = "csr")]
 mod renderer;
 
-#[cfg(feature = "csr")]
-#[cfg(test)]
+#[cfg(all(feature = "csr", any(test, feature = "test")))]
+/// Module containing utilities for testing yew-specific behavior.
 pub mod tests;
 
 /// The module that contains all events available in the framework.

--- a/packages/yew/src/tests/layout_tests.rs
+++ b/packages/yew/src/tests/layout_tests.rs
@@ -30,13 +30,18 @@ impl Component for Comp {
     }
 }
 
+/// A struct which defines the string of HTML that is the expected output of a [`VNode`].
 #[derive(Debug)]
 pub struct TestLayout<'a> {
+    /// Name of the test layout for inspecability.
     pub name: &'a str,
+    /// The node which should be rendered.
     pub node: VNode,
+    /// The expected HTML string output of rendering `node`.
     pub expected: &'a str,
 }
 
+/// Iterate over multiple layouts and check them for correctness.
 pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
     let document = gloo::utils::document();
     let scope: AnyScope = AnyScope::test();

--- a/packages/yew/src/tests/mod.rs
+++ b/packages/yew/src/tests/mod.rs
@@ -1,1 +1,2 @@
+/// Utilities for testing how [`VNode`]s are rendered.
 pub mod layout_tests;


### PR DESCRIPTION
#### Description

Following up from https://github.com/yewstack/yew/discussions/3578 but important bits are reexplained here.
Pulls in code from https://github.com/yewstack/yew/pull/3463.


This PR adds a function with which a single component is rendered once and the resulting web_sys::Element is returned. This allows then querying the resulting element to run verification on only a subset of the resulting HTML code instead of all of it. This means that tests can be more fine-tuned resulting in less breakage through things such as style changes.

#### Limitations

Interactions with the DOM aren't possible with this since the scheduler doesn't run again. I would be interested in suggestions on how to implement that, so that users can get an experience similar to the JavaScript "DOM Testing Library" where the following is possible:

```js
import {render, fireEvent, screen} from '@testing-library/react'

test('loads items eventually', async () => {
  render(<Page />)

  // Click button
  fireEvent.click(screen.getByText('Load'))

  // Wait for page to update with query text
  const items = await screen.findAllByText(/Item #[0-9]: /)
  expect(items).toHaveLength(10)
})
```

A crate called [frontest](https://github.com/zvolin/frontest-rs) was able to achieve a similar result with Yew 0.19 the following way:

```rust
pub async fn render(content: Html) -> Element {
    let div = gloo::utils::document().create_element("div").unwrap();
    gloo::utils::body().append_child(&div).unwrap();
    let res = div.clone();
    ::yew::start_app_with_props_in_element::<Wrapper>(div, WrapperProps { content });
    res
}
```

However, using Yew 0.21's `Renderer::<Wrapper>::with_root_and_props(...).render()` does not lead to the same results - the div created div is simply empty. I assume that the scheduler isn't started but I don't know enough about the internals of Yew.

Being able to offer this functionality would make testing Yew apps significantly easier.

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
