### PR TITLE
fix dependency not working with rustc 1.78

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "divan"
-version = "0.1.17"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0583193020b29b03682d8d33bb53a5b0f50df6daacece12ca99b904cfdcb8c4"
+checksum = "a0d567df2c9c2870a43f3f2bd65aaeb18dbce1c18f217c3e564b4fbaeb3ee56c"
 dependencies = [
  "cfg-if",
  "clap",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "divan-macros"
-version = "0.1.17"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
+checksum = "27540baf49be0d484d8f0130d7d8da3011c32a44d4fc873368154f1510e574a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -790,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2132,10 +2132,11 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
+ "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -2721,7 +2722,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3161,7 +3162,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3924,7 +3925,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/packages/yew-router/src/router.rs
+++ b/packages/yew-router/src/router.rs
@@ -87,7 +87,7 @@ fn base_router(props: &RouterProps) -> Html {
             history.clone(),
             old_basename.as_ref().or(basename.as_ref()).cloned(),
         );
-        *old_basename = basename.clone();
+        old_basename.clone_from(&basename);
         let location = history.location();
         let stripped = old_navigator.strip_basename(Cow::from(location.path()));
         let prefixed = navigator.prefix_basename(&stripped);

--- a/tools/website-test/Cargo.toml
+++ b/tools/website-test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 build = "build.rs"
 publish = false
-rust-version = "1.81"
+rust-version = "1.78"
 
 [dependencies]
 yew-agent = { path = "../../packages/yew-agent/" }

--- a/tools/website-test/build.rs
+++ b/tools/website-test/build.rs
@@ -40,7 +40,13 @@ fn should_combine_code_blocks(path: &Path) -> io::Result<bool> {
     }
     let mut buf = [0u8; 32];
     file.read_exact(&mut buf)?;
-    Ok(buf.trim_ascii_end().ends_with(FLAG))
+    // TODO: Use trim_ascii_end() when MSRV is updated to 1.80+
+    let trimmed = buf
+        .iter()
+        .rposition(|&b| !b.is_ascii_whitespace())
+        .map(|i| &buf[..=i])
+        .unwrap_or(&buf[..0]);
+    Ok(trimmed.ends_with(FLAG))
 }
 
 fn apply_diff(src: &mut String, preamble: &str, added: &str, removed: &str) -> Result {
@@ -117,7 +123,8 @@ fn combined_code_blocks(path: &Path) -> Result<String> {
                 }
                 removed += line;
                 removed += "\n";
-            } else if line.trim_ascii() == "// ..." {
+            // TODO: Use trim_ascii() when MSRV is updated to 1.80+
+            } else if line.trim() == "// ..." {
                 // disregard the preamble
                 preamble.clear();
             } else {


### PR DESCRIPTION
@its-the-shrimp website-tools had rustverion = 1.81 

and we use the MSRV 1.78 everywhere else

I think this inconsistency messed with package version selection and it made it nearly impossible select the right packages versions for some rustc versions. ( try `cargo +1.78 clippy --all-targets --all-features --workspace -- -D warnings`)

This workflow fails for example https://github.com/yewstack/yew/actions/runs/16846151256/job/47725925995 and I had a hard time generating a correct lockfile even when I pin the the offending package to lower versions with 1.78.

I think it's a good idea to keep them consistent for now.


