### PR TITLE
Add generic type hints to boxed hooks

### DIFF
--- a/packages/yew-macro/src/hook/mod.rs
+++ b/packages/yew-macro/src/hook/mod.rs
@@ -144,11 +144,13 @@ pub fn hook_impl(hook: HookFn) -> syn::Result<TokenStream> {
 
         let as_boxed_fn = with_output.then(|| quote! { as #boxed_fn_type });
 
+        let generic_types = generics.type_params().map(|t| &t.ident);
+
         // We need boxing implementation for `impl Trait` arguments.
         quote! {
             let #boxed_inner_ident = ::std::boxed::Box::new(
                     move |#ctx_ident: &mut ::yew::functional::HookContext| #inner_fn_rt {
-                        #inner_fn_ident (#ctx_ident, #(#input_args,)*)
+                        #inner_fn_ident :: <#(#generic_types,)*> (#ctx_ident, #(#input_args,)*)
                     }
                 ) #as_boxed_fn;
 

--- a/packages/yew-macro/tests/hook_attr/hook-trait-item-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-trait-item-pass.rs
@@ -1,0 +1,22 @@
+use std::marker::PhantomData;
+
+pub struct QueryState<T> {
+    p: PhantomData<T>
+}
+
+pub trait MyTrait {
+    type Associated;
+}
+
+
+#[yew::hook]
+pub fn use_query_state<Props>(
+    selector: impl yew::html::IntoPropValue<bool>,
+) -> QueryState<Props::Associated>
+where
+    Props: MyTrait,
+{
+    QueryState::<Props::Associated> { p: PhantomData::<Props::Associated> }
+}
+
+fn main() {}


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->
When using complex type constructs in a boxed hook, the compiler can get confused and request a type hint on the call to the inner function.
This PR simply adds all generic types of the outer hook function as explicit types to the call of the inner function.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
