### PR TITLE
Fix hidden files not being uploaded with version upgrade in #3576

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -136,3 +136,5 @@ jobs:
           name: results
           path: artifacts/
           if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1


### PR DESCRIPTION
#### Description

It was not prominently explained that "hidden" files, i.e. starting with "." are now ignored with upload-artifact v4.4. This is only a problem when uploading globbed directories in benchmark where we don't know the full path by default.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
