### PR TITLE
website: update link to unmaintained documentation

### DIFF
--- a/website/versioned_docs/version-0.21/concepts/basic-web-technologies/js.mdx
+++ b/website/versioned_docs/version-0.21/concepts/basic-web-technologies/js.mdx
@@ -18,7 +18,7 @@ sometimes rely on calling JavaScript. What follows is an overview of the involve
 
 [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) is a library and tool that bridges calls between JavaScript and Rust functions.
 
-We highly recommend you take a look at their [documentation](https://rustwasm.github.io/docs/wasm-bindgen/) and our [quick guide](./wasm-bindgen.mdx).
+We highly recommend you take a look at their [documentation](https://wasm-bindgen.github.io/wasm-bindgen/) and our [quick guide](./wasm-bindgen.mdx).
 
 ## web-sys
 
@@ -50,4 +50,4 @@ let document = window()
 </TabItem>
 </Tabs>
 
-Once again we highly recommend you take a look at their [documentation](https://rustwasm.github.io/docs/wasm-bindgen/) and our [quick guide](./web-sys.mdx).
+Once again we highly recommend you take a look at their [documentation](https://wasm-bindgen.github.io/wasm-bindgen/) and our [quick guide](./web-sys.mdx).


### PR DESCRIPTION
#### Description

Documentation at https://rustwasm.github.io/docs/wasm-bindgen/ is no longer maintained. Add link to https://wasm-bindgen.github.io/wasm-bindgen/ instead.

<img width="2213" height="329" alt="image" src="https://github.com/user-attachments/assets/b7cd39b5-f899-43d0-9b2b-166d957be6e4" />
