### PR TITLE
Raise MSRV to 1.76

### DIFF
--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - 1.64.0
+          - 1.76.0
           - stable
 
     steps:
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - 1.64.0
+          - 1.76.0
           - stable
           - nightly
 

--- a/packages/yew-agent-macro/Cargo.toml
+++ b/packages/yew-agent-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yew-agent-macro"
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.76.0"
 authors = ["Kaede Hoshikawa <futursolo@icloud.com>"]
 repository = "https://github.com/yewstack/yew"
 homepage = "https://yew.rs"

--- a/packages/yew-agent/Cargo.toml
+++ b/packages/yew-agent/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 readme = "../../README.md"
 description = "Agents for Yew"
 license = "MIT OR Apache-2.0"
-rust-version = "1.64.0"
+rust-version = "1.76.0"
 
 [dependencies]
 yew = { version = "0.21.0", path = "../yew" }

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["web", "wasm", "frontend", "webasm", "webassembly"]
 categories = ["gui", "web-programming", "wasm"]
 description = "A framework for making client-side single-page apps"
-rust-version = "1.64.0"
+rust-version = "1.76.0"
 
 [lib]
 proc-macro = true

--- a/packages/yew-macro/Makefile.toml
+++ b/packages/yew-macro/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.test]
 clear = true
-toolchain = "1.64.0"
+toolchain = "1.76.0"
 command = "cargo"
 # test target can be optionally specified like `cargo make test html_macro`,
 args = ["test", "${@}"]

--- a/packages/yew-macro/tests/classes_macro/classes-fail.stderr
+++ b/packages/yew-macro/tests/classes_macro/classes-fail.stderr
@@ -17,16 +17,16 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
   |              ^^ the trait `From<{integer}>` is not implemented for `Classes`
   |
   = help: the following other types implement trait `From<T>`:
-            <Classes as From<&'static str>>
-            <Classes as From<&Option<T>>>
-            <Classes as From<&String>>
-            <Classes as From<&[T]>>
-            <Classes as From<&implicit_clone::unsync::string::IString>>
             <Classes as From<Cow<'static, str>>>
-            <Classes as From<Option<T>>>
+            <Classes as From<implicit_clone::unsync::string::IString>>
+            <Classes as From<Vec<T>>>
             <Classes as From<String>>
+            <Classes as From<Option<T>>>
+            <Classes as From<[T; SIZE]>>
+            <Classes as From<&String>>
+            <Classes as From<&implicit_clone::unsync::string::IString>>
           and $N others
-  = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
+  = note: required for `{integer}` to implement `Into<Classes>`
 note: required by a bound in `Classes::push`
  --> $WORKSPACE/packages/yew/src/html/classes.rs
   |
@@ -40,16 +40,16 @@ error[E0277]: the trait bound `Classes: From<{float}>` is not satisfied
   |              ^^^^ the trait `From<{float}>` is not implemented for `Classes`
   |
   = help: the following other types implement trait `From<T>`:
-            <Classes as From<&'static str>>
-            <Classes as From<&Option<T>>>
-            <Classes as From<&String>>
-            <Classes as From<&[T]>>
-            <Classes as From<&implicit_clone::unsync::string::IString>>
             <Classes as From<Cow<'static, str>>>
-            <Classes as From<Option<T>>>
+            <Classes as From<implicit_clone::unsync::string::IString>>
+            <Classes as From<Vec<T>>>
             <Classes as From<String>>
+            <Classes as From<Option<T>>>
+            <Classes as From<[T; SIZE]>>
+            <Classes as From<&String>>
+            <Classes as From<&implicit_clone::unsync::string::IString>>
           and $N others
-  = note: required because of the requirements on the impl of `Into<Classes>` for `{float}`
+  = note: required for `{float}` to implement `Into<Classes>`
 note: required by a bound in `Classes::push`
  --> $WORKSPACE/packages/yew/src/html/classes.rs
   |
@@ -60,22 +60,25 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
  --> tests/classes_macro/classes-fail.rs:9:14
   |
 9 |     classes!(vec![42]);
-  |              ^^^ the trait `From<{integer}>` is not implemented for `Classes`
+  |              ---^^^^^
+  |              |
+  |              the trait `From<{integer}>` is not implemented for `Classes`
+  |              required by a bound introduced by this call
   |
   = help: the following other types implement trait `From<T>`:
-            <Classes as From<&'static str>>
-            <Classes as From<&Option<T>>>
-            <Classes as From<&String>>
-            <Classes as From<&[T]>>
-            <Classes as From<&implicit_clone::unsync::string::IString>>
             <Classes as From<Cow<'static, str>>>
-            <Classes as From<Option<T>>>
+            <Classes as From<implicit_clone::unsync::string::IString>>
+            <Classes as From<Vec<T>>>
             <Classes as From<String>>
+            <Classes as From<Option<T>>>
+            <Classes as From<[T; SIZE]>>
+            <Classes as From<&String>>
+            <Classes as From<&implicit_clone::unsync::string::IString>>
           and $N others
-  = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
-  = note: required because of the requirements on the impl of `From<Vec<{integer}>>` for `Classes`
+  = note: required for `{integer}` to implement `Into<Classes>`
+  = note: required for `Classes` to implement `From<Vec<{integer}>>`
   = note: 1 redundant requirement hidden
-  = note: required because of the requirements on the impl of `Into<Classes>` for `Vec<{integer}>`
+  = note: required for `Vec<{integer}>` to implement `Into<Classes>`
 note: required by a bound in `Classes::push`
  --> $WORKSPACE/packages/yew/src/html/classes.rs
   |
@@ -89,19 +92,19 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
    |              ^^^^ the trait `From<{integer}>` is not implemented for `Classes`
    |
    = help: the following other types implement trait `From<T>`:
-             <Classes as From<&'static str>>
-             <Classes as From<&Option<T>>>
-             <Classes as From<&String>>
-             <Classes as From<&[T]>>
-             <Classes as From<&implicit_clone::unsync::string::IString>>
              <Classes as From<Cow<'static, str>>>
-             <Classes as From<Option<T>>>
+             <Classes as From<implicit_clone::unsync::string::IString>>
+             <Classes as From<Vec<T>>>
              <Classes as From<String>>
+             <Classes as From<Option<T>>>
+             <Classes as From<[T; SIZE]>>
+             <Classes as From<&String>>
+             <Classes as From<&implicit_clone::unsync::string::IString>>
            and $N others
-   = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
-   = note: required because of the requirements on the impl of `From<Option<{integer}>>` for `Classes`
+   = note: required for `{integer}` to implement `Into<Classes>`
+   = note: required for `Classes` to implement `From<Option<{integer}>>`
    = note: 1 redundant requirement hidden
-   = note: required because of the requirements on the impl of `Into<Classes>` for `Option<{integer}>`
+   = note: required for `Option<{integer}>` to implement `Into<Classes>`
 note: required by a bound in `Classes::push`
   --> $WORKSPACE/packages/yew/src/html/classes.rs
    |
@@ -115,19 +118,19 @@ error[E0277]: the trait bound `Classes: From<u32>` is not satisfied
    |              ^^^^ the trait `From<u32>` is not implemented for `Classes`
    |
    = help: the following other types implement trait `From<T>`:
-             <Classes as From<&'static str>>
-             <Classes as From<&Option<T>>>
-             <Classes as From<&String>>
-             <Classes as From<&[T]>>
-             <Classes as From<&implicit_clone::unsync::string::IString>>
              <Classes as From<Cow<'static, str>>>
-             <Classes as From<Option<T>>>
+             <Classes as From<implicit_clone::unsync::string::IString>>
+             <Classes as From<Vec<T>>>
              <Classes as From<String>>
+             <Classes as From<Option<T>>>
+             <Classes as From<[T; SIZE]>>
+             <Classes as From<&String>>
+             <Classes as From<&implicit_clone::unsync::string::IString>>
            and $N others
-   = note: required because of the requirements on the impl of `Into<Classes>` for `u32`
-   = note: required because of the requirements on the impl of `From<Option<u32>>` for `Classes`
+   = note: required for `u32` to implement `Into<Classes>`
+   = note: required for `Classes` to implement `From<Option<u32>>`
    = note: 1 redundant requirement hidden
-   = note: required because of the requirements on the impl of `Into<Classes>` for `Option<u32>`
+   = note: required for `Option<u32>` to implement `Into<Classes>`
 note: required by a bound in `Classes::push`
   --> $WORKSPACE/packages/yew/src/html/classes.rs
    |
@@ -141,16 +144,16 @@ error[E0277]: the trait bound `Classes: From<{integer}>` is not satisfied
    |                     ^^ the trait `From<{integer}>` is not implemented for `Classes`
    |
    = help: the following other types implement trait `From<T>`:
-             <Classes as From<&'static str>>
-             <Classes as From<&Option<T>>>
-             <Classes as From<&String>>
-             <Classes as From<&[T]>>
-             <Classes as From<&implicit_clone::unsync::string::IString>>
              <Classes as From<Cow<'static, str>>>
-             <Classes as From<Option<T>>>
+             <Classes as From<implicit_clone::unsync::string::IString>>
+             <Classes as From<Vec<T>>>
              <Classes as From<String>>
+             <Classes as From<Option<T>>>
+             <Classes as From<[T; SIZE]>>
+             <Classes as From<&String>>
+             <Classes as From<&implicit_clone::unsync::string::IString>>
            and $N others
-   = note: required because of the requirements on the impl of `Into<Classes>` for `{integer}`
+   = note: required for `{integer}` to implement `Into<Classes>`
 note: required by a bound in `Classes::push`
   --> $WORKSPACE/packages/yew/src/html/classes.rs
    |

--- a/packages/yew-macro/tests/classes_macro_test.rs
+++ b/packages/yew-macro/tests/classes_macro_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.64), test)]
+#[rustversion::attr(stable(1.76), test)]
 fn classes_macro() {
     let t = trybuild::TestCases::new();
     t.pass("tests/classes_macro/*-pass.rs");

--- a/packages/yew-macro/tests/derive_props/fail.stderr
+++ b/packages/yew-macro/tests/derive_props/fail.stderr
@@ -32,10 +32,12 @@ error[E0277]: the trait bound `Value: Default` is not satisfied
   |                     ^^^^^^^^^^ the trait `Default` is not implemented for `Value`
   |
 note: required by a bound in `Option::<T>::unwrap_or_default`
+ --> $RUST/core/src/option.rs
   = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Value` with `#[derive(Default)]`
   |
-8 |     #[derive(Default)]
+8 +     #[derive(Default)]
+9 |     struct Value;
   |
 
 error[E0369]: binary operation `==` cannot be applied to type `Value`
@@ -47,35 +49,16 @@ error[E0369]: binary operation `==` cannot be applied to type `Value`
 13 |         value: Value,
    |         ^^^^^^^^^^^^
    |
-note: an implementation of `PartialEq<_>` might be missing for `Value`
+note: an implementation of `PartialEq` might be missing for `Value`
   --> tests/derive_props/fail.rs:8:5
    |
 8  |     struct Value;
-   |     ^^^^^^^^^^^^ must implement `PartialEq<_>`
+   |     ^^^^^^^^^^^^ must implement `PartialEq`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Value` with `#[derive(PartialEq)]`
    |
-8  |     #[derive(PartialEq)]
-   |
-
-error[E0369]: binary operation `!=` cannot be applied to type `Value`
-  --> tests/derive_props/fail.rs:13:9
-   |
-9  |     #[derive(Clone, Properties, PartialEq)]
-   |                                 --------- in this derive macro expansion
-...
-13 |         value: Value,
-   |         ^^^^^^^^^^^^
-   |
-note: an implementation of `PartialEq<_>` might be missing for `Value`
-  --> tests/derive_props/fail.rs:8:5
-   |
-8  |     struct Value;
-   |     ^^^^^^^^^^^^ must implement `PartialEq<_>`
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider annotating `Value` with `#[derive(PartialEq)]`
-   |
-8  |     #[derive(PartialEq)]
+8  +     #[derive(PartialEq)]
+9  |     struct Value;
    |
 
 error[E0277]: the trait bound `AssertAllProps: HasProp<t3::_Props::value, _>` is not satisfied
@@ -85,26 +68,29 @@ error[E0277]: the trait bound `AssertAllProps: HasProp<t3::_Props::value, _>` is
    |                        ^^^^^ the trait `HasProp<t3::_Props::value, _>` is not implemented for `AssertAllProps`
    |
    = help: the following other types implement trait `HasProp<P, How>`:
-             <CheckChildrenPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <CheckContextProviderPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasContextProviderPropschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasContextProviderPropschildren<B> as HasProp<children, HasContextProviderPropschildren<B>>>
-             <HasContextProviderPropscontext<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasContextProviderPropscontext<B> as HasProp<yew::context::_ContextProviderProps::context, HasContextProviderPropscontext<B>>>
-             <suspense::component::CheckSuspensePropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <t10::CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t1::CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t2::HasPropsvalue<B> as HasProp<t2::_Props::value, t2::HasPropsvalue<B>>>
+             <t2::HasPropsvalue<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t2::CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t3::HasPropsvalue<B> as HasProp<t3::_Props::value, t3::HasPropsvalue<B>>>
+             <t3::HasPropsvalue<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t3::CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t4::HasPropsvalue<B> as HasProp<t4::_Props::value, t4::HasPropsvalue<B>>>
            and $N others
-note: required because of the requirements on the impl of `HasAllProps<t3::Props, (_,)>` for `t3::CheckPropsAll<AssertAllProps>`
+note: required for `t3::CheckPropsAll<AssertAllProps>` to implement `HasAllProps<t3::Props, (_,)>`
   --> tests/derive_props/fail.rs:29:21
    |
 29 |     #[derive(Clone, Properties, PartialEq)]
-   |                     ^^^^^^^^^^
-   = note: required because of the requirements on the impl of `AllPropsFor<t3::PropsBuilder, (_,)>` for `AssertAllProps`
+   |                     ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   = note: required for `AssertAllProps` to implement `AllPropsFor<t3::PropsBuilder, (_,)>`
 note: required by a bound in `html::component::properties::__macro::PreBuild::<Token, B>::build`
   --> $WORKSPACE/packages/yew/src/html/component/properties.rs
    |
+   |         pub fn build<How>(self) -> B::Output
+   |                ----- required by a bound in this associated function
+   |         where
    |             Token: AllPropsFor<B, How>,
-   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `html::component::properties::__macro::PreBuild::<Token, B>::build`
+   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `PreBuild::<Token, B>::build`
    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AssertAllProps: HasProp<t4::_Props::value, _>` is not satisfied
@@ -114,54 +100,53 @@ error[E0277]: the trait bound `AssertAllProps: HasProp<t4::_Props::value, _>` is
    |                        ^^^^^ the trait `HasProp<t4::_Props::value, _>` is not implemented for `AssertAllProps`
    |
    = help: the following other types implement trait `HasProp<P, How>`:
-             <CheckChildrenPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <CheckContextProviderPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasContextProviderPropschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasContextProviderPropschildren<B> as HasProp<children, HasContextProviderPropschildren<B>>>
-             <HasContextProviderPropscontext<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasContextProviderPropscontext<B> as HasProp<yew::context::_ContextProviderProps::context, HasContextProviderPropscontext<B>>>
-             <suspense::component::CheckSuspensePropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <t10::CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t1::CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t2::HasPropsvalue<B> as HasProp<t2::_Props::value, t2::HasPropsvalue<B>>>
+             <t2::HasPropsvalue<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t2::CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t3::HasPropsvalue<B> as HasProp<t3::_Props::value, t3::HasPropsvalue<B>>>
+             <t3::HasPropsvalue<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t3::CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <t4::HasPropsvalue<B> as HasProp<t4::_Props::value, t4::HasPropsvalue<B>>>
            and $N others
-note: required because of the requirements on the impl of `HasAllProps<t4::Props, (_,)>` for `t4::CheckPropsAll<AssertAllProps>`
+note: required for `t4::CheckPropsAll<AssertAllProps>` to implement `HasAllProps<t4::Props, (_,)>`
   --> tests/derive_props/fail.rs:41:21
    |
 41 |     #[derive(Clone, Properties, PartialEq)]
-   |                     ^^^^^^^^^^
-   = note: required because of the requirements on the impl of `AllPropsFor<t4::PropsBuilder, (_,)>` for `AssertAllProps`
+   |                     ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   = note: required for `AssertAllProps` to implement `AllPropsFor<t4::PropsBuilder, (_,)>`
 note: required by a bound in `html::component::properties::__macro::PreBuild::<Token, B>::build`
   --> $WORKSPACE/packages/yew/src/html/component/properties.rs
    |
+   |         pub fn build<How>(self) -> B::Output
+   |                ----- required by a bound in this associated function
+   |         where
    |             Token: AllPropsFor<B, How>,
-   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `html::component::properties::__macro::PreBuild::<Token, B>::build`
+   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `PreBuild::<Token, B>::build`
    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> tests/derive_props/fail.rs:66:19
    |
 66 |         #[prop_or(123)]
-   |                   ^^^
+   |                   ^^^- help: try using a conversion method: `.to_string()`
    |                   |
-   |                   expected struct `String`, found integer
+   |                   expected `String`, found integer
    |                   arguments to this function are incorrect
    |
-note: associated function defined here
-help: try using a conversion method
-   |
-66 |         #[prop_or(123.to_string())]
-   |                      ++++++++++++
-66 |         #[prop_or(123.to_string())]
-   |                      ++++++++++++
+note: method defined here
+  --> $RUST/core/src/option.rs
 
-error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
+error[E0277]: expected a `FnOnce()` closure, found `{integer}`
   --> tests/derive_props/fail.rs:76:24
    |
 76 |         #[prop_or_else(123)]
-   |                        ^^^ expected an `FnOnce<()>` closure, found `{integer}`
+   |                        ^^^ expected an `FnOnce()` closure, found `{integer}`
    |
    = help: the trait `FnOnce<()>` is not implemented for `{integer}`
    = note: wrap the `{integer}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Option::<T>::unwrap_or_else`
+  --> $RUST/core/src/option.rs
 
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
    --> tests/derive_props/fail.rs:96:24
@@ -173,11 +158,13 @@ error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
     |     -------------------------- takes 1 argument
     |
 note: required by a bound in `Option::<T>::unwrap_or_else`
+   --> $RUST/core/src/option.rs
 
-error[E0271]: type mismatch resolving `<fn() -> i32 {t10::foo} as FnOnce<()>>::Output == String`
+error[E0271]: expected `foo` to be a fn item that returns `String`, but it returns `i32`
    --> tests/derive_props/fail.rs:110:24
     |
 110 |         #[prop_or_else(foo)]
-    |                        ^^^ expected struct `String`, found `i32`
+    |                        ^^^ expected `String`, found `i32`
     |
 note: required by a bound in `Option::<T>::unwrap_or_else`
+   --> $RUST/core/src/option.rs

--- a/packages/yew-macro/tests/derive_props_test.rs
+++ b/packages/yew-macro/tests/derive_props_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.64), test)]
+#[rustversion::attr(stable(1.76), test)]
 fn derive_props() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_props/pass.rs");

--- a/packages/yew-macro/tests/function_attr_test.rs
+++ b/packages/yew-macro/tests/function_attr_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.64), test)]
+#[rustversion::attr(stable(1.76), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/function_component_attr/*-pass.rs");

--- a/packages/yew-macro/tests/function_component_attr/bad-return-type-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/bad-return-type-fail.stderr
@@ -11,6 +11,6 @@ error[E0277]: the trait bound `u32: IntoHtmlResult` is not satisfied
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoHtmlResult` is not implemented for `u32`
    |
    = help: the following other types implement trait `IntoHtmlResult`:
-             Result<VNode, RenderError>
              VNode
+             Result<VNode, RenderError>
    = note: this error originates in the attribute macro `function_component` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
+++ b/packages/yew-macro/tests/function_component_attr/generic-props-fail.stderr
@@ -1,11 +1,13 @@
 error[E0412]: cannot find type `INVALID` in this scope
   --> tests/function_component_attr/generic-props-fail.rs:25:19
    |
-20 | fn compile_fail() {
-   |                - help: you might be missing a type parameter: `<INVALID>`
-...
 25 |     html! { <Comp<INVALID> /> };
    |                   ^^^^^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+20 | fn compile_fail<INVALID>() {
+   |                +++++++++
 
 error[E0277]: the trait bound `AssertAllProps: HasProp<a, _>` is not satisfied
   --> tests/function_component_attr/generic-props-fail.rs:22:14
@@ -14,35 +16,59 @@ error[E0277]: the trait bound `AssertAllProps: HasProp<a, _>` is not satisfied
    |              ^^^^ the trait `HasProp<a, _>` is not implemented for `AssertAllProps`
    |
    = help: the following other types implement trait `HasProp<P, How>`:
-             <CheckChildrenPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <CheckContextProviderPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasContextProviderPropschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasContextProviderPropschildren<B> as HasProp<children, HasContextProviderPropschildren<B>>>
-             <HasContextProviderPropscontext<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasContextProviderPropscontext<B> as HasProp<yew::context::_ContextProviderProps::context, HasContextProviderPropscontext<B>>>
+             <HasPropsa<B> as HasProp<a, HasPropsa<B>>>
              <HasPropsa<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <CheckPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <HasContextProviderPropscontext<B> as HasProp<yew::context::_ContextProviderProps::context, HasContextProviderPropscontext<B>>>
+             <HasContextProviderPropscontext<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <HasContextProviderPropschildren<B> as HasProp<children, HasContextProviderPropschildren<B>>>
+             <HasContextProviderPropschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <CheckContextProviderPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
            and $N others
-note: required because of the requirements on the impl of `HasAllProps<Props, (_,)>` for `CheckPropsAll<AssertAllProps>`
+note: required for `CheckPropsAll<AssertAllProps>` to implement `HasAllProps<Props, (_,)>`
   --> tests/function_component_attr/generic-props-fail.rs:3:17
    |
 3  | #[derive(Clone, Properties, PartialEq)]
-   |                 ^^^^^^^^^^
-   = note: required because of the requirements on the impl of `AllPropsFor<PropsBuilder, (_,)>` for `AssertAllProps`
+   |                 ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   = note: required for `AssertAllProps` to implement `AllPropsFor<PropsBuilder, (_,)>`
 note: required by a bound in `yew::html::component::properties::__macro::PreBuild::<Token, B>::build`
   --> $WORKSPACE/packages/yew/src/html/component/properties.rs
    |
+   |         pub fn build<How>(self) -> B::Output
+   |                ----- required by a bound in this associated function
+   |         where
    |             Token: AllPropsFor<B, How>,
-   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `yew::html::component::properties::__macro::PreBuild::<Token, B>::build`
+   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `PreBuild::<Token, B>::build`
    = note: this error originates in the macro `html` which comes from the expansion of the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Comp<MissingTypeBounds>: yew::BaseComponent` is not satisfied
   --> tests/function_component_attr/generic-props-fail.rs:27:14
    |
 27 |     html! { <Comp<MissingTypeBounds> /> };
-   |              ^^^^ the trait `yew::BaseComponent` is not implemented for `Comp<MissingTypeBounds>`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^ the trait `yew::BaseComponent` is not implemented for `Comp<MissingTypeBounds>`
    |
    = help: the trait `yew::BaseComponent` is implemented for `Comp<P>`
+
+error[E0277]: the trait bound `MissingTypeBounds: yew::Properties` is not satisfied
+  --> tests/function_component_attr/generic-props-fail.rs:27:14
+   |
+27 |     html! { <Comp<MissingTypeBounds> /> };
+   |              ^^^^ the trait `yew::Properties` is not implemented for `MissingTypeBounds`
+   |
+   = help: the following other types implement trait `yew::Properties`:
+             Props
+             ContextProviderProps<T>
+             ChildrenProps
+             SuspenseProps
+             ()
+note: required by a bound in `Comp`
+  --> tests/function_component_attr/generic-props-fail.rs:11:8
+   |
+8  | #[function_component(Comp)]
+   |                      ---- required by a bound in this struct
+...
+11 |     P: Properties + PartialEq,
+   |        ^^^^^^^^^^ required by this bound in `Comp`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `new` exists for struct `VChild<Comp<MissingTypeBounds>>`, but its trait bounds were not satisfied
@@ -56,33 +82,25 @@ error[E0599]: the function or associated item `new` exists for struct `VChild<Co
    |
    = note: the following trait bounds were not satisfied:
            `Comp<MissingTypeBounds>: yew::BaseComponent`
-note: the following trait must be implemented
+note: the trait `yew::BaseComponent` must be implemented
   --> $WORKSPACE/packages/yew/src/html/component/mod.rs
    |
    | pub trait BaseComponent: Sized + 'static {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `MissingTypeBounds: yew::Properties` is not satisfied
+error[E0277]: the trait bound `Comp<MissingTypeBounds>: yew::BaseComponent` is not satisfied
   --> tests/function_component_attr/generic-props-fail.rs:27:14
    |
 27 |     html! { <Comp<MissingTypeBounds> /> };
-   |              ^^^^ the trait `yew::Properties` is not implemented for `MissingTypeBounds`
+   |              ^^^^ the trait `yew::BaseComponent` is not implemented for `Comp<MissingTypeBounds>`
    |
-   = help: the following other types implement trait `yew::Properties`:
-             ()
-             ChildrenProps
-             ContextProviderProps<T>
-             Props
-             SuspenseProps
-note: required by a bound in `Comp`
-  --> tests/function_component_attr/generic-props-fail.rs:11:8
+   = help: the trait `yew::BaseComponent` is implemented for `Comp<P>`
+note: required by a bound in `VChild`
+  --> $WORKSPACE/packages/yew/src/virtual_dom/vcomp.rs
    |
-8  | #[function_component(Comp)]
-   |                      ---- required by a bound in this
-...
-11 |     P: Properties + PartialEq,
-   |        ^^^^^^^^^^ required by this bound in `Comp`
+   | pub struct VChild<COMP: BaseComponent> {
+   |                         ^^^^^^^^^^^^^ required by this bound in `VChild`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0107]: missing generics for struct `Comp`
@@ -101,4 +119,4 @@ note: struct defined here, with 1 generic parameter: `P`
 help: add missing generic argument
    |
 30 |     html! { <Comp<P> /> };
-   |              ~~~~~~~
+   |                  +++

--- a/packages/yew-macro/tests/hook_attr_test.rs
+++ b/packages/yew-macro/tests/hook_attr_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.64), test)]
+#[rustversion::attr(stable(1.76), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/hook_attr/*-pass.rs");

--- a/packages/yew-macro/tests/hook_macro_test.rs
+++ b/packages/yew-macro/tests/hook_macro_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.64), test)]
+#[rustversion::attr(stable(1.76), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/hook_macro/*-pass.rs");

--- a/packages/yew-macro/tests/html_macro/block-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/block-fail.stderr
@@ -2,16 +2,18 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
  --> tests/html_macro/block-fail.rs:6:15
   |
 6 |             { () }
-  |               ^^ `()` cannot be formatted with the default formatter
+  |               ^^
+  |               |
+  |               `()` cannot be formatted with the default formatter
+  |               required by a bound introduced by this call
   |
   = help: the trait `std::fmt::Display` is not implemented for `()`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: required because of the requirements on the impl of `ToString` for `()`
-  = note: required because of the requirements on the impl of `From<()>` for `VNode`
-  = note: required because of the requirements on the impl of `Into<VNode>` for `()`
+  = note: required for `()` to implement `ToString`
+  = note: required for `VNode` to implement `From<()>`
+  = note: required for `()` to implement `Into<VNode>`
   = note: 2 redundant requirements hidden
-  = note: required because of the requirements on the impl of `Into<NodeSeq<(), VNode>>` for `()`
-  = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: required for `()` to implement `Into<NodeSeq<(), VNode>>`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> tests/html_macro/block-fail.rs:15:17
@@ -21,11 +23,14 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `ToString` for `()`
-   = note: required because of the requirements on the impl of `From<()>` for `VNode`
-   = note: required because of the requirements on the impl of `Into<VNode>` for `()`
+   = note: required for `()` to implement `ToString`
+   = note: required for `VNode` to implement `From<()>`
+   = note: required for `()` to implement `Into<VNode>`
 note: required by a bound in `into_node_iter`
   --> $WORKSPACE/packages/yew/src/utils/mod.rs
    |
+   | pub fn into_node_iter<IT, T, R>(it: IT) -> impl Iterator<Item = R>
+   |        -------------- required by a bound in this function
+...
    |     T: Into<R>,
    |        ^^^^^^^ required by this bound in `into_node_iter`

--- a/packages/yew-macro/tests/html_macro/component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-fail.stderr
@@ -406,7 +406,7 @@ error[E0308]: mismatched types
   --> tests/html_macro/component-fail.rs:53:22
    |
 53 |     html! { <Child ..p1 ..p2 /> };
-   |              -----   ^^^^^^^ expected struct `ChildProperties`, found struct `std::ops::Range`
+   |              -----   ^^^^^^^ expected `ChildProperties`, found `Range<_>`
    |              |
    |              expected due to this
    |
@@ -464,6 +464,7 @@ error[E0277]: the trait bound `(): IntoPropValue<String>` is not satisfied
    |                          required by a bound introduced by this call
    |
    = help: the trait `IntoPropValue<VNode>` is implemented for `()`
+   = help: for that trait implementation, expected `VNode`, found `String`
 note: required by a bound in `ChildPropertiesBuilder::string`
   --> tests/html_macro/component-fail.rs:4:17
    |
@@ -471,7 +472,7 @@ note: required by a bound in `ChildPropertiesBuilder::string`
    |                 ^^^^^^^^^^ required by this bound in `ChildPropertiesBuilder::string`
 ...
 7  |     pub string: String,
-   |         ------ required by a bound in this
+   |         ------ required by a bound in this associated function
    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfied
@@ -483,14 +484,14 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
    |                          required by a bound introduced by this call
    |
    = help: the following other types implement trait `IntoPropValue<T>`:
-             f32
-             f64
-             i128
+             isize
+             i8
              i16
              i32
              i64
-             i8
-             isize
+             i128
+             usize
+             u8
            and $N others
 note: required by a bound in `ChildPropertiesBuilder::string`
   --> tests/html_macro/component-fail.rs:4:17
@@ -499,7 +500,7 @@ note: required by a bound in `ChildPropertiesBuilder::string`
    |                 ^^^^^^^^^^ required by this bound in `ChildPropertiesBuilder::string`
 ...
 7  |     pub string: String,
-   |         ------ required by a bound in this
+   |         ------ required by a bound in this associated function
    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfied
@@ -511,14 +512,14 @@ error[E0277]: the trait bound `{integer}: IntoPropValue<String>` is not satisfie
    |                          required by a bound introduced by this call
    |
    = help: the following other types implement trait `IntoPropValue<T>`:
-             f32
-             f64
-             i128
+             isize
+             i8
              i16
              i32
              i64
-             i8
-             isize
+             i128
+             usize
+             u8
            and $N others
 note: required by a bound in `ChildPropertiesBuilder::string`
   --> tests/html_macro/component-fail.rs:4:17
@@ -527,7 +528,7 @@ note: required by a bound in `ChildPropertiesBuilder::string`
    |                 ^^^^^^^^^^ required by this bound in `ChildPropertiesBuilder::string`
 ...
 7  |     pub string: String,
-   |         ------ required by a bound in this
+   |         ------ required by a bound in this associated function
    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `r#ref` on type `ChildProperties`
@@ -555,16 +556,8 @@ error[E0277]: the trait bound `u32: IntoPropValue<i32>` is not satisfied
    |                    |
    |                    required by a bound introduced by this call
    |
-   = help: the following other types implement trait `IntoPropValue<T>`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and $N others
+   = help: the trait `IntoPropValue<VNode>` is implemented for `u32`
+   = help: for that trait implementation, expected `VNode`, found `i32`
 note: required by a bound in `ChildPropertiesBuilder::int`
   --> tests/html_macro/component-fail.rs:4:17
    |
@@ -572,7 +565,7 @@ note: required by a bound in `ChildPropertiesBuilder::int`
    |                 ^^^^^^^^^^ required by this bound in `ChildPropertiesBuilder::int`
 ...
 8  |     pub int: i32,
-   |         --- required by a bound in this
+   |         --- required by a bound in this associated function
    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AssertAllProps: HasProp<int, _>` is not satisfied
@@ -582,26 +575,29 @@ error[E0277]: the trait bound `AssertAllProps: HasProp<int, _>` is not satisfied
    |              ^^^^^ the trait `HasProp<int, _>` is not implemented for `AssertAllProps`
    |
    = help: the following other types implement trait `HasProp<P, How>`:
-             <CheckChildContainerPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <CheckChildPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <CheckChildrenPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <CheckContextProviderPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <CheckHtmlInPropsPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasChildContainerPropertieschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
-             <HasChildContainerPropertieschildren<B> as HasProp<_ChildContainerProperties::children, HasChildContainerPropertieschildren<B>>>
+             <HasChildPropertiesint<B> as HasProp<int, HasChildPropertiesint<B>>>
              <HasChildPropertiesint<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <CheckChildPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <HasChildContainerPropertieschildren<B> as HasProp<_ChildContainerProperties::children, HasChildContainerPropertieschildren<B>>>
+             <HasChildContainerPropertieschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <CheckChildContainerPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+             <HasHtmlInPropsPropertiesheader<B> as HasProp<header, HasHtmlInPropsPropertiesheader<B>>>
+             <HasHtmlInPropsPropertiesheader<B> as HasProp<P, &dyn HasProp<P, How>>>
            and $N others
-note: required because of the requirements on the impl of `HasAllProps<ChildProperties, (_,)>` for `CheckChildPropertiesAll<AssertAllProps>`
+note: required for `CheckChildPropertiesAll<AssertAllProps>` to implement `HasAllProps<ChildProperties, (_,)>`
   --> tests/html_macro/component-fail.rs:4:17
    |
 4  | #[derive(Clone, Properties, PartialEq)]
-   |                 ^^^^^^^^^^
-   = note: required because of the requirements on the impl of `AllPropsFor<ChildPropertiesBuilder, (_,)>` for `AssertAllProps`
+   |                 ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+   = note: required for `AssertAllProps` to implement `AllPropsFor<ChildPropertiesBuilder, (_,)>`
 note: required by a bound in `yew::html::component::properties::__macro::PreBuild::<Token, B>::build`
   --> $WORKSPACE/packages/yew/src/html/component/properties.rs
    |
+   |         pub fn build<How>(self) -> B::Output
+   |                ----- required by a bound in this associated function
+   |         where
    |             Token: AllPropsFor<B, How>,
-   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `yew::html::component::properties::__macro::PreBuild::<Token, B>::build`
+   |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `PreBuild::<Token, B>::build`
    = note: this error originates in the macro `html` which comes from the expansion of the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `children` on type `ChildProperties`
@@ -610,7 +606,6 @@ error[E0609]: no field `children` on type `ChildProperties`
 103 |     html! { <Child>{ "Not allowed" }</Child> };
     |              ^^^^^ unknown field
     |
-    = note: available fields are: `string`, `int`
     = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `children` found for struct `ChildPropertiesBuilder` in the current scope
@@ -630,7 +625,6 @@ error[E0609]: no field `children` on type `ChildProperties`
 110 |         <Child ..ChildProperties { string: "hello".to_owned(), int: 5 }>
     |          ^^^^^ unknown field
     |
-    = note: available fields are: `string`, `int`
     = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AssertAllProps: HasProp<_ChildContainerProperties::children, _>` is not satisfied
@@ -640,26 +634,29 @@ error[E0277]: the trait bound `AssertAllProps: HasProp<_ChildContainerProperties
     |              ^^^^^^^^^^^^^^ the trait `HasProp<_ChildContainerProperties::children, _>` is not implemented for `AssertAllProps`
     |
     = help: the following other types implement trait `HasProp<P, How>`:
-              <CheckChildContainerPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <CheckChildPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <CheckChildrenPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <CheckContextProviderPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <CheckHtmlInPropsPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <HasChildContainerPropertieschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <HasChildContainerPropertieschildren<B> as HasProp<_ChildContainerProperties::children, HasChildContainerPropertieschildren<B>>>
+              <HasChildPropertiesint<B> as HasProp<int, HasChildPropertiesint<B>>>
               <HasChildPropertiesint<B> as HasProp<P, &dyn HasProp<P, How>>>
+              <CheckChildPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+              <HasChildContainerPropertieschildren<B> as HasProp<_ChildContainerProperties::children, HasChildContainerPropertieschildren<B>>>
+              <HasChildContainerPropertieschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
+              <CheckChildContainerPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+              <HasHtmlInPropsPropertiesheader<B> as HasProp<header, HasHtmlInPropsPropertiesheader<B>>>
+              <HasHtmlInPropsPropertiesheader<B> as HasProp<P, &dyn HasProp<P, How>>>
             and $N others
-note: required because of the requirements on the impl of `HasAllProps<ChildContainerProperties, (_,)>` for `CheckChildContainerPropertiesAll<AssertAllProps>`
+note: required for `CheckChildContainerPropertiesAll<AssertAllProps>` to implement `HasAllProps<ChildContainerProperties, (_,)>`
    --> tests/html_macro/component-fail.rs:24:17
     |
 24  | #[derive(Clone, Properties, PartialEq)]
-    |                 ^^^^^^^^^^
-    = note: required because of the requirements on the impl of `AllPropsFor<ChildContainerPropertiesBuilder, (_,)>` for `AssertAllProps`
+    |                 ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+    = note: required for `AssertAllProps` to implement `AllPropsFor<ChildContainerPropertiesBuilder, (_,)>`
 note: required by a bound in `yew::html::component::properties::__macro::PreBuild::<Token, B>::build`
    --> $WORKSPACE/packages/yew/src/html/component/properties.rs
     |
+    |         pub fn build<How>(self) -> B::Output
+    |                ----- required by a bound in this associated function
+    |         where
     |             Token: AllPropsFor<B, How>,
-    |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `yew::html::component::properties::__macro::PreBuild::<Token, B>::build`
+    |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `PreBuild::<Token, B>::build`
     = note: this error originates in the macro `html` which comes from the expansion of the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AssertAllProps: HasProp<_ChildContainerProperties::children, _>` is not satisfied
@@ -669,33 +666,38 @@ error[E0277]: the trait bound `AssertAllProps: HasProp<_ChildContainerProperties
     |              ^^^^^^^^^^^^^^ the trait `HasProp<_ChildContainerProperties::children, _>` is not implemented for `AssertAllProps`
     |
     = help: the following other types implement trait `HasProp<P, How>`:
-              <CheckChildContainerPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <CheckChildPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <CheckChildrenPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <CheckContextProviderPropsAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <CheckHtmlInPropsPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <HasChildContainerPropertieschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
-              <HasChildContainerPropertieschildren<B> as HasProp<_ChildContainerProperties::children, HasChildContainerPropertieschildren<B>>>
+              <HasChildPropertiesint<B> as HasProp<int, HasChildPropertiesint<B>>>
               <HasChildPropertiesint<B> as HasProp<P, &dyn HasProp<P, How>>>
+              <CheckChildPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+              <HasChildContainerPropertieschildren<B> as HasProp<_ChildContainerProperties::children, HasChildContainerPropertieschildren<B>>>
+              <HasChildContainerPropertieschildren<B> as HasProp<P, &dyn HasProp<P, How>>>
+              <CheckChildContainerPropertiesAll<B> as HasProp<P, &dyn HasProp<P, How>>>
+              <HasHtmlInPropsPropertiesheader<B> as HasProp<header, HasHtmlInPropsPropertiesheader<B>>>
+              <HasHtmlInPropsPropertiesheader<B> as HasProp<P, &dyn HasProp<P, How>>>
             and $N others
-note: required because of the requirements on the impl of `HasAllProps<ChildContainerProperties, (_,)>` for `CheckChildContainerPropertiesAll<AssertAllProps>`
+note: required for `CheckChildContainerPropertiesAll<AssertAllProps>` to implement `HasAllProps<ChildContainerProperties, (_,)>`
    --> tests/html_macro/component-fail.rs:24:17
     |
 24  | #[derive(Clone, Properties, PartialEq)]
-    |                 ^^^^^^^^^^
-    = note: required because of the requirements on the impl of `AllPropsFor<ChildContainerPropertiesBuilder, (_,)>` for `AssertAllProps`
+    |                 ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+    = note: required for `AssertAllProps` to implement `AllPropsFor<ChildContainerPropertiesBuilder, (_,)>`
 note: required by a bound in `yew::html::component::properties::__macro::PreBuild::<Token, B>::build`
    --> $WORKSPACE/packages/yew/src/html/component/properties.rs
     |
+    |         pub fn build<How>(self) -> B::Output
+    |                ----- required by a bound in this associated function
+    |         where
     |             Token: AllPropsFor<B, How>,
-    |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `yew::html::component::properties::__macro::PreBuild::<Token, B>::build`
+    |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `PreBuild::<Token, B>::build`
     = note: this error originates in the macro `html` which comes from the expansion of the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::VText: IntoPropValue<ChildrenRenderer<VChild<Child>>>` is not satisfied
-   --> tests/html_macro/component-fail.rs:117:14
+   --> tests/html_macro/component-fail.rs:117:31
     |
 117 |     html! { <ChildContainer>{ "Not allowed" }</ChildContainer> };
-    |              ^^^^^^^^^^^^^^ the trait `IntoPropValue<ChildrenRenderer<VChild<Child>>>` is not implemented for `yew::virtual_dom::VText`
+    |              --------------   ^^^^^^^^^^^^^ the trait `IntoPropValue<ChildrenRenderer<VChild<Child>>>` is not implemented for `yew::virtual_dom::VText`
+    |              |
+    |              required by a bound introduced by this call
     |
     = help: the following other types implement trait `IntoPropValue<T>`:
               <yew::virtual_dom::VText as IntoPropValue<ChildrenRenderer<VNode>>>
@@ -707,8 +709,8 @@ note: required by a bound in `ChildContainerPropertiesBuilder::children`
     |                 ^^^^^^^^^^ required by this bound in `ChildContainerPropertiesBuilder::children`
 25  | pub struct ChildContainerProperties {
 26  |     pub children: ChildrenWithProps<Child>,
-    |         -------- required by a bound in this
-    = note: this error originates in the macro `html` which comes from the expansion of the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
+    |         -------- required by a bound in this associated function
+    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `VChild<Child>: From<VNode>` is not satisfied
    --> tests/html_macro/component-fail.rs:118:29
@@ -716,15 +718,18 @@ error[E0277]: the trait bound `VChild<Child>: From<VNode>` is not satisfied
 118 |     html! { <ChildContainer><></></ChildContainer> };
     |                             ^ the trait `From<VNode>` is not implemented for `VChild<Child>`
     |
-    = note: required because of the requirements on the impl of `Into<VChild<Child>>` for `VNode`
+    = note: required for `VNode` to implement `Into<VChild<Child>>`
 
 error[E0277]: the trait bound `VNode: IntoPropValue<ChildrenRenderer<VChild<Child>>>` is not satisfied
-   --> tests/html_macro/component-fail.rs:119:14
+   --> tests/html_macro/component-fail.rs:119:30
     |
 119 |     html! { <ChildContainer><other /></ChildContainer> };
-    |              ^^^^^^^^^^^^^^ the trait `IntoPropValue<ChildrenRenderer<VChild<Child>>>` is not implemented for `VNode`
+    |              --------------  ^^^^^ the trait `IntoPropValue<ChildrenRenderer<VChild<Child>>>` is not implemented for `VNode`
+    |              |
+    |              required by a bound introduced by this call
     |
     = help: the trait `IntoPropValue<ChildrenRenderer<VNode>>` is implemented for `VNode`
+    = help: for that trait implementation, expected `VNode`, found `VChild<Child>`
 note: required by a bound in `ChildContainerPropertiesBuilder::children`
    --> tests/html_macro/component-fail.rs:24:17
     |
@@ -732,5 +737,5 @@ note: required by a bound in `ChildContainerPropertiesBuilder::children`
     |                 ^^^^^^^^^^ required by this bound in `ChildContainerPropertiesBuilder::children`
 25  | pub struct ChildContainerProperties {
 26  |     pub children: ChildrenWithProps<Child>,
-    |         -------- required by a bound in this
-    = note: this error originates in the macro `html` which comes from the expansion of the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
+    |         -------- required by a bound in this associated function
+    = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-macro/tests/html_macro/component-unimplemented-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/component-unimplemented-fail.stderr
@@ -5,7 +5,7 @@ error[E0277]: the trait bound `Unimplemented: yew::Component` is not satisfied
   |              ^^^^^^^^^^^^^ the trait `yew::Component` is not implemented for `Unimplemented`
   |
   = help: the trait `yew::Component` is implemented for `ContextProvider<T>`
-  = note: required because of the requirements on the impl of `BaseComponent` for `Unimplemented`
+  = note: required for `Unimplemented` to implement `BaseComponent`
   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `new` exists for struct `VChild<Unimplemented>`, but its trait bounds were not satisfied
@@ -19,7 +19,7 @@ error[E0599]: the function or associated item `new` exists for struct `VChild<Un
   |
   = note: the following trait bounds were not satisfied:
           `Unimplemented: BaseComponent`
-note: the following trait must be implemented
+note: the trait `BaseComponent` must be implemented
  --> $WORKSPACE/packages/yew/src/html/component/mod.rs
   |
   | pub trait BaseComponent: Sized + 'static {

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -342,7 +342,16 @@ error[E0308]: mismatched types
    |     |                      expected `bool`, found integer
    |     arguments to this enum variant are incorrect
    |
+help: the type constructed contains `{integer}` due to the type of the argument passed
+  --> tests/html_macro/element-fail.rs:36:5
+   |
+36 |     html! { <input checked=1 /> };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^-^^^^^
+   |                            |
+   |                            this argument influences the type of `{{root}}`
 note: tuple variant defined here
+  --> $RUST/core/src/option.rs
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> tests/html_macro/element-fail.rs:37:29
@@ -350,12 +359,25 @@ error[E0308]: mismatched types
 37 |     html! { <input checked={Some(false)} /> };
    |     ------------------------^^^^^^^^^^^------
    |     |                       |
-   |     |                       expected `bool`, found enum `Option`
+   |     |                       expected `bool`, found `Option<bool>`
    |     arguments to this enum variant are incorrect
    |
    = note: expected type `bool`
               found enum `Option<bool>`
+help: the type constructed contains `Option<bool>` due to the type of the argument passed
+  --> tests/html_macro/element-fail.rs:37:5
+   |
+37 |     html! { <input checked={Some(false)} /> };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^
+   |                             |
+   |                             this argument influences the type of `{{root}}`
 note: tuple variant defined here
+  --> $RUST/core/src/option.rs
+   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `Option::is_some` to test if the `Option` has a value
+   |
+37 |     html! { <input checked={Some(false).is_some()} /> };
+   |                                        ++++++++++
 
 error[E0308]: mismatched types
   --> tests/html_macro/element-fail.rs:38:29
@@ -376,10 +398,14 @@ error[E0308]: mismatched types
   --> tests/html_macro/element-fail.rs:39:30
    |
 39 |     html! { <input disabled={Some(true)} /> };
-   |                              ^^^^^^^^^^ expected `bool`, found enum `Option`
+   |                              ^^^^^^^^^^ expected `bool`, found `Option<bool>`
    |
    = note: expected type `bool`
               found enum `Option<bool>`
+help: use `Option::is_some` to test if the `Option` has a value
+   |
+39 |     html! { <input disabled={Some(true).is_some()} /> };
+   |                                        ++++++++++
 
 error[E0308]: mismatched types
   --> tests/html_macro/element-fail.rs:40:30
@@ -403,6 +429,7 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<implicit_clone::unsync::
    |                          ^^ the trait `IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not implemented for `()`
    |
    = help: the trait `IntoPropValue<VNode>` is implemented for `()`
+   = help: for that trait implementation, expected `VNode`, found `Option<implicit_clone::unsync::string::IString>`
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not satisfied
   --> tests/html_macro/element-fail.rs:44:27
@@ -411,6 +438,7 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<implicit_clone::unsync::
    |                           ^^ the trait `IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not implemented for `()`
    |
    = help: the trait `IntoPropValue<VNode>` is implemented for `()`
+   = help: for that trait implementation, expected `VNode`, found `Option<implicit_clone::unsync::string::IString>`
 
 error[E0277]: the trait bound `(): IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not satisfied
   --> tests/html_macro/element-fail.rs:45:22
@@ -419,6 +447,7 @@ error[E0277]: the trait bound `(): IntoPropValue<Option<implicit_clone::unsync::
    |                      ^^ the trait `IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not implemented for `()`
    |
    = help: the trait `IntoPropValue<VNode>` is implemented for `()`
+   = help: for that trait implementation, expected `VNode`, found `Option<implicit_clone::unsync::string::IString>`
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not satisfied
   --> tests/html_macro/element-fail.rs:46:28
@@ -427,64 +456,70 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<implicit_clone:
    |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not implemented for `NotToString`
    |
    = help: the following other types implement trait `IntoPropValue<T>`:
-             <&'static [(K, V)] as IntoPropValue<implicit_clone::unsync::map::IMap<K, V>>>
-             <&'static [T] as IntoPropValue<implicit_clone::unsync::array::IArray<T>>>
-             <&'static str as IntoPropValue<Classes>>
-             <&'static str as IntoPropValue<Option<String>>>
-             <&'static str as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
-             <&'static str as IntoPropValue<String>>
-             <&'static str as IntoPropValue<implicit_clone::unsync::string::IString>>
-             <&String as IntoPropValue<VNode>>
+             <bool as IntoPropValue<VNode>>
+             <char as IntoPropValue<VNode>>
+             <isize as IntoPropValue<VNode>>
+             <i8 as IntoPropValue<VNode>>
+             <i16 as IntoPropValue<VNode>>
+             <i32 as IntoPropValue<VNode>>
+             <i64 as IntoPropValue<VNode>>
+             <i128 as IntoPropValue<VNode>>
            and $N others
 
 error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not satisfied
   --> tests/html_macro/element-fail.rs:47:23
    |
 47 |     html! { <a media={Some(NotToString)} /> };
-   |                       ^^^^ the trait `IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not implemented for `Option<NotToString>`
+   |                       ----^^^^^^^^^^^^^
+   |                       |
+   |                       the trait `IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not implemented for `Option<NotToString>`
+   |                       required by a bound introduced by this call
    |
    = help: the following other types implement trait `IntoPropValue<T>`:
-             <Option<&'static str> as IntoPropValue<Option<String>>>
-             <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
              <Option<Cow<'static, str>> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
-             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
-             <Option<String> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
              <Option<VChild<T>> as IntoPropValue<Option<ChildrenRenderer<C>>>>
              <Option<VNode> as IntoPropValue<VNode>>
+             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
+             <Option<String> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
+             <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
+             <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not satisfied
   --> tests/html_macro/element-fail.rs:48:22
    |
 48 |     html! { <a href={Some(5)} /> };
-   |                      ^^^^ the trait `IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not implemented for `Option<{integer}>`
+   |                      ----^^^
+   |                      |
+   |                      the trait `IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not implemented for `Option<{integer}>`
+   |                      required by a bound introduced by this call
    |
    = help: the following other types implement trait `IntoPropValue<T>`:
-             <Option<&'static str> as IntoPropValue<Option<String>>>
-             <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
              <Option<Cow<'static, str>> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
-             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
-             <Option<String> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
              <Option<VChild<T>> as IntoPropValue<Option<ChildrenRenderer<C>>>>
              <Option<VNode> as IntoPropValue<VNode>>
+             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
+             <Option<String> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
+             <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
+             <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
 
-error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `{integer}`
+error[E0277]: expected a `Fn(MouseEvent)` closure, found `{integer}`
   --> tests/html_macro/element-fail.rs:51:28
    |
 51 |     html! { <input onclick=1 /> };
    |     -----------------------^-----
    |     |                      |
-   |     |                      expected an `Fn<(MouseEvent,)>` closure, found `{integer}`
+   |     |                      expected an `Fn(MouseEvent)` closure, found `{integer}`
    |     required by a bound introduced by this call
    |
    = help: the trait `Fn<(MouseEvent,)>` is not implemented for `{integer}`
    = help: the following other types implement trait `IntoEventCallback<EVENT>`:
-             &yew::Callback<EVENT>
-             Option<T>
-             Option<yew::Callback<EVENT>>
              yew::Callback<EVENT>
-   = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `{integer}`
+             Option<yew::Callback<EVENT>>
+             Option<T>
+             &yew::Callback<EVENT>
+   = note: required for `{integer}` to implement `IntoEventCallback<MouseEvent>`
 note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
   --> $WORKSPACE/packages/yew/src/html/listener/events.rs
    |
@@ -495,23 +530,26 @@ note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
 ...  |
    | |     ontransitionstart(TransitionEvent)
    | | }
-   | |_^ required by this bound in `yew::html::onclick::Wrapper::__macro_new`
+   | | ^
+   | | |
+   | |_required by a bound in this associated function
+   |   required by this bound in `Wrapper::__macro_new`
    = note: this error originates in the macro `impl_action` which comes from the expansion of the macro `impl_short` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
+error[E0277]: expected a `Fn(MouseEvent)` closure, found `yew::Callback<String>`
   --> tests/html_macro/element-fail.rs:52:29
    |
 52 |     html! { <input onclick={Callback::from(|a: String| ())} /> };
    |     ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------
    |     |                       |
-   |     |                       expected an `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
+   |     |                       expected an `Fn(MouseEvent)` closure, found `yew::Callback<String>`
    |     required by a bound introduced by this call
    |
    = help: the trait `Fn<(MouseEvent,)>` is not implemented for `yew::Callback<String>`
    = help: the following other types implement trait `IntoEventCallback<EVENT>`:
-             &yew::Callback<EVENT>
              yew::Callback<EVENT>
-   = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
+             &yew::Callback<EVENT>
+   = note: required for `yew::Callback<String>` to implement `IntoEventCallback<MouseEvent>`
 note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
   --> $WORKSPACE/packages/yew/src/html/listener/events.rs
    |
@@ -522,7 +560,10 @@ note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
 ...  |
    | |     ontransitionstart(TransitionEvent)
    | | }
-   | |_^ required by this bound in `yew::html::onclick::Wrapper::__macro_new`
+   | | ^
+   | | |
+   | |_required by a bound in this associated function
+   |   required by this bound in `Wrapper::__macro_new`
    = note: this error originates in the macro `impl_action` which comes from the expansion of the macro `impl_short` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>` is not satisfied
@@ -535,8 +576,8 @@ error[E0277]: the trait bound `Option<{integer}>: IntoEventCallback<FocusEvent>`
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `IntoEventCallback<EVENT>`:
-             Option<T>
              Option<yew::Callback<EVENT>>
+             Option<T>
 note: required by a bound in `yew::html::onfocus::Wrapper::__macro_new`
   --> $WORKSPACE/packages/yew/src/html/listener/events.rs
    |
@@ -547,49 +588,57 @@ note: required by a bound in `yew::html::onfocus::Wrapper::__macro_new`
 ...  |
    | |     ontransitionstart(TransitionEvent)
    | | }
-   | |_^ required by this bound in `yew::html::onfocus::Wrapper::__macro_new`
+   | | ^
+   | | |
+   | |_required by a bound in this associated function
+   |   required by this bound in `Wrapper::__macro_new`
    = note: this error originates in the macro `impl_action` which comes from the expansion of the macro `impl_short` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
   --> tests/html_macro/element-fail.rs:56:25
    |
 56 |     html! { <input ref={()} /> };
-   |                         ^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
+   |                         ^^
+   |                         |
+   |                         the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
+   |                         required by a bound introduced by this call
    |
    = help: the trait `IntoPropValue<VNode>` is implemented for `()`
-   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: for that trait implementation, expected `VNode`, found `yew::NodeRef`
 
 error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>` is not satisfied
   --> tests/html_macro/element-fail.rs:57:25
    |
 57 |     html! { <input ref={Some(NodeRef::default())} /> };
-   |                         ^^^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `Option<yew::NodeRef>`
+   |                         ----^^^^^^^^^^^^^^^^^^^^
+   |                         |
+   |                         the trait `IntoPropValue<yew::NodeRef>` is not implemented for `Option<yew::NodeRef>`
+   |                         required by a bound introduced by this call
    |
    = help: the following other types implement trait `IntoPropValue<T>`:
-             <Option<&'static str> as IntoPropValue<Option<String>>>
-             <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
              <Option<Cow<'static, str>> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
-             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
-             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
-             <Option<String> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
              <Option<VChild<T>> as IntoPropValue<Option<ChildrenRenderer<C>>>>
              <Option<VNode> as IntoPropValue<VNode>>
-   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+             <Option<Rc<str>> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
+             <Option<String> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
+             <Option<&'static str> as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
+             <Option<&'static str> as IntoPropValue<Option<String>>>
+             <Option<F> as IntoPropValue<Option<yew::Callback<I, O>>>>
 
-error[E0277]: expected a `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
+error[E0277]: expected a `Fn(MouseEvent)` closure, found `yew::Callback<String>`
   --> tests/html_macro/element-fail.rs:58:29
    |
 58 |     html! { <input onclick={Callback::from(|a: String| ())} /> };
    |     ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------
    |     |                       |
-   |     |                       expected an `Fn<(MouseEvent,)>` closure, found `yew::Callback<String>`
+   |     |                       expected an `Fn(MouseEvent)` closure, found `yew::Callback<String>`
    |     required by a bound introduced by this call
    |
    = help: the trait `Fn<(MouseEvent,)>` is not implemented for `yew::Callback<String>`
    = help: the following other types implement trait `IntoEventCallback<EVENT>`:
-             &yew::Callback<EVENT>
              yew::Callback<EVENT>
-   = note: required because of the requirements on the impl of `IntoEventCallback<MouseEvent>` for `yew::Callback<String>`
+             &yew::Callback<EVENT>
+   = note: required for `yew::Callback<String>` to implement `IntoEventCallback<MouseEvent>`
 note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
   --> $WORKSPACE/packages/yew/src/html/listener/events.rs
    |
@@ -600,7 +649,10 @@ note: required by a bound in `yew::html::onclick::Wrapper::__macro_new`
 ...  |
    | |     ontransitionstart(TransitionEvent)
    | | }
-   | |_^ required by this bound in `yew::html::onclick::Wrapper::__macro_new`
+   | | ^
+   | | |
+   | |_required by a bound in this associated function
+   |   required by this bound in `Wrapper::__macro_new`
    = note: this error originates in the macro `impl_action` which comes from the expansion of the macro `impl_short` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotToString: IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not satisfied
@@ -610,24 +662,27 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<implicit_clone:
    |                            ^^^^^^^^^^^ the trait `IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not implemented for `NotToString`
    |
    = help: the following other types implement trait `IntoPropValue<T>`:
-             <&'static [(K, V)] as IntoPropValue<implicit_clone::unsync::map::IMap<K, V>>>
-             <&'static [T] as IntoPropValue<implicit_clone::unsync::array::IArray<T>>>
-             <&'static str as IntoPropValue<Classes>>
-             <&'static str as IntoPropValue<Option<String>>>
-             <&'static str as IntoPropValue<Option<implicit_clone::unsync::string::IString>>>
-             <&'static str as IntoPropValue<String>>
-             <&'static str as IntoPropValue<implicit_clone::unsync::string::IString>>
-             <&String as IntoPropValue<VNode>>
+             <bool as IntoPropValue<VNode>>
+             <char as IntoPropValue<VNode>>
+             <isize as IntoPropValue<VNode>>
+             <i8 as IntoPropValue<VNode>>
+             <i16 as IntoPropValue<VNode>>
+             <i32 as IntoPropValue<VNode>>
+             <i64 as IntoPropValue<VNode>>
+             <i128 as IntoPropValue<VNode>>
            and $N others
 
 error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied
   --> tests/html_macro/element-fail.rs:62:25
    |
 62 |     html! { <input ref={()} /> };
-   |                         ^^ the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
+   |                         ^^
+   |                         |
+   |                         the trait `IntoPropValue<yew::NodeRef>` is not implemented for `()`
+   |                         required by a bound introduced by this call
    |
    = help: the trait `IntoPropValue<VNode>` is implemented for `()`
-   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: for that trait implementation, expected `VNode`, found `yew::NodeRef`
 
 error[E0277]: the trait bound `implicit_clone::unsync::string::IString: From<{integer}>` is not satisfied
   --> tests/html_macro/element-fail.rs:77:16
@@ -636,9 +691,10 @@ error[E0277]: the trait bound `implicit_clone::unsync::string::IString: From<{in
    |                ^^ the trait `From<{integer}>` is not implemented for `implicit_clone::unsync::string::IString`
    |
    = help: the following other types implement trait `From<T>`:
-             <implicit_clone::unsync::string::IString as From<&'static str>>
-             <implicit_clone::unsync::string::IString as From<&implicit_clone::unsync::string::IString>>
              <implicit_clone::unsync::string::IString as From<Cow<'static, str>>>
              <implicit_clone::unsync::string::IString as From<Rc<str>>>
              <implicit_clone::unsync::string::IString as From<String>>
-   = note: required because of the requirements on the impl of `Into<implicit_clone::unsync::string::IString>` for `{integer}`
+             <implicit_clone::unsync::string::IString as From<Arguments<'_>>>
+             <implicit_clone::unsync::string::IString as From<&implicit_clone::unsync::string::IString>>
+             <implicit_clone::unsync::string::IString as From<&'static str>>
+   = note: required for `{integer}` to implement `Into<implicit_clone::unsync::string::IString>`

--- a/packages/yew-macro/tests/html_macro/generic-component-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/generic-component-fail.stderr
@@ -20,7 +20,7 @@ error: mismatched closing tags: expected `Generic<String>`, found `Generic<Path>
   --> tests/html_macro/generic-component-fail.rs:50:14
    |
 50 |     html! { <Generic<String>></Generic<Path>> };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected a valid closing tag for component
        note: found opening tag `<Generic<String>>`

--- a/packages/yew-macro/tests/html_macro/iterable-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/iterable-fail.stderr
@@ -11,16 +11,19 @@ error[E0277]: `()` is not an iterator
   |                 ^^ `()` is not an iterator
   |
   = help: the trait `Iterator` is not implemented for `()`
-  = note: required because of the requirements on the impl of `IntoIterator` for `()`
+  = note: required for `()` to implement `IntoIterator`
 
 error[E0277]: `()` is not an iterator
  --> tests/html_macro/iterable-fail.rs:6:17
   |
 6 |     html! { for {()} };
-  |                 ^^^^ `()` is not an iterator
+  |                 ^--^
+  |                 ||
+  |                 |this tail expression is of type `()`
+  |                 `()` is not an iterator
   |
   = help: the trait `Iterator` is not implemented for `()`
-  = note: required because of the requirements on the impl of `IntoIterator` for `()`
+  = note: required for `()` to implement `IntoIterator`
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
  --> tests/html_macro/iterable-fail.rs:7:17
@@ -31,11 +34,12 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = help: the trait `std::fmt::Display` is not implemented for `()`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = help: the trait `FromIterator<A>` is implemented for `VNode`
-  = note: required because of the requirements on the impl of `ToString` for `()`
-  = note: required because of the requirements on the impl of `From<()>` for `VNode`
-  = note: required because of the requirements on the impl of `Into<VNode>` for `()`
-  = note: required because of the requirements on the impl of `FromIterator<()>` for `VNode`
+  = note: required for `()` to implement `ToString`
+  = note: required for `VNode` to implement `From<()>`
+  = note: required for `()` to implement `Into<VNode>`
+  = note: required for `VNode` to implement `FromIterator<()>`
 note: required by a bound in `collect`
+ --> $RUST/core/src/iter/traits/iterator.rs
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> tests/html_macro/iterable-fail.rs:10:17
@@ -46,11 +50,12 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = help: the trait `FromIterator<A>` is implemented for `VNode`
-   = note: required because of the requirements on the impl of `ToString` for `()`
-   = note: required because of the requirements on the impl of `From<()>` for `VNode`
-   = note: required because of the requirements on the impl of `Into<VNode>` for `()`
-   = note: required because of the requirements on the impl of `FromIterator<()>` for `VNode`
+   = note: required for `()` to implement `ToString`
+   = note: required for `VNode` to implement `From<()>`
+   = note: required for `()` to implement `Into<VNode>`
+   = note: required for `VNode` to implement `FromIterator<()>`
 note: required by a bound in `collect`
+  --> $RUST/core/src/iter/traits/iterator.rs
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> tests/html_macro/iterable-fail.rs:13:17
@@ -61,12 +66,13 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = help: the trait `FromIterator<A>` is implemented for `VNode`
-   = note: required because of the requirements on the impl of `std::fmt::Display` for `&()`
-   = note: required because of the requirements on the impl of `ToString` for `&()`
-   = note: required because of the requirements on the impl of `From<&()>` for `VNode`
-   = note: required because of the requirements on the impl of `Into<VNode>` for `&()`
-   = note: required because of the requirements on the impl of `FromIterator<&()>` for `VNode`
+   = note: required for `&()` to implement `std::fmt::Display`
+   = note: required for `&()` to implement `ToString`
+   = note: required for `VNode` to implement `From<&()>`
+   = note: required for `&()` to implement `Into<VNode>`
+   = note: required for `VNode` to implement `FromIterator<&()>`
 note: required by a bound in `collect`
+  --> $RUST/core/src/iter/traits/iterator.rs
 
 error[E0277]: `()` is not an iterator
   --> tests/html_macro/iterable-fail.rs:18:19
@@ -75,9 +81,12 @@ error[E0277]: `()` is not an iterator
    |                   ^^ `()` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `()`
-   = note: required because of the requirements on the impl of `IntoIterator` for `()`
+   = note: required for `()` to implement `IntoIterator`
 note: required by a bound in `into_node_iter`
   --> $WORKSPACE/packages/yew/src/utils/mod.rs
    |
+   | pub fn into_node_iter<IT, T, R>(it: IT) -> impl Iterator<Item = R>
+   |        -------------- required by a bound in this function
+   | where
    |     IT: IntoIterator<Item = T>,
    |         ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `into_node_iter`

--- a/packages/yew-macro/tests/html_macro/list-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/list-fail.stderr
@@ -44,7 +44,7 @@ error: expected an expression following this equals sign
   --> tests/html_macro/list-fail.rs:18:17
    |
 18 |     html! { <key=></> };
-   |                 ^^
+   |                 ^
 
 error: the property value must be either a literal or enclosed in braces. Consider adding braces around your expression.: Expr::MethodCall {
            attrs: [],

--- a/packages/yew-macro/tests/html_macro/node-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/node-fail.stderr
@@ -42,9 +42,9 @@ error[E0425]: cannot find value `invalid` in this scope
   |
 help: consider importing one of these items
   |
-1 | use core::ptr::invalid;
+1 + use core::ptr::invalid;
   |
-1 | use std::ptr::invalid;
+1 + use std::ptr::invalid;
   |
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
@@ -56,17 +56,17 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = help: the trait `std::fmt::Display` is not implemented for `()`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = help: the following other types implement trait `From<T>`:
-            <VNode as From<ChildrenRenderer<VNode>>>
-            <VNode as From<T>>
-            <VNode as From<VChild<COMP>>>
             <VNode as From<yew::virtual_dom::VComp>>
+            <VNode as From<VChild<COMP>>>
+            <VNode as From<ChildrenRenderer<VNode>>>
             <VNode as From<yew::virtual_dom::VList>>
             <VNode as From<yew::virtual_dom::VPortal>>
             <VNode as From<yew::virtual_dom::VSuspense>>
             <VNode as From<yew::virtual_dom::VTag>>
             <VNode as From<yew::virtual_dom::VText>>
-  = note: required because of the requirements on the impl of `ToString` for `()`
-  = note: required because of the requirements on the impl of `From<()>` for `VNode`
+            <VNode as From<T>>
+  = note: required for `()` to implement `ToString`
+  = note: required for `VNode` to implement `From<()>`
   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
@@ -78,15 +78,15 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = help: the following other types implement trait `From<T>`:
-             <VNode as From<ChildrenRenderer<VNode>>>
-             <VNode as From<T>>
-             <VNode as From<VChild<COMP>>>
              <VNode as From<yew::virtual_dom::VComp>>
+             <VNode as From<VChild<COMP>>>
+             <VNode as From<ChildrenRenderer<VNode>>>
              <VNode as From<yew::virtual_dom::VList>>
              <VNode as From<yew::virtual_dom::VPortal>>
              <VNode as From<yew::virtual_dom::VSuspense>>
              <VNode as From<yew::virtual_dom::VTag>>
              <VNode as From<yew::virtual_dom::VText>>
-   = note: required because of the requirements on the impl of `ToString` for `()`
-   = note: required because of the requirements on the impl of `From<()>` for `VNode`
+             <VNode as From<T>>
+   = note: required for `()` to implement `ToString`
+   = note: required for `VNode` to implement `From<()>`
    = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packages/yew-macro/tests/html_macro_test.rs
+++ b/packages/yew-macro/tests/html_macro_test.rs
@@ -1,7 +1,7 @@
 use yew::{html, html_nested};
 
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.64), test)]
+#[rustversion::attr(stable(1.76), test)]
 fn html_macro() {
     let t = trybuild::TestCases::new();
 

--- a/packages/yew-macro/tests/props_macro/props-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/props-fail.stderr
@@ -14,7 +14,7 @@ error: expected ident
   --> tests/props_macro/props-fail.rs:13:31
    |
 13 |     yew::props!(Props { a: 1, ..props });
-   |                               ^^
+   |                               ^
 
 error[E0425]: cannot find value `does_not_exist` in this scope
   --> tests/props_macro/props-fail.rs:15:25
@@ -28,7 +28,7 @@ error[E0609]: no field `fail` on type `Props`
 10 |     yew::props!(Props { a: 5, fail: 10 });
    |                               ^^^^ unknown field
    |
-   = note: available fields are: `a`
+   = note: available field is: `a`
 
 error[E0599]: no method named `fail` found for struct `PropsBuilder` in the current scope
   --> tests/props_macro/props-fail.rs:10:31
@@ -45,7 +45,7 @@ error[E0609]: no field `does_not_exist` on type `Props`
 15 |     yew::props!(Props { does_not_exist });
    |                         ^^^^^^^^^^^^^^ unknown field
    |
-   = note: available fields are: `a`
+   = note: available field is: `a`
 
 error[E0599]: no method named `does_not_exist` found for struct `PropsBuilder` in the current scope
   --> tests/props_macro/props-fail.rs:15:25

--- a/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
+++ b/packages/yew-macro/tests/props_macro/resolve-prop-fail.stderr
@@ -1,17 +1,42 @@
 error[E0277]: can't compare `Props` with `Props`
- --> tests/props_macro/resolve-prop-fail.rs:3:17
+ --> tests/props_macro/resolve-prop-fail.rs:4:8
   |
-3 | #[derive(Clone, Properties)]
-  |                 ^^^^^^^^^^ no implementation for `Props == Props`
+4 | struct Props {}
+  |        ^^^^^ no implementation for `Props == Props`
   |
   = help: the trait `PartialEq` is not implemented for `Props`
 note: required by a bound in `yew::Properties`
  --> $WORKSPACE/packages/yew/src/html/component/properties.rs
   |
   | pub trait Properties: PartialEq {
-  |                       ^^^^^^^^^ required by this bound in `yew::Properties`
-  = note: this error originates in the derive macro `Properties` (in Nightly builds, run with -Z macro-backtrace for more info)
+  |                       ^^^^^^^^^ required by this bound in `Properties`
 help: consider annotating `Props` with `#[derive(PartialEq)]`
   |
-4 | #[derive(PartialEq)]
+4 + #[derive(PartialEq)]
+5 | struct Props {}
   |
+
+error[E0277]: can't compare `Props` with `Props`
+ --> tests/props_macro/resolve-prop-fail.rs:9:23
+  |
+9 |     type Properties = Props;
+  |                       ^^^^^ no implementation for `Props == Props`
+  |
+  = help: the trait `PartialEq` is not implemented for `Props`
+  = help: the following other types implement trait `yew::Properties`:
+            Props
+            ContextProviderProps<T>
+            ChildrenProps
+            SuspenseProps
+            ()
+  = note: required for `<MyComp as yew::Component>::Properties` to implement `yew::Properties`
+note: required by a bound in `yew::Component::Properties`
+ --> $WORKSPACE/packages/yew/src/html/component/mod.rs
+  |
+  |     type Properties: Properties;
+  |                      ^^^^^^^^^^ required by this bound in `Component::Properties`
+help: consider annotating `Props` with `#[derive(PartialEq)]`
+  |
+4   + #[derive(PartialEq)]
+5   | struct Props {}
+    |

--- a/packages/yew-macro/tests/props_macro_test.rs
+++ b/packages/yew-macro/tests/props_macro_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.64), test)]
+#[rustversion::attr(stable(1.76), test)]
 fn props_macro() {
     let t = trybuild::TestCases::new();
     t.pass("tests/props_macro/*-pass.rs");

--- a/packages/yew-router-macro/Cargo.toml
+++ b/packages/yew-router-macro/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Contains macros used with yew-router"
 repository = "https://github.com/yewstack/yew"
-rust-version = "1.64.0"
+rust-version = "1.76.0"
 
 [lib]
 proc-macro = true

--- a/packages/yew-router-macro/Makefile.toml
+++ b/packages/yew-router-macro/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.test]
 clear = true
-toolchain = "1.64.0"
+toolchain = "1.76.0"
 command = "cargo"
 args = ["test"]
 

--- a/packages/yew-router-macro/tests/routable_derive_test.rs
+++ b/packages/yew-router-macro/tests/routable_derive_test.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-#[rustversion::attr(stable(1.64), test)]
+#[rustversion::attr(stable(1.76), test)]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/routable_derive/*-pass.rs");

--- a/packages/yew-router/Cargo.toml
+++ b/packages/yew-router/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["web", "yew", "router"]
 categories = ["gui", "web-programming"]
 description = "A router implementation for the Yew framework"
 repository = "https://github.com/yewstack/yew"
-rust-version = "1.64.0"
+rust-version = "1.76.0"
 
 [dependencies]
 yew = { version = "0.21.0", path = "../yew", default-features= false }

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["web", "webasm", "javascript"]
 categories = ["gui", "wasm", "web-programming"]
 description = "A framework for creating reliable and efficient web applications"
 readme = "../../README.md"
-rust-version = "1.64.0"
+rust-version = "1.76.0"
 
 [dependencies]
 console_error_panic_hook = "0.1"

--- a/packages/yew/src/scheduler.rs
+++ b/packages/yew/src/scheduler.rs
@@ -46,15 +46,6 @@ impl TopologicalQueue {
     }
 
     /// Take a single entry, preferring parents over children
-    #[rustversion::before(1.66)]
-    fn pop_topmost(&mut self) -> Option<QueueEntry> {
-        // BTreeMap::pop_first is available after 1.66.
-        let key = *self.inner.keys().next()?;
-        self.inner.remove(&key)
-    }
-
-    /// Take a single entry, preferring parents over children
-    #[rustversion::since(1.66)]
     #[allow(clippy::incompatible_msrv)]
     #[inline]
     fn pop_topmost(&mut self) -> Option<QueueEntry> {

--- a/packages/yew/src/scheduler.rs
+++ b/packages/yew/src/scheduler.rs
@@ -46,7 +46,6 @@ impl TopologicalQueue {
     }
 
     /// Take a single entry, preferring parents over children
-    #[allow(clippy::incompatible_msrv)]
     #[inline]
     fn pop_topmost(&mut self) -> Option<QueueEntry> {
         self.inner.pop_first().map(|(_, v)| v)

--- a/packages/yew/src/server_renderer.rs
+++ b/packages/yew/src/server_renderer.rs
@@ -145,21 +145,7 @@ where
     // These implementations should be merged once https://github.com/tokio-rs/tracing/issues/2503 is resolved.
 
     /// Renders Yew Application into a string Stream
-    #[rustversion::since(1.70)]
     #[allow(clippy::let_with_type_underscore)]
-    #[tracing::instrument(
-        level = tracing::Level::DEBUG,
-        name = "render_stream",
-        skip(self),
-        fields(hydratable = self.hydratable),
-    )]
-    #[inline(always)]
-    pub fn render_stream(self) -> impl Stream<Item = String> {
-        self.render_stream_inner()
-    }
-
-    /// Renders Yew Application into a string Stream
-    #[rustversion::before(1.70)]
     #[tracing::instrument(
         level = tracing::Level::DEBUG,
         name = "render_stream",

--- a/website/docs/getting-started/introduction.mdx
+++ b/website/docs/getting-started/introduction.mdx
@@ -11,7 +11,7 @@ bundler for Rust.
 To install Rust, follow the [official instructions](https://www.rust-lang.org/tools/install).
 
 :::important
-The minimum supported Rust version (MSRV) for Yew is `1.64.0`. Older versions will not compile.
+The minimum supported Rust version (MSRV) for Yew is `1.76.0`. Older versions will not compile.
 You can check your toolchain version using
 `rustup show` (under "active toolchain") or `rustc --version`. To update your
 toolchain, run `rustup update`.

--- a/website/versioned_docs/version-0.21/getting-started/introduction.mdx
+++ b/website/versioned_docs/version-0.21/getting-started/introduction.mdx
@@ -11,7 +11,7 @@ bundler for Rust.
 To install Rust, follow the [official instructions](https://www.rust-lang.org/tools/install).
 
 :::important
-The minimum supported Rust version (MSRV) for Yew is `1.64.0`. Older versions will not compile.
+The minimum supported Rust version (MSRV) for Yew is `1.76.0`. Older versions will not compile.
 You can check your toolchain version using
 `rustup show` (under "active toolchain") or `rustc --version`. To update your
 toolchain, run `rustup update`.


### PR DESCRIPTION
#### Description

Raise MSRV to 1.76

1.76 is (almost*) 6 months old so this change brings Yew's MSRV to the same as Tokio and Hyper.

\* It will be 6 months old by first week of August so not a huge deal at the moment

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have updated tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
