### PR TITLE
rand 0.8 -> 0.9

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build benchmark-struct app
         working-directory: yew/tools/benchmark-struct
         run: |
-          wasm-pack build \
+          RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build \
             --release \
             --target web \
             --no-typescript \
@@ -101,7 +101,7 @@ jobs:
       - name: Build benchmark-hooks app
         working-directory: yew/tools/benchmark-hooks
         run: |
-          wasm-pack build \
+          RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build \
             --release \
             --target web \
             --no-typescript \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ name = "boids"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "gloo",
- "rand 0.8.5",
+ "rand 0.9.0",
  "serde",
  "web-sys",
  "yew",
@@ -861,10 +861,10 @@ dependencies = [
 name = "function_memory_game"
 version = "0.1.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "gloo",
  "nanoid",
- "rand 0.8.5",
+ "rand 0.9.0",
  "serde",
  "strum",
  "strum_macros",
@@ -876,7 +876,7 @@ dependencies = [
 name = "function_router"
 version = "0.1.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "gloo",
  "instant",
  "lipsum",
@@ -1006,10 +1006,10 @@ dependencies = [
 name = "game_of_life"
 version = "0.1.4"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "gloo",
  "log",
- "rand 0.8.5",
+ "rand 0.9.0",
  "wasm-logger",
  "yew",
 ]
@@ -1044,8 +1044,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -1302,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1506,7 +1508,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -1872,8 +1874,8 @@ dependencies = [
 name = "js-framework-benchmark-yew"
 version = "1.0.0"
 dependencies = [
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.3.1",
+ "rand 0.9.0",
  "wasm-bindgen",
  "web-sys",
  "yew",
@@ -1883,7 +1885,7 @@ dependencies = [
 name = "js-framework-benchmark-yew-hooks"
 version = "1.0.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "rand 0.9.0",
  "wasm-bindgen",
  "web-sys",
@@ -1916,10 +1918,10 @@ name = "keyed_list"
 version = "0.1.0"
 dependencies = [
  "fake",
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "instant",
  "log",
- "rand 0.8.5",
+ "rand 0.9.0",
  "wasm-logger",
  "web-sys",
  "yew",
@@ -2017,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchit"
@@ -2118,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -2612,7 +2614,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -3132,15 +3134,15 @@ dependencies = [
 
 [[package]]
 name = "target-triple"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3414,7 +3416,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.2",
+ "winnow 0.7.3",
 ]
 
 [[package]]
@@ -3552,9 +3554,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicase"
@@ -3564,9 +3566,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-width"
@@ -4043,9 +4045,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]

--- a/ci/build-examples.sh
+++ b/ci/build-examples.sh
@@ -25,7 +25,7 @@ for path in examples/*; do
     # shellcheck disable=SC2164
     cd "$path"
     dist_dir="$output/$example"
-    export RUSTFLAGS="--cfg nightly_yew"
+    export RUSTFLAGS="--cfg nightly_yew --cfg getrandom_backend=\"wasm_js\""
 
     trunk build --release --dist "$dist_dir" --public-url "$PUBLIC_URL_PREFIX/$example" --no-sri
 

--- a/examples/boids/Cargo.toml
+++ b/examples/boids/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anyhow = "1.0"
-getrandom = { version = "0.2", features = ["js"] }
-rand = "0.8"
+getrandom = { version = "0.3", features = ["wasm_js"] }
+rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 yew = { path = "../../packages/yew", features = ["csr"] }
 gloo = "0.11"

--- a/examples/boids/src/boid.rs
+++ b/examples/boids/src/boid.rs
@@ -18,18 +18,18 @@ pub struct Boid {
 
 impl Boid {
     pub fn new_random(settings: &Settings) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let max_radius = settings.min_distance / 2.0;
         let min_radius = max_radius / 6.0;
         // by using the third power large boids become rarer
-        let radius = min_radius + rng.gen::<f64>().powi(3) * (max_radius - min_radius);
+        let radius = min_radius + rng.random::<f64>().powi(3) * (max_radius - min_radius);
 
         Self {
-            position: Vector2D::new(rng.gen::<f64>() * SIZE.x, rng.gen::<f64>() * SIZE.y),
-            velocity: Vector2D::from_polar(rng.gen::<f64>() * math::TAU, settings.max_speed),
+            position: Vector2D::new(rng.random::<f64>() * SIZE.x, rng.random::<f64>() * SIZE.y),
+            velocity: Vector2D::from_polar(rng.random::<f64>() * math::TAU, settings.max_speed),
             radius,
-            hue: rng.gen::<f64>() * math::TAU,
+            hue: rng.random::<f64>() * math::TAU,
         }
     }
 

--- a/examples/function_memory_game/Cargo.toml
+++ b/examples/function_memory_game/Cargo.toml
@@ -11,8 +11,8 @@ strum = "0.27"
 strum_macros = "0.27"
 gloo = "0.11"
 nanoid = "0.4"
-rand = "0.8"
-getrandom = { version = "0.2", features = ["js"] }
+rand = "0.9"
+getrandom = { version = "0.3", features = ["wasm_js"] }
 yew = { path = "../../packages/yew", features = ["csr"] }
 
 [dependencies.web-sys]

--- a/examples/function_memory_game/src/helper.rs
+++ b/examples/function_memory_game/src/helper.rs
@@ -1,6 +1,6 @@
 use nanoid::nanoid;
 use rand::seq::SliceRandom;
-use rand::thread_rng;
+use rand::rng;
 
 use crate::constant::RAW_CARDS;
 use crate::state::Card;
@@ -8,7 +8,7 @@ use crate::state::Card;
 pub fn shuffle_cards() -> Vec<Card> {
     let mut raw_cards = RAW_CARDS;
 
-    raw_cards.shuffle(&mut thread_rng());
+    raw_cards.shuffle(&mut rng());
 
     raw_cards
         .iter()

--- a/examples/function_memory_game/src/helper.rs
+++ b/examples/function_memory_game/src/helper.rs
@@ -1,6 +1,6 @@
 use nanoid::nanoid;
-use rand::seq::SliceRandom;
 use rand::rng;
+use rand::seq::SliceRandom;
 
 use crate::constant::RAW_CARDS;
 use crate::state::Card;

--- a/examples/function_router/Cargo.toml
+++ b/examples/function_router/Cargo.toml
@@ -17,7 +17,7 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 once_cell = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.3.1", features = ["wasm_js"] }
 
 [[bin]]
 name = "function_router"

--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 log = "0.4"
-rand = "0.8"
+rand = "0.9"
 wasm-logger = "0.2"
 yew = { path = "../../packages/yew", features = ["csr"] }
 gloo = "0.11"

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -27,7 +27,7 @@ pub struct App {
 impl App {
     pub fn random_mutate(&mut self) {
         for cellule in self.cellules.iter_mut() {
-            if rand::thread_rng().gen() {
+            if rand::rng().random() {
                 cellule.set_alive();
             } else {
                 cellule.set_dead();

--- a/examples/keyed_list/Cargo.toml
+++ b/examples/keyed_list/Cargo.toml
@@ -7,10 +7,10 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 fake = "4.0.0"
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = "0.4"
-rand = "0.8"
+rand = "0.9"
 wasm-logger = "0.2"
 yew = { path = "../../packages/yew", features = ["csr"] }
 

--- a/examples/keyed_list/src/main.rs
+++ b/examples/keyed_list/src/main.rs
@@ -93,10 +93,13 @@ impl Component for App {
                 true
             }
             Msg::SwapRandom => {
-                let (a, b) = random::choose_two_distinct_mut(&mut self.persons).unwrap();
-                log::info!("Swapping {} and {}.", a.info().id, b.info().id);
-                std::mem::swap(a, b);
-                true
+                if let Some((a, b)) = random::choose_two_distinct_mut(&mut self.persons) {
+                    log::info!("Swapping {} and {}.", a.info().id, b.info().id);
+                    std::mem::swap(a, b);
+                    true
+                } else {
+                    false
+                }
             }
             Msg::ReverseList => {
                 self.persons.reverse();

--- a/examples/keyed_list/src/random.rs
+++ b/examples/keyed_list/src/random.rs
@@ -1,46 +1,32 @@
-use rand::distributions::Bernoulli;
-use rand::Rng;
+use rand::{distr::Bernoulli, Rng};
 
 /// `0 <= p <= 1`
 pub fn chance(p: f64) -> bool {
     let d = Bernoulli::new(p).unwrap();
-    rand::thread_rng().sample(d)
+    rand::rng().sample(d)
 }
 
 /// half-open: [min, max)
 pub fn range_exclusive(min: usize, max: usize) -> usize {
-    let len: usize = rand::thread_rng().gen();
-    len % (max - min) + min
-}
-
-/// Choose two distinct indices `(a, b)` such that `a < b`.
-pub fn choose_two_distinct_indices<T>(items: &[T]) -> Option<(usize, usize)> {
-    match items.len() {
-        0 | 1 => None,
-        2 => Some((0, 1)),
-        n => {
-            let first = range_exclusive(0, n);
-            // find another index that isn't `first`
-            let second = loop {
-                let i = range_exclusive(0, n);
-                // this must be true at some point because there are at least three items
-                if i != first {
-                    break i;
-                }
-            };
-
-            // make sure that `a < b`
-            if first > second {
-                Some((second, first))
-            } else {
-                Some((first, second))
-            }
-        }
-    }
+    rand::rng().random_range(min..max)
 }
 
 pub fn choose_two_distinct_mut<T>(items: &mut [T]) -> Option<(&mut T, &mut T)> {
-    let (lo, hi) = choose_two_distinct_indices(items)?;
+    let (lo, hi) = {
+        // Choose two distinct indices `(a, b)` such that `a < b`.
+        match items.len() {
+            0 | 1 => return None,
+            _ => {
+                let indexes = rand::seq::index::sample(&mut rand::rng(), items.len(), 2);
+                let (a, b) = (indexes.index(0), indexes.index(1));
+                if a < b {
+                    (a, b)
+                } else {
+                    (b, a)
+                }
+            }
+        }
+    };
 
     // a = `items[0..hi]` which contains `lo` because `lo < hi`
     // b = `items[hi..]` where `items[hi] == b[0]`

--- a/examples/keyed_list/src/random.rs
+++ b/examples/keyed_list/src/random.rs
@@ -1,4 +1,5 @@
-use rand::{distr::Bernoulli, Rng};
+use rand::distr::Bernoulli;
+use rand::Rng;
 
 /// `0 <= p <= 1`
 pub fn chance(p: f64) -> bool {

--- a/tools/benchmark-hooks/Cargo.toml
+++ b/tools/benchmark-hooks/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rand = { version = "0.9.0", features = ["small_rng"] }
-getrandom = { version = "0.2.15", features = ["js"] }
+getrandom = { version = "0.3.1", features = ["wasm_js"] }
 wasm-bindgen = "0.2.92"
 web-sys = { version = "0.3.70", features = ["Window"]}
 yew = { version = "0.21.0", features = ["csr"], path = "../../packages/yew" }

--- a/tools/benchmark-struct/Cargo.toml
+++ b/tools/benchmark-struct/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-rand = { version = "0.8", features = ["small_rng"] }
-getrandom = { version = "0.2.15", features = ["js"] }
+rand = { version = "0.9", features = ["small_rng"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 wasm-bindgen = "0.2.92"
 web-sys = { version = "0.3.70", features = ["Window"]}
 yew = { version = "0.21.0", features = ["csr"], path = "../../packages/yew" }

--- a/tools/benchmark-struct/src/lib.rs
+++ b/tools/benchmark-struct/src/lib.rs
@@ -89,7 +89,7 @@ impl Component for App {
             rows: Vec::new(),
             next_id: 1,
             selected_id: None,
-            rng: SmallRng::from_entropy(),
+            rng: SmallRng::from_os_rng(),
             on_select: ctx.link().callback(Msg::Select),
             on_remove: ctx.link().callback(Msg::Remove),
         }


### PR DESCRIPTION
rand new version 0.9 requires some special `RUSTFLAG` to build for wasm and renamed a bunch of functions.




