### PR TITLE
Fix CI.

### DIFF
--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -57,7 +57,7 @@ impl PropField {
         props_name: &'a Ident,
         vis: &'a Visibility,
         token: &'a GenericParam,
-    ) -> PropFieldCheck<'_> {
+    ) -> PropFieldCheck<'a> {
         let check_struct = self.to_check_name(props_name);
         let check_arg = self.to_check_arg_name(props_name);
         PropFieldCheck {

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -295,6 +295,7 @@ mod renderer;
 
 #[cfg(feature = "csr")]
 #[cfg(test)]
+#[allow(missing_docs)]
 pub mod tests;
 
 /// The module that contains all events available in the framework.

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -293,7 +293,7 @@ mod app_handle;
 #[cfg(feature = "csr")]
 mod renderer;
 
-#[cfg(feature = "csr")]
+#[cfg(all(feature = "csr", target_arch = "wasm32"))]
 #[cfg(test)]
 pub(crate) mod tests;
 

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -295,7 +295,7 @@ mod renderer;
 
 #[cfg(feature = "csr")]
 #[cfg(test)]
-pub(crate) mod tests;
+pub mod tests;
 
 /// The module that contains all events available in the framework.
 pub mod events {

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -295,7 +295,7 @@ mod renderer;
 
 #[cfg(feature = "csr")]
 #[cfg(test)]
-pub mod tests;
+pub(crate) mod tests;
 
 /// The module that contains all events available in the framework.
 pub mod events {

--- a/packages/yew/src/lib.rs
+++ b/packages/yew/src/lib.rs
@@ -293,7 +293,7 @@ mod app_handle;
 #[cfg(feature = "csr")]
 mod renderer;
 
-#[cfg(all(feature = "csr", target_arch = "wasm32"))]
+#[cfg(feature = "csr")]
 #[cfg(test)]
 pub(crate) mod tests;
 

--- a/packages/yew/src/tests/layout_tests.rs
+++ b/packages/yew/src/tests/layout_tests.rs
@@ -31,12 +31,14 @@ impl Component for Comp {
 }
 
 #[derive(Debug)]
+#[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
 pub(crate) struct TestLayout<'a> {
     pub name: &'a str,
     pub node: VNode,
     pub expected: &'a str,
 }
 
+#[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
 pub(crate) fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
     let document = gloo::utils::document();
     let scope: AnyScope = AnyScope::test();

--- a/packages/yew/src/tests/layout_tests.rs
+++ b/packages/yew/src/tests/layout_tests.rs
@@ -31,15 +31,15 @@ impl Component for Comp {
 }
 
 #[derive(Debug)]
-#[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
-pub(crate) struct TestLayout<'a> {
+#[allow(missing_docs)]
+pub struct TestLayout<'a> {
     pub name: &'a str,
     pub node: VNode,
     pub expected: &'a str,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), allow(unused))]
-pub(crate) fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
+#[allow(missing_docs)]
+pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
     let document = gloo::utils::document();
     let scope: AnyScope = AnyScope::test();
     let parent_element = document.create_element("div").unwrap();

--- a/packages/yew/src/tests/layout_tests.rs
+++ b/packages/yew/src/tests/layout_tests.rs
@@ -31,13 +31,13 @@ impl Component for Comp {
 }
 
 #[derive(Debug)]
-pub struct TestLayout<'a> {
+pub(crate) struct TestLayout<'a> {
     pub name: &'a str,
     pub node: VNode,
     pub expected: &'a str,
 }
 
-pub fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
+pub(crate) fn diff_layouts(layouts: Vec<TestLayout<'_>>) {
     let document = gloo::utils::document();
     let scope: AnyScope = AnyScope::test();
     let parent_element = document.create_element("div").unwrap();

--- a/packages/yew/src/tests/mod.rs
+++ b/packages/yew/src/tests/mod.rs
@@ -1,1 +1,2 @@
+#[allow(missing_docs)]
 pub mod layout_tests;

--- a/tools/website-test/build.rs
+++ b/tools/website-test/build.rs
@@ -62,7 +62,7 @@ impl Level {
 
     fn write_into(&self, dst: &mut String, name: &str, level: usize) -> fmt::Result {
         self.write_space(dst, level);
-        let name = name.replace(&['-', '.'], "_");
+        let name = name.replace(['-', '.'], "_");
         writeln!(dst, "pub mod {name} {{")?;
 
         self.write_inner(dst, level + 1)?;

--- a/tools/website-test/build.rs
+++ b/tools/website-test/build.rs
@@ -62,7 +62,7 @@ impl Level {
 
     fn write_into(&self, dst: &mut String, name: &str, level: usize) -> fmt::Result {
         self.write_space(dst, level);
-        let name = name.replace(|c| c == '-' || c == '.', "_");
+        let name = name.replace(&['-', '.'], "_");
         writeln!(dst, "pub mod {name} {{")?;
 
         self.write_inner(dst, level + 1)?;


### PR DESCRIPTION
#### Description

Fixes warnings/errors encountered in CI, using https://github.com/yewstack/yew/pull/3725 for reference. The errors were presumably due to Rust 1.81's updated checks.

#### Checklist

- [x] I have reviewed my own code
