### PR TITLE
key: avoid allocation for non Rc<str> From implementations

### DIFF
--- a/packages/yew/src/virtual_dom/key.rs
+++ b/packages/yew/src/virtual_dom/key.rs
@@ -11,7 +11,7 @@ use crate::html::ImplicitClone;
 /// Keys are cheap to clone.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Key {
-    key: Rc<str>,
+    key: Rc<String>,
 }
 
 impl Display for Key {
@@ -30,14 +30,21 @@ impl Deref for Key {
 
 impl From<Rc<str>> for Key {
     fn from(key: Rc<str>) -> Self {
-        Self { key }
+        Self {
+            key: Rc::from(key.to_string()),
+        }
     }
 }
 
-impl From<&'_ str> for Key {
-    fn from(key: &'_ str) -> Self {
-        let key: Rc<str> = Rc::from(key);
-        Self::from(key)
+impl From<Rc<String>> for Key {
+    fn from(key: Rc<String>) -> Self {
+        Self { key: key.clone() }
+    }
+}
+
+impl From<String> for Key {
+    fn from(key: String) -> Self {
+        Self { key: Rc::new(key) }
     }
 }
 
@@ -47,13 +54,13 @@ macro_rules! key_impl_from_to_string {
     ($type:ty) => {
         impl From<$type> for Key {
             fn from(key: $type) -> Self {
-                Self::from(key.to_string().as_str())
+                Self::from(key.to_string())
             }
         }
     };
 }
 
-key_impl_from_to_string!(String);
+key_impl_from_to_string!(&'_ str);
 key_impl_from_to_string!(char);
 key_impl_from_to_string!(u8);
 key_impl_from_to_string!(u16);
@@ -84,6 +91,7 @@ mod test {
         let _ = html! {
             <key="string literal">
                 <img key={"String".to_owned()} />
+                <p key={Rc::<String>::from("RcString".to_string())}></p>
                 <p key={Rc::<str>::from("rc")}></p>
                 <key='a'>
                     <p key=11_usize></p>


### PR DESCRIPTION
`From<&str> for Rc` clones the content of the &str, so there are two allocations for most types: `to_string()` and `Rc::from`.

Using a Rc<String> instead of Rc<str> internally can avoid this additional allocation for most types, and completely avoid it for `String`. This will now allocate when using it for Rc<str> directly (which wasn't the case previously).

Since direct use of Rc<str> will not happen very often, I'd argue that this tradeoff is better than the status quo.

#### Description

change the internal type of `Key` to avoid allocations in most cases

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
