### PR TITLE
Remove manual allow(clippy::incompatible_msrv) attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -457,11 +457,8 @@ impl ToTokens for HtmlElement {
                 #[rustversion::since(1.88)]
                 fn derive_debug_tag(vtag: &Ident) -> String {
                     let span = vtag.span().unwrap();
-                    #[allow(clippy::incompatible_msrv)]
-                    {
                     // the file, line, column methods are stable since 1.88
                     format!("[{}:{}:{}] ", span.file(), span.line(), span.column())
-                    }
                 }
                 #[rustversion::before(1.88)]
                 fn derive_debug_tag(_: &Ident) -> &'static str {


### PR DESCRIPTION
rustversion 1.0.22 now turns off incompatible_msrv automatically