### PR TITLE
yew-router: Dynamic basename.

### DIFF
--- a/packages/yew-router/src/lib.rs
+++ b/packages/yew-router/src/lib.rs
@@ -88,6 +88,10 @@ pub mod history {
         AnyHistory, BrowserHistory, HashHistory, History, HistoryError, HistoryResult, Location,
         MemoryHistory,
     };
+
+    pub(crate) mod query {
+        pub(crate) use gloo::history::query::Raw;
+    }
 }
 
 pub mod prelude {

--- a/packages/yew-router/src/lib.rs
+++ b/packages/yew-router/src/lib.rs
@@ -88,10 +88,6 @@ pub mod history {
         AnyHistory, BrowserHistory, HashHistory, History, HistoryError, HistoryResult, Location,
         MemoryHistory,
     };
-
-    pub(crate) mod query {
-        pub(crate) use gloo::history::query::Raw;
-    }
 }
 
 pub mod prelude {

--- a/packages/yew-router/src/navigator.rs
+++ b/packages/yew-router/src/navigator.rs
@@ -159,7 +159,7 @@ impl Navigator {
     pub(crate) fn prefix_basename<'a>(&self, route_s: &'a str) -> Cow<'a, str> {
         match self.basename() {
             Some(base) => {
-                if route_s.is_empty() && route_s.is_empty() {
+                if base.is_empty() && route_s.is_empty() {
                     Cow::from("/")
                 } else {
                     Cow::from(format!("{base}{route_s}"))

--- a/packages/yew-router/src/router.rs
+++ b/packages/yew-router/src/router.rs
@@ -2,10 +2,10 @@
 use std::borrow::Cow;
 use std::rc::Rc;
 
+use gloo::history::query::Raw;
 use yew::prelude::*;
 use yew::virtual_dom::AttrValue;
 
-use crate::history::query::Raw;
 use crate::history::{AnyHistory, BrowserHistory, HashHistory, History, Location};
 use crate::navigator::Navigator;
 use crate::utils::{base_url, strip_slash_suffix};
@@ -77,7 +77,8 @@ fn base_router(props: &RouterProps) -> Html {
     let basename = basename.map(|m| strip_slash_suffix(&m).to_string());
     let navigator = Navigator::new(history.clone(), basename.clone());
 
-    let old_basename = use_state_eq(|| Option::<String>::None);
+    let old_basename = use_mut_ref(|| Option::<String>::None);
+    let mut old_basename = old_basename.borrow_mut();
     if basename != *old_basename {
         // If `old_basename` is `Some`, path is probably prefixed with `old_basename`.
         // If `old_basename` is `None`, path may or may not be prefixed with the new `basename`,
@@ -86,7 +87,7 @@ fn base_router(props: &RouterProps) -> Html {
             history.clone(),
             old_basename.as_ref().or(basename.as_ref()).cloned(),
         );
-        old_basename.set(basename.clone());
+        *old_basename = basename.clone();
         let location = history.location();
         let stripped = old_navigator.strip_basename(Cow::from(location.path()));
         let prefixed = navigator.prefix_basename(&stripped);

--- a/packages/yew-router/src/router.rs
+++ b/packages/yew-router/src/router.rs
@@ -74,7 +74,7 @@ fn base_router(props: &RouterProps) -> Html {
         basename,
     } = props.clone();
 
-    let basename = basename.map(|m| strip_slash_suffix(&m).to_string());
+    let basename = basename.map(|m| strip_slash_suffix(&m).to_owned());
     let navigator = Navigator::new(history.clone(), basename.clone());
 
     let old_basename = use_mut_ref(|| Option::<String>::None);
@@ -96,6 +96,11 @@ fn base_router(props: &RouterProps) -> Html {
             history
                 .replace_with_query(prefixed, Raw(location.query_str()))
                 .unwrap_or_else(|never| match never {});
+        } else {
+            // Reaching here is possible if the page loads with the correct path, including the
+            // initial basename. In that case, the new basename would be stripped and then
+            // prefixed right back. While replacing the history would probably be harmless,
+            // we might as well avoid doing it.
         }
     }
 


### PR DESCRIPTION
#### Description

1. Currently, if `basename` changes, the URL isn't updated and the old `basename` is persisted until the next navigation. With this PR, `basename` changes take effect immediately.
2. Currently, if `basename` is initially `Some`, the URL may lack the `basename` until the next nagvigation. With this PR, the `basename` is immediately added to the URL.

#### Motivation

In my application, base path is used for something resembling a workspace while route is used for something resembling a page id with parameters. The base path may not exist (the default 'workspace') or may change (when moving between 'workspaces').

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have tested my changes in my app
- [x] I have ~~added tests~~ modified existing test to test all new functionality
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->