### PR TITLE
Added a `serde` feature to yew

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,6 +1768,7 @@ checksum = "1bd41bf647018e1da0e32dac34d02135d61d7204cee650e4633eddbd0b23ec38"
 dependencies = [
  "implicit-clone-derive",
  "indexmap",
+ "serde",
 ]
 
 [[package]]
@@ -1788,6 +1789,7 @@ checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -101,6 +101,7 @@ hydration = ["csr", "dep:bincode"]
 not_browser_env = []
 default = []
 test = []
+serde = ["implicit-clone/serde"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
#### Description

This adds a `serde` feature to Yew that enables the `serde` feature in its dependency, `implicit-clone`, allowing much more flexibility, such as using `AttrValue`s as state passed to the client in a hydrated SSR app

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
