### PR TITLE
Upgrade Docusaurus to 3.8.1 with system color mode support

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -15,6 +15,9 @@ module.exports = {
     organizationName: 'yewstack', // Usually your GitHub org/user name.
     projectName: 'yew', // Usually your repo name.
     themeConfig: {
+        colorMode: {
+            respectPrefersColorScheme: true,
+        },
         docs: {
             sidebar: {
                 hideable: true,

--- a/website/i18n/ja/code.json
+++ b/website/i18n/ja/code.json
@@ -193,7 +193,7 @@
   },
   "theme.colorToggle.ariaLabel": {
     "message": "ダークモードとライトモードを切り替える (現在は {mode})",
-    "description": "The ARIA label for the navbar color mode toggle"
+    "description": "The ARIA label for the color mode toggle"
   },
   "theme.colorToggle.ariaLabel.mode.dark": {
     "message": "ダークモード",
@@ -296,14 +296,6 @@
   "theme.DocSidebarItem.collapseCategoryAriaLabel": {
     "message": "Collapse sidebar category '{label}'",
     "description": "The ARIA label to collapse the sidebar category"
-  },
-  "theme.unlistedContent.title": {
-    "message": "非公開のページ",
-    "description": "The unlisted content banner title"
-  },
-  "theme.unlistedContent.message": {
-    "message": "このページは限定公開です。検索エンジンには表示されません。リンクを持っているユーザーのみアクセスできます。",
-    "description": "The unlisted content banner message"
   },
   "theme.SearchPage.inputPlaceholder": {
     "message": "検索するキーワードを入力してください",
@@ -448,5 +440,17 @@
   "theme.blog.author.noPosts": {
     "message": "この著者による投稿はまだありません。",
     "description": "The text for authors with 0 blog post"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "システムモード",
+    "description": "The name for the system color mode"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "ドロップダウンを展開",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "ドロップダウンを折りたたむ",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
   }
 }

--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -193,7 +193,7 @@
   },
   "theme.colorToggle.ariaLabel": {
     "message": "Switch between dark and light mode (currently {mode})",
-    "description": "The ARIA label for the navbar color mode toggle"
+    "description": "The ARIA label for the color mode toggle"
   },
   "theme.colorToggle.ariaLabel.mode.dark": {
     "message": "dark mode",
@@ -440,5 +440,17 @@
   "theme.blog.author.noPosts": {
     "message": "This author has not written any posts yet.",
     "description": "The text for authors with 0 blog post"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "系统模式",
+    "description": "The name for the system color mode"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "展开下拉菜单",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "收起下拉菜单",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
   }
 }

--- a/website/i18n/zh-Hant/code.json
+++ b/website/i18n/zh-Hant/code.json
@@ -193,7 +193,7 @@
   },
   "theme.colorToggle.ariaLabel": {
     "message": "Switch between dark and light mode (currently {mode})",
-    "description": "The ARIA label for the navbar color mode toggle"
+    "description": "The ARIA label for the color mode toggle"
   },
   "theme.colorToggle.ariaLabel.mode.dark": {
     "message": "dark mode",
@@ -440,5 +440,17 @@
   "theme.blog.author.noPosts": {
     "message": "This author has not written any posts yet.",
     "description": "The text for authors with 0 blog post"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "系統模式",
+    "description": "The name for the system color mode"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "展開下拉選單",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "收起下拉選單",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
   }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,9 +8,9 @@
             "name": "yew-docs",
             "version": "0.0.0",
             "dependencies": {
-                "@docusaurus/core": "^3.7.0",
-                "@docusaurus/plugin-client-redirects": "^3.7.0",
-                "@docusaurus/preset-classic": "^3.7.0",
+                "@docusaurus/core": "^3.8.1",
+                "@docusaurus/plugin-client-redirects": "^3.8.1",
+                "@docusaurus/preset-classic": "^3.8.1",
                 "@mdx-js/react": "^3.1.0",
                 "@svgr/webpack": "^8.1.0",
                 "clsx": "^2.1.1",
@@ -24,7 +24,7 @@
             },
             "devDependencies": {
                 "@docusaurus/module-type-aliases": "^3.0.0",
-                "@docusaurus/tsconfig": "3.7.0",
+                "@docusaurus/tsconfig": "3.8.1",
                 "@types/react": "^19.0.8",
                 "@types/react-helmet": "^6.1.11",
                 "@types/react-router-dom": "^5.3.3",
@@ -42,10 +42,25 @@
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
             "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@algolia/abtesting": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.1.0.tgz",
+            "integrity": "sha512-sEyWjw28a/9iluA37KLGu8vjxEIlb60uxznfTUmXImy7H5NvbpSO6yYgmgH5KiD7j+zTUUihiST0jEP12IoXow==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/autocomplete-core": {
@@ -94,99 +109,99 @@
             }
         },
         "node_modules/@algolia/client-abtesting": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.20.0.tgz",
-            "integrity": "sha512-YaEoNc1Xf2Yk6oCfXXkZ4+dIPLulCx8Ivqj0OsdkHWnsI3aOJChY5qsfyHhDBNSOhqn2ilgHWxSfyZrjxBcAww==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.35.0.tgz",
+            "integrity": "sha512-uUdHxbfHdoppDVflCHMxRlj49/IllPwwQ2cQ8DLC4LXr3kY96AHBpW0dMyi6ygkn2MtFCc6BxXCzr668ZRhLBQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.20.0.tgz",
-            "integrity": "sha512-CIT9ni0+5sYwqehw+t5cesjho3ugKQjPVy/iPiJvtJX4g8Cdb6je6SPt2uX72cf2ISiXCAX9U3cY0nN0efnRDw==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.35.0.tgz",
+            "integrity": "sha512-SunAgwa9CamLcRCPnPHx1V2uxdQwJGqb1crYrRWktWUdld0+B2KyakNEeVn5lln4VyeNtW17Ia7V7qBWyM/Skw==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.0.tgz",
-            "integrity": "sha512-iSTFT3IU8KNpbAHcBUJw2HUrPnMXeXLyGajmCL7gIzWOsYM4GabZDHXOFx93WGiXMti1dymz8k8R+bfHv1YZmA==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.35.0.tgz",
+            "integrity": "sha512-ipE0IuvHu/bg7TjT2s+187kz/E3h5ssfTtjpg1LbWMgxlgiaZIgTTbyynM7NfpSJSKsgQvCQxWjGUO51WSCu7w==",
             "license": "MIT",
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-insights": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.20.0.tgz",
-            "integrity": "sha512-w9RIojD45z1csvW1vZmAko82fqE/Dm+Ovsy2ElTsjFDB0HMAiLh2FO86hMHbEXDPz6GhHKgGNmBRiRP8dDPgJg==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.35.0.tgz",
+            "integrity": "sha512-UNbCXcBpqtzUucxExwTSfAe8gknAJ485NfPN6o1ziHm6nnxx97piIbcBQ3edw823Tej2Wxu1C0xBY06KgeZ7gA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.20.0.tgz",
-            "integrity": "sha512-p/hftHhrbiHaEcxubYOzqVV4gUqYWLpTwK+nl2xN3eTrSW9SNuFlAvUBFqPXSVBqc6J5XL9dNKn3y8OA1KElSQ==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.35.0.tgz",
+            "integrity": "sha512-/KWjttZ6UCStt4QnWoDAJ12cKlQ+fkpMtyPmBgSS2WThJQdSV/4UWcqCUqGH7YLbwlj3JjNirCu3Y7uRTClxvA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-query-suggestions": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.20.0.tgz",
-            "integrity": "sha512-m4aAuis5vZi7P4gTfiEs6YPrk/9hNTESj3gEmGFgfJw3hO2ubdS4jSId1URd6dGdt0ax2QuapXufcrN58hPUcw==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.35.0.tgz",
+            "integrity": "sha512-8oCuJCFf/71IYyvQQC+iu4kgViTODbXDk3m7yMctEncRSRV+u2RtDVlpGGfPlJQOrAY7OONwJlSHkmbbm2Kp/w==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.20.0.tgz",
-            "integrity": "sha512-KL1zWTzrlN4MSiaK1ea560iCA/UewMbS4ZsLQRPoDTWyrbDKVbztkPwwv764LAqgXk0fvkNZvJ3IelcK7DqhjQ==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.35.0.tgz",
+            "integrity": "sha512-FfmdHTrXhIduWyyuko1YTcGLuicVbhUyRjO3HbXE4aP655yKZgdTIfMhZ/V5VY9bHuxv/fGEh3Od1Lvv2ODNTg==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -199,81 +214,81 @@
             "license": "MIT"
         },
         "node_modules/@algolia/ingestion": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.20.0.tgz",
-            "integrity": "sha512-shj2lTdzl9un4XJblrgqg54DoK6JeKFO8K8qInMu4XhE2JuB8De6PUuXAQwiRigZupbI0xq8aM0LKdc9+qiLQA==",
+            "version": "1.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.35.0.tgz",
+            "integrity": "sha512-gPzACem9IL1Co8mM1LKMhzn1aSJmp+Vp434An4C0OBY4uEJRcqsLN3uLBlY+bYvFg8C8ImwM9YRiKczJXRk0XA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/monitoring": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.20.0.tgz",
-            "integrity": "sha512-aF9blPwOhKtWvkjyyXh9P5peqmhCA1XxLBRgItT+K6pbT0q4hBDQrCid+pQZJYy4HFUKjB/NDDwyzFhj/rwKhw==",
+            "version": "1.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.35.0.tgz",
+            "integrity": "sha512-w9MGFLB6ashI8BGcQoVt7iLgDIJNCn4OIu0Q0giE3M2ItNrssvb8C0xuwJQyTy1OFZnemG0EB1OvXhIHOvQwWw==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/recommend": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.20.0.tgz",
-            "integrity": "sha512-T6B/WPdZR3b89/F9Vvk6QCbt/wrLAtrGoL8z4qPXDFApQ8MuTFWbleN/4rHn6APWO3ps+BUePIEbue2rY5MlRw==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.35.0.tgz",
+            "integrity": "sha512-AhrVgaaXAb8Ue0u2nuRWwugt0dL5UmRgS9LXe0Hhz493a8KFeZVUE56RGIV3hAa6tHzmAV7eIoqcWTQvxzlJeQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.0.tgz",
-            "integrity": "sha512-t6//lXsq8E85JMenHrI6mhViipUT5riNhEfCcvtRsTV+KIBpC6Od18eK864dmBhoc5MubM0f+sGpKOqJIlBSCg==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.35.0.tgz",
+            "integrity": "sha512-diY415KLJZ6x1Kbwl9u96Jsz0OstE3asjXtJ9pmk1d+5gPuQ5jQyEsgC+WmEXzlec3iuVszm8AzNYYaqw6B+Zw==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0"
+                "@algolia/client-common": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-fetch": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.20.0.tgz",
-            "integrity": "sha512-FHxYGqRY+6bgjKsK4aUsTAg6xMs2S21elPe4Y50GB0Y041ihvw41Vlwy2QS6K9ldoftX4JvXodbKTcmuQxywdQ==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.35.0.tgz",
+            "integrity": "sha512-uydqnSmpAjrgo8bqhE9N1wgcB98psTRRQXcjc4izwMB7yRl9C8uuAQ/5YqRj04U0mMQ+fdu2fcNF6m9+Z1BzDQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0"
+                "@algolia/client-common": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.0.tgz",
-            "integrity": "sha512-kmtQClq/w3vtPteDSPvaW9SPZL/xrIgMrxZyAgsFwrJk0vJxqyC5/hwHmrCraDnStnGSADnLpBf4SpZnwnkwWw==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.35.0.tgz",
+            "integrity": "sha512-RgLX78ojYOrThJHrIiPzT4HW3yfQa0D7K+MQ81rhxqaNyNBu4F1r+72LNHYH/Z+y9I1Mrjrd/c/Ue5zfDgAEjQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0"
+                "@algolia/client-common": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -292,23 +307,23 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.27.1",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
-            "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+            "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -353,15 +368,15 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
-            "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+            "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.26.5",
-                "@babel/types": "^7.26.5",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.28.3",
+                "@babel/types": "^7.28.2",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             },
             "engines": {
@@ -381,13 +396,13 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
-            "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.26.5",
-                "@babel/helper-validator-option": "^7.25.9",
+                "@babel/compat-data": "^7.27.2",
+                "@babel/helper-validator-option": "^7.27.1",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -461,19 +476,28 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
-            "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+            "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.22.6",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "debug": "^4.1.1",
+                "@babel/helper-compilation-targets": "^7.27.2",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "debug": "^4.4.1",
                 "lodash.debounce": "^4.0.8",
-                "resolve": "^1.14.2"
+                "resolve": "^1.22.10"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
@@ -490,13 +514,13 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -532,9 +556,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -588,27 +612,27 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -642,12 +666,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.10",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
-            "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+            "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.10"
+                "@babel/types": "^7.28.2"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1561,16 +1585,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.9.tgz",
-            "integrity": "sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
+            "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-plugin-utils": "^7.25.9",
-                "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.6",
-                "babel-plugin-polyfill-regenerator": "^0.6.1",
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "babel-plugin-polyfill-corejs2": "^0.4.14",
+                "babel-plugin-polyfill-corejs3": "^0.13.0",
+                "babel-plugin-polyfill-regenerator": "^0.6.5",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -1578,6 +1602,19 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+            "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-define-polyfill-provider": "^0.6.5",
+                "core-js-compat": "^3.43.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
@@ -1903,58 +1940,57 @@
             }
         },
         "node_modules/@babel/runtime-corejs3": {
-            "version": "7.26.10",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.10.tgz",
-            "integrity": "sha512-uITFQYO68pMEYR46AHgQoyBg7KPPJDAbGn4jUTIRgCFJIp88MIBUianVOplhZDEec07bp9zIyr4Kp0FCyQzmWg==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.3.tgz",
+            "integrity": "sha512-LKYxD2CIfocUFNREQ1yk+dW+8OH8CRqmgatBZYXb+XhuObO8wsDpEoCNri5bKld9cnj8xukqZjxSX8p1YiRF8Q==",
             "license": "MIT",
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
+                "core-js-pure": "^3.43.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.26.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-            "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/parser": "^7.26.9",
-                "@babel/types": "^7.26.9"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.26.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
-            "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+            "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.26.5",
-                "@babel/parser": "^7.26.7",
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.7",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.3",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.28.3",
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.2",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.10",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
-            "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1971,9 +2007,9 @@
             }
         },
         "node_modules/@csstools/cascade-layer-name-parser": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-2.0.4.tgz",
-            "integrity": "sha512-7DFHlPuIxviKYZrOiwVU/PiHLm3lLUR23OMuEEtfEOQTOp9hzQ2JjdY6X5H18RVuUPJqSCI+qNnD5iOLMVE0bA==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-2.0.5.tgz",
+            "integrity": "sha512-p1ko5eHgV+MgXFVa4STPKpvPxr6ReS8oS2jzTukjR74i5zJNyWO1ZM1m8YKBXnzDKWfBN1ztLYlHxbVemDD88A==",
             "funding": [
                 {
                     "type": "github",
@@ -1989,14 +2025,14 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             }
         },
         "node_modules/@csstools/color-helpers": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.1.tgz",
-            "integrity": "sha512-MKtmkA0BX87PKaO1NFRTFH+UnkgnmySQOvNxJubsadusqPEC2aJ9MOQiMceZJJ6oitUl/i0L6u0M1IrmAOmgBA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+            "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
             "funding": [
                 {
                     "type": "github",
@@ -2013,9 +2049,9 @@
             }
         },
         "node_modules/@csstools/css-calc": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.1.tgz",
-            "integrity": "sha512-rL7kaUnTkL9K+Cvo2pnCieqNpTKgQzy5f+N+5Iuko9HAoasP+xgprVh7KN/MaJVvVL1l0EzQq2MoqBHKSrDrag==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2031,14 +2067,14 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             }
         },
         "node_modules/@csstools/css-color-parser": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.7.tgz",
-            "integrity": "sha512-nkMp2mTICw32uE5NN+EsJ4f5N+IGFeCFu4bGpiKgb2Pq/7J/MpyLBeQ5ry4KKtRFZaYs6sTmcMYrSRIyj5DFKA==",
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+            "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
             "funding": [
                 {
                     "type": "github",
@@ -2051,21 +2087,21 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/color-helpers": "^5.0.1",
-                "@csstools/css-calc": "^2.1.1"
+                "@csstools/color-helpers": "^5.0.2",
+                "@csstools/css-calc": "^2.1.4"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             }
         },
         "node_modules/@csstools/css-parser-algorithms": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
-            "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2081,13 +2117,13 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-tokenizer": "^3.0.4"
             }
         },
         "node_modules/@csstools/css-tokenizer": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
-            "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
             "funding": [
                 {
                     "type": "github",
@@ -2104,9 +2140,9 @@
             }
         },
         "node_modules/@csstools/media-query-list-parser": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.2.tgz",
-            "integrity": "sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+            "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2122,14 +2158,14 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             }
         },
         "node_modules/@csstools/postcss-cascade-layers": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.1.tgz",
-            "integrity": "sha512-XOfhI7GShVcKiKwmPAnWSqd2tBR0uxt+runAxttbSp/LY2U16yAVPmAf7e9q4JJ0d+xMNmpwNDLBXnmRCl3HMQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.2.tgz",
+            "integrity": "sha512-nWBE08nhO8uWl6kSAeCx4im7QfVko3zLrtgWZY4/bP87zrSPpSyN/3W3TDqz1jJuH+kbKOHXg5rJnK+ZVYcFFg==",
             "funding": [
                 {
                     "type": "github",
@@ -2175,9 +2211,9 @@
             }
         },
         "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -2188,9 +2224,9 @@
             }
         },
         "node_modules/@csstools/postcss-color-function": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.7.tgz",
-            "integrity": "sha512-aDHYmhNIHR6iLw4ElWhf+tRqqaXwKnMl0YsQ/X105Zc4dQwe6yJpMrTN6BwOoESrkDjOYMOfORviSSLeDTJkdQ==",
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.10.tgz",
+            "integrity": "sha512-4dY0NBu7NVIpzxZRgh/Q/0GPSz/jLSw0i/u3LTUor0BkQcz/fNhN10mSWBDsL0p9nDb0Ky1PD6/dcGbhACuFTQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2203,10 +2239,10 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-color-parser": "^3.0.7",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -2217,9 +2253,9 @@
             }
         },
         "node_modules/@csstools/postcss-color-mix-function": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.7.tgz",
-            "integrity": "sha512-e68Nev4CxZYCLcrfWhHH4u/N1YocOfTmw67/kVX5Rb7rnguqqLyxPjhHWjSBX8o4bmyuukmNf3wrUSU3//kT7g==",
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.10.tgz",
+            "integrity": "sha512-P0lIbQW9I4ShE7uBgZRib/lMTf9XMjJkFl/d6w4EMNHu2qvQ6zljJGEcBkw/NsBtq/6q3WrmgxSS8kHtPMkK4Q==",
             "funding": [
                 {
                     "type": "github",
@@ -2232,10 +2268,39 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-color-parser": "^3.0.7",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+                "@csstools/utilities": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4"
+            }
+        },
+        "node_modules/@csstools/postcss-color-mix-variadic-function-arguments": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-variadic-function-arguments/-/postcss-color-mix-variadic-function-arguments-1.0.0.tgz",
+            "integrity": "sha512-Z5WhouTyD74dPFPrVE7KydgNS9VvnjB8qcdes9ARpCOItb4jTnm7cHp4FhxCRUoyhabD0WVv43wbkJ4p8hLAlQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "dependencies": {
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -2246,9 +2311,9 @@
             }
         },
         "node_modules/@csstools/postcss-content-alt-text": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-content-alt-text/-/postcss-content-alt-text-2.0.4.tgz",
-            "integrity": "sha512-YItlZUOuZJCBlRaCf8Aucc1lgN41qYGALMly0qQllrxYJhiyzlI6RxOTMUvtWk+KhS8GphMDsDhKQ7KTPfEMSw==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-content-alt-text/-/postcss-content-alt-text-2.0.6.tgz",
+            "integrity": "sha512-eRjLbOjblXq+byyaedQRSrAejKGNAFued+LcbzT+LCL78fabxHkxYjBbxkroONxHHYu2qxhFK2dBStTLPG3jpQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2261,9 +2326,9 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -2274,9 +2339,9 @@
             }
         },
         "node_modules/@csstools/postcss-exponential-functions": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-2.0.6.tgz",
-            "integrity": "sha512-IgJA5DQsQLu/upA3HcdvC6xEMR051ufebBTIXZ5E9/9iiaA7juXWz1ceYj814lnDYP/7eWjZnw0grRJlX4eI6g==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-2.0.9.tgz",
+            "integrity": "sha512-abg2W/PI3HXwS/CZshSa79kNWNZHdJPMBXeZNyPQFbbj8sKO3jXxOt/wF7juJVjyDTc6JrvaUZYFcSBZBhaxjw==",
             "funding": [
                 {
                     "type": "github",
@@ -2289,9 +2354,9 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-calc": "^2.1.1",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             },
             "engines": {
                 "node": ">=18"
@@ -2327,9 +2392,9 @@
             }
         },
         "node_modules/@csstools/postcss-gamut-mapping": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.7.tgz",
-            "integrity": "sha512-gzFEZPoOkY0HqGdyeBXR3JP218Owr683u7KOZazTK7tQZBE8s2yhg06W1tshOqk7R7SWvw9gkw2TQogKpIW8Xw==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.10.tgz",
+            "integrity": "sha512-QDGqhJlvFnDlaPAfCYPsnwVA6ze+8hhrwevYWlnUeSjkkZfBpcCO42SaUD8jiLlq7niouyLgvup5lh+f1qessg==",
             "funding": [
                 {
                     "type": "github",
@@ -2342,9 +2407,9 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-color-parser": "^3.0.7",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             },
             "engines": {
                 "node": ">=18"
@@ -2354,9 +2419,9 @@
             }
         },
         "node_modules/@csstools/postcss-gradients-interpolation-method": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.7.tgz",
-            "integrity": "sha512-WgEyBeg6glUeTdS2XT7qeTFBthTJuXlS9GFro/DVomj7W7WMTamAwpoP4oQCq/0Ki2gvfRYFi/uZtmRE14/DFA==",
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.10.tgz",
+            "integrity": "sha512-HHPauB2k7Oits02tKFUeVFEU2ox/H3OQVrP3fSOKDxvloOikSal+3dzlyTZmYsb9FlY9p5EUpBtz0//XBmy+aw==",
             "funding": [
                 {
                     "type": "github",
@@ -2369,10 +2434,10 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-color-parser": "^3.0.7",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -2383,9 +2448,9 @@
             }
         },
         "node_modules/@csstools/postcss-hwb-function": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.7.tgz",
-            "integrity": "sha512-LKYqjO+wGwDCfNIEllessCBWfR4MS/sS1WXO+j00KKyOjm7jDW2L6jzUmqASEiv/kkJO39GcoIOvTTfB3yeBUA==",
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.10.tgz",
+            "integrity": "sha512-nOKKfp14SWcdEQ++S9/4TgRKchooLZL0TUFdun3nI4KPwCjETmhjta1QT4ICQcGVWQTvrsgMM/aLB5We+kMHhQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2398,10 +2463,10 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-color-parser": "^3.0.7",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -2412,9 +2477,9 @@
             }
         },
         "node_modules/@csstools/postcss-ic-unit": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-4.0.0.tgz",
-            "integrity": "sha512-9QT5TDGgx7wD3EEMN3BSUG6ckb6Eh5gSPT5kZoVtUuAonfPmLDJyPhqR4ntPpMYhUKAMVKAg3I/AgzqHMSeLhA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-4.0.2.tgz",
+            "integrity": "sha512-lrK2jjyZwh7DbxaNnIUjkeDmU8Y6KyzRBk91ZkI5h8nb1ykEfZrtIVArdIjX4DHMIBGpdHrgP0n4qXDr7OHaKA==",
             "funding": [
                 {
                     "type": "github",
@@ -2427,7 +2492,7 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -2439,9 +2504,9 @@
             }
         },
         "node_modules/@csstools/postcss-initial": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-initial/-/postcss-initial-2.0.0.tgz",
-            "integrity": "sha512-dv2lNUKR+JV+OOhZm9paWzYBXOCi+rJPqJ2cJuhh9xd8USVrd0cBEPczla81HNOyThMQWeCcdln3gZkQV2kYxA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-initial/-/postcss-initial-2.0.1.tgz",
+            "integrity": "sha512-L1wLVMSAZ4wovznquK0xmC7QSctzO4D0Is590bxpGqhqjboLXYA16dWZpfwImkdOgACdQ9PqXsuRroW6qPlEsg==",
             "funding": [
                 {
                     "type": "github",
@@ -2461,9 +2526,9 @@
             }
         },
         "node_modules/@csstools/postcss-is-pseudo-class": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.1.tgz",
-            "integrity": "sha512-JLp3POui4S1auhDR0n8wHd/zTOWmMsmK3nQd3hhL6FhWPaox5W7j1se6zXOG/aP07wV2ww0lxbKYGwbBszOtfQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.3.tgz",
+            "integrity": "sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2509,9 +2574,9 @@
             }
         },
         "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -2522,9 +2587,9 @@
             }
         },
         "node_modules/@csstools/postcss-light-dark-function": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-light-dark-function/-/postcss-light-dark-function-2.0.7.tgz",
-            "integrity": "sha512-ZZ0rwlanYKOHekyIPaU+sVm3BEHCe+Ha0/px+bmHe62n0Uc1lL34vbwrLYn6ote8PHlsqzKeTQdIejQCJ05tfw==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-light-dark-function/-/postcss-light-dark-function-2.0.9.tgz",
+            "integrity": "sha512-1tCZH5bla0EAkFAI2r0H33CDnIBeLUaJh1p+hvvsylJ4svsv2wOmJjJn+OXwUZLXef37GYbRIVKX+X+g6m+3CQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2537,9 +2602,9 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -2641,9 +2706,9 @@
             }
         },
         "node_modules/@csstools/postcss-logical-viewport-units": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-viewport-units/-/postcss-logical-viewport-units-3.0.3.tgz",
-            "integrity": "sha512-OC1IlG/yoGJdi0Y+7duz/kU/beCwO+Gua01sD6GtOtLi7ByQUpcIqs7UE/xuRPay4cHgOMatWdnDdsIDjnWpPw==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-viewport-units/-/postcss-logical-viewport-units-3.0.4.tgz",
+            "integrity": "sha512-q+eHV1haXA4w9xBwZLKjVKAWn3W2CMqmpNpZUk5kRprvSiBEGMgrNH3/sJZ8UA3JgyHaOt3jwT9uFa4wLX4EqQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2656,7 +2721,7 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-tokenizer": "^3.0.3",
+                "@csstools/css-tokenizer": "^3.0.4",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -2667,9 +2732,9 @@
             }
         },
         "node_modules/@csstools/postcss-media-minmax": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-2.0.6.tgz",
-            "integrity": "sha512-J1+4Fr2W3pLZsfxkFazK+9kr96LhEYqoeBszLmFjb6AjYs+g9oDAw3J5oQignLKk3rC9XHW+ebPTZ9FaW5u5pg==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-2.0.9.tgz",
+            "integrity": "sha512-af9Qw3uS3JhYLnCbqtZ9crTvvkR+0Se+bBqSr7ykAnl9yKhk6895z9rf+2F4dClIDJWxgn0iZZ1PSdkhrbs2ig==",
             "funding": [
                 {
                     "type": "github",
@@ -2682,10 +2747,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/css-calc": "^2.1.1",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/media-query-list-parser": "^4.0.2"
+                "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/media-query-list-parser": "^4.0.3"
             },
             "engines": {
                 "node": ">=18"
@@ -2695,9 +2760,9 @@
             }
         },
         "node_modules/@csstools/postcss-media-queries-aspect-ratio-number-values": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-media-queries-aspect-ratio-number-values/-/postcss-media-queries-aspect-ratio-number-values-3.0.4.tgz",
-            "integrity": "sha512-AnGjVslHMm5xw9keusQYvjVWvuS7KWK+OJagaG0+m9QnIjZsrysD2kJP/tr/UJIyYtMCtu8OkUd+Rajb4DqtIQ==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-media-queries-aspect-ratio-number-values/-/postcss-media-queries-aspect-ratio-number-values-3.0.5.tgz",
+            "integrity": "sha512-zhAe31xaaXOY2Px8IYfoVTB3wglbJUVigGphFLj6exb7cjZRH9A6adyE22XfFK3P2PzwRk0VDeTJmaxpluyrDg==",
             "funding": [
                 {
                     "type": "github",
@@ -2710,9 +2775,9 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/media-query-list-parser": "^4.0.2"
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/media-query-list-parser": "^4.0.3"
             },
             "engines": {
                 "node": ">=18"
@@ -2773,9 +2838,9 @@
             }
         },
         "node_modules/@csstools/postcss-oklab-function": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.7.tgz",
-            "integrity": "sha512-I6WFQIbEKG2IO3vhaMGZDkucbCaUSXMxvHNzDdnfsTCF5tc0UlV3Oe2AhamatQoKFjBi75dSEMrgWq3+RegsOQ==",
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.10.tgz",
+            "integrity": "sha512-ZzZUTDd0fgNdhv8UUjGCtObPD8LYxMH+MJsW9xlZaWTV8Ppr4PtxlHYNMmF4vVWGl0T6f8tyWAKjoI6vePSgAg==",
             "funding": [
                 {
                     "type": "github",
@@ -2788,10 +2853,10 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-color-parser": "^3.0.7",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -2802,9 +2867,9 @@
             }
         },
         "node_modules/@csstools/postcss-progressive-custom-properties": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.0.0.tgz",
-            "integrity": "sha512-XQPtROaQjomnvLUSy/bALTR5VCtTVUFwYs1SblvYgLSeTo2a/bMNwUwo2piXw5rTv/FEYiy5yPSXBqg9OKUx7Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.1.0.tgz",
+            "integrity": "sha512-YrkI9dx8U4R8Sz2EJaoeD9fI7s7kmeEBfmO+UURNeL6lQI7VxF6sBE+rSqdCBn4onwqmxFdBU3lTwyYb/lCmxA==",
             "funding": [
                 {
                     "type": "github",
@@ -2827,9 +2892,9 @@
             }
         },
         "node_modules/@csstools/postcss-random-function": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-random-function/-/postcss-random-function-1.0.2.tgz",
-            "integrity": "sha512-vBCT6JvgdEkvRc91NFoNrLjgGtkLWt47GKT6E2UDn3nd8ZkMBiziQ1Md1OiKoSsgzxsSnGKG3RVdhlbdZEkHjA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-random-function/-/postcss-random-function-2.0.1.tgz",
+            "integrity": "sha512-q+FQaNiRBhnoSNo+GzqGOIBKoHQ43lYz0ICrV+UudfWnEF6ksS6DsBIJSISKQT2Bvu3g4k6r7t0zYrk5pDlo8w==",
             "funding": [
                 {
                     "type": "github",
@@ -2842,9 +2907,9 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-calc": "^2.1.1",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             },
             "engines": {
                 "node": ">=18"
@@ -2854,9 +2919,9 @@
             }
         },
         "node_modules/@csstools/postcss-relative-color-syntax": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.7.tgz",
-            "integrity": "sha512-apbT31vsJVd18MabfPOnE977xgct5B1I+Jpf+Munw3n6kKb1MMuUmGGH+PT9Hm/fFs6fe61Q/EWnkrb4bNoNQw==",
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.10.tgz",
+            "integrity": "sha512-8+0kQbQGg9yYG8hv0dtEpOMLwB9M+P7PhacgIzVzJpixxV4Eq9AUQtQw8adMmAJU1RBBmIlpmtmm3XTRd/T00g==",
             "funding": [
                 {
                     "type": "github",
@@ -2869,10 +2934,10 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-color-parser": "^3.0.7",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -2908,9 +2973,9 @@
             }
         },
         "node_modules/@csstools/postcss-scope-pseudo-class/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -2921,9 +2986,9 @@
             }
         },
         "node_modules/@csstools/postcss-sign-functions": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-sign-functions/-/postcss-sign-functions-1.1.1.tgz",
-            "integrity": "sha512-MslYkZCeMQDxetNkfmmQYgKCy4c+w9pPDfgOBCJOo/RI1RveEUdZQYtOfrC6cIZB7sD7/PHr2VGOcMXlZawrnA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-sign-functions/-/postcss-sign-functions-1.1.4.tgz",
+            "integrity": "sha512-P97h1XqRPcfcJndFdG95Gv/6ZzxUBBISem0IDqPZ7WMvc/wlO+yU0c5D/OCpZ5TJoTt63Ok3knGk64N+o6L2Pg==",
             "funding": [
                 {
                     "type": "github",
@@ -2936,9 +3001,9 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-calc": "^2.1.1",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             },
             "engines": {
                 "node": ">=18"
@@ -2948,9 +3013,9 @@
             }
         },
         "node_modules/@csstools/postcss-stepped-value-functions": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-4.0.6.tgz",
-            "integrity": "sha512-/dwlO9w8vfKgiADxpxUbZOWlL5zKoRIsCymYoh1IPuBsXODKanKnfuZRr32DEqT0//3Av1VjfNZU9yhxtEfIeA==",
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-4.0.9.tgz",
+            "integrity": "sha512-h9btycWrsex4dNLeQfyU3y3w40LMQooJWFMm/SK9lrKguHDcFl4VMkncKKoXi2z5rM9YGWbUQABI8BT2UydIcA==",
             "funding": [
                 {
                     "type": "github",
@@ -2963,9 +3028,9 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-calc": "^2.1.1",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             },
             "engines": {
                 "node": ">=18"
@@ -2975,9 +3040,9 @@
             }
         },
         "node_modules/@csstools/postcss-text-decoration-shorthand": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.1.tgz",
-            "integrity": "sha512-xPZIikbx6jyzWvhms27uugIc0I4ykH4keRvoa3rxX5K7lEhkbd54rjj/dv60qOCTisoS+3bmwJTeyV1VNBrXaw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.2.tgz",
+            "integrity": "sha512-8XvCRrFNseBSAGxeaVTaNijAu+FzUvjwFXtcrynmazGb/9WUdsPCpBX+mHEHShVRq47Gy4peYAoxYs8ltUnmzA==",
             "funding": [
                 {
                     "type": "github",
@@ -2990,7 +3055,7 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/color-helpers": "^5.0.1",
+                "@csstools/color-helpers": "^5.0.2",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -3001,9 +3066,9 @@
             }
         },
         "node_modules/@csstools/postcss-trigonometric-functions": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-4.0.6.tgz",
-            "integrity": "sha512-c4Y1D2Why/PeccaSouXnTt6WcNHJkoJRidV2VW9s5gJ97cNxnLgQ4Qj8qOqkIR9VmTQKJyNcbF4hy79ZQnWD7A==",
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-4.0.9.tgz",
+            "integrity": "sha512-Hnh5zJUdpNrJqK9v1/E3BbrQhaDTj5YiX7P61TOvUhoDHnUmsNNxcDAgkQ32RrcWx9GVUvfUNPcUkn8R3vIX6A==",
             "funding": [
                 {
                     "type": "github",
@@ -3016,9 +3081,9 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-calc": "^2.1.1",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
+                "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
             },
             "engines": {
                 "node": ">=18"
@@ -3081,15 +3146,47 @@
             }
         },
         "node_modules/@docsearch/css": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.3.tgz",
-            "integrity": "sha512-1nELpMV40JDLJ6rpVVFX48R1jsBFIQ6RnEQDsLFGmzOjPWTOMlZqUcXcvRx8VmYV/TqnS1l784Ofz+ZEb+wEOQ==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.9.0.tgz",
+            "integrity": "sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==",
             "license": "MIT"
         },
+        "node_modules/@docsearch/react": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.9.0.tgz",
+            "integrity": "sha512-mb5FOZYZIkRQ6s/NWnM98k879vu5pscWqTLubLFBO87igYYT4VzVazh4h5o/zCvTIZgEt3PvsCOMOswOUo9yHQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/autocomplete-core": "1.17.9",
+                "@algolia/autocomplete-preset-algolia": "1.17.9",
+                "@docsearch/css": "3.9.0",
+                "algoliasearch": "^5.14.2"
+            },
+            "peerDependencies": {
+                "@types/react": ">= 16.8.0 < 20.0.0",
+                "react": ">= 16.8.0 < 20.0.0",
+                "react-dom": ">= 16.8.0 < 20.0.0",
+                "search-insights": ">= 1 < 3"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                },
+                "search-insights": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@docusaurus/babel": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.7.0.tgz",
-            "integrity": "sha512-0H5uoJLm14S/oKV3Keihxvh8RV+vrid+6Gv+2qhuzbqHanawga8tYnsdpjEyt36ucJjqlby2/Md2ObWjA02UXQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1.tgz",
+            "integrity": "sha512-3brkJrml8vUbn9aeoZUlJfsI/GqyFcDgQJwQkmBtclJgWDEQBKKeagZfOgx0WfUQhagL1sQLNW0iBdxnI863Uw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.9",
@@ -3102,8 +3199,8 @@
                 "@babel/runtime": "^7.25.9",
                 "@babel/runtime-corejs3": "^7.25.9",
                 "@babel/traverse": "^7.25.9",
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
                 "babel-plugin-dynamic-import-node": "^2.3.3",
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0"
@@ -3113,31 +3210,30 @@
             }
         },
         "node_modules/@docusaurus/bundler": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.7.0.tgz",
-            "integrity": "sha512-CUUT9VlSGukrCU5ctZucykvgCISivct+cby28wJwCC/fkQFgAHRp/GKv2tx38ZmXb7nacrKzFTcp++f9txUYGg==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.1.tgz",
+            "integrity": "sha512-/z4V0FRoQ0GuSLToNjOSGsk6m2lQUG4FRn8goOVoZSRsTrU8YR2aJacX5K3RG18EaX9b+52pN4m1sL3MQZVsQA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.9",
-                "@docusaurus/babel": "3.7.0",
-                "@docusaurus/cssnano-preset": "3.7.0",
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
+                "@docusaurus/babel": "3.8.1",
+                "@docusaurus/cssnano-preset": "3.8.1",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
                 "babel-loader": "^9.2.1",
-                "clean-css": "^5.3.2",
+                "clean-css": "^5.3.3",
                 "copy-webpack-plugin": "^11.0.0",
-                "css-loader": "^6.8.1",
+                "css-loader": "^6.11.0",
                 "css-minimizer-webpack-plugin": "^5.0.1",
                 "cssnano": "^6.1.2",
                 "file-loader": "^6.2.0",
                 "html-minifier-terser": "^7.2.0",
-                "mini-css-extract-plugin": "^2.9.1",
+                "mini-css-extract-plugin": "^2.9.2",
                 "null-loader": "^4.0.1",
-                "postcss": "^8.4.26",
-                "postcss-loader": "^7.3.3",
-                "postcss-preset-env": "^10.1.0",
-                "react-dev-utils": "^12.0.1",
+                "postcss": "^8.5.4",
+                "postcss-loader": "^7.3.4",
+                "postcss-preset-env": "^10.2.1",
                 "terser-webpack-plugin": "^5.3.9",
                 "tslib": "^2.6.0",
                 "url-loader": "^4.1.1",
@@ -3157,18 +3253,18 @@
             }
         },
         "node_modules/@docusaurus/core": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-            "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.1.tgz",
+            "integrity": "sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/babel": "3.7.0",
-                "@docusaurus/bundler": "3.7.0",
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/mdx-loader": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-common": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/babel": "3.8.1",
+                "@docusaurus/bundler": "3.8.1",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/mdx-loader": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-common": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "boxen": "^6.2.1",
                 "chalk": "^4.1.2",
                 "chokidar": "^3.5.3",
@@ -3176,19 +3272,19 @@
                 "combine-promises": "^1.1.0",
                 "commander": "^5.1.0",
                 "core-js": "^3.31.1",
-                "del": "^6.1.1",
                 "detect-port": "^1.5.1",
                 "escape-html": "^1.0.3",
                 "eta": "^2.2.0",
                 "eval": "^0.1.8",
+                "execa": "5.1.1",
                 "fs-extra": "^11.1.1",
                 "html-tags": "^3.3.1",
                 "html-webpack-plugin": "^5.6.0",
                 "leven": "^3.1.0",
                 "lodash": "^4.17.21",
+                "open": "^8.4.0",
                 "p-map": "^4.0.0",
                 "prompts": "^2.4.2",
-                "react-dev-utils": "^12.0.1",
                 "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
                 "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
                 "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
@@ -3197,7 +3293,7 @@
                 "react-router-dom": "^5.3.4",
                 "semver": "^7.5.4",
                 "serve-handler": "^6.1.6",
-                "shelljs": "^0.8.5",
+                "tinypool": "^1.0.2",
                 "tslib": "^2.6.0",
                 "update-notifier": "^6.0.2",
                 "webpack": "^5.95.0",
@@ -3218,13 +3314,13 @@
             }
         },
         "node_modules/@docusaurus/cssnano-preset": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.7.0.tgz",
-            "integrity": "sha512-X9GYgruZBSOozg4w4dzv9uOz8oK/EpPVQXkp0MM6Tsgp/nRIU9hJzJ0Pxg1aRa3xCeEQTOimZHcocQFlLwYajQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.1.tgz",
+            "integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
             "license": "MIT",
             "dependencies": {
                 "cssnano-preset-advanced": "^6.1.2",
-                "postcss": "^8.4.38",
+                "postcss": "^8.5.4",
                 "postcss-sort-media-queries": "^5.2.0",
                 "tslib": "^2.6.0"
             },
@@ -3233,9 +3329,9 @@
             }
         },
         "node_modules/@docusaurus/logger": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-            "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1.tgz",
+            "integrity": "sha512-2wjeGDhKcExEmjX8k1N/MRDiPKXGF2Pg+df/bDDPnnJWHXnVEZxXj80d6jcxp1Gpnksl0hF8t/ZQw9elqj2+ww==",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",
@@ -3246,21 +3342,21 @@
             }
         },
         "node_modules/@docusaurus/mdx-loader": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-            "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
+            "integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "@mdx-js/mdx": "^3.0.0",
                 "@slorber/remark-comment": "^1.0.0",
                 "escape-html": "^1.0.3",
                 "estree-util-value-to-estree": "^3.0.1",
                 "file-loader": "^6.2.0",
                 "fs-extra": "^11.1.1",
-                "image-size": "^1.0.2",
+                "image-size": "^2.0.2",
                 "mdast-util-mdx": "^3.0.0",
                 "mdast-util-to-string": "^4.0.0",
                 "rehype-raw": "^7.0.0",
@@ -3285,17 +3381,17 @@
             }
         },
         "node_modules/@docusaurus/module-type-aliases": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.7.0.tgz",
-            "integrity": "sha512-g7WdPqDNaqA60CmBrr0cORTrsOit77hbsTj7xE2l71YhBn79sxdm7WMK7wfhcaafkbpIh7jv5ef5TOpf1Xv9Lg==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1.tgz",
+            "integrity": "sha512-6xhvAJiXzsaq3JdosS7wbRt/PwEPWHr9eM4YNYqVlbgG1hSK3uQDXTVvQktasp3VO6BmfYWPozueLWuj4gB+vg==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.7.0",
+                "@docusaurus/types": "3.8.1",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
                 "@types/react-router-dom": "*",
-                "react-helmet-async": "npm:@slorber/react-helmet-async@*",
+                "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
                 "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
             },
             "peerDependencies": {
@@ -3304,16 +3400,16 @@
             }
         },
         "node_modules/@docusaurus/plugin-client-redirects": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.7.0.tgz",
-            "integrity": "sha512-6B4XAtE5ZVKOyhPgpgMkb7LwCkN+Hgd4vOnlbwR8nCdTQhLjz8MHbGlwwvZ/cay2SPNRX5KssqKAlcHVZP2m8g==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.8.1.tgz",
+            "integrity": "sha512-F+86R7PBn6VNgy/Ux8w3ZRypJGJEzksbejQKlbTC8u6uhBUhfdXWkDp6qdOisIoW0buY5nLqucvZt1zNJzhJhA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-common": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-common": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "eta": "^2.2.0",
                 "fs-extra": "^11.1.1",
                 "lodash": "^4.17.21",
@@ -3328,24 +3424,24 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-blog": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.7.0.tgz",
-            "integrity": "sha512-EFLgEz6tGHYWdPU0rK8tSscZwx+AsyuBW/r+tNig2kbccHYGUJmZtYN38GjAa3Fda4NU+6wqUO5kTXQSRBQD3g==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1.tgz",
+            "integrity": "sha512-vNTpMmlvNP9n3hGEcgPaXyvTljanAKIUkuG9URQ1DeuDup0OR7Ltvoc8yrmH+iMZJbcQGhUJF+WjHLwuk8HSdw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/mdx-loader": "3.7.0",
-                "@docusaurus/theme-common": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-common": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/mdx-loader": "3.8.1",
+                "@docusaurus/theme-common": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-common": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "cheerio": "1.0.0-rc.12",
                 "feed": "^4.2.2",
                 "fs-extra": "^11.1.1",
                 "lodash": "^4.17.21",
-                "reading-time": "^1.5.0",
+                "schema-dts": "^1.1.2",
                 "srcset": "^4.0.0",
                 "tslib": "^2.6.0",
                 "unist-util-visit": "^5.0.0",
@@ -3362,25 +3458,26 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-docs": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.7.0.tgz",
-            "integrity": "sha512-GXg5V7kC9FZE4FkUZA8oo/NrlRb06UwuICzI6tcbzj0+TVgjq/mpUXXzSgKzMS82YByi4dY2Q808njcBCyy6tQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1.tgz",
+            "integrity": "sha512-oByRkSZzeGNQByCMaX+kif5Nl2vmtj2IHQI2fWjCfCootsdKZDPFLonhIp5s3IGJO7PLUfe0POyw0Xh/RrGXJA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/mdx-loader": "3.7.0",
-                "@docusaurus/module-type-aliases": "3.7.0",
-                "@docusaurus/theme-common": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-common": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/mdx-loader": "3.8.1",
+                "@docusaurus/module-type-aliases": "3.8.1",
+                "@docusaurus/theme-common": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-common": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "@types/react-router-config": "^5.0.7",
                 "combine-promises": "^1.1.0",
                 "fs-extra": "^11.1.1",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
+                "schema-dts": "^1.1.2",
                 "tslib": "^2.6.0",
                 "utility-types": "^3.10.0",
                 "webpack": "^5.88.1"
@@ -3394,16 +3491,16 @@
             }
         },
         "node_modules/@docusaurus/plugin-content-pages": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.7.0.tgz",
-            "integrity": "sha512-YJSU3tjIJf032/Aeao8SZjFOrXJbz/FACMveSMjLyMH4itQyZ2XgUIzt4y+1ISvvk5zrW4DABVT2awTCqBkx0Q==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.1.tgz",
+            "integrity": "sha512-a+V6MS2cIu37E/m7nDJn3dcxpvXb6TvgdNI22vJX8iUTp8eoMoPa0VArEbWvCxMY/xdC26WzNv4wZ6y0iIni/w==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/mdx-loader": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/mdx-loader": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "fs-extra": "^11.1.1",
                 "tslib": "^2.6.0",
                 "webpack": "^5.88.1"
@@ -3416,17 +3513,33 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-debug": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.7.0.tgz",
-            "integrity": "sha512-Qgg+IjG/z4svtbCNyTocjIwvNTNEwgRjSXXSJkKVG0oWoH0eX/HAPiu+TS1HBwRPQV+tTYPWLrUypYFepfujZA==",
+        "node_modules/@docusaurus/plugin-css-cascade-layers": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.1.tgz",
+            "integrity": "sha512-VQ47xRxfNKjHS5ItzaVXpxeTm7/wJLFMOPo1BkmoMG4Cuz4nuI+Hs62+RMk1OqVog68Swz66xVPK8g9XTrBKRw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
+                "tslib": "^2.6.0"
+            },
+            "engines": {
+                "node": ">=18.0"
+            }
+        },
+        "node_modules/@docusaurus/plugin-debug": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.1.tgz",
+            "integrity": "sha512-nT3lN7TV5bi5hKMB7FK8gCffFTBSsBsAfV84/v293qAmnHOyg1nr9okEw8AiwcO3bl9vije5nsUvP0aRl2lpaw==",
+            "license": "MIT",
+            "dependencies": {
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
                 "fs-extra": "^11.1.1",
-                "react-json-view-lite": "^1.2.0",
+                "react-json-view-lite": "^2.3.0",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3437,27 +3550,15 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/plugin-debug/node_modules/react-json-view-lite": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.5.0.tgz",
-            "integrity": "sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
-            }
-        },
         "node_modules/@docusaurus/plugin-google-analytics": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.7.0.tgz",
-            "integrity": "sha512-otIqiRV/jka6Snjf+AqB360XCeSv7lQC+DKYW+EUZf6XbuE8utz5PeUQ8VuOcD8Bk5zvT1MC4JKcd5zPfDuMWA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.1.tgz",
+            "integrity": "sha512-Hrb/PurOJsmwHAsfMDH6oVpahkEGsx7F8CWMjyP/dw1qjqmdS9rcV1nYCGlM8nOtD3Wk/eaThzUB5TSZsGz+7Q==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3469,14 +3570,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-gtag": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.7.0.tgz",
-            "integrity": "sha512-M3vrMct1tY65ModbyeDaMoA+fNJTSPe5qmchhAbtqhDD/iALri0g9LrEpIOwNaoLmm6lO88sfBUADQrSRSGSWA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.1.tgz",
+            "integrity": "sha512-tKE8j1cEZCh8KZa4aa80zpSTxsC2/ZYqjx6AAfd8uA8VHZVw79+7OTEP2PoWi0uL5/1Is0LF5Vwxd+1fz5HlKg==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "@types/gtag.js": "^0.0.12",
                 "tslib": "^2.6.0"
             },
@@ -3489,14 +3590,14 @@
             }
         },
         "node_modules/@docusaurus/plugin-google-tag-manager": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.7.0.tgz",
-            "integrity": "sha512-X8U78nb8eiMiPNg3jb9zDIVuuo/rE1LjGDGu+5m5CX4UBZzjMy+klOY2fNya6x8ACyE/L3K2erO1ErheP55W/w==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.1.tgz",
+            "integrity": "sha512-iqe3XKITBquZq+6UAXdb1vI0fPY5iIOitVjPQ581R1ZKpHr0qe+V6gVOrrcOHixPDD/BUKdYwkxFjpNiEN+vBw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3508,17 +3609,17 @@
             }
         },
         "node_modules/@docusaurus/plugin-sitemap": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.7.0.tgz",
-            "integrity": "sha512-bTRT9YLZ/8I/wYWKMQke18+PF9MV8Qub34Sku6aw/vlZ/U+kuEuRpQ8bTcNOjaTSfYsWkK4tTwDMHK2p5S86cA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1.tgz",
+            "integrity": "sha512-+9YV/7VLbGTq8qNkjiugIelmfUEVkTyLe6X8bWq7K5qPvGXAjno27QAfFq63mYfFFbJc7z+pudL63acprbqGzw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-common": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-common": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "fs-extra": "^11.1.1",
                 "sitemap": "^7.1.1",
                 "tslib": "^2.6.0"
@@ -3532,15 +3633,15 @@
             }
         },
         "node_modules/@docusaurus/plugin-svgr": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.7.0.tgz",
-            "integrity": "sha512-HByXIZTbc4GV5VAUkZ2DXtXv1Qdlnpk3IpuImwSnEzCDBkUMYcec5282hPjn6skZqB25M1TYCmWS91UbhBGxQg==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.1.tgz",
+            "integrity": "sha512-rW0LWMDsdlsgowVwqiMb/7tANDodpy1wWPwCcamvhY7OECReN3feoFwLjd/U4tKjNY3encj0AJSTxJA+Fpe+Gw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "@svgr/core": "8.1.0",
                 "@svgr/webpack": "^8.1.0",
                 "tslib": "^2.6.0",
@@ -3555,25 +3656,26 @@
             }
         },
         "node_modules/@docusaurus/preset-classic": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.7.0.tgz",
-            "integrity": "sha512-nPHj8AxDLAaQXs+O6+BwILFuhiWbjfQWrdw2tifOClQoNfuXDjfjogee6zfx6NGHWqshR23LrcN115DmkHC91Q==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz",
+            "integrity": "sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/plugin-content-blog": "3.7.0",
-                "@docusaurus/plugin-content-docs": "3.7.0",
-                "@docusaurus/plugin-content-pages": "3.7.0",
-                "@docusaurus/plugin-debug": "3.7.0",
-                "@docusaurus/plugin-google-analytics": "3.7.0",
-                "@docusaurus/plugin-google-gtag": "3.7.0",
-                "@docusaurus/plugin-google-tag-manager": "3.7.0",
-                "@docusaurus/plugin-sitemap": "3.7.0",
-                "@docusaurus/plugin-svgr": "3.7.0",
-                "@docusaurus/theme-classic": "3.7.0",
-                "@docusaurus/theme-common": "3.7.0",
-                "@docusaurus/theme-search-algolia": "3.7.0",
-                "@docusaurus/types": "3.7.0"
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/plugin-content-blog": "3.8.1",
+                "@docusaurus/plugin-content-docs": "3.8.1",
+                "@docusaurus/plugin-content-pages": "3.8.1",
+                "@docusaurus/plugin-css-cascade-layers": "3.8.1",
+                "@docusaurus/plugin-debug": "3.8.1",
+                "@docusaurus/plugin-google-analytics": "3.8.1",
+                "@docusaurus/plugin-google-gtag": "3.8.1",
+                "@docusaurus/plugin-google-tag-manager": "3.8.1",
+                "@docusaurus/plugin-sitemap": "3.8.1",
+                "@docusaurus/plugin-svgr": "3.8.1",
+                "@docusaurus/theme-classic": "3.8.1",
+                "@docusaurus/theme-common": "3.8.1",
+                "@docusaurus/theme-search-algolia": "3.8.1",
+                "@docusaurus/types": "3.8.1"
             },
             "engines": {
                 "node": ">=18.0"
@@ -3584,31 +3686,31 @@
             }
         },
         "node_modules/@docusaurus/theme-classic": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.7.0.tgz",
-            "integrity": "sha512-MnLxG39WcvLCl4eUzHr0gNcpHQfWoGqzADCly54aqCofQX6UozOS9Th4RK3ARbM9m7zIRv3qbhggI53dQtx/hQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.1.tgz",
+            "integrity": "sha512-bqDUCNqXeYypMCsE1VcTXSI1QuO4KXfx8Cvl6rYfY0bhhqN6d2WZlRkyLg/p6pm+DzvanqHOyYlqdPyP0iz+iw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/mdx-loader": "3.7.0",
-                "@docusaurus/module-type-aliases": "3.7.0",
-                "@docusaurus/plugin-content-blog": "3.7.0",
-                "@docusaurus/plugin-content-docs": "3.7.0",
-                "@docusaurus/plugin-content-pages": "3.7.0",
-                "@docusaurus/theme-common": "3.7.0",
-                "@docusaurus/theme-translations": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-common": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/mdx-loader": "3.8.1",
+                "@docusaurus/module-type-aliases": "3.8.1",
+                "@docusaurus/plugin-content-blog": "3.8.1",
+                "@docusaurus/plugin-content-docs": "3.8.1",
+                "@docusaurus/plugin-content-pages": "3.8.1",
+                "@docusaurus/theme-common": "3.8.1",
+                "@docusaurus/theme-translations": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-common": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "@mdx-js/react": "^3.0.0",
                 "clsx": "^2.0.0",
                 "copy-text-to-clipboard": "^3.2.0",
                 "infima": "0.2.0-alpha.45",
                 "lodash": "^4.17.21",
                 "nprogress": "^0.2.0",
-                "postcss": "^8.4.26",
+                "postcss": "^8.5.4",
                 "prism-react-renderer": "^2.3.0",
                 "prismjs": "^1.29.0",
                 "react-router-dom": "^5.3.4",
@@ -3625,15 +3727,15 @@
             }
         },
         "node_modules/@docusaurus/theme-common": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.7.0.tgz",
-            "integrity": "sha512-8eJ5X0y+gWDsURZnBfH0WabdNm8XMCXHv8ENy/3Z/oQKwaB/EHt5lP9VsTDTf36lKEp0V6DjzjFyFIB+CetL0A==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.1.tgz",
+            "integrity": "sha512-UswMOyTnPEVRvN5Qzbo+l8k4xrd5fTFu2VPPfD6FcW/6qUtVLmJTQCktbAL3KJ0BVXGm5aJXz/ZrzqFuZERGPw==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/mdx-loader": "3.7.0",
-                "@docusaurus/module-type-aliases": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-common": "3.7.0",
+                "@docusaurus/mdx-loader": "3.8.1",
+                "@docusaurus/module-type-aliases": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-common": "3.8.1",
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
                 "@types/react-router-config": "*",
@@ -3653,19 +3755,19 @@
             }
         },
         "node_modules/@docusaurus/theme-search-algolia": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.7.0.tgz",
-            "integrity": "sha512-Al/j5OdzwRU1m3falm+sYy9AaB93S1XF1Lgk9Yc6amp80dNxJVplQdQTR4cYdzkGtuQqbzUA8+kaoYYO0RbK6g==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.1.tgz",
+            "integrity": "sha512-NBFH5rZVQRAQM087aYSRKQ9yGEK9eHd+xOxQjqNpxMiV85OhJDD4ZGz6YJIod26Fbooy54UWVdzNU0TFeUUUzQ==",
             "license": "MIT",
             "dependencies": {
-                "@docsearch/react": "^3.8.1",
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/plugin-content-docs": "3.7.0",
-                "@docusaurus/theme-common": "3.7.0",
-                "@docusaurus/theme-translations": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-validation": "3.7.0",
+                "@docsearch/react": "^3.9.0",
+                "@docusaurus/core": "3.8.1",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/plugin-content-docs": "3.8.1",
+                "@docusaurus/theme-common": "3.8.1",
+                "@docusaurus/theme-translations": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-validation": "3.8.1",
                 "algoliasearch": "^5.17.1",
                 "algoliasearch-helper": "^3.22.6",
                 "clsx": "^2.0.0",
@@ -3683,54 +3785,10 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/@docsearch/react": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.3.tgz",
-            "integrity": "sha512-6UNrg88K7lJWmuS6zFPL/xgL+n326qXqZ7Ybyy4E8P/6Rcblk3GE8RXxeol4Pd5pFpKMhOhBhzABKKwHtbJCIg==",
-            "license": "MIT",
-            "dependencies": {
-                "@algolia/autocomplete-core": "1.17.9",
-                "@algolia/autocomplete-preset-algolia": "1.17.9",
-                "@docsearch/css": "3.8.3",
-                "algoliasearch": "^5.14.2"
-            },
-            "peerDependencies": {
-                "@types/react": ">= 16.8.0 < 19.0.0",
-                "react": ">= 16.8.0 < 19.0.0",
-                "react-dom": ">= 16.8.0 < 19.0.0",
-                "search-insights": ">= 1 < 3"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "react": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                },
-                "search-insights": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/@types/react": {
-            "version": "18.3.18",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-            "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/prop-types": "*",
-                "csstype": "^3.0.2"
-            }
-        },
         "node_modules/@docusaurus/theme-translations": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.7.0.tgz",
-            "integrity": "sha512-Ewq3bEraWDmienM6eaNK7fx+/lHMtGDHQyd1O+4+3EsDxxUmrzPkV7Ct3nBWTuE0MsoZr3yNwQVKjllzCMuU3g==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.1.tgz",
+            "integrity": "sha512-OTp6eebuMcf2rJt4bqnvuwmm3NVXfzfYejL+u/Y1qwKhZPrjPoKWfk1CbOP5xH5ZOPkiAsx4dHdQBRJszK3z2g==",
             "license": "MIT",
             "dependencies": {
                 "fs-extra": "^11.1.1",
@@ -3741,16 +3799,16 @@
             }
         },
         "node_modules/@docusaurus/tsconfig": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.7.0.tgz",
-            "integrity": "sha512-vRsyj3yUZCjscgfgcFYjIsTcAru/4h4YH2/XAE8Rs7wWdnng98PgWKvP5ovVc4rmRpRg2WChVW0uOy2xHDvDBQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.8.1.tgz",
+            "integrity": "sha512-XBWCcqhRHhkhfolnSolNL+N7gj3HVE3CoZVqnVjfsMzCoOsuQw2iCLxVVHtO+rePUUfouVZHURDgmqIySsF66A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@docusaurus/types": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.7.0.tgz",
-            "integrity": "sha512-kOmZg5RRqJfH31m+6ZpnwVbkqMJrPOG5t0IOl4i/+3ruXyNfWzZ0lVtVrD0u4ONc/0NOsS9sWYaxxWNkH1LdLQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.1.tgz",
+            "integrity": "sha512-ZPdW5AB+pBjiVrcLuw3dOS6BFlrG0XkS2lDGsj8TizcnREQg3J8cjsgfDviszOk4CweNfwo1AEELJkYaMUuOPg==",
             "license": "MIT",
             "dependencies": {
                 "@mdx-js/mdx": "^3.0.0",
@@ -3783,15 +3841,16 @@
             }
         },
         "node_modules/@docusaurus/utils": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-            "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.1.tgz",
+            "integrity": "sha512-P1ml0nvOmEFdmu0smSXOqTS1sxU5tqvnc0dA4MTKV39kye+bhQnjkIKEE18fNOvxjyB86k8esoCIFM3x4RykOQ==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@docusaurus/utils-common": "3.7.0",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/types": "3.8.1",
+                "@docusaurus/utils-common": "3.8.1",
                 "escape-string-regexp": "^4.0.0",
+                "execa": "5.1.1",
                 "file-loader": "^6.2.0",
                 "fs-extra": "^11.1.1",
                 "github-slugger": "^1.5.0",
@@ -3801,9 +3860,9 @@
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
                 "micromatch": "^4.0.5",
+                "p-queue": "^6.6.2",
                 "prompts": "^2.4.2",
                 "resolve-pathname": "^3.0.0",
-                "shelljs": "^0.8.5",
                 "tslib": "^2.6.0",
                 "url-loader": "^4.1.1",
                 "utility-types": "^3.10.0",
@@ -3814,12 +3873,12 @@
             }
         },
         "node_modules/@docusaurus/utils-common": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-            "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.1.tgz",
+            "integrity": "sha512-zTZiDlvpvoJIrQEEd71c154DkcriBecm4z94OzEE9kz7ikS3J+iSlABhFXM45mZ0eN5pVqqr7cs60+ZlYLewtg==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/types": "3.7.0",
+                "@docusaurus/types": "3.8.1",
                 "tslib": "^2.6.0"
             },
             "engines": {
@@ -3827,14 +3886,14 @@
             }
         },
         "node_modules/@docusaurus/utils-validation": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-            "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.1.tgz",
+            "integrity": "sha512-gs5bXIccxzEbyVecvxg6upTwaUbfa0KMmTj7HhHzc016AGyxH2o73k1/aOD0IFrdCsfJNt37MqNI47s2MgRZMA==",
             "license": "MIT",
             "dependencies": {
-                "@docusaurus/logger": "3.7.0",
-                "@docusaurus/utils": "3.7.0",
-                "@docusaurus/utils-common": "3.7.0",
+                "@docusaurus/logger": "3.8.1",
+                "@docusaurus/utils": "3.8.1",
+                "@docusaurus/utils-common": "3.8.1",
                 "fs-extra": "^11.2.0",
                 "joi": "^17.9.2",
                 "js-yaml": "^4.1.0",
@@ -3849,7 +3908,7 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
             "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "eslint-visitor-keys": "^3.3.0"
             },
@@ -3864,7 +3923,7 @@
             "version": "4.10.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
             "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
@@ -3873,7 +3932,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
             "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -3897,7 +3956,7 @@
             "version": "13.24.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -3913,7 +3972,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "engines": {
                 "node": ">=10"
@@ -3926,7 +3985,7 @@
             "version": "8.57.0",
             "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
             "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3950,7 +4009,7 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
             "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "deprecated": "Use @eslint/config-array instead",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^2.0.2",
@@ -3965,7 +4024,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "engines": {
                 "node": ">=12.22"
@@ -3980,7 +4039,7 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "deprecated": "Use @eslint/object-schema instead",
-            "devOptional": true,
+            "dev": true,
             "peer": true
         },
         "node_modules/@jest/schemas": {
@@ -4013,30 +4072,19 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
             "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -4051,14 +4099,16 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.30",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+            "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -5046,25 +5096,11 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/parse-json": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-            "license": "MIT"
-        },
         "node_modules/@types/prismjs": {
             "version": "1.26.5",
             "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
             "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
             "license": "MIT"
-        },
-        "node_modules/@types/prop-types": {
-            "version": "15.7.14",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-            "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/@types/qs": {
             "version": "6.9.18",
@@ -5750,33 +5786,34 @@
             }
         },
         "node_modules/algoliasearch": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.20.0.tgz",
-            "integrity": "sha512-groO71Fvi5SWpxjI9Ia+chy0QBwT61mg6yxJV27f5YFf+Mw+STT75K6SHySpP8Co5LsCrtsbCH5dJZSRtkSKaQ==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.35.0.tgz",
+            "integrity": "sha512-Y+moNhsqgLmvJdgTsO4GZNgsaDWv8AOGAaPeIeHKlDn/XunoAqYbA+XNpBd1dW8GOXAUDyxC9Rxc7AV4kpFcIg==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-abtesting": "5.20.0",
-                "@algolia/client-analytics": "5.20.0",
-                "@algolia/client-common": "5.20.0",
-                "@algolia/client-insights": "5.20.0",
-                "@algolia/client-personalization": "5.20.0",
-                "@algolia/client-query-suggestions": "5.20.0",
-                "@algolia/client-search": "5.20.0",
-                "@algolia/ingestion": "1.20.0",
-                "@algolia/monitoring": "1.20.0",
-                "@algolia/recommend": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/abtesting": "1.1.0",
+                "@algolia/client-abtesting": "5.35.0",
+                "@algolia/client-analytics": "5.35.0",
+                "@algolia/client-common": "5.35.0",
+                "@algolia/client-insights": "5.35.0",
+                "@algolia/client-personalization": "5.35.0",
+                "@algolia/client-query-suggestions": "5.35.0",
+                "@algolia/client-search": "5.35.0",
+                "@algolia/ingestion": "1.35.0",
+                "@algolia/monitoring": "1.35.0",
+                "@algolia/recommend": "5.35.0",
+                "@algolia/requester-browser-xhr": "5.35.0",
+                "@algolia/requester-fetch": "5.35.0",
+                "@algolia/requester-node-http": "5.35.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/algoliasearch-helper": {
-            "version": "3.24.1",
-            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.24.1.tgz",
-            "integrity": "sha512-knYRACqLH9UpeR+WRUrBzBFR2ulGuOjI2b525k4PNeqZxeFMHJE7YcL7s6Jh12Qza0rtHqZdgHMfeuaaAkf4wA==",
+            "version": "3.26.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.26.0.tgz",
+            "integrity": "sha512-Rv2x3GXleQ3ygwhkhJubhhYGsICmShLAiqtUuJTUkr9uOCOXyF2E71LVT4XDnVffbknv8XgScP4U0Oxtgm+hIw==",
             "license": "MIT",
             "dependencies": {
                 "@algolia/events": "^4.0.1"
@@ -5909,6 +5946,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -5921,19 +5959,10 @@
                 "astring": "bin/astring"
             }
         },
-        "node_modules/at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "node_modules/autoprefixer": {
-            "version": "10.4.20",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-            "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+            "version": "10.4.21",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+            "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5950,11 +5979,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3",
-                "caniuse-lite": "^1.0.30001646",
+                "browserslist": "^4.24.4",
+                "caniuse-lite": "^1.0.30001702",
                 "fraction.js": "^4.3.7",
                 "normalize-range": "^0.1.2",
-                "picocolors": "^1.0.1",
+                "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "bin": {
@@ -5994,13 +6023,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.12",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
-            "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+            "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.22.6",
-                "@babel/helper-define-polyfill-provider": "^0.6.3",
+                "@babel/compat-data": "^7.27.7",
+                "@babel/helper-define-polyfill-provider": "^0.6.5",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -6030,12 +6059,12 @@
             }
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
-            "integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+            "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.3"
+                "@babel/helper-define-polyfill-provider": "^0.6.5"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -6187,9 +6216,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.24.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+            "version": "4.25.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
+            "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6206,10 +6235,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001688",
-                "electron-to-chromium": "^1.5.73",
+                "caniuse-lite": "^1.0.30001733",
+                "electron-to-chromium": "^1.5.199",
                 "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.1"
+                "update-browserslist-db": "^1.1.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -6348,9 +6377,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001696",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
-            "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
+            "version": "1.0.30001735",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
+            "integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6805,9 +6834,9 @@
             }
         },
         "node_modules/consola": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
-            "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
             "license": "MIT",
             "engines": {
                 "node": "^14.18.0 || >=16.10.0"
@@ -6942,12 +6971,12 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.40.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
-            "integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
+            "version": "3.45.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz",
+            "integrity": "sha512-gRoVMBawZg0OnxaVv3zpqLLxaHmsubEGyTnqdpI/CEBvX4JadI1dMSHxagThprYRtSVbuQxvi6iUatdPxohHpA==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.3"
+                "browserslist": "^4.25.1"
             },
             "funding": {
                 "type": "opencollective",
@@ -6955,9 +6984,9 @@
             }
         },
         "node_modules/core-js-pure": {
-            "version": "3.40.0",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.40.0.tgz",
-            "integrity": "sha512-AtDzVIgRrmRKQai62yuSIN5vNiQjcJakJb4fbhVw3ehxx7Lohphvw9SGNWKhLFqSxC4ilD0g/L1huAYFQU3Q6A==",
+            "version": "3.45.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.0.tgz",
+            "integrity": "sha512-OtwjqcDpY2X/eIIg1ol/n0y/X8A9foliaNt1dSK0gV3J2/zw+89FcNG3mPK+N8YWts4ZFUPxnrAzsxs/lf8yDA==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -7062,9 +7091,9 @@
             }
         },
         "node_modules/css-blank-pseudo/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -7136,9 +7165,9 @@
             }
         },
         "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -7288,9 +7317,9 @@
             }
         },
         "node_modules/cssdb": {
-            "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.2.3.tgz",
-            "integrity": "sha512-9BDG5XmJrJQQnJ51VFxXCAtpZ5ebDlAREmO8sxMOVU0aSxN/gocbctjIG5LMh3WBUq+xTlb/jw2LoljBEqraTA==",
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.3.1.tgz",
+            "integrity": "sha512-XnDRQMXucLueX92yDe0LPKupXetWoFOgawr4O4X41l5TltgK2NVbJJVDnnOywDYfW1sTJ28AcXGKOqdRKwCcmQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7454,11 +7483,12 @@
             "license": "MIT"
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -7521,7 +7551,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true
         },
         "node_modules/deepmerge": {
@@ -7596,28 +7626,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/del": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-            "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-            "license": "MIT",
-            "dependencies": {
-                "globby": "^11.0.1",
-                "graceful-fs": "^4.2.4",
-                "is-glob": "^4.0.1",
-                "is-path-cwd": "^2.2.0",
-                "is-path-inside": "^3.0.2",
-                "p-map": "^4.0.0",
-                "rimraf": "^3.0.2",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7681,38 +7689,6 @@
                 "node": ">= 4.0.0"
             }
         },
-        "node_modules/detect-port-alt": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
-            "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
-            "license": "MIT",
-            "dependencies": {
-                "address": "^1.0.1",
-                "debug": "^2.6.0"
-            },
-            "bin": {
-                "detect": "bin/detect-port",
-                "detect-port": "bin/detect-port"
-            },
-            "engines": {
-                "node": ">= 4.2.1"
-            }
-        },
-        "node_modules/detect-port-alt/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/detect-port-alt/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "license": "MIT"
-        },
         "node_modules/devlop": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -7739,6 +7715,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "license": "MIT",
             "dependencies": {
                 "path-type": "^4.0.0"
             },
@@ -7762,7 +7739,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
@@ -7910,9 +7887,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.90",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.90.tgz",
-            "integrity": "sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug==",
+            "version": "1.5.200",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
+            "integrity": "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -8060,7 +8037,7 @@
             "version": "8.57.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
@@ -8116,7 +8093,7 @@
             "version": "7.2.2",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
             "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -8133,7 +8110,7 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -8145,7 +8122,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
@@ -8158,7 +8135,7 @@
             "version": "13.23.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
             "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -8174,7 +8151,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "engines": {
                 "node": ">=10"
@@ -8187,7 +8164,7 @@
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
             "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "acorn": "^8.9.0",
@@ -8205,6 +8182,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -8217,7 +8195,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
             "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -8296,9 +8274,9 @@
             }
         },
         "node_modules/estree-util-value-to-estree": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.3.3.tgz",
-            "integrity": "sha512-Db+m1WSD4+mUO7UgMeKkAwdbfNWwIxLt48XF2oFU9emPfXkIu+k5/nlOj313v7wqtAPo0f9REhUvznFrPkG8CQ==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.4.0.tgz",
+            "integrity": "sha512-Zlp+gxis+gCfK12d3Srl2PdX2ybsEA8ZYy6vQGVQTNNYLEGRQQ56XB64bjemN8kxIKXP1nC9ip4Z+ILy9LGzvQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
@@ -8502,6 +8480,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
             "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+            "license": "MIT",
             "dependencies": {
                 "is-extendable": "^0.1.0"
             },
@@ -8538,7 +8517,7 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "devOptional": true,
+            "dev": true,
             "peer": true
         },
         "node_modules/fast-uri": {
@@ -8630,7 +8609,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
@@ -8673,15 +8652,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/filesize": {
-            "version": "8.0.7",
-            "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
-            "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">= 0.4.0"
             }
         },
         "node_modules/fill-range": {
@@ -8748,6 +8718,8 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -8771,7 +8743,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
             "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
@@ -8786,7 +8758,7 @@
             "version": "3.2.9",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
             "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true
         },
         "node_modules/follow-redirects": {
@@ -8807,103 +8779,6 @@
                 "debug": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/fork-ts-checker-webpack-plugin": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz",
-            "integrity": "sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.8.3",
-                "@types/json-schema": "^7.0.5",
-                "chalk": "^4.1.0",
-                "chokidar": "^3.4.2",
-                "cosmiconfig": "^6.0.0",
-                "deepmerge": "^4.2.2",
-                "fs-extra": "^9.0.0",
-                "glob": "^7.1.6",
-                "memfs": "^3.1.2",
-                "minimatch": "^3.0.4",
-                "schema-utils": "2.7.0",
-                "semver": "^7.3.2",
-                "tapable": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=10",
-                "yarn": ">=1.0.0"
-            },
-            "peerDependencies": {
-                "eslint": ">= 6",
-                "typescript": ">= 2.7",
-                "vue-template-compiler": "*",
-                "webpack": ">= 4"
-            },
-            "peerDependenciesMeta": {
-                "eslint": {
-                    "optional": true
-                },
-                "vue-template-compiler": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/fork-ts-checker-webpack-plugin/node_modules/cosmiconfig": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-            "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.1.0",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0",
-                "yaml": "^1.7.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "license": "MIT",
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-            "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.4",
-                "ajv": "^6.12.2",
-                "ajv-keywords": "^3.4.1"
-            },
-            "engines": {
-                "node": ">= 8.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/fork-ts-checker-webpack-plugin/node_modules/tapable": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/form-data-encoder": {
@@ -9066,7 +8941,8 @@
         "node_modules/github-slugger": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
-            "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
+            "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
+            "license": "ISC"
         },
         "node_modules/glob": {
             "version": "7.2.3",
@@ -9127,44 +9003,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/global-modules": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-            "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-            "license": "MIT",
-            "dependencies": {
-                "global-prefix": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/global-prefix": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-            "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-            "license": "MIT",
-            "dependencies": {
-                "ini": "^1.3.5",
-                "kind-of": "^6.0.2",
-                "which": "^1.3.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/global-prefix/node_modules/which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "which": "bin/which"
-            }
-        },
         "node_modules/globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -9178,6 +9016,7 @@
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
             "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "license": "MIT",
             "dependencies": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -9251,12 +9090,13 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/gray-matter": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
             "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+            "license": "MIT",
             "dependencies": {
                 "js-yaml": "^3.13.1",
                 "kind-of": "^6.0.2",
@@ -9271,6 +9111,7 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -9279,6 +9120,7 @@
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
             "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -9365,16 +9207,16 @@
             }
         },
         "node_modules/hast-util-from-parse5": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.2.tgz",
-            "integrity": "sha512-SfMzfdAi/zAoZ1KkFEyyeXBn7u/ShQrfd675ZEE9M3qj+PMFX05xubzRyF76CCSJu8au9jgVxDV1+okFvgZU4A==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+            "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
                 "devlop": "^1.0.0",
                 "hastscript": "^9.0.0",
-                "property-information": "^6.0.0",
+                "property-information": "^7.0.0",
                 "vfile": "^6.0.0",
                 "vfile-location": "^5.0.0",
                 "web-namespaces": "^2.0.0"
@@ -9382,6 +9224,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-from-parse5/node_modules/property-information": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+            "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/hast-util-parse-selector": {
@@ -9501,20 +9353,30 @@
             }
         },
         "node_modules/hastscript": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.0.tgz",
-            "integrity": "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "comma-separated-tokens": "^2.0.0",
                 "hast-util-parse-selector": "^4.0.0",
-                "property-information": "^6.0.0",
+                "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hastscript/node_modules/property-information": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+            "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/he": {
@@ -9889,28 +9751,15 @@
             }
         },
         "node_modules/image-size": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-            "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+            "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
             "license": "MIT",
-            "dependencies": {
-                "queue": "6.0.2"
-            },
             "bin": {
                 "image-size": "bin/image-size.js"
             },
             "engines": {
                 "node": ">=16.x"
-            }
-        },
-        "node_modules/immer": {
-            "version": "9.0.21",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-            "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/immer"
             }
         },
         "node_modules/immutable": {
@@ -9994,14 +9843,6 @@
             "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
             "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
         },
-        "node_modules/interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
         "node_modules/invariant": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -10072,11 +9913,15 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.0"
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -10110,6 +9955,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
             "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10196,15 +10042,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-path-cwd": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -10239,15 +10076,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-root": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
-            "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/is-stream": {
@@ -10355,9 +10183,10 @@
             }
         },
         "node_modules/jiti": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-            "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
+            "version": "1.21.7",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+            "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+            "license": "MIT",
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -10421,7 +10250,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "devOptional": true,
+            "dev": true,
             "peer": true
         },
         "node_modules/json5": {
@@ -10508,7 +10337,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
@@ -10560,6 +10389,8 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -10591,7 +10422,7 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "devOptional": true,
+            "dev": true,
             "peer": true
         },
         "node_modules/lodash.uniq": {
@@ -10797,9 +10628,9 @@
             }
         },
         "node_modules/mdast-util-gfm": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz",
-            "integrity": "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
             "license": "MIT",
             "dependencies": {
                 "mdast-util-from-markdown": "^2.0.0",
@@ -10869,9 +10700,9 @@
             "license": "MIT"
         },
         "node_modules/mdast-util-gfm-footnote": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz",
-            "integrity": "sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -12896,9 +12727,9 @@
             }
         },
         "node_modules/mini-css-extract-plugin": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.2.tgz",
-            "integrity": "sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
+            "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
             "license": "MIT",
             "dependencies": {
                 "schema-utils": "^4.0.0",
@@ -12951,9 +12782,10 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/multicast-dns": {
             "version": "7.2.5",
@@ -12969,15 +12801,16 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -12989,7 +12822,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/negotiator": {
             "version": "0.6.4",
@@ -13277,7 +13110,7 @@
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
             "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "@aashutoshrathi/word-wrap": "^1.2.3",
@@ -13300,10 +13133,20 @@
                 "node": ">=12.20"
             }
         },
+        "node_modules/p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -13318,6 +13161,8 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -13343,6 +13188,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-queue": {
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+            "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "eventemitter3": "^4.0.4",
+                "p-timeout": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/p-retry": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -13356,13 +13217,16 @@
                 "node": ">=8"
             }
         },
-        "node_modules/p-try": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+        "node_modules/p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
             "license": "MIT",
+            "dependencies": {
+                "p-finally": "^1.0.0"
+            },
             "engines": {
-                "node": ">=6"
+                "node": ">=8"
             }
         },
         "node_modules/package-json": {
@@ -13452,11 +13316,12 @@
             "license": "ISC"
         },
         "node_modules/parse5": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-            "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "license": "MIT",
             "dependencies": {
-                "entities": "^4.4.0"
+                "entities": "^6.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -13473,6 +13338,18 @@
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/parseurl": {
@@ -13498,6 +13375,8 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -13527,7 +13406,8 @@
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "license": "MIT"
         },
         "node_modules/path-to-regexp": {
             "version": "1.9.0",
@@ -13659,9 +13539,9 @@
             }
         },
         "node_modules/pkg-dir/node_modules/yocto-queue": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-            "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+            "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.20"
@@ -13670,83 +13550,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/pkg-up": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-            "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-            "license": "MIT",
-            "dependencies": {
-                "find-up": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-up/node_modules/find-up": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-            "license": "MIT",
-            "dependencies": {
-                "locate-path": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/pkg-up/node_modules/locate-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-            "license": "MIT",
-            "dependencies": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/pkg-up/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "license": "MIT",
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pkg-up/node_modules/p-locate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-            "license": "MIT",
-            "dependencies": {
-                "p-limit": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/pkg-up/node_modules/path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/postcss": {
-            "version": "8.4.42",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.42.tgz",
-            "integrity": "sha512-hywKUQB9Ra4dR1mGhldy5Aj1X3MWDSIA1cEi+Uy0CjheLvP6Ual5RlwMCh8i/X121yEDLDIKBsrCQ8ba3FDMfQ==",
+            "version": "8.5.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -13761,10 +13568,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.0.1",
-                "source-map-js": "^1.2.0"
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -13796,9 +13604,9 @@
             }
         },
         "node_modules/postcss-attribute-case-insensitive/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -13840,9 +13648,9 @@
             }
         },
         "node_modules/postcss-color-functional-notation": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.7.tgz",
-            "integrity": "sha512-EZvAHsvyASX63vXnyXOIynkxhaHRSsdb7z6yiXKIovGXAolW4cMZ3qoh7k3VdTsLBS6VGdksGfIo3r6+waLoOw==",
+            "version": "7.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.10.tgz",
+            "integrity": "sha512-k9qX+aXHBiLTRrWoCJuUFI6F1iF6QJQUXNVWJVSbqZgj57jDhBlOvD8gNUGl35tgqDivbGLhZeW3Ongz4feuKA==",
             "funding": [
                 {
                     "type": "github",
@@ -13855,10 +13663,10 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-color-parser": "^3.0.7",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -13955,9 +13763,9 @@
             }
         },
         "node_modules/postcss-custom-media": {
-            "version": "11.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-11.0.5.tgz",
-            "integrity": "sha512-SQHhayVNgDvSAdX9NQ/ygcDQGEY+aSF4b/96z7QUX6mqL5yl/JgG/DywcF6fW9XbnCRE+aVYk+9/nqGuzOPWeQ==",
+            "version": "11.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-11.0.6.tgz",
+            "integrity": "sha512-C4lD4b7mUIw+RZhtY7qUbf4eADmb7Ey8BFA2px9jUbwg7pjTZDl4KY4bvlUV+/vXQvzQRfiGEVJyAbtOsCMInw==",
             "funding": [
                 {
                     "type": "github",
@@ -13970,10 +13778,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/cascade-layer-name-parser": "^2.0.4",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/media-query-list-parser": "^4.0.2"
+                "@csstools/cascade-layer-name-parser": "^2.0.5",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/media-query-list-parser": "^4.0.3"
             },
             "engines": {
                 "node": ">=18"
@@ -13983,9 +13791,9 @@
             }
         },
         "node_modules/postcss-custom-properties": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.4.tgz",
-            "integrity": "sha512-QnW8FCCK6q+4ierwjnmXF9Y9KF8q0JkbgVfvQEMa93x1GT8FvOiUevWCN2YLaOWyByeDX8S6VFbZEeWoAoXs2A==",
+            "version": "14.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.6.tgz",
+            "integrity": "sha512-fTYSp3xuk4BUeVhxCSJdIPhDLpJfNakZKoiTDx7yRGCdlZrSJR7mWKVOBS4sBF+5poPQFMj2YdXx1VHItBGihQ==",
             "funding": [
                 {
                     "type": "github",
@@ -13998,9 +13806,9 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/cascade-layer-name-parser": "^2.0.4",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
+                "@csstools/cascade-layer-name-parser": "^2.0.5",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
                 "@csstools/utilities": "^2.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -14012,9 +13820,9 @@
             }
         },
         "node_modules/postcss-custom-selectors": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-8.0.4.tgz",
-            "integrity": "sha512-ASOXqNvDCE0dAJ/5qixxPeL1aOVGHGW2JwSy7HyjWNbnWTQCl+fDc968HY1jCmZI0+BaYT5CxsOiUhavpG/7eg==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-8.0.5.tgz",
+            "integrity": "sha512-9PGmckHQswiB2usSO6XMSswO2yFWVoCAuih1yl9FVcwkscLjRKjwsjM3t+NIWpSU2Jx3eOiK2+t4vVTQaoCHHg==",
             "funding": [
                 {
                     "type": "github",
@@ -14027,9 +13835,9 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/cascade-layer-name-parser": "^2.0.4",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
+                "@csstools/cascade-layer-name-parser": "^2.0.5",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
                 "postcss-selector-parser": "^7.0.0"
             },
             "engines": {
@@ -14040,9 +13848,9 @@
             }
         },
         "node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -14078,9 +13886,9 @@
             }
         },
         "node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -14154,9 +13962,9 @@
             }
         },
         "node_modules/postcss-double-position-gradients": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-6.0.0.tgz",
-            "integrity": "sha512-JkIGah3RVbdSEIrcobqj4Gzq0h53GG4uqDPsho88SgY84WnpkTpI0k50MFK/sX7XqVisZ6OqUfFnoUO6m1WWdg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-6.0.2.tgz",
+            "integrity": "sha512-7qTqnL7nfLRyJK/AHSVrrXOuvDDzettC+wGoienURV8v2svNbu6zJC52ruZtHaO6mfcagFmuTGFdzRsJKB3k5Q==",
             "funding": [
                 {
                     "type": "github",
@@ -14169,7 +13977,7 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -14206,9 +14014,9 @@
             }
         },
         "node_modules/postcss-focus-visible/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -14244,9 +14052,9 @@
             }
         },
         "node_modules/postcss-focus-within/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -14314,9 +14122,9 @@
             }
         },
         "node_modules/postcss-lab-function": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.7.tgz",
-            "integrity": "sha512-+ONj2bpOQfsCKZE2T9VGMyVVdGcGUpr7u3SVfvkJlvhTRmDCfY25k4Jc8fubB9DclAPR4+w8uVtDZmdRgdAHig==",
+            "version": "7.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.10.tgz",
+            "integrity": "sha512-tqs6TCEv9tC1Riq6fOzHuHcZyhg4k3gIAMB8GGY/zA1ssGdm6puHMVE7t75aOSoFg7UD2wyrFFhbldiCMyyFTQ==",
             "funding": [
                 {
                     "type": "github",
@@ -14329,10 +14137,10 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/css-color-parser": "^3.0.7",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
+                "@csstools/css-color-parser": "^3.0.10",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
                 "@csstools/utilities": "^2.0.0"
             },
             "engines": {
@@ -14365,9 +14173,9 @@
             }
         },
         "node_modules/postcss-logical": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-8.0.0.tgz",
-            "integrity": "sha512-HpIdsdieClTjXLOyYdUPAX/XQASNIwdKt5hoZW08ZOAiI+tbV0ta1oclkpVkW5ANU+xJvk3KkA0FejkjGLXUkg==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-8.1.0.tgz",
+            "integrity": "sha512-pL1hXFQ2fEXNKiNiAgtfA005T9FBxky5zkX6s4GZM2D8RkVgRqz3f4g1JUoq925zXv495qk8UNldDwh8uGEDoA==",
             "funding": [
                 {
                     "type": "github",
@@ -14533,9 +14341,9 @@
             }
         },
         "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -14561,9 +14369,9 @@
             }
         },
         "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -14589,9 +14397,9 @@
             }
         },
         "node_modules/postcss-nesting": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.1.tgz",
-            "integrity": "sha512-VbqqHkOBOt4Uu3G8Dm8n6lU5+9cJFxiuty9+4rcoyRPO9zZS1JIs6td49VIoix3qYqELHlJIn46Oih9SAKo+yQ==",
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+            "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
             "funding": [
                 {
                     "type": "github",
@@ -14604,7 +14412,7 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/selector-resolve-nested": "^3.0.0",
+                "@csstools/selector-resolve-nested": "^3.1.0",
                 "@csstools/selector-specificity": "^5.0.0",
                 "postcss-selector-parser": "^7.0.0"
             },
@@ -14616,9 +14424,9 @@
             }
         },
         "node_modules/postcss-nesting/node_modules/@csstools/selector-resolve-nested": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.0.0.tgz",
-            "integrity": "sha512-ZoK24Yku6VJU1gS79a5PFmC8yn3wIapiKmPgun0hZgEI5AOqgH2kiPRsPz1qkGv4HL+wuDLH83yQyk6inMYrJQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+            "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
             "funding": [
                 {
                     "type": "github",
@@ -14660,9 +14468,9 @@
             }
         },
         "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -14903,9 +14711,9 @@
             }
         },
         "node_modules/postcss-preset-env": {
-            "version": "10.1.3",
-            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.1.3.tgz",
-            "integrity": "sha512-9qzVhcMFU/MnwYHyYpJz4JhGku/4+xEiPTmhn0hj3IxnUYlEF9vbh7OC1KoLAnenS6Fgg43TKNp9xcuMeAi4Zw==",
+            "version": "10.2.4",
+            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.2.4.tgz",
+            "integrity": "sha512-q+lXgqmTMdB0Ty+EQ31SuodhdfZetUlwCA/F0zRcd/XdxjzI+Rl2JhZNz5US2n/7t9ePsvuhCnEN4Bmu86zXlA==",
             "funding": [
                 {
                     "type": "github",
@@ -14918,62 +14726,63 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/postcss-cascade-layers": "^5.0.1",
-                "@csstools/postcss-color-function": "^4.0.7",
-                "@csstools/postcss-color-mix-function": "^3.0.7",
-                "@csstools/postcss-content-alt-text": "^2.0.4",
-                "@csstools/postcss-exponential-functions": "^2.0.6",
+                "@csstools/postcss-cascade-layers": "^5.0.2",
+                "@csstools/postcss-color-function": "^4.0.10",
+                "@csstools/postcss-color-mix-function": "^3.0.10",
+                "@csstools/postcss-color-mix-variadic-function-arguments": "^1.0.0",
+                "@csstools/postcss-content-alt-text": "^2.0.6",
+                "@csstools/postcss-exponential-functions": "^2.0.9",
                 "@csstools/postcss-font-format-keywords": "^4.0.0",
-                "@csstools/postcss-gamut-mapping": "^2.0.7",
-                "@csstools/postcss-gradients-interpolation-method": "^5.0.7",
-                "@csstools/postcss-hwb-function": "^4.0.7",
-                "@csstools/postcss-ic-unit": "^4.0.0",
-                "@csstools/postcss-initial": "^2.0.0",
-                "@csstools/postcss-is-pseudo-class": "^5.0.1",
-                "@csstools/postcss-light-dark-function": "^2.0.7",
+                "@csstools/postcss-gamut-mapping": "^2.0.10",
+                "@csstools/postcss-gradients-interpolation-method": "^5.0.10",
+                "@csstools/postcss-hwb-function": "^4.0.10",
+                "@csstools/postcss-ic-unit": "^4.0.2",
+                "@csstools/postcss-initial": "^2.0.1",
+                "@csstools/postcss-is-pseudo-class": "^5.0.3",
+                "@csstools/postcss-light-dark-function": "^2.0.9",
                 "@csstools/postcss-logical-float-and-clear": "^3.0.0",
                 "@csstools/postcss-logical-overflow": "^2.0.0",
                 "@csstools/postcss-logical-overscroll-behavior": "^2.0.0",
                 "@csstools/postcss-logical-resize": "^3.0.0",
-                "@csstools/postcss-logical-viewport-units": "^3.0.3",
-                "@csstools/postcss-media-minmax": "^2.0.6",
-                "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.4",
+                "@csstools/postcss-logical-viewport-units": "^3.0.4",
+                "@csstools/postcss-media-minmax": "^2.0.9",
+                "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.5",
                 "@csstools/postcss-nested-calc": "^4.0.0",
                 "@csstools/postcss-normalize-display-values": "^4.0.0",
-                "@csstools/postcss-oklab-function": "^4.0.7",
-                "@csstools/postcss-progressive-custom-properties": "^4.0.0",
-                "@csstools/postcss-random-function": "^1.0.2",
-                "@csstools/postcss-relative-color-syntax": "^3.0.7",
+                "@csstools/postcss-oklab-function": "^4.0.10",
+                "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+                "@csstools/postcss-random-function": "^2.0.1",
+                "@csstools/postcss-relative-color-syntax": "^3.0.10",
                 "@csstools/postcss-scope-pseudo-class": "^4.0.1",
-                "@csstools/postcss-sign-functions": "^1.1.1",
-                "@csstools/postcss-stepped-value-functions": "^4.0.6",
-                "@csstools/postcss-text-decoration-shorthand": "^4.0.1",
-                "@csstools/postcss-trigonometric-functions": "^4.0.6",
+                "@csstools/postcss-sign-functions": "^1.1.4",
+                "@csstools/postcss-stepped-value-functions": "^4.0.9",
+                "@csstools/postcss-text-decoration-shorthand": "^4.0.2",
+                "@csstools/postcss-trigonometric-functions": "^4.0.9",
                 "@csstools/postcss-unset-value": "^4.0.0",
-                "autoprefixer": "^10.4.19",
-                "browserslist": "^4.23.1",
+                "autoprefixer": "^10.4.21",
+                "browserslist": "^4.25.0",
                 "css-blank-pseudo": "^7.0.1",
                 "css-has-pseudo": "^7.0.2",
                 "css-prefers-color-scheme": "^10.0.0",
-                "cssdb": "^8.2.3",
+                "cssdb": "^8.3.0",
                 "postcss-attribute-case-insensitive": "^7.0.1",
                 "postcss-clamp": "^4.1.0",
-                "postcss-color-functional-notation": "^7.0.7",
+                "postcss-color-functional-notation": "^7.0.10",
                 "postcss-color-hex-alpha": "^10.0.0",
                 "postcss-color-rebeccapurple": "^10.0.0",
-                "postcss-custom-media": "^11.0.5",
-                "postcss-custom-properties": "^14.0.4",
-                "postcss-custom-selectors": "^8.0.4",
+                "postcss-custom-media": "^11.0.6",
+                "postcss-custom-properties": "^14.0.6",
+                "postcss-custom-selectors": "^8.0.5",
                 "postcss-dir-pseudo-class": "^9.0.1",
-                "postcss-double-position-gradients": "^6.0.0",
+                "postcss-double-position-gradients": "^6.0.2",
                 "postcss-focus-visible": "^10.0.1",
                 "postcss-focus-within": "^9.0.1",
                 "postcss-font-variant": "^5.0.0",
                 "postcss-gap-properties": "^6.0.0",
                 "postcss-image-set-function": "^7.0.0",
-                "postcss-lab-function": "^7.0.7",
-                "postcss-logical": "^8.0.0",
-                "postcss-nesting": "^13.0.1",
+                "postcss-lab-function": "^7.0.10",
+                "postcss-logical": "^8.1.0",
+                "postcss-nesting": "^13.0.2",
                 "postcss-opacity-percentage": "^3.0.0",
                 "postcss-overflow-shorthand": "^6.0.0",
                 "postcss-page-break": "^3.0.4",
@@ -15015,9 +14824,9 @@
             }
         },
         "node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -15108,9 +14917,9 @@
             }
         },
         "node_modules/postcss-selector-not/node_modules/postcss-selector-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -15201,7 +15010,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
@@ -15359,15 +15168,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/queue": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-            "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "~2.0.3"
-            }
-        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -15473,50 +15273,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-dev-utils": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
-            "integrity": "sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.16.0",
-                "address": "^1.1.2",
-                "browserslist": "^4.18.1",
-                "chalk": "^4.1.2",
-                "cross-spawn": "^7.0.3",
-                "detect-port-alt": "^1.1.6",
-                "escape-string-regexp": "^4.0.0",
-                "filesize": "^8.0.6",
-                "find-up": "^5.0.0",
-                "fork-ts-checker-webpack-plugin": "^6.5.0",
-                "global-modules": "^2.0.0",
-                "globby": "^11.0.4",
-                "gzip-size": "^6.0.0",
-                "immer": "^9.0.7",
-                "is-root": "^2.1.0",
-                "loader-utils": "^3.2.0",
-                "open": "^8.4.0",
-                "pkg-up": "^3.1.0",
-                "prompts": "^2.4.2",
-                "react-error-overlay": "^6.0.11",
-                "recursive-readdir": "^2.2.2",
-                "shell-quote": "^1.7.3",
-                "strip-ansi": "^6.0.1",
-                "text-table": "^0.2.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/react-dev-utils/node_modules/loader-utils": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
-            "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12.13.0"
-            }
-        },
         "node_modules/react-dom": {
             "version": "19.0.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
@@ -15528,12 +15284,6 @@
             "peerDependencies": {
                 "react": "^19.0.0"
             }
-        },
-        "node_modules/react-error-overlay": {
-            "version": "6.0.11",
-            "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
-            "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
-            "license": "MIT"
         },
         "node_modules/react-fast-compare": {
             "version": "3.2.2",
@@ -15563,6 +15313,18 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/react-json-view-lite": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.4.2.tgz",
+            "integrity": "sha512-m7uTsXDgPQp8R9bJO4HD/66+i218eyQPAb+7/dGQpwg8i4z2afTFqtHJPQFHvJfgDCjGQ1HSGlL3HtrZDa3Tdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0"
+            }
         },
         "node_modules/react-loadable": {
             "name": "@docusaurus/react-loadable",
@@ -15665,35 +15427,6 @@
             },
             "engines": {
                 "node": ">=8.10.0"
-            }
-        },
-        "node_modules/reading-time": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
-            "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
-            "license": "MIT"
-        },
-        "node_modules/rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/recursive-readdir": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
-            "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
-            "license": "MIT",
-            "dependencies": {
-                "minimatch": "^3.0.5"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/regenerate": {
@@ -15875,9 +15608,9 @@
             }
         },
         "node_modules/remark-gfm": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.0.tgz",
-            "integrity": "sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+            "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -16084,16 +15817,20 @@
             "license": "MIT"
         },
         "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "version": "1.22.10",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.13.0",
+                "is-core-module": "^2.16.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
             "bin": {
                 "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -16328,6 +16065,12 @@
             "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
             "license": "MIT"
         },
+        "node_modules/schema-dts": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.5.tgz",
+            "integrity": "sha512-RJr9EaCmsLzBX2NDiO5Z3ux2BVosNZN5jo0gWgsyKvxKIUL5R3swNvoorulAeL9kLB0iTSX7V6aokhla2m7xbg==",
+            "license": "Apache-2.0"
+        },
         "node_modules/schema-utils": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
@@ -16392,6 +16135,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
             "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+            "license": "MIT",
             "dependencies": {
                 "extend-shallow": "^2.0.1",
                 "kind-of": "^6.0.0"
@@ -16492,12 +16236,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/send/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT"
         },
         "node_modules/send/node_modules/range-parser": {
             "version": "1.2.1",
@@ -16702,22 +16440,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-            "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/side-channel": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -16856,6 +16578,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -16898,9 +16621,10 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16964,7 +16688,8 @@
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/srcset": {
             "version": "4.0.0",
@@ -16988,9 +16713,9 @@
             }
         },
         "node_modules/std-env": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
-            "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
             "license": "MIT"
         },
         "node_modules/string_decoder": {
@@ -17088,6 +16813,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
             "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -17151,6 +16877,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -17305,7 +17032,9 @@
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/thunky": {
             "version": "1.1.0",
@@ -17322,6 +17051,15 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
             "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+        },
+        "node_modules/tinypool": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -17392,7 +17130,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "devOptional": true,
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
@@ -17460,6 +17198,7 @@
             "version": "5.7.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
             "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -17662,9 +17401,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-            "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -18512,15 +18251,6 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "license": "ISC"
         },
-        "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/yew-docs": {
             "resolved": "",
             "link": true
@@ -18529,6 +18259,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },

--- a/website/package.json
+++ b/website/package.json
@@ -17,9 +17,9 @@
         "fmt:write": "prettier --write ."
     },
     "dependencies": {
-        "@docusaurus/core": "^3.7.0",
-        "@docusaurus/plugin-client-redirects": "^3.7.0",
-        "@docusaurus/preset-classic": "^3.7.0",
+        "@docusaurus/core": "^3.8.1",
+        "@docusaurus/plugin-client-redirects": "^3.8.1",
+        "@docusaurus/preset-classic": "^3.8.1",
         "@mdx-js/react": "^3.1.0",
         "@svgr/webpack": "^8.1.0",
         "clsx": "^2.1.1",
@@ -48,7 +48,7 @@
     },
     "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.0.0",
-        "@docusaurus/tsconfig": "3.7.0",
+        "@docusaurus/tsconfig": "3.8.1",
         "@types/react": "^19.0.8",
         "@types/react-helmet": "^6.1.11",
         "@types/react-router-dom": "^5.3.3",


### PR DESCRIPTION
1. bumped docusaurus deps from 3.7.x to 3.8.1
2. Now we have an extra "OS color mode" option alongside light and dark (3.8.0 feature)
3. Made the OS color mode the default mode instead of "light" (docusaurus default)