### PR TITLE
fix: set default-features = false for futures at workspace level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -934,17 +933,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ web-sys = "0.3"
 gloo = "0.11"
 serde = "1"
 serde_json = "1"
-futures = "0.3"
+futures = { version = "0.3", default-features = false }
 log = "0.4"
 wasm-logger = "0.2"
 rand = "0.9"

--- a/examples/ssr_router/Cargo.toml
+++ b/examples/ssr_router/Cargo.toml
@@ -17,7 +17,7 @@ required-features = ["ssr"]
 yew = { path = "../../packages/yew" }
 function_router = { path = "../function_router" }
 log = "0.4"
-futures = { workspace = true, features = ["std"], default-features = false }
+futures = { workspace = true, features = ["std"] }
 hyper-util = "0.1.17"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -25,7 +25,7 @@ slab = "0.4"
 wasm-bindgen.workspace = true
 yew-macro = { version = "^0.22.0", path = "../yew-macro" }
 thiserror.workspace = true
-futures = { workspace = true, default-features = false, features = ["std"] }
+futures = { workspace = true, features = ["std"] }
 html-escape = { version = "0.2.13", optional = true }
 implicit-clone = { workspace = true, features = ["map"] }
 base64ct = { version = "1.6.0", features = ["std"], optional = true }


### PR DESCRIPTION
as per a cargo warning. member crate level default-features are ignored and might become a hard error in the future