### PR TITLE
Fix CI for 1.80 & benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,6 +49,10 @@ jobs:
           cache-dependency-path: js-framework-benchmark/package-lock.json
 
       - uses: Swatinem/rust-cache@v2
+      - name: Setup chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          install-chromedriver: true
 
       - name: setup js-framework-benchmark
         working-directory: js-framework-benchmark

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ lto = true
 codegen-units = 1
 panic = "abort"
 opt-level = 3
+

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -28,3 +28,7 @@ prettyplease = "0.2"
 rustversion = "1"
 trybuild = "1"
 yew = { path = "../yew" }
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(nightly_yew)'] }
+

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -100,3 +100,7 @@ default = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "documenting"]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(nightly_yew)'] }
+

--- a/packages/yew/src/dom_bundle/blist.rs
+++ b/packages/yew/src/dom_bundle/blist.rs
@@ -248,6 +248,7 @@ impl BList {
         let rights_to = rev_bundles.len() - matching_len_start;
         let mut spliced_middle =
             rev_bundles.splice(matching_len_end..rights_to, std::iter::empty());
+        #[allow(clippy::mutable_key_type)]
         let mut spare_bundles: HashSet<KeyedEntry> =
             HashSet::with_capacity((matching_len_end..rights_to).len());
         for (idx, r) in (&mut spliced_middle).enumerate() {


### PR DESCRIPTION
#### Description

Fix clippy CI for 1.80

This is the main culprit: https://blog.rust-lang.org/2024/05/06/check-cfg.html

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests

