### PR TITLE
Fix the getting started guide for windows users

### DIFF
--- a/website/docs/getting-started/build-a-sample-app.mdx
+++ b/website/docs/getting-started/build-a-sample-app.mdx
@@ -8,10 +8,24 @@ the boilerplate needed for a basic Yew app or manually set up a small project.
 ## Using a starter template
 
 Install [`cargo-generate`](https://github.com/cargo-generate/cargo-generate) by following their installation instructions
-then run the following command:
+then run the following commands:
+
+### Checkout and customize project
 
 ```shell
 cargo generate --git https://github.com/yewstack/yew-trunk-minimal-template
+```
+
+### Build project
+
+```shell
+trunk build
+```
+
+### Serve project
+
+```shell
+trunk serve
 ```
 
 ## Setting up the application manually

--- a/website/docs/getting-started/build-a-sample-app.mdx
+++ b/website/docs/getting-started/build-a-sample-app.mdx
@@ -16,13 +16,14 @@ then run the following commands:
 cargo generate --git https://github.com/yewstack/yew-trunk-minimal-template
 ```
 
-### Build project
+### Build project 
+This step is only needed when this guide has been run on Microsoft windows.
 
 ```shell
 trunk build
 ```
 
-### Serve project
+### Run project
 
 ```shell
 trunk serve


### PR DESCRIPTION
#### Description

By adding these commands to the instructions, the getting started guide is more failsafe (for windows users). As a windows user I did run into the following problem: https://github.com/trunk-rs/trunk/issues/681

By adding `trunk build` it fixes the example to use it on windows on powershell. 

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests