### PR TITLE
ci: improve rust-cache configuration for 100 GB cache limit

### DIFF
--- a/.github/workflows/benchmark-core.yml
+++ b/.github/workflows/benchmark-core.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Restore Rust cache for yew packages
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: yew-packages
           workspaces: |
             yew-master
             current-pr

--- a/.github/workflows/benchmark-ssr.yml
+++ b/.github/workflows/benchmark-ssr.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Restore Rust cache for yew packages
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: yew-packages
           workspaces: |
             yew-master
             current-pr

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Restore Rust cache for yew packages
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: yew-packages
+          save-if: ${{ github.ref == 'refs/heads/master' }}
           workspaces: |
             yew
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: clippy
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Lint feature soundness
         if: matrix.profile == 'dev'
@@ -66,7 +66,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: clippy
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run clippy
         run: |

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -25,9 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: yew-packages
 
       # for wasm-bindgen-cli, always use stable rust
       - name: Setup toolchain
@@ -35,15 +32,19 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install wasm-bindgen-cli
-        shell: bash
-        run: ./ci/install-wasm-bindgen-cli.sh
-
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Install wasm-bindgen-cli
+        shell: bash
+        run: ./ci/install-wasm-bindgen-cli.sh
 
       - uses: browser-actions/setup-geckodriver@latest
         with:
@@ -73,25 +74,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: yew-packages
-
       # for wasm-bindgen-cli, always use stable rust
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
 
-      - name: Install wasm-bindgen-cli
-        shell: bash
-        run: ./ci/install-wasm-bindgen-cli.sh
-
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
           targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Install wasm-bindgen-cli
+        shell: bash
+        run: ./ci/install-wasm-bindgen-cli.sh
 
       - uses: browser-actions/setup-geckodriver@latest
         with:
@@ -132,7 +133,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: yew-packages
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run native tests
         env:
@@ -162,7 +163,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: yew-packages
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run tests
         env:
@@ -197,6 +198,8 @@ jobs:
           source ~/.bashrc
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run WASI tests for yew
         run: |
@@ -232,6 +235,8 @@ jobs:
           source ~/.bashrc
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Build and run ${{ matrix.package }}
         run: |

--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -25,8 +25,6 @@ jobs:
           components: rust-src
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: publish-examples
 
       - uses: jetli/trunk-action@v0.5.1
         with:

--- a/.github/workflows/size-cmp.yml
+++ b/.github/workflows/size-cmp.yml
@@ -49,10 +49,8 @@ jobs:
           components: rust-src
           targets: wasm32-unknown-unknown
 
-      - name: Restore Rust cache for master
+      - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: size-compare
 
       - name: Setup Trunk
         uses: jetli/trunk-action@v0.5.1

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: yew-packages
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - uses: browser-actions/setup-geckodriver@latest
         with:


### PR DESCRIPTION
#### Description

- Remove all `shared-key` parameters from `Swatinem/rust-cache`, letting each job use the default `add-job-id-key` for per-job cache isolation
- Add `save-if: ${{ github.ref == 'refs/heads/master' }}` so only master builds save caches (PRs restore from master but don't save)
- Fix step ordering in `doc_tests` and `integration_tests` so `rust-cache` runs after toolchain setup (as required by the action's README)

#### Background

PR #3520 identified that using `shared-key` causes unrelated jobs to share cache entries, leading to suboptimal cache usage. However, the fix was blocked by the 10 GB cache size limit.

PR #3711 then intentionally added `shared-key` everywhere to minimize the number of cache entries, trading cache accuracy for smaller total size.

Now that the GitHub Actions cache limit has been raised to 100 GB (thanks to @siku2 ), we can afford per-job caching. This PR revisits the approach from #3520 and goes further:
