### PR TITLE
remove now stable doctest-xcompile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,8 +3,3 @@ runner = 'wasm-bindgen-test-runner'
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "wasi"))']
 runner = 'wasmtime -W unknown-imports-trap=y'
-
-# This section needs to be last.
-# GitHub Actions modifies this section.
-[unstable]
-doctest-xcompile = true

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -22,4 +22,4 @@ jobs:
           components: rustfmt
 
       - name: Run fmt
-        run: cargo +nightly fmt --all -- --check --unstable-features
+        run: cargo +nightly fmt --all -- --check


### PR DESCRIPTION
we do this check in the workflows:

```
cargo +nightly fmt --all -- --unstable-features
warning: unused config key `unstable.doctest-xcompile` in `/home/maa/Projects/yew/.cargo/config.toml`
```

The warnng appears because doctest-xcompile was stabilized in Cargo 1.89.0 (May 2025). The feature is now enabled by default in nightly and the config key is no longer needed.
