### PR TITLE
yew-macro: remove transitive dependency on syn 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,6 +2470,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4056,7 +4078,7 @@ version = "0.21.0"
 dependencies = [
  "once_cell",
  "prettyplease",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.76.0"
 proc-macro = true
 
 [dependencies]
-proc-macro-error2 = { version = "2", features = ["nightly"] }
+proc-macro-error2 = "2"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits", "visit-mut"] }
@@ -28,6 +28,10 @@ prettyplease = "0.2"
 rustversion = "1"
 trybuild = "1"
 yew = { path = "../yew" }
+
+[features]
+default = []
+nightly_yew = ["proc-macro-error2/nightly"]
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(nightly_yew)'] }

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.76.0"
 proc-macro = true
 
 [dependencies]
-proc-macro-error2 = "2"
+proc-macro-error2 = { version = "2", features = ["nightly"] }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits", "visit-mut"] }

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.76.0"
 proc-macro = true
 
 [dependencies]
-proc-macro-error = "1"
+proc-macro-error2 = "2"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits", "visit-mut"] }
@@ -31,4 +31,3 @@ yew = { path = "../yew" }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(nightly_yew)'] }
-

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -29,9 +29,8 @@ rustversion = "1"
 trybuild = "1"
 yew = { path = "../yew" }
 
-[features]
-default = []
-nightly_yew = ["proc-macro-error2/nightly"]
+[target.'cfg(nightly_yew)'.dependencies]
+proc-macro-error2 = { version = "2", features = ["nightly"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(nightly_yew)'] }

--- a/packages/yew-macro/src/hook/body.rs
+++ b/packages/yew-macro/src/hook/body.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
 use syn::{

--- a/packages/yew-macro/src/hook/mod.rs
+++ b/packages/yew-macro/src/hook/mod.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{

--- a/packages/yew-macro/src/hook/signature.rs
+++ b/packages/yew-macro/src/hook/signature.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use quote::{quote, ToTokens};
 use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Delimiter, Group, Span, TokenStream};
-use proc_macro_error::emit_warning;
+use proc_macro_error2::emit_warning;
 use quote::{quote, quote_spanned, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream};

--- a/packages/yew-macro/src/html_tree/lint/mod.rs
+++ b/packages/yew-macro/src/html_tree/lint/mod.rs
@@ -1,7 +1,7 @@
 //! Lints to catch possible misuse of the `html!` macro use. At the moment these are mostly focused
 //! on accessibility.
 
-use proc_macro_error::emit_warning;
+use proc_macro_error2::emit_warning;
 use syn::spanned::Spanned;
 
 use super::html_element::{HtmlElement, TagName};

--- a/packages/yew-macro/src/lib.rs
+++ b/packages/yew-macro/src/lib.rs
@@ -112,14 +112,14 @@ pub fn derive_props(input: TokenStream) -> TokenStream {
     TokenStream::from(input.into_token_stream())
 }
 
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro]
 pub fn html_nested(input: TokenStream) -> TokenStream {
     let root = parse_macro_input!(input as HtmlRoot);
     TokenStream::from(root.into_token_stream())
 }
 
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro]
 pub fn html(input: TokenStream) -> TokenStream {
     let root = parse_macro_input!(input as HtmlRootVNode);
@@ -138,7 +138,7 @@ pub fn classes(input: TokenStream) -> TokenStream {
     TokenStream::from(classes.into_token_stream())
 }
 
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn function_component(attr: TokenStream, item: TokenStream) -> proc_macro::TokenStream {
     let item = parse_macro_input!(item as FunctionComponent);
@@ -149,7 +149,7 @@ pub fn function_component(attr: TokenStream, item: TokenStream) -> proc_macro::T
         .into()
 }
 
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn hook(attr: TokenStream, item: TokenStream) -> proc_macro::TokenStream {
     let item = parse_macro_input!(item as HookFn);


### PR DESCRIPTION
#### Description

I've been enjoying yew and wanted to find a place I could make small contributions. I'm happy to put in some effort to remove duplicate dependencies.

There's a [rustsec release](https://rustsec.org/advisories/RUSTSEC-2024-0370.html) out on `proc-macro-error`, the issue being the crate is unmaintained. Potential replacements include `proc-macro-error2` which seems to be API compatible. `proc-macro-error2` also removes some needless build scripts improving compilation times.

Overall, replacing `proc-macro-error` with `proc-macro-error2` leads to an 8% reduction in (single threaded) compilation of yew.

`cargo build --release --timings -j1` results below.

**Before**
![image](https://github.com/user-attachments/assets/806d78a6-baaf-407b-9bff-0dc3214f225a)

**After**
![image](https://github.com/user-attachments/assets/4d226c9e-c5ee-40c7-a29c-9092f5b957d0)

#### Checklist

The existing test suite passes, I don't believe there is a test I could write for this PR.

**Before**
```
$ cargo tree -d | grep syn
syn v1.0.109
syn v2.0.79
```

**After**
```
$ cargo tree -d | grep syn
```