### PR TITLE
Namespace support for `VRaw`.

### DIFF
--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -199,7 +199,7 @@ mod tests {
     fn braw_works_svg() {
         let (root, scope, parent) = setup_parent_svg();
 
-        const HTML: &str = r#"<circle cx="50" cy="50" r="40"><circle/>"#;
+        const HTML: &str = r#"<circle cx="50" cy="50" r="40"></circle>"#;
         let elem = VNode::from_html_unchecked(HTML.into());
         let (_, mut elem) = elem.attach(&root, &scope, &parent, DomSlot::at_end());
         assert_braw(&mut elem);

--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -199,7 +199,7 @@ mod tests {
     fn braw_works_svg() {
         let (root, scope, parent) = setup_parent_svg();
 
-        const HTML: &str = r#"<circle cx="50" cy="50" r="40" />"#;
+        const HTML: &str = r#"<circle cx="50" cy="50" r="40"><circle/>"#;
         let elem = VNode::from_html_unchecked(HTML.into());
         let (_, mut elem) = elem.attach(&root, &scope, &parent, DomSlot::at_end());
         assert_braw(&mut elem);

--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -18,7 +18,7 @@ impl BRaw {
     fn create_elements(html: &str, parent_namespace: Option<&str>) -> Vec<Node> {
         let div = if let Some(namespace) = parent_namespace {
             gloo::utils::document()
-                .create_element_ns("div", namespace)
+                .create_element_ns(namespace, "div")
                 .unwrap()
         } else {
             gloo::utils::document().create_element("div").unwrap()

--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -177,7 +177,9 @@ mod tests {
     use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
     use super::*;
-    use crate::dom_bundle::utils::{setup_parent, setup_parent_and_sibling, SIBLING_CONTENT};
+    use crate::dom_bundle::utils::{
+        setup_parent, setup_parent_and_sibling, setup_parent_svg, SIBLING_CONTENT,
+    };
     use crate::virtual_dom::VNode;
 
     wasm_bindgen_test_configure!(run_in_browser);

--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn braw_works_svg() {
-        let (root, scope, parent) = setup_parent();
+        let (root, scope, parent) = setup_parent_svg();
 
         const HTML: &str = r#"<circle cx="50" cy="50" r="40" />"#;
         let elem = VNode::from_html_unchecked(HTML.into());
@@ -210,7 +210,7 @@ mod tests {
                 .unwrap()
                 .unchecked_into::<Element>()
                 .namespace_uri(),
-            Some(SVG_NAMESPACE)
+            Some(SVG_NAMESPACE.to_owned())
         );
     }
 

--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -205,7 +205,11 @@ mod tests {
         assert_braw(&mut elem);
         assert_eq!(parent.inner_html(), HTML);
         assert_eq!(
-            parent.first_child().unwrap().namespace_uri(),
+            parent
+                .first_child()
+                .unwrap()
+                .unchecked_into::<Element>()
+                .namespace_uri(),
             Some(SVG_NAMESPACE)
         );
     }

--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -3,8 +3,8 @@ use web_sys::{Element, Node};
 
 use super::{BNode, BSubtree, DomSlot, Reconcilable, ReconcileTarget};
 use crate::html::AnyScope;
-use crate::virtual_dom::VRaw;
 use crate::virtual_dom::vtag::{MATHML_NAMESPACE, SVG_NAMESPACE};
+use crate::virtual_dom::VRaw;
 use crate::AttrValue;
 
 #[derive(Debug)]
@@ -17,7 +17,9 @@ pub struct BRaw {
 impl BRaw {
     fn create_elements(html: &str, parent_namespace: Option<&str>) -> Vec<Node> {
         let div = if let Some(namespace) = parent_namespace {
-            gloo::utils::document().create_element_ns("div", namespace).unwrap()
+            gloo::utils::document()
+                .create_element_ns("div", namespace)
+                .unwrap()
         } else {
             gloo::utils::document().create_element("div").unwrap()
         };
@@ -77,13 +79,13 @@ impl Reconcilable for VRaw {
         slot: DomSlot,
     ) -> (DomSlot, Self::Bundle) {
         let namespace = if parent
-                .namespace_uri()
-                .map_or(false, |ns| ns == SVG_NAMESPACE)
+            .namespace_uri()
+            .map_or(false, |ns| ns == SVG_NAMESPACE)
         {
             Some(SVG_NAMESPACE)
         } else if parent
-                .namespace_uri()
-                .map_or(false, |ns| ns == MATHML_NAMESPACE)
+            .namespace_uri()
+            .map_or(false, |ns| ns == MATHML_NAMESPACE)
         {
             Some(MATHML_NAMESPACE)
         } else {

--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -16,13 +16,9 @@ pub struct BRaw {
 
 impl BRaw {
     fn create_elements(html: &str, parent_namespace: Option<&str>) -> Vec<Node> {
-        let div = if let Some(namespace) = parent_namespace {
-            gloo::utils::document()
-                .create_element_ns(namespace, "div")
-                .unwrap()
-        } else {
-            gloo::utils::document().create_element("div").unwrap()
-        };
+        let div = gloo::utils::document()
+            .create_element_ns(parent_namespace, "div")
+            .unwrap();
         div.set_inner_html(html);
         let children = div.child_nodes();
         let children = js_sys::Array::from(&children);

--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -190,7 +190,22 @@ mod tests {
         let elem = VNode::from_html_unchecked(HTML.into());
         let (_, mut elem) = elem.attach(&root, &scope, &parent, DomSlot::at_end());
         assert_braw(&mut elem);
-        assert_eq!(parent.inner_html(), HTML)
+        assert_eq!(parent.inner_html(), HTML);
+    }
+
+    #[test]
+    fn braw_works_svg() {
+        let (root, scope, parent) = setup_parent();
+
+        const HTML: &str = r#"<circle cx="50" cy="50" r="40" />"#;
+        let elem = VNode::from_html_unchecked(HTML.into());
+        let (_, mut elem) = elem.attach(&root, &scope, &parent, DomSlot::at_end());
+        assert_braw(&mut elem);
+        assert_eq!(parent.inner_html(), HTML);
+        assert_eq!(
+            parent.first_child().unwrap().namespace_uri(),
+            Some(SVG_NAMESPACE)
+        );
     }
 
     #[test]

--- a/packages/yew/src/dom_bundle/utils.rs
+++ b/packages/yew/src/dom_bundle/utils.rs
@@ -64,10 +64,23 @@ mod tests {
 
     use crate::dom_bundle::{BSubtree, DomSlot};
     use crate::html::AnyScope;
+    use crate::virtual_dom::vtag::SVG_NAMESPACE;
 
     pub fn setup_parent() -> (BSubtree, AnyScope, Element) {
         let scope = AnyScope::test();
         let parent = document().create_element("div").unwrap();
+        let root = BSubtree::create_root(&parent);
+
+        document().body().unwrap().append_child(&parent).unwrap();
+
+        (root, scope, parent)
+    }
+
+    pub fn setup_parent_svg() -> (BSubtree, AnyScope, Element) {
+        let scope = AnyScope::test();
+        let parent = document()
+            .create_element_ns(Some(SVG_NAMESPACE), "svg")
+            .unwrap();
         let root = BSubtree::create_root(&parent);
 
         document().body().unwrap().append_child(&parent).unwrap();

--- a/packages/yew/src/virtual_dom/vnode.rs
+++ b/packages/yew/src/virtual_dom/vnode.rs
@@ -76,8 +76,8 @@ impl VNode {
     ///
     /// # Behavior in browser
     ///
-    /// In the browser, this function creates an element, sets the passed HTML to its `innerHTML`
-    /// and inserts the contents of it into the DOM.
+    /// In the browser, this function creates an element with the same XML namespace as the parent,
+    /// sets the passed HTML to its `innerHTML` and inserts the contents of it into the DOM.
     ///
     /// # Behavior on server
     ///


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change. -->

Fixes #3641

When attaching `Html` to DOM, create the temporary parent with the same namespaceURI as the actual parent.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->

#### Unanswered questions

- Should it support any namespace URI or just SVG and MathML? (currently the latter)
