### PR TITLE
fix: allow bare None for Option props in html! macro

### DIFF
--- a/packages/yew/src/html/conversion/into_prop_value.rs
+++ b/packages/yew/src/html/conversion/into_prop_value.rs
@@ -570,4 +570,80 @@ mod test {
             let _ = html! { <Child>{&attr_value}</Child> };
         }
     }
+
+    #[test]
+    fn test_bare_none_option_string_prop() {
+        use crate::prelude::*;
+
+        #[derive(PartialEq, Properties)]
+        pub struct Props {
+            pub foo: Option<String>,
+        }
+
+        #[component]
+        fn Comp(_props: &Props) -> Html {
+            html! {}
+        }
+
+        let _ = html! { <Comp foo={None} /> };
+        let _ = html! { <Comp foo="hello" /> };
+        let _ = html! { <Comp foo={Some("hello")} /> };
+    }
+
+    #[test]
+    fn test_bare_none_option_attr_value_prop() {
+        use crate::prelude::*;
+
+        #[derive(PartialEq, Properties)]
+        pub struct Props {
+            pub foo: Option<AttrValue>,
+        }
+
+        #[component]
+        fn Comp(_props: &Props) -> Html {
+            html! {}
+        }
+
+        let _ = html! { <Comp foo={None} /> };
+        let _ = html! { <Comp foo="hello" /> };
+        let _ = html! { <Comp foo={AttrValue::from("hello")} /> };
+    }
+
+    #[test]
+    fn test_bare_none_option_html_prop() {
+        use crate::prelude::*;
+
+        #[derive(PartialEq, Properties)]
+        pub struct Props {
+            pub title: Option<Html>,
+        }
+
+        #[component]
+        fn Comp(_props: &Props) -> Html {
+            html! {}
+        }
+
+        let _ = html! { <Comp title={None} /> };
+        let _ = html! { <Comp title={Option::<Html>::None} /> };
+    }
+
+    #[test]
+    fn test_bare_none_optional_prop_with_default() {
+        use crate::prelude::*;
+
+        #[derive(PartialEq, Properties)]
+        pub struct Props {
+            #[prop_or_default]
+            pub foo: Option<String>,
+        }
+
+        #[component]
+        fn Comp(_props: &Props) -> Html {
+            html! {}
+        }
+
+        let _ = html! { <Comp foo={None} /> };
+        let _ = html! { <Comp foo="hello" /> };
+        let _ = html! { <Comp /> };
+    }
 }


### PR DESCRIPTION
Fixes #3747
Unblocks #4020 


- `Properties` derive: for props whose type is `Option<_>`, generates an additional `{name}_none()` setter that assigns `Some(None)` directly, bypassing `IntoPropValue`
- `html!` macro: detects when a prop value is literally `None` and routes to the `_none` setter instead of the normal one

This means `None` never goes through trait resolution, so it works regardless of how many `IntoPropValue<Option<T>>` impls exist.

#### Caveat

If a user passes `None` to a non-`Option` prop (e.g. `foo: String` with `foo={None}`), the error changes from a type inference failure to `no method named foo_none found`. It might be a bit cryptic to the user but both are compile errors pointing to the correct line, only the message text differs. I think this is acceptible as it is an uncommon mistake.

#### checklist

- [x] I have reviewed my own code
- [x] I have added tests
