### PR TITLE
Simplify todo example

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -33,11 +33,7 @@ impl Component for App {
 
     fn create(_ctx: &Context<Self>) -> Self {
         let entries = LocalStorage::get(KEY).unwrap_or_else(|_| Vec::new());
-        let state = State {
-            entries,
-            filter: Filter::All,
-            edit_value: "".into(),
-        };
+        let state = State::new(entries);
         let focus_ref = NodeRef::default();
         Self { state, focus_ref }
     }
@@ -79,10 +75,10 @@ impl Component for App {
             }
             Msg::ToggleAll => {
                 let status = !self.state.is_all_completed();
-                self.state.toggle_all(status);
+                self.state.set_completed(status);
             }
             Msg::Toggle(idx) => {
-                self.state.toggle(idx);
+                self.state.toggle_completed(idx);
             }
             Msg::ClearCompleted => {
                 self.state.clear_completed();
@@ -120,7 +116,14 @@ impl Component for App {
                         />
                         <label for="toggle-all" />
                         <ul class="todo-list">
-                            { for self.state.entries.iter().filter(|e| self.state.filter.fits(e)).enumerate().map(|e| self.view_entry(e, ctx.link())) }
+                            { for self
+                                .state
+                                .entries
+                                .iter()
+                                .enumerate()
+                                .filter(|(_, entry)| self.state.filter.fits(entry))
+                                .map(|(i, e)| self.view_entry((i, e), ctx.link()))
+                            }
                         </ul>
                     </section>
                     <footer class={classes!("footer", hidden_class)}>

--- a/examples/todomvc/src/state.rs
+++ b/examples/todomvc/src/state.rs
@@ -11,6 +11,14 @@ pub struct State {
 }
 
 impl State {
+    pub fn new(entries: Vec<Entry>) -> Self {
+        Self {
+            entries,
+            filter: Filter::All,
+            edit_value: "".into(),
+        }
+    }
+
     pub fn total(&self) -> usize {
         self.entries.len()
     }
@@ -37,26 +45,15 @@ impl State {
     }
 
     pub fn clear_completed(&mut self) {
-        let entries = self
-            .entries
-            .drain(..)
-            .filter(|e| Filter::Active.fits(e))
-            .collect();
-        self.entries = entries;
+        self.entries.retain(|e| Filter::Active.fits(e));
     }
 
-    pub fn toggle(&mut self, idx: usize) {
-        let filter = self.filter;
-        let entry = self
-            .entries
-            .iter_mut()
-            .filter(|e| filter.fits(e))
-            .nth(idx)
-            .unwrap();
+    pub fn toggle_completed(&mut self, idx: usize) {
+        let entry = self.entries.get_mut(idx).unwrap();
         entry.completed = !entry.completed;
     }
 
-    pub fn toggle_all(&mut self, value: bool) {
+    pub fn set_completed(&mut self, value: bool) {
         for entry in &mut self.entries {
             if self.filter.fits(entry) {
                 entry.completed = value;
@@ -65,13 +62,7 @@ impl State {
     }
 
     pub fn toggle_edit(&mut self, idx: usize) {
-        let filter = self.filter;
-        let entry = self
-            .entries
-            .iter_mut()
-            .filter(|e| filter.fits(e))
-            .nth(idx)
-            .unwrap();
+        let entry = self.entries.get_mut(idx).unwrap();
         entry.editing = !entry.editing;
     }
 
@@ -85,29 +76,13 @@ impl State {
         if val.is_empty() {
             self.remove(idx);
         } else {
-            let filter = self.filter;
-            let entry = self
-                .entries
-                .iter_mut()
-                .filter(|e| filter.fits(e))
-                .nth(idx)
-                .unwrap();
+            let entry = self.entries.get_mut(idx).unwrap();
             entry.description = val;
             entry.editing = !entry.editing;
         }
     }
 
     pub fn remove(&mut self, idx: usize) {
-        let idx = {
-            let entries = self
-                .entries
-                .iter()
-                .enumerate()
-                .filter(|&(_, e)| self.filter.fits(e))
-                .collect::<Vec<_>>();
-            let &(idx, _) = entries.get(idx).unwrap();
-            idx
-        };
         self.entries.remove(idx);
     }
 }


### PR DESCRIPTION
#### Description

Refactored the TODO example for readability and performance. Specifically:

1. When creating the visible list of items, enumerate elements before filtering. This simplifies filtering in state.rs
2. Renamed `toggle_all` to `set_completed` to be clearer on intention
3. Renamed `toggle` to `toggle_completed` to be inline with `set_completed`
4. Created `new` function for state (I'm not sure why I did this, can revert 🙂)
5. Use `Vec::retain` to remove completed entries

As a newcomer I found it a bit hard to follow all of the iterator work being done in the `state.rs` file. It seemed that most were because the indexes were calculated after filtration in the view side, and hopefully this PR makes it easier for others.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
