### PR TITLE
Fix documentation typo in web-sys.mdx

### DIFF
--- a/website/versioned_docs/version-0.18.0/concepts/wasm-bindgen/web-sys.mdx
+++ b/website/versioned_docs/version-0.18.0/concepts/wasm-bindgen/web-sys.mdx
@@ -129,7 +129,7 @@ document.getElementById('mousemoveme').onmousemove = (e) => {
 
 ### `web-sys` example
 
-Using `web-sys` alone the above JavaSciprt example could be implemented like this:
+Using `web-sys` alone the above JavaScript example could be implemented like this:
 
 ```toml title=Cargo.toml
 [dependencies]

--- a/website/versioned_docs/version-0.21/concepts/basic-web-technologies/web-sys.mdx
+++ b/website/versioned_docs/version-0.21/concepts/basic-web-technologies/web-sys.mdx
@@ -145,7 +145,7 @@ document.getElementById('mousemoveme').onmousemove = (e) => {
 
 ### `web-sys` example
 
-Using `web-sys` alone the above JavaSciprt example could be implemented like this:
+Using `web-sys` alone the above JavaScript example could be implemented like this:
 
 ```toml title=Cargo.toml
 [dependencies]


### PR DESCRIPTION
#### Description

Fix documentation typo in the `web-sys` example section by replacing `JavaSciprt` with `JavaScript`.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
