### PR TITLE
Fix autocompletion in html macro for rust-analyzer

### DIFF
--- a/packages/yew-macro/src/html_tree/html_node.rs
+++ b/packages/yew-macro/src/html_tree/html_node.rs
@@ -3,7 +3,7 @@ use quote::{quote, quote_spanned, ToTokens};
 use syn::buffer::Cursor;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;
-use syn::{Expr, Lit};
+use syn::Lit;
 
 use super::ToNodeIterator;
 use crate::stringify::Stringify;
@@ -11,7 +11,7 @@ use crate::PeekValue;
 
 pub enum HtmlNode {
     Literal(Box<Lit>),
-    Expression(Box<Expr>),
+    Expression(Box<TokenStream>),
 }
 
 impl Parse for HtmlNode {

--- a/packages/yew-macro/src/html_tree/mod.rs
+++ b/packages/yew-macro/src/html_tree/mod.rs
@@ -247,7 +247,7 @@ impl HtmlChildrenTree {
                 .iter()
                 .map(|child| quote_spanned! {child.span()=> ::std::convert::Into::into(#child) });
             return quote! {
-                ::std::vec![#(#children_into),*]
+                [#(#children_into),*].to_vec()
             };
         }
 


### PR DESCRIPTION
#### Description

In rust-analyzer it was not possible to get autocompletion suggestions inside of expression in the `html!` macro. This change should fix that. The first part is removing usage of the `vec!` macro as that seemed to hinder autocompletion and the second part is allowing to parse invalid expressions so rust-analyzer gets some output from the macro.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests. No, I think this is not testable
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
