### PR TITLE
key: avoid string copy for From<String> implementation

### DIFF
--- a/packages/yew/src/virtual_dom/key.rs
+++ b/packages/yew/src/virtual_dom/key.rs
@@ -41,6 +41,12 @@ impl From<&'_ str> for Key {
     }
 }
 
+impl From<String> for Key {
+    fn from(key: String) -> Self {
+        Self::from(key.as_str())
+    }
+}
+
 impl ImplicitClone for Key {}
 
 macro_rules! key_impl_from_to_string {
@@ -53,7 +59,6 @@ macro_rules! key_impl_from_to_string {
     };
 }
 
-key_impl_from_to_string!(String);
 key_impl_from_to_string!(char);
 key_impl_from_to_string!(u8);
 key_impl_from_to_string!(u16);


### PR DESCRIPTION
The macro uses `to_string().as_str()` which copies the string. Avoid that by using `as_str()` directly on the source.

#### Description

Omits one string copy for `From<String>`

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
