### PR TITLE
fix: correct version label showing duplicate "Next" in localized pages

### DIFF
--- a/website/i18n/ja/docusaurus-plugin-content-docs/version-0.22.json
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/version-0.22.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "0.22",
     "description": "The label for version 0.22"
   },
   "sidebar.docs.category.Getting Started": {

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.22.json
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.22.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "0.22",
     "description": "The label for version 0.22"
   },
   "sidebar.docs.category.Getting Started": {

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/version-0.22.json
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/version-0.22.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "0.22",
     "description": "The label for version 0.22"
   },
   "sidebar.docs.category.Getting Started": {


### PR DESCRIPTION
fixes the issue that Localized pages like `yew.rs/ja` have two "Next" in the version selection dropdown

Seems like a miss when 0.22.0 was released