### PR TITLE
yew-macro: silence non-normalised element name warnings for SVG elements

### DIFF
--- a/packages/yew-macro/src/derive_props/field.rs
+++ b/packages/yew-macro/src/derive_props/field.rs
@@ -200,7 +200,7 @@ pub struct PropFieldCheck<'a> {
     check_arg: GenericParam,
 }
 
-impl<'a> PropFieldCheck<'a> {
+impl PropFieldCheck<'_> {
     pub fn to_fake_prop_decl(&self) -> proc_macro2::TokenStream {
         let Self { this, .. } = self;
         if !this.is_required() {

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -11,6 +11,45 @@ use crate::props::{ElementProps, Prop, PropDirective};
 use crate::stringify::{Stringify, Value};
 use crate::{is_ide_completion, non_capitalized_ascii, Peek, PeekValue};
 
+fn is_normalised_element_name(name: &str) -> bool {
+    match name {
+        "animateMotion"
+        | "animateTransform"
+        | "clipPath"
+        | "feBlend"
+        | "feColorMatrix"
+        | "feComponentTransfer"
+        | "feComposite"
+        | "feConvolveMatrix"
+        | "feDiffuseLighting"
+        | "feDisplacementMap"
+        | "feDistantLight"
+        | "feDropShadow"
+        | "feFlood"
+        | "feFuncA"
+        | "feFuncB"
+        | "feFuncG"
+        | "feFuncR"
+        | "feGaussianBlur"
+        | "feImage"
+        | "feMerge"
+        | "feMergeNode"
+        | "feMorphology"
+        | "feOffset"
+        | "fePointLight"
+        | "feSpecularLighting"
+        | "feSpotLight"
+        | "feTile"
+        | "feTurbulence"
+        | "foreignObject"
+        | "glyphRef"
+        | "linearGradient"
+        | "radialGradient"
+        | "textPath" => true,
+        _ => !name.chars().any(|c| c.is_ascii_uppercase()),
+    }
+}
+
 pub struct HtmlElement {
     pub name: TagName,
     pub props: ElementProps,
@@ -310,9 +349,9 @@ impl ToTokens for HtmlElement {
             TagName::Lit(dashedname) => {
                 let name_span = dashedname.span();
                 let name = dashedname.to_ascii_lowercase_string();
-                if name != dashedname.to_string() {
+                if !is_normalised_element_name(&dashedname.to_string()) {
                     emit_warning!(
-                        dashedname.span(),
+                        name_span.clone(),
                         format!(
                             "The tag '{dashedname}' is not matching its normalized form '{name}'. If you want \
                              to keep this form, change this to a dynamic tag `@{{\"{dashedname}\"}}`."

--- a/packages/yew-macro/tests/html_macro_test.rs
+++ b/packages/yew-macro/tests/html_macro_test.rs
@@ -35,7 +35,7 @@ fn dynamic_tags_catch_non_ascii() {
 #[test]
 fn html_nested_macro_on_html_element() {
     let _node = html_nested! {
-        <div/>
+        <feBlend/>
     };
     let _node = html_nested! {
         <input/>

--- a/packages/yew/src/dom_bundle/blist.rs
+++ b/packages/yew/src/dom_bundle/blist.rs
@@ -54,7 +54,7 @@ struct NodeWriter<'s> {
     slot: DomSlot,
 }
 
-impl<'s> NodeWriter<'s> {
+impl NodeWriter<'_> {
     /// Write a new node that has no ancestor
     fn add(self, node: VNode) -> (Self, BNode) {
         test_log!("adding: {:?}", node);

--- a/packages/yew/src/dom_bundle/mod.rs
+++ b/packages/yew/src/dom_bundle/mod.rs
@@ -49,7 +49,6 @@ pub(crate) struct Bundle(BNode);
 
 impl Bundle {
     /// Creates a new bundle.
-
     pub const fn new() -> Self {
         Self(BNode::List(BList::new()))
     }


### PR DESCRIPTION
#### Description

As the edit in the macro test shows, SVG elements that are named in the camelCase convention don't trigger the warning for a non-nomalised form of their name

Modifications outside of yew-macro had to be done to please Clippy

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
