### PR TITLE
Provide reference ref for benchmark action and make it less spammy

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   benchmark:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'performance')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/post-benchmark.yml
+++ b/.github/workflows/post-benchmark.yml
@@ -48,3 +48,4 @@ jobs:
           # Enable job summary
           summary-always: true
           comment-always: true
+          ref: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
#### Description

It's apparently not possible to also provide a PR number for the comment to target, since that is automically determined by the action (and wrong for workflow_run workflows)

See also: benchmark-action/github-action-benchmark#250

Currently, all comments target the master commit, because the `workflow_run` action runs in the context of the main branch. Fixed by providing a [`ref`](https://github.com/benchmark-action/github-action-benchmark/tree/fe4e90e7735310d03ca4b1d8f0eb1d425c55be00?tab=readme-ov-file#ref-optional).

#### Checklist

- [x] I have reviewed my own code
