### PR TITLE
use_future_with: simplify code a bit by using read-only use_memo rather than use_state

### DIFF
--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -94,7 +94,7 @@ where
     let output = use_state(|| None);
     // We only commit a result if it comes from the latest spawned future. Otherwise, this
     // might trigger pointless updates or even override newer state.
-    let latest_id = use_state(|| Cell::new(0u32));
+    let latest_id = use_memo_base(|()| (Cell::new(0u32), ()), ());
 
     let suspension = {
         let output = output.clone();

--- a/packages/yew/src/suspense/hooks.rs
+++ b/packages/yew/src/suspense/hooks.rs
@@ -94,8 +94,7 @@ where
     let output = use_state(|| None);
     // We only commit a result if it comes from the latest spawned future. Otherwise, this
     // might trigger pointless updates or even override newer state.
-    let latest_id = use_memo_base(|()| (Cell::new(0u32), ()), ());
-
+    let latest_id = use_ref(|| Cell::new(0u32));
     let suspension = {
         let output = output.clone();
 


### PR DESCRIPTION
#### Description

Slight code simplification: here `latest_id` is never used as mutable, so might as well make it non-mutable by using `use_memo_base`

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code

There was no relevant test to add for this code simplification