### PR TITLE
`#[hook]`: `clippy::multiple_bound_locations` lint no longer triggered

### DIFF
--- a/packages/yew-macro/src/hook/lifetime.rs
+++ b/packages/yew-macro/src/hook/lifetime.rs
@@ -10,7 +10,6 @@ use syn::{
 // borrowed from the awesome async-trait crate.
 pub struct CollectLifetimes {
     pub elided: Vec<Lifetime>,
-    pub explicit: Vec<Lifetime>,
     pub name: &'static str,
     pub default_span: Span,
 
@@ -23,7 +22,6 @@ impl CollectLifetimes {
     pub fn new(name: &'static str, default_span: Span) -> Self {
         CollectLifetimes {
             elided: Vec::new(),
-            explicit: Vec::new(),
             name,
             default_span,
 
@@ -55,8 +53,6 @@ impl CollectLifetimes {
     fn visit_lifetime(&mut self, lifetime: &mut Lifetime) {
         if lifetime.ident == "_" {
             *lifetime = self.next_lifetime(lifetime.span());
-        } else {
-            self.explicit.push(lifetime.clone());
         }
     }
 

--- a/packages/yew-macro/src/hook/mod.rs
+++ b/packages/yew-macro/src/hook/mod.rs
@@ -2,9 +2,10 @@ use proc_macro2::{Span, TokenStream};
 use proc_macro_error::emit_error;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
 use syn::{
-    parse_file, parse_quote, visit_mut, Attribute, Ident, ItemFn, LitStr, ReturnType, Signature,
-    Type,
+    visit_mut, AttrStyle, Attribute, Block, Expr, ExprPath, File, Ident, Item, ItemFn, LitStr,
+    Meta, MetaNameValue, ReturnType, Signature, Stmt, Token, Type,
 };
 
 mod body;
@@ -51,16 +52,26 @@ impl Parse for HookFn {
 
 impl HookFn {
     fn doc_attr(&self) -> Attribute {
-        let vis = &self.inner.vis;
-        let sig = &self.inner.sig;
+        let span = self.inner.span();
 
-        let sig_s = quote! { #vis #sig {
-            __yew_macro_dummy_function_body__
-        } }
-        .to_string();
-
-        let sig_file = parse_file(&sig_s).unwrap();
-        let sig_formatted = prettyplease::unparse(&sig_file);
+        let sig_formatted = prettyplease::unparse(&File {
+            shebang: None,
+            attrs: vec![],
+            items: vec![Item::Fn(ItemFn {
+                block: Box::new(Block {
+                    brace_token: Default::default(),
+                    stmts: vec![Stmt::Expr(
+                        Expr::Path(ExprPath {
+                            attrs: vec![],
+                            qself: None,
+                            path: Ident::new("__yew_macro_dummy_function_body__", span).into(),
+                        }),
+                        None,
+                    )],
+                }),
+                ..self.inner.clone()
+            })],
+        });
 
         let literal = LitStr::new(
             &format!(
@@ -78,10 +89,22 @@ When used in function components and hooks, this hook is equivalent to:
                     "/* implementation omitted */"
                 )
             ),
-            Span::mixed_site(),
+            span,
         );
 
-        parse_quote!(#[doc = #literal])
+        Attribute {
+            pound_token: Default::default(),
+            style: AttrStyle::Outer,
+            bracket_token: Default::default(),
+            meta: Meta::NameValue(MetaNameValue {
+                path: Ident::new("doc", span).into(),
+                eq_token: Token![=](span),
+                value: Expr::Lit(syn::ExprLit {
+                    attrs: vec![],
+                    lit: literal.into(),
+                }),
+            }),
+        }
     }
 }
 

--- a/packages/yew-macro/src/lib.rs
+++ b/packages/yew-macro/src/lib.rs
@@ -140,7 +140,7 @@ pub fn classes(input: TokenStream) -> TokenStream {
 
 #[proc_macro_error::proc_macro_error]
 #[proc_macro_attribute]
-pub fn function_component(attr: TokenStream, item: TokenStream) -> proc_macro::TokenStream {
+pub fn function_component(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as FunctionComponent);
     let attr = parse_macro_input!(attr as FunctionComponentName);
 
@@ -151,7 +151,7 @@ pub fn function_component(attr: TokenStream, item: TokenStream) -> proc_macro::T
 
 #[proc_macro_error::proc_macro_error]
 #[proc_macro_attribute]
-pub fn hook(attr: TokenStream, item: TokenStream) -> proc_macro::TokenStream {
+pub fn hook(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as HookFn);
 
     if let Some(m) = proc_macro2::TokenStream::from(attr).into_iter().next() {


### PR DESCRIPTION


#### Description

The logic for rewriting the function signature of the hook is rewritten to emit a function that doesn't trigger the `clippy::multiple_bound_locations` lint

Fixes #3708

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
