### PR TITLE
if xmlns attribute is specified, use that namespace when creating ele…

### DIFF
--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -233,7 +233,14 @@ impl Reconcilable for VTag {
 impl VTag {
     fn create_element(&self, parent: &Element) -> Element {
         let tag = self.tag();
-
+        
+        // check for an xmlns attribute. If it exists, create an element with the specified namespace
+        let xmlns = self.attributes.iter().find(|(k, _)| *k == "xmlns").map(|(_, v)| v);
+        if let Some(xmlns) = xmlns {
+            document()
+                .create_element_ns(Some(xmlns), tag)
+                .expect("can't create namespaced element for vtag")
+        } else
         if tag == "svg"
             || parent
                 .namespace_uri()


### PR DESCRIPTION
#### Description

This change in VTag create_element checks for the xmlns attribute. If specified, then it uses that as the namespace when creating the element. 

This makes it possible to use HTML within an SVG foreignObject with the correct namespace like this:

```
<@{"foreignObject"} width=100 height=100 >
  <div xmlns="http://www.w3.org/1999/xhtml" style="width:20em;height:20em">
          <span>{"Test"}</span>
          <table>
                <tr>
                    <th>{"Header 1"}</th>
                    <th>{"Header 2"}</th>
                </tr>
                <tr>
                    <td>{"Test"}</td>
                    <td>{"Test"}</td>
                </tr>
          </table>
  </div>
</@>
```

Fixes #3034 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
