### PR TITLE
fix: resolve clippy warnings introduced in Rust 1.94

### DIFF
--- a/examples/function_router/src/components/pagination.rs
+++ b/examples/function_router/src/components/pagination.rs
@@ -131,12 +131,12 @@ pub fn Links(props: &Props) -> Html {
         page, total_pages, ..
     } = *props;
 
-    let pages_prev = page.checked_sub(1).unwrap_or_default() as usize;
+    let pages_prev = page.saturating_sub(1) as usize;
     let pages_next = (total_pages - page) as usize;
 
     let links_left = LINKS_PER_SIDE.min(pages_prev)
             // if there are less than `LINKS_PER_SIDE` to the right, we add some more on the left.
-            + LINKS_PER_SIDE.checked_sub(pages_next).unwrap_or_default();
+            + LINKS_PER_SIDE.saturating_sub(pages_next);
     let links_right = 2 * LINKS_PER_SIDE - links_left;
 
     html! {

--- a/examples/keyed_list/src/main.rs
+++ b/examples/keyed_list/src/main.rs
@@ -106,8 +106,7 @@ impl Component for App {
                 true
             }
             Msg::SortById => {
-                self.persons
-                    .sort_unstable_by(|a, b| a.info().id.cmp(&b.info().id));
+                self.persons.sort_unstable_by_key(|a| a.info().id);
                 true
             }
             Msg::SortByName => {

--- a/examples/router/src/components/pagination.rs
+++ b/examples/router/src/components/pagination.rs
@@ -95,12 +95,12 @@ impl Pagination {
             page, total_pages, ..
         } = *props;
 
-        let pages_prev = page.checked_sub(1).unwrap_or_default() as usize;
+        let pages_prev = page.saturating_sub(1) as usize;
         let pages_next = (total_pages - page) as usize;
 
         let links_left = LINKS_PER_SIDE.min(pages_prev)
             // if there are less than `LINKS_PER_SIDE` to the right, we add some more on the left.
-            + LINKS_PER_SIDE.checked_sub(pages_next).unwrap_or_default();
+            + LINKS_PER_SIDE.saturating_sub(pages_next);
         let links_right = 2 * LINKS_PER_SIDE - links_left;
 
         html! {

--- a/packages/yew-macro/src/html_tree/tag.rs
+++ b/packages/yew-macro/src/html_tree/tag.rs
@@ -107,14 +107,12 @@ impl TagTokens {
             let next = input.parse()?;
             if let TokenTree::Punct(punct) = &next {
                 match punct.as_char() {
-                    '/' => {
-                        if angle_count == 1 && input.peek(Token![>]) {
-                            div = Some(syn::token::Slash {
-                                spans: [punct.span()],
-                            });
-                            gt = input.parse()?;
-                            break;
-                        }
+                    '/' if angle_count == 1 && input.peek(Token![>]) => {
+                        div = Some(syn::token::Slash {
+                            spans: [punct.span()],
+                        });
+                        gt = input.parse()?;
+                        break;
                     }
                     '>' => {
                         angle_count = angle_count.checked_sub(1).ok_or_else(|| {

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -175,19 +175,20 @@ impl Reconcilable for VTag {
         match bundle {
             // If the ancestor is a tag of the same type, don't recreate, keep the
             // old tag and update its attributes and children.
-            BNode::Tag(ex) if self.key == ex.key => {
-                if match (&self.inner, &ex.inner) {
-                    (VTagInner::Input(_), BTagInner::Input(_)) => true,
-                    (VTagInner::Textarea { .. }, BTagInner::Textarea { .. }) => true,
-                    (VTagInner::Other { tag: l, .. }, BTagInner::Other { tag: r, .. })
-                        if l == r =>
-                    {
-                        true
-                    }
-                    _ => false,
-                } {
-                    return self.reconcile(root, parent_scope, parent, slot, ex.deref_mut());
-                }
+            BNode::Tag(ex)
+                if self.key == ex.key
+                    && match (&self.inner, &ex.inner) {
+                        (VTagInner::Input(_), BTagInner::Input(_)) => true,
+                        (VTagInner::Textarea { .. }, BTagInner::Textarea { .. }) => true,
+                        (VTagInner::Other { tag: l, .. }, BTagInner::Other { tag: r, .. })
+                            if l == r =>
+                        {
+                            true
+                        }
+                        _ => false,
+                    } =>
+            {
+                return self.reconcile(root, parent_scope, parent, slot, ex.deref_mut());
             }
             _ => {}
         };

--- a/packages/yew/src/html/component/lifecycle.rs
+++ b/packages/yew/src/html/component/lifecycle.rs
@@ -192,14 +192,13 @@ where
     }
 
     fn flush_messages(&mut self) -> bool {
-        self.context
-            .link()
-            .pending_messages
-            .drain()
-            .into_iter()
-            .fold(false, |acc, msg| {
-                self.component.update(&self.context, msg) || acc
-            })
+        let mut changed = false;
+        for msg in self.context.link().pending_messages.drain() {
+            if self.component.update(&self.context, msg) {
+                changed = true;
+            }
+        }
+        changed
     }
 
     #[cfg(feature = "csr")]


### PR DESCRIPTION
#### Description
Rust 1.94 released today.
CI borked because clippy has become more capable.