### PR TITLE
Fix: Hydratation of empty lists next to components.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,6 +2206,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "papergrid"
@@ -2772,6 +2788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,14 +2812,14 @@ dependencies = [
  "bytes",
  "clap",
  "futures 0.3.29",
- "log",
  "reqwest",
  "serde",
+ "time",
  "tokio",
+ "tracing-subscriber",
+ "tracing-web",
  "uuid",
  "warp",
- "wasm-bindgen-futures",
- "wasm-logger",
  "yew",
 ]
 
@@ -3034,12 +3059,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
+ "js-sys",
  "powerfmt",
  "serde",
  "time-core",
@@ -3274,6 +3310,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-web"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a141feebd51f8d91ebfd785af50fca223c570b86852166caa3b141defe7c"
+dependencies = [
+ "js-sys",
+ "tracing-core",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3409,6 +3484,12 @@ checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/packages/yew/src/callback.rs
+++ b/packages/yew/src/callback.rs
@@ -25,7 +25,9 @@ macro_rules! generate_callback_impls {
             }
         }
 
-        #[allow(clippy::vtable_address_comparisons)]
+        // We are okay with comparisons from different compilation units to result in false
+        // not-equal results. This should only lead in the worst-case to some unneeded re-renders.
+        #[allow(ambiguous_wide_pointer_comparisons)]
         impl<IN, OUT> PartialEq for $callback<IN, OUT> {
             fn eq(&self, other: &$callback<IN, OUT>) -> bool {
                 let ($callback { cb }, $callback { cb: rhs_cb }) = (self, other);

--- a/packages/yew/src/dom_bundle/blist.rs
+++ b/packages/yew/src/dom_bundle/blist.rs
@@ -11,7 +11,7 @@ use super::{test_log, BNode, BSubtree, DomSlot};
 use crate::dom_bundle::{Reconcilable, ReconcileTarget};
 use crate::html::AnyScope;
 use crate::utils::RcExt;
-use crate::virtual_dom::{Key, VList, VNode, VText};
+use crate::virtual_dom::{Key, VList, VNode};
 
 /// This struct represents a mounted [VList]
 #[derive(Debug)]
@@ -427,15 +427,7 @@ impl Reconcilable for VList {
         // The left items are known since we want to insert them
         // (self.children). For the right ones, we will look at the bundle,
         // i.e. the current DOM list element that we want to replace with self.
-        let (key, mut fully_keyed, mut lefts) = self.split_for_blist();
-
-        if lefts.is_empty() {
-            // Without a placeholder the next element becomes first
-            // and corrupts the order of rendering
-            // We use empty text element to stake out a place
-            lefts.push(VText::new("").into());
-            fully_keyed = false;
-        }
+        let (key, fully_keyed, lefts) = self.split_for_blist();
 
         let rights = &mut blist.rev_children;
         test_log!("lefts: {:?}", lefts);

--- a/packages/yew/src/dom_bundle/utils.rs
+++ b/packages/yew/src/dom_bundle/utils.rs
@@ -50,7 +50,6 @@ mod feat_hydration {
 
 #[cfg(feature = "hydration")]
 pub(super) use feat_hydration::*;
-
 #[cfg(test)]
 // this is needed because clippy doesn't like the import not being used
 #[allow(unused_imports)]

--- a/packages/yew/src/dom_bundle/utils.rs
+++ b/packages/yew/src/dom_bundle/utils.rs
@@ -52,6 +52,11 @@ mod feat_hydration {
 pub(super) use feat_hydration::*;
 
 #[cfg(test)]
+// this is needed because clippy doesn't like the import not being used
+#[allow(unused_imports)]
+pub(super) use tests::*;
+
+#[cfg(test)]
 mod tests {
     #![allow(dead_code)]
 
@@ -87,8 +92,3 @@ mod tests {
         (root, scope, parent, sibling)
     }
 }
-
-#[cfg(test)]
-// this is needed because clippy doesn't like the import not being used
-#[allow(unused_imports)]
-pub(super) use tests::*;

--- a/packages/yew/src/functional/hooks/use_reducer.rs
+++ b/packages/yew/src/functional/hooks/use_reducer.rs
@@ -130,7 +130,10 @@ where
     T: Reducible,
 {
     fn eq(&self, rhs: &Self) -> bool {
-        #[allow(clippy::vtable_address_comparisons)]
+        // We are okay with comparisons from different compilation units to result in false
+        // not-equal results. This should only lead in the worst-case to some unneeded
+        // re-renders.
+        #[allow(ambiguous_wide_pointer_comparisons)]
         Rc::ptr_eq(&self.dispatch, &rhs.dispatch)
     }
 }

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -430,7 +430,9 @@ impl ComponentState {
         fields(component.id = self.comp_id)
     )]
     fn render(&mut self, shared_state: &Shared<Option<ComponentState>>) {
-        match self.inner.view() {
+        let view = self.inner.view();
+        tracing::trace!(?view, "render result");
+        match view {
             Ok(vnode) => self.commit_render(shared_state, vnode),
             Err(RenderError::Suspended(susp)) => self.suspend(shared_state, susp),
         };

--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -642,7 +642,7 @@ mod feat_hydration {
     use web_sys::{Element, HtmlScriptElement};
 
     use super::*;
-    use crate::dom_bundle::{BSubtree, DomSlot, DynamicDomSlot, Fragment};
+    use crate::dom_bundle::{BSubtree, DynamicDomSlot, Fragment};
     use crate::html::component::lifecycle::{ComponentRenderState, CreateRunner, RenderRunner};
     use crate::scheduler;
     use crate::virtual_dom::Collectable;
@@ -679,12 +679,6 @@ mod feat_hydration {
             let collectable = Collectable::for_component::<COMP>();
 
             let mut fragment = Fragment::collect_between(fragment, &collectable, &parent);
-            let next_sibling = if let Some(n) = fragment.front() {
-                Some(n.clone())
-            } else {
-                fragment.sibling_at_end().cloned()
-            };
-            internal_ref.reassign(DomSlot::create(next_sibling));
 
             let prepared_state = match fragment
                 .back()

--- a/packages/yew/src/suspense/suspension.rs
+++ b/packages/yew/src/suspense/suspension.rs
@@ -105,7 +105,7 @@ impl Future for Suspension {
 
         let waker = cx.waker().clone();
         self.listen(Callback::from(move |_| {
-            waker.clone().wake();
+            waker.wake_by_ref();
         }));
 
         Poll::Pending

--- a/packages/yew/src/virtual_dom/listeners.rs
+++ b/packages/yew/src/virtual_dom/listeners.rs
@@ -187,9 +187,11 @@ impl PartialEq for Listeners {
                     lhs.iter()
                         .zip(rhs.iter())
                         .all(|(lhs, rhs)| match (lhs, rhs) {
-                            (Some(lhs), Some(rhs)) =>
-                            {
-                                #[allow(clippy::vtable_address_comparisons)]
+                            (Some(lhs), Some(rhs)) => {
+                                // We are okay with comparisons from different compilation units to
+                                // result in false not-equal results. This should only lead in the
+                                // worst-case to some unneeded re-renders.
+                                #[allow(ambiguous_wide_pointer_comparisons)]
                                 Rc::ptr_eq(lhs, rhs)
                             }
                             (None, None) => true,


### PR DESCRIPTION
#### Description

Hydrating empty lists could fail when they were placed next to suspensions and other components. The underlying issue is caused by an historical extra empty text element that was used for empty lists to make them non-empty (and give other components a dom position to hook to). For hydration though, this extra element is basically a mismatch, so shouldn't exist. It was then added to Dom, which *should* have triggered an error

> Should not use a trapped DomSlot. Please report this as an internal bug in yew.

since it tries to insert itself before a component that hasn't received the `reuse` fix-up that notifies components of their hydrated siblings.

Instead, the `DomSlot` of a hydrating component was reassigned to the first element of its fragment. Which is, in general, wrong: Note that hydrating a component or suspension keeps some of the nodes in Dom, but crucially, extra comment nodes to delimit fragments are removed. Hence, the component's internal slot would refer to such a comment node as its "position", but the comment node was then removed when the subsequent suspense was hydrated.

```rust
#[function_component]
pub fn Bar() -> Html {
    html!{}
}
#[function_component]
pub fn App() -> Html {
    html! {
        <>
            {html! {}}
            <Bar />
        </>
    }
}


```

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
