### PR TITLE
Change note to tip in examples.mdx

### DIFF
--- a/website/docs/getting-started/examples.mdx
+++ b/website/docs/getting-started/examples.mdx
@@ -8,8 +8,8 @@ We also welcome Pull Requests and issues for when they inevitably get neglected 
 
 For more details including a list of examples, refer to the [README].
 
-:::note
-Most of the examples have a live deployment that can be found at https://examples.yew.rs/< example_name >.
+:::tip
+Most of the examples have a live deployment that can be found at `https://examples.yew.rs/< example_name >`.
 Click the shield on their README page in their respective sub-folder to navigate to the live demo.
 :::
 

--- a/website/versioned_docs/version-0.20/getting-started/examples.mdx
+++ b/website/versioned_docs/version-0.20/getting-started/examples.mdx
@@ -8,8 +8,8 @@ We also welcome Pull Requests and issues for when they inevitably get neglected 
 
 For more details including a list of examples, refer to the [README].
 
-:::note
-Most of the examples have a live deployment that can be found at https://examples.yew.rs/< example_name >.
+:::tip
+Most of the examples have a live deployment that can be found at `https://examples.yew.rs/< example_name >`.
 Click the shield on their individual README page in their respective sub-folder to navigate to the live demo.
 :::
 

--- a/website/versioned_docs/version-0.21/getting-started/examples.mdx
+++ b/website/versioned_docs/version-0.21/getting-started/examples.mdx
@@ -8,8 +8,8 @@ We also welcome Pull Requests and issues for when they inevitably get neglected 
 
 For more details including a list of examples, refer to the [README].
 
-:::note
-Most of the examples have a live deployment that can be found at https://examples.yew.rs/< example_name >.
+:::tip
+Most of the examples have a live deployment that can be found at `https://examples.yew.rs/< example_name >`.
 Click the shield on their README page in their respective sub-folder to navigate to the live demo.
 :::
 


### PR DESCRIPTION
#### Description

Just a small tweak to make the hint to access the live rendering of the examples more conspicuous.

I also put the plaheholder URL into backticks to make it clear it is a single unit, and to prevent the left part of it from being clicked, since [it leads](https://yew.rs/getting-started/examples) to a 404 page.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
