### PR TITLE
fix: explicitly type MouseEvent in website code snippet

### DIFF
--- a/website/docs/concepts/basic-web-technologies/web-sys.mdx
+++ b/website/docs/concepts/basic-web-technologies/web-sys.mdx
@@ -166,7 +166,7 @@ features = [
 use wasm_bindgen::{prelude::Closure, JsCast};
 use web_sys::{console, Document, HtmlElement, MouseEvent};
 
-let mousemove = Closure::<dyn Fn(MouseEvent)>::wrap(Box::new(|e| {
+let mousemove = Closure::<dyn Fn(MouseEvent)>::wrap(Box::new(|e: MouseEvent| {
     let rect = e
         .target()
         .expect("mouse event doesn't have a target")


### PR DESCRIPTION
https://github.com/wasm-bindgen/wasm-bindgen/pull/4893 (January 22, 2026) made it necessary to add an explicity type here
