### PR TITLE
Explicit duplicate key check

### DIFF
--- a/.github/workflows/benchmark-core.yml
+++ b/.github/workflows/benchmark-core.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-core
+          include-hidden-files: true
           path: |
             .PR_NUMBER
             yew-master/tools/output.log

--- a/.github/workflows/benchmark-ssr.yml
+++ b/.github/workflows/benchmark-ssr.yml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-ssr
+          include-hidden-files: true
           path: |
             .PR_NUMBER
             yew-master/tools/output.json

--- a/.github/workflows/build-api-docs.yml
+++ b/.github/workflows/build-api-docs.yml
@@ -60,5 +60,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pr-info
+          include-hidden-files: true
           path: .PR_INFO
           retention-days: 1

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -62,5 +62,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pr-info
+          include-hidden-files: true
           path: .PR_INFO
           retention-days: 1

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -69,5 +69,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: size-cmp-${{ matrix.target }}-info
+          include-hidden-files: true
           path: ".SIZE_CMP_INFO"
           retention-days: 1

--- a/ci/install-wasm-bindgen-cli.sh
+++ b/ci/install-wasm-bindgen-cli.sh
@@ -10,4 +10,6 @@ if [ "$VERSION" = "" ]; then
   VERSION=$(cargo pkgid --frozen wasm-bindgen | cut -d "@" -f 2)
 fi
 
-cargo +stable install --version $VERSION wasm-bindgen-cli
+if [ "$(wasm-bindgen --version)" != "wasm-bindgen $VERSION" ]; then
+  cargo +stable install --version "$VERSION" wasm-bindgen-cli --force
+fi

--- a/packages/yew/src/dom_bundle/blist.rs
+++ b/packages/yew/src/dom_bundle/blist.rs
@@ -218,7 +218,8 @@ impl BList {
                 let key = key!(n);
                 debug_assert!(
                     keys.insert(key!(n)),
-                    "duplicate key detected: {key} at index {idx}. Keys in keyed lists must be unique!",
+                    "duplicate key detected: {key} at index {idx}. Keys in keyed lists must be \
+                     unique!",
                 );
             }
         }
@@ -259,28 +260,30 @@ impl BList {
         let rights_to = rev_bundles.len() - matching_len_start;
         let mut bundle_middle = matching_len_end..rights_to;
         if bundle_middle.start > bundle_middle.end {
-            // If this range is "inverted", this implies that the incoming nodes in lefts contain a duplicate key! Pictogram:
+            // If this range is "inverted", this implies that the incoming nodes in lefts contain a
+            // duplicate key!
+            // Pictogram:
             //                                         v lefts_to
             // lefts:              | SSSSSSSS | ------ | EEEEEEEE |
             //                                ↕ matching_len_start
             // rev_bundles.rev():  | SSS | ?? | EEE |
             //                           ^ rights_to
-            // Both a key from the (S)tarting portion and (E)nding portion of lefts has matched a key in the ? portion of bundles.
-            // Since the former can't overlap, a key must be duplicate.
-            // Duplicates might lead to us forgetting about some bundles entirely.
-            // It is NOT straight forward to adjust the below code to consistently check and handle this. The duplicate keys might
+            // Both a key from the (S)tarting portion and (E)nding portion of lefts has matched a
+            // key in the ? portion of bundles. Since the former can't overlap, a key
+            // must be duplicate. Duplicates might lead to us forgetting about some
+            // bundles entirely. It is NOT straight forward to adjust the below code to
+            // consistently check and handle this. The duplicate keys might
             // be in the start or end portion.
-            // With debug_assertions we can never reach this. For production code, hope for the best by pretending. We still need
-            // to adjust some things so splicing doesn't panic:
+            // With debug_assertions we can never reach this. For production code, hope for the best
+            // by pretending. We still need to adjust some things so splicing doesn't
+            // panic:
             matching_len_start = 0;
             bundle_middle = matching_len_end..rev_bundles.len();
         }
         let (matching_len_start, bundle_middle) = (matching_len_start, bundle_middle);
 
-        #[allow(
-            clippy::mutable_key_type,
-            reason = "BNode contains js objects that look suspicious to clippy but are harmless"
-        )]
+        // BNode contains js objects that look suspicious to clippy but are harmless
+        #[allow(clippy::mutable_key_type)]
         let mut spare_bundles: HashSet<KeyedEntry> = HashSet::with_capacity(bundle_middle.len());
         let mut spliced_middle = rev_bundles.splice(bundle_middle, std::iter::empty());
         for (idx, r) in (&mut spliced_middle).enumerate() {
@@ -1463,7 +1466,8 @@ mod layout_tests_keys {
     }
 
     #[test]
-    //#[should_panic(expected = "duplicate key detected: vtag at index 1")] // can't inspect panic message in wasm :/
+    //#[should_panic(expected = "duplicate key detected: vtag at index 1")]
+    // can't inspect panic message in wasm :/
     #[should_panic]
     fn duplicate_keys() {
         let mut layouts = vec![];

--- a/packages/yew/src/dom_bundle/blist.rs
+++ b/packages/yew/src/dom_bundle/blist.rs
@@ -212,6 +212,17 @@ impl BList {
             rev_bundles.iter().map(|v| key!(v)),
         );
 
+        if cfg!(debug_assertions) {
+            let mut keys = HashSet::with_capacity(left_vdoms.len());
+            for (idx, n) in left_vdoms.iter().enumerate() {
+                let key = key!(n);
+                debug_assert!(
+                    keys.insert(key!(n)),
+                    "duplicate key detected: {key} at index {idx}. Keys in keyed lists must be unique!",
+                );
+            }
+        }
+
         // If there is no key mismatch, apply the unkeyed approach
         // Corresponds to adding or removing items from the back of the list
         if matching_len_end == std::cmp::min(left_vdoms.len(), rev_bundles.len()) {
@@ -239,20 +250,48 @@ impl BList {
 
         // Step 2. Diff matching children in the middle, that is between the first and last key
         // mismatch Find first key mismatch from the front
-        let matching_len_start = matching_len(
+        let mut matching_len_start = matching_len(
             lefts.iter().map(|v| key!(v)),
             rev_bundles.iter().map(|v| key!(v)).rev(),
         );
 
         // Step 2.1. Splice out the existing middle part and build a lookup by key
         let rights_to = rev_bundles.len() - matching_len_start;
-        let mut spliced_middle =
-            rev_bundles.splice(matching_len_end..rights_to, std::iter::empty());
-        #[allow(clippy::mutable_key_type)]
-        let mut spare_bundles: HashSet<KeyedEntry> =
-            HashSet::with_capacity((matching_len_end..rights_to).len());
+        let mut bundle_middle = matching_len_end..rights_to;
+        if bundle_middle.start > bundle_middle.end {
+            // If this range is "inverted", this implies that the incoming nodes in lefts contain a duplicate key! Pictogram:
+            //                                         v lefts_to
+            // lefts:              | SSSSSSSS | ------ | EEEEEEEE |
+            //                                ↕ matching_len_start
+            // rev_bundles.rev():  | SSS | ?? | EEE |
+            //                           ^ rights_to
+            // Both a key from the (S)tarting portion and (E)nding portion of lefts has matched a key in the ? portion of bundles.
+            // Since the former can't overlap, a key must be duplicate.
+            // Duplicates might lead to us forgetting about some bundles entirely.
+            // It is NOT straight forward to adjust the below code to consistently check and handle this. The duplicate keys might
+            // be in the start or end portion.
+            // With debug_assertions we can never reach this. For production code, hope for the best by pretending. We still need
+            // to adjust some things so splicing doesn't panic:
+            matching_len_start = 0;
+            bundle_middle = matching_len_end..rev_bundles.len();
+        }
+        let (matching_len_start, bundle_middle) = (matching_len_start, bundle_middle);
+
+        #[allow(
+            clippy::mutable_key_type,
+            reason = "BNode contains js objects that look suspicious to clippy but are harmless"
+        )]
+        let mut spare_bundles: HashSet<KeyedEntry> = HashSet::with_capacity(bundle_middle.len());
+        let mut spliced_middle = rev_bundles.splice(bundle_middle, std::iter::empty());
         for (idx, r) in (&mut spliced_middle).enumerate() {
-            spare_bundles.insert(KeyedEntry(idx, r));
+            #[cold]
+            fn duplicate_in_bundle(root: &BSubtree, parent: &Element, r: BNode) {
+                test_log!("removing: {:?}", r);
+                r.detach(root, parent, false);
+            }
+            if let Some(KeyedEntry(_, dup)) = spare_bundles.replace(KeyedEntry(idx, r)) {
+                duplicate_in_bundle(root, parent, dup);
+            }
         }
 
         // Step 2.2. Put the middle part back together in the new key order
@@ -1419,6 +1458,26 @@ mod layout_tests_keys {
                 expected: "<p>3</p><p>2</p><p>1</p>",
             },
         ]);
+
+        diff_layouts(layouts);
+    }
+
+    #[test]
+    //#[should_panic(expected = "duplicate key detected: vtag at index 1")] // can't inspect panic message in wasm :/
+    #[should_panic]
+    fn duplicate_keys() {
+        let mut layouts = vec![];
+
+        layouts.push(TestLayout {
+            name: "A list with duplicate keys",
+            node: html! {
+                <>
+                    <i key="vtag" />
+                    <i key="vtag" />
+                </>
+            },
+            expected: "<i></i><i></i>",
+        });
 
         diff_layouts(layouts);
     }

--- a/packages/yew/src/renderer.rs
+++ b/packages/yew/src/renderer.rs
@@ -24,6 +24,10 @@ pub fn set_custom_panic_hook(hook: Box<dyn Fn(&PanicInfo<'_>) + Sync + Send + 's
 }
 
 fn set_default_panic_hook() {
+    if std::thread::panicking() {
+        // very unlikely, but avoid hitting this when running parallel tests.
+        return;
+    }
     if !PANIC_HOOK_IS_SET.with(|hook_is_set| hook_is_set.replace(true)) {
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     }


### PR DESCRIPTION
A discussion on discord shows a hard to read error message when accidentally using duplicate keys in lists.
While this is still not supported with this PR, change this to a nicer error message, identifying the offending index and key in the list.

Example stack trace:

```
slice index starts at 3 but ends at 2

$__rust_start_panic    @    
$rust_panic    @    
$std::panicking::rust_panic_with_hook::h76c11b8da342ec83    @    
$std::panicking::begin_panic_handler::{{closure}}::h66f67617d4dba49d    @    
$std::sys::backtrace::__rust_end_short_backtrace::h622a24dbddaa3376    @    
$rust_begin_unwind    @    
$core::panicking::panic_fmt::h4fd7a00ecfbf278a    @    
$core::slice::index::slice_index_order_fail::do_panic::runtime::hc8b046ffeba454c8    @    
$core::slice::index::slice_index_order_fail::h99288b888202ded2    @    
$core::slice::index::range::hf7288dd9129769c0    @    
$alloc::vec::Vec<T,A>::drain::h7f8c579b770e112f    @    
$alloc::vec::Vec<T,A>::splice::h14dfdac10dd4d213    @    
$yew::dom_bundle::blist::BList::apply_keyed::h67738f26f9ea56a7    @    
$yew::dom_bundle::blist::<impl yew::dom_bundle::traits::Reconcilable for yew::virtual_dom::vlist::VList>::reconcile::h69c9ea01d4616fbc    @
```