### PR TITLE
Bugfix: rust-analyzer can't resolve symbols in #[function_component]

### DIFF
--- a/packages/yew-macro/src/hook/body.rs
+++ b/packages/yew-macro/src/hook/body.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use proc_macro_error::emit_error;
-use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
 use syn::{
     parse_quote_spanned, visit_mut, Expr, ExprCall, ExprClosure, ExprForLoop, ExprIf, ExprLoop,
@@ -52,7 +51,8 @@ impl VisitMut for BodyRewriter {
                             note = "see: https://yew.rs/docs/next/concepts/function-components/hooks"
                         );
                     } else {
-                        *i = parse_quote_spanned! { i.span() => ::yew::functional::Hook::run(#i, #ctx_ident) };
+                        // Use Span::call_site() instead of i.span() to fix rust-analyzer nav
+                        *i = parse_quote_spanned! { proc_macro2::Span::call_site() => ::yew::functional::Hook::run(#i, #ctx_ident) };
                     }
 
                     return;
@@ -78,7 +78,8 @@ impl VisitMut for BodyRewriter {
                                 note = "see: https://yew.rs/docs/next/concepts/function-components/hooks"
                             );
                         } else {
-                            *i = parse_quote_spanned! { i.span() => ::yew::functional::Hook::run(#i, #ctx_ident) };
+                            // Use Span::call_site() instead of i.span() to fix rust-analyzer nav
+                            *i = parse_quote_spanned! { proc_macro2::Span::call_site() => ::yew::functional::Hook::run(#i, #ctx_ident) };
                         }
                     } else {
                         visit_mut::visit_expr_macro_mut(self, m);


### PR DESCRIPTION
#### Description

**Problem:** When `yew-macro` is sourced from a remote (crates.io or github), `rust-analyzer` "control-click" resolution of code inside `#[function_component]` definitions fails to resolve; instead, it resolves to the top of the main `yew` crate.

**Cause:** apparently, spans get mangled during cross-crate resolution when the crate is from a remote such as crates.io or github, etc. When `yew-macro` is overridden with a local path patch in Cargo.toml, e.g.:
```toml
[patch.crates-io]
yew-macro = { version = "0.21", path = "/Users/tom/src/yew-macro-0.21.0" }
```,
even if the source is **copied verbatim** from the crates.io cache, this problem does not occur, making reproduction for the yew authors difficult.

**Solution:** anchor parse_quote_spanned! calls to their call sites.

**Impact:** fixes control-click editor navigation for all symbols in `#[function_component]` bodies.

Fixes #3904 

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [ ] I have added tests - **NO**
- [x] This requires human testing because it concerns `rust-analyzer` behavior inside of an IDE. Instead of tests, I have added comments to the changes to indicate why they were changed.
