### PR TITLE
fix(yew-router): use path instead of basename in strip_basename fallback

### DIFF
--- a/packages/yew-router/src/navigator.rs
+++ b/packages/yew-router/src/navigator.rs
@@ -177,7 +177,7 @@ impl Navigator {
                     .unwrap_or(path);
 
                 if !path.starts_with('/') {
-                    path = format!("/{m}").into();
+                    path = format!("/{path}").into();
                 }
 
                 path


### PR DESCRIPTION
Fixes #4028
