### PR TITLE
ci: use action to avoid rate limiting

### DIFF
--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -32,8 +32,18 @@ jobs:
         with:
           version: 'latest'
 
+      - name: Get latest wasm-opt version
+        id: wasm-opt
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: WebAssembly/binaryen
+          excludes: prerelease, draft
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build examples
         run: cargo run -p build-examples --bin build-examples
+        env:
+          LATEST_WASM_OPT_VERSION: ${{ steps.wasm-opt.outputs.release }}
 
       - name: Deploy to Firebase
         uses: siku2/action-hosting-deploy@v1

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -59,8 +59,18 @@ jobs:
         with:
           version: "latest"
 
+      - name: Get latest wasm-opt version
+        id: wasm-opt
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: WebAssembly/binaryen
+          excludes: prerelease, draft
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build examples
         run: cargo run -p build-examples --bin build-examples
+        env:
+          LATEST_WASM_OPT_VERSION: ${{ steps.wasm-opt.outputs.release }}
 
       - name: Collect size information
         run: python3 ci/collect_sizes.py

--- a/tools/build-examples/src/lib.rs
+++ b/tools/build-examples/src/lib.rs
@@ -1,5 +1,5 @@
-use std::fs;
 use std::path::Path;
+use std::{env, fs};
 
 use serde::Deserialize;
 use toml::Table;
@@ -13,6 +13,16 @@ struct GitHubRelease {
 }
 
 pub fn get_latest_wasm_opt_version() -> String {
+    if let Ok(version) = env::var("LATEST_WASM_OPT_VERSION") {
+        if !version.is_empty() {
+            return version;
+        }
+    }
+
+    get_latest_wasm_opt_version_from_api()
+}
+
+fn get_latest_wasm_opt_version_from_api() -> String {
     let url = "https://api.github.com/repos/WebAssembly/binaryen/releases/latest";
     let client = reqwest::blocking::Client::new();
 


### PR DESCRIPTION
size comparison workflow was flaky due to rate limiting

```
thread 'main' (2243) panicked at tools/build-examples/src/lib.rs:35:9:
GitHub API request failed with status: 403 Forbidden. Details: {"message":"API rate limit exceeded for 13.83.216.100. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```

this fixes it by using an action authenticating with our github token