### PR TITLE
Apply attributes before inserting elements into the DOM

### DIFF
--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -123,10 +123,15 @@ impl Reconcilable for VTag {
             key,
             ..
         } = self;
-        slot.insert(parent, &el);
 
+        // Apply attributes BEFORE inserting the element into the DOM
+        // This is crucial for SVG animation elements where the animation
+        // starts immediately upon DOM insertion
         let attributes = attributes.apply(root, &el);
         let listeners = listeners.apply(root, &el);
+
+        // Now insert the element with attributes already set
+        slot.insert(parent, &el);
 
         let inner = match self.inner {
             VTagInner::Input(f) => {


### PR DESCRIPTION
#### Description

Fixes #3758

 The problem was that SVG animation elements (like `<set>` and `<animate>`) were having their attributes applied AFTER being inserted into the DOM, causing animations to start immediately with
  default values instead of respecting the begin attribute.
  
 I tested locally with `<set>` and `<animate>` alike in minimal repos and confirmed this fix to work.
  
 I'm not sure how to write a test for this. An idea is we can this in the test:

```html
        <svg width="100" height="100">
            <rect width="100" height="100" fill="black" >
                <set attributeName="fill" to="white" begin="20s" />
            </rect>
        </svg>
```

and take a screenshot and check if all pixels are white.