### PR TITLE
Only rewrite async closure for rust version before 1.85.0

### DIFF
--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -22,10 +22,10 @@ quote = "1"
 syn = { version = "2", features = ["full", "extra-traits", "visit-mut"] }
 once_cell = "1"
 prettyplease = "0.2"
+rustversion = "1"
 
 # testing
 [dev-dependencies]
-rustversion = "1"
 trybuild = "1"
 yew = { path = "../yew" }
 

--- a/packages/yew-macro/src/use_prepared_state.rs
+++ b/packages/yew-macro/src/use_prepared_state.rs
@@ -58,10 +58,52 @@ impl Parse for PreparedState {
 }
 
 impl PreparedState {
+    // Async closure was not stable, so we rewrite it to closure + async block
+    #[rustversion::before(1.85)]
+    pub fn rewrite_to_closure_with_async_block(&self) -> ExprClosure {
+        use proc_macro2::Span;
+        use syn::parse_quote;
+
+        let async_token = match &self.closure.asyncness {
+            Some(m) => m,
+            None => return self.closure.clone(),
+        };
+
+        // The async block always need to be move so input can be moved into it.
+        let move_token = self
+            .closure
+            .capture
+            .unwrap_or_else(|| Token![move](Span::call_site()));
+        let body = &self.closure.body;
+
+        let inner = parse_quote! {
+            #async_token #move_token {
+                #body
+            }
+        };
+
+        let mut closure = self.closure.clone();
+
+        closure.asyncness = None;
+        // We omit the output type as it's an opaque future type.
+        closure.output = ReturnType::Default;
+
+        closure.body = inner;
+
+        closure.attrs.push(parse_quote! { #[allow(unused_braces)] });
+
+        closure
+    }
+
+    #[rustversion::since(1.85)]
+    pub fn rewrite_to_closure_with_async_block(&self) -> ExprClosure {
+        self.closure.clone()
+    }
+
     pub fn to_token_stream_with_closure(&self) -> TokenStream {
         let deps = &self.deps;
         let rt = &self.return_type;
-        let closure = &self.closure;
+        let closure = self.rewrite_to_closure_with_async_block();
 
         match &self.closure.asyncness {
             Some(_) => quote! {

--- a/packages/yew/src/functional/hooks/use_prepared_state/mod.rs
+++ b/packages/yew/src/functional/hooks/use_prepared_state/mod.rs
@@ -85,7 +85,6 @@ pub use feat_ssr::*;
 /// You MUST denote the return type of the closure with `|deps| -> ReturnType { ... }`. This
 /// type is used during client side rendering to deserialize the state prepared on the server
 /// side.
-///
 pub use use_prepared_state_macro as use_prepared_state;
 // With SSR.
 #[doc(hidden)]

--- a/packages/yew/src/functional/hooks/use_prepared_state/mod.rs
+++ b/packages/yew/src/functional/hooks/use_prepared_state/mod.rs
@@ -47,7 +47,7 @@ pub use feat_ssr::*;
 /// # { todo!() }
 /// ```
 ///
-/// The first argument can also be an [async closure](https://github.com/rust-lang/rust/issues/62290).
+/// The first argument can also be an async closure
 ///
 /// `let state = use_prepared_state!(async |deps| -> ReturnType { ... }, deps)?;`
 ///
@@ -86,9 +86,6 @@ pub use feat_ssr::*;
 /// type is used during client side rendering to deserialize the state prepared on the server
 /// side.
 ///
-/// Whilst async closure is an unstable feature, the procedural macro will rewrite this to a
-/// closure that returns an async block automatically. You can use this hook with async closure
-/// in stable Rust.
 pub use use_prepared_state_macro as use_prepared_state;
 // With SSR.
 #[doc(hidden)]

--- a/tools/benchmark-ssr/src/main.rs
+++ b/tools/benchmark-ssr/src/main.rs
@@ -141,8 +141,9 @@ async fn bench_concurrent_task() -> Duration {
 
     #[function_component]
     fn Comp() -> HtmlResult {
-        let _state = use_prepared_state!((), async move |_| -> () {
+        let _state = use_prepared_state!((), async move |_| -> usize {
             sleep(Duration::from_secs(1)).await;
+            42
         })?;
 
         Ok(Html::default())


### PR DESCRIPTION
async closure is stablized and it's no longer necessary to rewrite it into closure and async block


