### PR TITLE
fix: emit clear error for miscapitalized HTML attribute names

### DIFF
--- a/packages/yew-macro/tests/html_macro/element-fail.rs
+++ b/packages/yew-macro/tests/html_macro/element-fail.rs
@@ -88,6 +88,11 @@ fn compile_fail() {
     html! { <input type=() /> };
     html! { <input value=() /> };
     html! { <input string=NotToString /> };
+
+    // case-insensitive attribute collision (issue #3996)
+    html! { <form onSubmit={Callback::from(|_e: SubmitEvent| {})} /> };
+    html! { <input onClick={Callback::from(|_e: MouseEvent| {})} /> };
+    html! { <input Disabled=true /> };
 }
 
 fn main() {}

--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -339,6 +339,24 @@ error: the property value must be either a literal or enclosed in braces. Consid
 90 |     html! { <input string=NotToString /> };
    |                           ^^^^^^^^^^^
 
+error: HTML attribute names are case-insensitive. Did you mean `onsubmit`?
+  --> tests/html_macro/element-fail.rs:93:19
+   |
+93 |     html! { <form onSubmit={Callback::from(|_e: SubmitEvent| {})} /> };
+   |                   ^^^^^^^^
+
+error: HTML attribute names are case-insensitive. Did you mean `onclick`?
+  --> tests/html_macro/element-fail.rs:94:20
+   |
+94 |     html! { <input onClick={Callback::from(|_e: MouseEvent| {})} /> };
+   |                    ^^^^^^^
+
+error: HTML attribute names are case-insensitive. Did you mean `disabled`?
+  --> tests/html_macro/element-fail.rs:95:20
+   |
+95 |     html! { <input Disabled=true /> };
+   |                    ^^^^^^^^
+
 error[E0308]: mismatched types
   --> tests/html_macro/element-fail.rs:36:28
    |


### PR DESCRIPTION
#### Description

When an attribute like `onSubmit` doesn't exactly match a known listener/boolean/special prop but matches case-insensitively, emit "Did you mean `onsubmit`?" instead of a cryptic IntoPropValue trait bound error.

Fixes #3996

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
