### PR TITLE
Fix serving of examples

### DIFF
--- a/ci/build-examples.sh
+++ b/ci/build-examples.sh
@@ -33,7 +33,7 @@ for path in examples/*; do
       export RUSTFLAGS="-Zshare-generics=n -Clto=thin $RUSTFLAGS"
     fi
 
-    trunk build --release --dist "$dist_dir" --public-url "$PUBLIC_URL_PREFIX$example"
+    trunk build --release --dist "$dist_dir" --public-url "$PUBLIC_URL_PREFIX/$example"
 
     # check that there are no undefined symbols. Those generate an import .. from 'env',
     # which isn't available in the browser.


### PR DESCRIPTION
Specifying an absolute URL as the public base is necessary since trunk 0.19

#### Description

Currently, examples are built and served in a way that, since trunk 0.19, links to wrong paths. E.g. "boids/index.html" links to "boids/some-resource.js" . By specifying an absolute public path, the links now point to "/boids/some-resource.js". The previously worked because an implicit "/" was added the specified path.

See also trunk-rs/trunk#668 for the issue introducing this change upstream.

Fixes #3694

#### Checklist


- [x] I have reviewed my own code
- [ ] I have added tests
