### PR TITLE
Fix CI

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -73,7 +73,7 @@ impl Component for App {
                     .filter(|e| self.state.filter.fits(e))
                     .nth(idx)
                     .unwrap();
-                self.state.edit_value = entry.description.clone();
+                self.state.edit_value.clone_from(&entry.description);
                 self.state.clear_all_edit();
                 self.state.toggle_edit(idx);
             }

--- a/packages/yew-macro/src/html_tree/lint/mod.rs
+++ b/packages/yew-macro/src/html_tree/lint/mod.rs
@@ -12,6 +12,7 @@ use crate::props::{ElementProps, Prop};
 /// use `proc-macro-error` (and the `emit_warning!` macro) to produce a warning. At present, these
 /// are only emitted on nightly.
 pub trait Lint {
+    #[cfg_attr(not(yew_lints), allow(dead_code))]
     fn lint(element: &HtmlElement);
 }
 

--- a/packages/yew-router/src/utils.rs
+++ b/packages/yew-router/src/utils.rs
@@ -8,7 +8,7 @@ pub(crate) fn strip_slash_suffix(path: &str) -> &str {
 
 static BASE_URL_LOADED: std::sync::Once = std::sync::Once::new();
 thread_local! {
-    static BASE_URL: RefCell<Option<String>> = RefCell::new(None);
+    static BASE_URL: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 // This exists so we can cache the base url. It costs us a `to_string` call instead of a DOM API

--- a/packages/yew/src/html/classes.rs
+++ b/packages/yew/src/html/classes.rs
@@ -165,6 +165,7 @@ impl IntoIterator for &Classes {
     }
 }
 
+#[allow(clippy::to_string_trait_impl)]
 impl ToString for Classes {
     fn to_string(&self) -> String {
         let mut iter = self.set.iter().cloned();

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -148,12 +148,14 @@ where
 /// methods.
 pub(crate) trait Stateful {
     fn view(&self) -> HtmlResult;
+    #[cfg(feature = "csr")]
     fn rendered(&mut self, first_render: bool);
     fn destroy(&mut self);
 
     fn any_scope(&self) -> AnyScope;
 
     fn flush_messages(&mut self) -> bool;
+    #[cfg(feature = "csr")]
     fn props_changed(&mut self, props: Rc<dyn Any>) -> bool;
 
     fn as_any(&self) -> &dyn Any;
@@ -170,6 +172,7 @@ where
         self.component.view(&self.context)
     }
 
+    #[cfg(feature = "csr")]
     fn rendered(&mut self, first_render: bool) {
         self.component.rendered(&self.context, first_render)
     }
@@ -198,6 +201,7 @@ where
             })
     }
 
+    #[cfg(feature = "csr")]
     fn props_changed(&mut self, props: Rc<dyn Any>) -> bool {
         let props = match Rc::downcast::<COMP::Properties>(props) {
             Ok(m) => m,

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -157,7 +157,6 @@ pub(crate) trait Stateful {
     fn props_changed(&mut self, props: Rc<dyn Any>) -> bool;
 
     fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
 
     #[cfg(feature = "hydration")]
     fn creation_mode(&self) -> RenderMode;
@@ -214,10 +213,6 @@ where
     }
 
     fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 }

--- a/packages/yew/src/renderer.rs
+++ b/packages/yew/src/renderer.rs
@@ -8,7 +8,7 @@ use crate::app_handle::AppHandle;
 use crate::html::BaseComponent;
 
 thread_local! {
-    static PANIC_HOOK_IS_SET: Cell<bool> = Cell::new(false);
+    static PANIC_HOOK_IS_SET: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Set a custom panic hook.

--- a/packages/yew/src/scheduler.rs
+++ b/packages/yew/src/scheduler.rs
@@ -55,6 +55,7 @@ impl TopologicalQueue {
 
     /// Take a single entry, preferring parents over children
     #[rustversion::since(1.66)]
+    #[allow(clippy::incompatible_msrv)]
     #[inline]
     fn pop_topmost(&mut self) -> Option<QueueEntry> {
         self.inner.pop_first().map(|(_, v)| v)

--- a/packages/yew/src/virtual_dom/vlist.rs
+++ b/packages/yew/src/virtual_dom/vlist.rs
@@ -45,10 +45,9 @@ impl Deref for VList {
         match self.children {
             Some(ref m) => m,
             None => {
-                // This is mutable because the Vec<VNode> is not Sync
-                static mut EMPTY: Vec<VNode> = Vec::new();
-                // SAFETY: The EMPTY value is always read-only
-                unsafe { &EMPTY }
+                // This can be replaced with `const { &Vec::new() }` in Rust 1.79.
+                const EMPTY: &Vec<VNode> = &Vec::new();
+                EMPTY
             }
         }
     }

--- a/tools/website-test/src/lib.rs
+++ b/tools/website-test/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_doctest_main)]
 pub mod tutorial;
 
 include!(concat!(env!("OUT_DIR"), "/website_tests.rs"));


### PR DESCRIPTION
#### Description

Fixes new rustc and clippy warnings that are generated by the latest Rust toolchain and causing CI failures.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
