### PR TITLE
fix comment readibility in code fences in dark mode

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -24,11 +24,5 @@
     --ifm-color-primary-light: #3ad9b7;
     --ifm-color-primary-lighter: #44dbba;
     --ifm-color-primary-lightest: #64e1c6;
-}
-
-.docusaurus-highlight-code-line {
-    background-color: rgb(72, 77, 91);
-    display: block;
-    margin: 0 calc(-1 * var(--ifm-pre-padding));
-    padding: 0 var(--ifm-pre-padding);
+    --docusaurus-highlighted-code-line-bg: rgb(55 60 75);
 }


### PR DESCRIPTION
#### Description

docusaurus v3 has a different rule name so our outdated css was doing nothing.

Also v3 default is is the same as the one mentioned in #3540 so it's indeed a very hard to read.

Fixes #3504

##### before:

<img width="571" height="62" alt="image" src="https://github.com/user-attachments/assets/0872e3e0-e382-4969-bf06-c61be1e7c192" />

##### after:

<img width="573" height="63" alt="image" src="https://github.com/user-attachments/assets/9b414db1-8d53-445e-9edb-99e327c48a3a" />


#### Checklist

- [x] I have reviewed my own code