### PR TITLE
fix: Fix indexmap compatibility for yew 0.21.0 (#3659)

### DIFF
--- a/packages/yew/src/html/conversion/into_prop_value.rs
+++ b/packages/yew/src/html/conversion/into_prop_value.rs
@@ -274,7 +274,7 @@ impl<K: Eq + std::hash::Hash + ImplicitClone + 'static, V: PartialEq + ImplicitC
     IntoPropValue<IMap<K, V>> for indexmap::IndexMap<K, V>
 {
     fn into_prop_value(self) -> IMap<K, V> {
-        IMap::from(self)
+        IMap::from_iter(self)
     }
 }
 


### PR DESCRIPTION
#### Description

Fix conversion from IndexMap to IMap in IntoPropValue implementation

This PR addresses an error in the IntoPropValue implementation for IndexMap to IMap conversion. The original code used `IMap::from(self)`, which failed because there's no direct `From` implementation for `IMap` from `indexmap::IndexMap`.

Changes made:
- Replace `IMap::from(self)` with `IMap::from_iter(self)`

Rationale:
- `from_iter` utilizes the `FromIterator` trait to construct an `IMap` from an iterator.
- `IndexMap` implements `IntoIterator`, allowing it to be used with `from_iter`.
- This approach avoids the need for a direct `From` implementation between `IMap` and `IndexMap`.

The change resolves the compilation error and provides a more flexible conversion method using existing trait implementations.

---------------------------------------------------------------------------------------------------------

This change may not directly resolve the Issue, but at least it resolved a similar error that was occurring in my environment

I added yew to the dependencies package,

```toml
yew = { version = "0.21", features = ["csr"] }
```

I added yew to the dependencies package, and ran into the error in this Issue when I did a simple HTML build to see how it worked.



Here is the code of main.rs at that time.

```rs
use yew::prelude::*;

#[function_component(App)]
fn app() -> Html {
    html! {
        <h1>{ "Hello World" }</h1>
    }
}

fn main() {
    yew::Renderer::<App>::new().render(); }
}
```


addresses #3659 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
