### PR TITLE
bug fix: in update, ToggleEdit(idx) holds an index to the unfiltered …

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -62,12 +62,7 @@ impl Component for App {
                 self.state.filter = filter;
             }
             Msg::ToggleEdit(idx) => {
-                let entry = self
-                    .state
-                    .entries
-                    .iter()
-                    .nth(idx)
-                    .unwrap();
+                let entry = self.state.entries.get(idx).unwrap();
                 self.state.edit_value.clone_from(&entry.description);
                 self.state.clear_all_edit();
                 self.state.toggle_edit(idx);


### PR DESCRIPTION
#### Description

Fixes a bug where double-clicking to edit a task in the filtered view would edit the wrong task.

**The Problem:**
- When filtering tasks (Active/Completed/All), the UI displays a filtered subset
- Double-clicking a task passes its index in the **unfiltered** list to `ToggleEdit`
- The `ToggleEdit` handler incorrectly filtered the list before looking up the index
- This caused an "off-by-n" error where the wrong task would be edited

**Steps to reproduce:**
1. Create 3 tasks
2. Mark the first task as completed
3. Filter to show only "Active" tasks (2 tasks remain)
4. Double-click the first visible task to edit it
5. **Bug**: The edit field shows the description of task #2 instead of task #1

**The Fix:**
Remove the `.filter()` call in the `ToggleEdit` handler since we're already using the correct unfiltered index.

Fixes #0000 <!-- replace with issue number or remove if not applicable -->

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ x] I have reviewed my own code
- [ x] I have tested the app in a browser
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
