### PR TITLE
Add `inert` to the boolean attributes list

### DIFF
--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -61,6 +61,7 @@ static BOOLEAN_SET: Lazy<HashSet<&'static str>> = Lazy::new(|| {
         "disabled",
         "formnovalidate",
         "hidden",
+        "inert",
         "ismap",
         "itemscope",
         "loop",


### PR DESCRIPTION
#### Description

Adds the [`inert`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) global boolean attribute, which was added to the HTML Standard in 2022.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
