### PR TITLE
Only use create_element_ns if needed

### DIFF
--- a/packages/yew/src/dom_bundle/braw.rs
+++ b/packages/yew/src/dom_bundle/braw.rs
@@ -16,9 +16,13 @@ pub struct BRaw {
 
 impl BRaw {
     fn create_elements(html: &str, parent_namespace: Option<&str>) -> Vec<Node> {
-        let div = gloo::utils::document()
-            .create_element_ns(parent_namespace, "div")
-            .unwrap();
+        let div = if parent_namespace.is_some() {
+            gloo::utils::document()
+                .create_element_ns(parent_namespace, "div")
+                .unwrap()
+        } else {
+            gloo::utils::document().create_element("div").unwrap()
+        };
         div.set_inner_html(html);
         let children = div.child_nodes();
         let children = js_sys::Array::from(&children);


### PR DESCRIPTION
#### Description

##### Summary

Using `create_element_ns` in `BRaw::create_elements` without a namespace and setting the inner HTML to the source for an SVG (with a proper `xmlns` attribute) fails in Chrome because the inner elements are fixed with no namespace. To address this issue, I've updated `BRaw::create_elements` to use `create_element` when the parent namespace is `None`.

##### The Story

When I upgraded to yew 0.22, I found that SVGs were not rendering properly. The way I was including an SVG was as follows (simplified to remove the ability to choose the icon).

```rs
#[component(Icon)]
pub fn icon(props: &IconProps) -> Html {
	let inner_svg = Html::from_html_unchecked(AttrValue::from(include_str!("assets/arrow-down.svg")));
	html! {
		<div class={classes!("svg-icon-container", props.class.clone())} title={props.title.clone()} onclick={props.onclick.clone()}>
			{inner_svg}
		</div>
	}
}
```

This renders properly in Firefox with both the old and new version, but does not render properly in Chrome with yew 0.22.

I was able to reproduce the issue that arose due to [this commit](https://github.com/yewstack/yew/commit/dbdd3b78e1f0aada1834dec5c6ee83449db9d220). If you open [a blank page](about:blank) in Chrome and run these commands at the console, an icon is added to the page.

```
let div1 = document.createElement("div");
div1.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-arrow-right"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>';
document.body.appendChild(div1.childNodes[0]);
```

If you change the first line to `createElementNS` with `null` for the namespace, an icon does not appear, but you can still see it if you inspect the page.

```
let div2 = document.createElementNS(null, "div");
div2.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-arrow-right"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>';
document.body.appendChild(div2.childNodes[0]);
```

Here is an image showing the `<svg>` in the inspect pane that is not rendered.

<img width="928" height="308" alt="image" src="https://github.com/user-attachments/assets/1daedac7-8b3b-4703-8dce-2c5a91ea11e6" />

If you inspect the namespace of the two SVG elements, you can see that Chrome has left the namespace blank on the second one.

<img width="566" height="403" alt="image" src="https://github.com/user-attachments/assets/f3b28ea8-5294-4d1f-8918-02b35c0bda8e" />

#### Checklist

I can't figure out a way to test this fix as it seems the tests are run in Firefox anyway.

- [X] I have reviewed my own code
- [ ] I have added tests
