### PR TITLE
docs: Move down inactive css styling solutions

### DIFF
--- a/website/docs/more/css.mdx
+++ b/website/docs/more/css.mdx
@@ -2,29 +2,27 @@
 title: 'CSS'
 ---
 
-A proposal for integrated CSS support can be found here:
-[https://github.com/yewstack/yew/issues/533](https://github.com/yewstack/yew/issues/533)
-
-This contains a lot of discussion about how to best integrate CSS support into Yew.
-
-Currently, the approach we have adopted is to encourage developers to build many systems, before
-adopting the most popular one.
-
-The community is currently developing several projects to make it easy to add styles to
-projects. A few are given below:
-
-#### Component Libraries
-
-- [yew_styles](https://github.com/spielrs/yew_styles) - A styling framework for Yew without any JavaScript dependencies.
-- [yew-mdc](https://github.com/Follpvosten/yew-mdc) - Material Design Components.
-- [muicss-yew](https://github.com/AlephAlpha/muicss-yew) - MUI CSS Components.
-- [Yewtify](https://github.com/yewstack/yewtify) – Implements the features provided by the Vuetify framework in Yew.
+Yew does not ship built-in CSS support, but the community maintains several styling
+solutions. Below are actively maintained projects you can use today.
 
 #### Styling Solutions
 
-- [stylist](https://github.com/futursolo/stylist-rs) - A CSS-in-Rust styling solution for WebAssembly Applications.
+- [stylist](https://github.com/futursolo/stylist-rs) - A CSS-in-Rust styling solution.
 - [tailwind-css](https://github.com/thedodd/trunk/tree/master/examples/yew-tailwindcss) - Tailwind Utility Classes.
 
 :::important contribute
 If you're developing a project adding styles to Yew please submit a PR adding yourself to this list!
 :::
+
+---
+
+#### Inactive Projects
+
+The projects below are no longer actively maintained but may still serve as useful
+references for learning or as starting points for new efforts. If you're interested
+in reviving or continuing any of them, contributions are welcome!
+
+- [yew_styles](https://github.com/spielrs/yew_styles) - A styling framework for Yew without any JavaScript dependencies.
+- [yew-mdc](https://github.com/Follpvosten/yew-mdc) - Material Design Components.
+- [muicss-yew](https://github.com/AlephAlpha/muicss-yew) - MUI CSS Components.
+- [Yewtify](https://github.com/yewstack/yewtify) – Implements the features provided by the Vuetify framework in Yew.


### PR DESCRIPTION
#### Description

Mark CSS component libraries as inactive in the docs 


### Inactive

| Project | Last Activity | Status |
|---------|--------------|--------|
| **yew_styles** | Last commit: Nov 2021 | 21 open issues, docs website is down. ~4+ years stale. |
| **yew-mdc** | Last commit: May 2020 | ~6 years stale. |
| **muicss-yew** | Last commit: Apr 2021 | Marked [WIP], ~5 years stale. |
| **Yewtify** | Last commit: Nov 2020 | Under yewstack org but ~5 years stale, 5 unanswered issues. |

### Active

| Project | Last Activity | Status |
|---------|--------------|--------|
| **stylist-rs** | Last commit: Feb 2026 (v0.14.0 released) | Actively maintained. CSS-in-Rust solution. |
| **trunk tailwind example** | trunk pushed: Feb 2026, example still exists | Still valid. The `yew-tailwindcss` example is present in the trunk repo which is actively maintained. |

Fixes #3915 

