### PR TITLE
chore: replace once_cell with std equivalents (LazyLock, OnceLock)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,6 @@ dependencies = [
  "chrono",
  "clap",
  "git2",
- "once_cell",
  "regex",
  "reqwest",
  "semver",
@@ -1899,7 +1898,6 @@ name = "js_callback"
 version = "0.1.0"
 dependencies = [
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "yew",
@@ -4204,7 +4202,6 @@ name = "yew-macro"
 version = "0.22.0"
 dependencies = [
  "implicit-clone",
- "once_cell",
  "prettyplease",
  "proc-macro-error",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ wasm-logger = "0.2"
 rand = "0.9"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
-once_cell = "1"
 rustversion = "1"
 strum = "0.27"
 strum_macros = "0.27"

--- a/examples/js_callback/Cargo.toml
+++ b/examples/js_callback/Cargo.toml
@@ -10,4 +10,3 @@ wasm-bindgen.workspace = true
 yew = { path = "../../packages/yew", features = ["csr"] }
 wasm-bindgen-futures.workspace = true
 js-sys.workspace = true
-once_cell.workspace = true

--- a/examples/js_callback/src/main.rs
+++ b/examples/js_callback/src/main.rs
@@ -1,4 +1,5 @@
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
+
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
@@ -7,7 +8,7 @@ use yew::suspense::{use_future, SuspensionResult};
 
 mod bindings;
 
-static WASM_BINDGEN_SNIPPETS_PATH: OnceCell<String> = OnceCell::new();
+static WASM_BINDGEN_SNIPPETS_PATH: OnceLock<String> = OnceLock::new();
 
 #[function_component]
 fn Important() -> Html {

--- a/packages/yew-macro/Cargo.toml
+++ b/packages/yew-macro/Cargo.toml
@@ -20,7 +20,6 @@ proc-macro-error = "1"
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
-once_cell.workspace = true
 prettyplease = "0.2"
 rustversion.workspace = true
 

--- a/packages/yew-macro/src/props/element.rs
+++ b/packages/yew-macro/src/props/element.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
 use syn::parse::{Parse, ParseStream};
 
 use super::{Prop, Props, SpecialProps};
@@ -48,7 +48,7 @@ impl Parse for ElementProps {
     }
 }
 
-static BOOLEAN_SET: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+static BOOLEAN_SET: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     [
         // Living Standard
         // From: https://html.spec.whatwg.org/#attributes-3
@@ -85,7 +85,7 @@ static BOOLEAN_SET: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     .into()
 });
 
-static LISTENER_SET: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+static LISTENER_SET: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     [
         // Living Standard
         // From: https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers

--- a/tools/changelog/Cargo.toml
+++ b/tools/changelog/Cargo.toml
@@ -16,4 +16,3 @@ serde = { workspace = true, features = ["derive"] }
 strum = { workspace = true, features = ["derive"] }
 clap = { workspace = true }
 semver = "1.0"
-once_cell.workspace = true

--- a/tools/changelog/src/create_log_line.rs
+++ b/tools/changelog/src/create_log_line.rs
@@ -1,18 +1,17 @@
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 use anyhow::{anyhow, Context, Result};
 use git2::{Error, Oid, Repository};
-use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::github_issue_labels_fetcher::GitHubIssueLabelsFetcher;
 use crate::github_user_fetcher::GitHubUsersFetcher;
 use crate::log_line::LogLine;
 
-static REGEX_FOR_ISSUE_ID_CAPTURE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\s*\(#(\d+)\)").unwrap());
-static GITHUB_ISSUE_LABELS_FETCHER: Lazy<Mutex<GitHubIssueLabelsFetcher>> =
-    Lazy::new(Default::default);
+static REGEX_FOR_ISSUE_ID_CAPTURE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\s*\(#(\d+)\)").unwrap());
+static GITHUB_ISSUE_LABELS_FETCHER: LazyLock<Mutex<GitHubIssueLabelsFetcher>> =
+    LazyLock::new(Default::default);
 
 pub fn create_log_line(
     repo: &Repository,


### PR DESCRIPTION
#### Description

we are able to drop once_cell entirely now.

#### Checklist

- [x] I have reviewed my own code

