### PR TITLE
Introduce a new use_async hook, that allows for setting dependencies

### DIFF
--- a/packages/yew/src/functional/hooks/mod.rs
+++ b/packages/yew/src/functional/hooks/mod.rs
@@ -1,3 +1,4 @@
+mod use_async;
 mod use_callback;
 mod use_context;
 mod use_effect;
@@ -9,6 +10,7 @@ mod use_ref;
 mod use_state;
 mod use_transitive_state;
 
+pub use use_async::*;
 pub use use_callback::*;
 pub use use_context::*;
 pub use use_effect::*;

--- a/packages/yew/src/functional/hooks/use_async.rs
+++ b/packages/yew/src/functional/hooks/use_async.rs
@@ -1,0 +1,56 @@
+use std::{fmt, future::Future};
+
+use crate::{functional::hook, use_effect_with, use_state, UseStateHandle};
+
+#[hook]
+pub fn use_async<Arg, F, Fut, Res>(deps: Arg, f: F) -> UseAsyncHandle<Res>
+where
+    Arg: 'static + PartialEq,
+    F: 'static + FnOnce(&Arg) -> Fut,
+    Fut: 'static + Future<Output = Res>,
+    Res: 'static,
+{
+    let result = use_state(|| None);
+    use_effect_with(deps, {
+        let result = result.clone();
+        move |deps| {
+            result.set(None);
+            let future = f(deps);
+            wasm_bindgen_futures::spawn_local(async move {
+                let res = future.await;
+                result.set(Some(res));
+            });
+        }
+    });
+    UseAsyncHandle { inner: result }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct UseAsyncHandle<T> {
+    inner: UseStateHandle<Option<T>>,
+}
+
+#[derive(Debug)]
+pub enum UseAsyncResult<'a, T> {
+    Pending,
+    Ready(&'a T),
+}
+
+impl<T: fmt::Debug> fmt::Debug for UseAsyncHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let inner_value: &Option<T> = &*self.inner;
+        match inner_value {
+            None => f.write_str("Pending"),
+            Some(val) => f.debug_tuple("Ready").field(val).finish(),
+        }
+    }
+}
+
+impl<T> UseAsyncHandle<T> {
+    pub fn status(&self) -> UseAsyncResult<'_, T> {
+        match &*self.inner {
+            None => UseAsyncResult::Pending,
+            Some(res) => UseAsyncResult::Ready(res),
+        }
+    }
+}

--- a/packages/yew/src/functional/hooks/use_async.rs
+++ b/packages/yew/src/functional/hooks/use_async.rs
@@ -16,7 +16,7 @@ where
         move |deps| {
             result.set(None);
             let future = f(deps);
-            wasm_bindgen_futures::spawn_local(async move {
+            yew::platform::spawn_local(async move {
                 let res = future.await;
                 result.set(Some(res));
             });
@@ -31,7 +31,7 @@ pub struct UseAsyncHandle<T> {
 }
 
 #[derive(Debug)]
-pub enum UseAsyncResult<'a, T> {
+pub enum UseAsyncStatus<'a, T> {
     Pending,
     Ready(&'a T),
 }
@@ -47,10 +47,10 @@ impl<T: fmt::Debug> fmt::Debug for UseAsyncHandle<T> {
 }
 
 impl<T> UseAsyncHandle<T> {
-    pub fn status(&self) -> UseAsyncResult<'_, T> {
+    pub fn status(&self) -> UseAsyncStatus<'_, T> {
         match &*self.inner {
-            None => UseAsyncResult::Pending,
-            Some(res) => UseAsyncResult::Ready(res),
+            None => UseAsyncStatus::Pending,
+            Some(res) => UseAsyncStatus::Ready(res),
         }
     }
 }


### PR DESCRIPTION
#### Description

Introduce an `use_async` hook, that performs a computation in another task and returns the result.

(Probably) fixes #364

The main API design question is whether we want to introduce the idea of cancellation in the API or not. Adding it afterwards would likely require adding a variant to `UseAsyncStatus`. This being said, Yew is not stable yet, and probably at least 90% of the use cases are covered by this API, so I think it makes sense to postpone the decision after verifying that there is an actual need.

This PR is not done yet, and is here mostly to gather feedback on whether this is something that Yew developers would be interested in having upstream. I'm using it in my own code [here](https://github.com/Ekleog/crdb/commit/2ed2777a607b894c3aa1e93e6584c33be27b6679), and thought it would likely be helpful to other people too.

The alternatives I know of are:
- The `use_async` and `use_async_with_options` from `yew_hooks`. They do not support introducing dependencies that would trigger a future re-computation.
- `yewtil`'s `LinkFuture`. Not having used it I'm less familiar with it, but AFAIU it requires struct components, which is not the direction Yew development seems to be moving towards.

#### Checklist

Things still missing if you confirm that this PR is of interest to you:
- [x] I have reviewed my own code
- [ ] I have added tests
- [ ] Writing clear documentation
- [ ] Fixing all of CI