### PR TITLE
fix: add IntoPropValue impls for Cow<'static, str>

### DIFF
--- a/packages/yew-macro/tests/html_macro/element-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/element-fail.stderr
@@ -472,7 +472,7 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<implicit_clone:
              `&'static [(K, V)]` implements `IntoPropValue<implicit_clone::unsync::map::IMap<K, V>>`
              `&'static [T]` implements `IntoPropValue<implicit_clone::unsync::array::IArray<T>>`
              `&'static str` implements `IntoPropValue<Classes>`
-             `&'static str` implements `IntoPropValue<Option<String>>`
+             `&'static str` implements `IntoPropValue<Cow<'static, str>>`
            and $N others
 
 error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not satisfied
@@ -487,12 +487,12 @@ error[E0277]: the trait bound `Option<NotToString>: IntoPropValue<Option<implici
    = help: the following other types implement trait `IntoPropValue<T>`:
              `Option<&String>` implements `IntoPropValue<Option<VNode>>`
              `Option<&implicit_clone::unsync::string::IString>` implements `IntoPropValue<Option<VNode>>`
+             `Option<&str>` implements `IntoPropValue<Option<Cow<'_, str>>>`
              `Option<&str>` implements `IntoPropValue<Option<String>>`
              `Option<&str>` implements `IntoPropValue<Option<VNode>>`
              `Option<&str>` implements `IntoPropValue<Option<implicit_clone::unsync::string::IString>>`
              `Option<Arc<String>>` implements `IntoPropValue<Option<VNode>>`
              `Option<Arc<str>>` implements `IntoPropValue<Option<VNode>>`
-             `Option<Cow<'_, str>>` implements `IntoPropValue<Option<VNode>>`
            and $N others
 
 error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_clone::unsync::string::IString>>` is not satisfied
@@ -507,12 +507,12 @@ error[E0277]: the trait bound `Option<{integer}>: IntoPropValue<Option<implicit_
    = help: the following other types implement trait `IntoPropValue<T>`:
              `Option<&String>` implements `IntoPropValue<Option<VNode>>`
              `Option<&implicit_clone::unsync::string::IString>` implements `IntoPropValue<Option<VNode>>`
+             `Option<&str>` implements `IntoPropValue<Option<Cow<'_, str>>>`
              `Option<&str>` implements `IntoPropValue<Option<String>>`
              `Option<&str>` implements `IntoPropValue<Option<VNode>>`
              `Option<&str>` implements `IntoPropValue<Option<implicit_clone::unsync::string::IString>>`
              `Option<Arc<String>>` implements `IntoPropValue<Option<VNode>>`
              `Option<Arc<str>>` implements `IntoPropValue<Option<VNode>>`
-             `Option<Cow<'_, str>>` implements `IntoPropValue<Option<VNode>>`
            and $N others
 
 error[E0277]: the trait bound `{integer}: IntoEventCallback<MouseEvent>` is not satisfied
@@ -625,12 +625,12 @@ error[E0277]: the trait bound `Option<yew::NodeRef>: IntoPropValue<yew::NodeRef>
    = help: the following other types implement trait `IntoPropValue<T>`:
              `Option<&String>` implements `IntoPropValue<Option<VNode>>`
              `Option<&implicit_clone::unsync::string::IString>` implements `IntoPropValue<Option<VNode>>`
+             `Option<&str>` implements `IntoPropValue<Option<Cow<'_, str>>>`
              `Option<&str>` implements `IntoPropValue<Option<String>>`
              `Option<&str>` implements `IntoPropValue<Option<VNode>>`
              `Option<&str>` implements `IntoPropValue<Option<implicit_clone::unsync::string::IString>>`
              `Option<Arc<String>>` implements `IntoPropValue<Option<VNode>>`
              `Option<Arc<str>>` implements `IntoPropValue<Option<VNode>>`
-             `Option<Cow<'_, str>>` implements `IntoPropValue<Option<VNode>>`
            and $N others
 
 error[E0277]: the trait bound `yew::Callback<String>: IntoEventCallback<MouseEvent>` is not satisfied
@@ -675,7 +675,7 @@ error[E0277]: the trait bound `NotToString: IntoPropValue<Option<implicit_clone:
              `&'static [(K, V)]` implements `IntoPropValue<implicit_clone::unsync::map::IMap<K, V>>`
              `&'static [T]` implements `IntoPropValue<implicit_clone::unsync::array::IArray<T>>`
              `&'static str` implements `IntoPropValue<Classes>`
-             `&'static str` implements `IntoPropValue<Option<String>>`
+             `&'static str` implements `IntoPropValue<Cow<'static, str>>`
            and $N others
 
 error[E0277]: the trait bound `(): IntoPropValue<yew::NodeRef>` is not satisfied

--- a/packages/yew/src/html/conversion/into_prop_value.rs
+++ b/packages/yew/src/html/conversion/into_prop_value.rs
@@ -255,6 +255,9 @@ impl_into_prop!(|value: &'static str| -> AttrValue { AttrValue::Static(value) })
 impl_into_prop!(|value: String| -> AttrValue { AttrValue::Rc(Rc::from(value)) });
 impl_into_prop!(|value: Rc<str>| -> AttrValue { AttrValue::Rc(value) });
 impl_into_prop!(|value: Cow<'static, str>| -> AttrValue { AttrValue::from(value) });
+impl_into_prop!(|value: &'static str| -> Cow<'static, str> { Cow::Borrowed(value) });
+impl_into_prop!(|value: String| -> Cow<'static, str> { Cow::Owned(value) });
+impl_into_prop!(|value: Rc<str>| -> Cow<'static, str> { Cow::Owned(value.to_string()) });
 
 impl<T: ImplicitClone + 'static> IntoPropValue<IArray<T>> for &'static [T] {
     fn into_prop_value(self) -> IArray<T> {
@@ -384,6 +387,12 @@ mod test {
         let _: Option<AttrValue> = "foo".into_prop_value();
         let _: Option<AttrValue> = Rc::<str>::from("foo").into_prop_value();
         let _: Option<AttrValue> = Cow::Borrowed("foo").into_prop_value();
+        let _: Cow<'static, str> = "foo".into_prop_value();
+        let _: Cow<'static, str> = String::from("foo").into_prop_value();
+        let _: Cow<'static, str> = Rc::<str>::from("foo").into_prop_value();
+        let _: Option<Cow<'static, str>> = Some("foo").into_prop_value();
+        let _: Option<Cow<'static, str>> = Some(String::from("foo")).into_prop_value();
+        let _: Option<Cow<'static, str>> = Some(Rc::<str>::from("foo")).into_prop_value();
     }
 
     #[test]


### PR DESCRIPTION

#### Description

The dynamic tag name issue (`<@{value} />` requiring `Cow<'static, str>`) was already resolved in #3431, which switched to `Into<AttrValue>`.

The remaining gap was that component props typed as `Cow<'static, str>` could not accept common string types directly in the `html!` macro. This PR adds the missing `IntoPropValue` implementations:
  - `&'static str` to `Cow<'static, str>` (zero-cost via `Cow::Borrowed`)
  - `String` to `Cow<'static, str>` (via `Cow::Owned`)
  - `Rc<str>` to `Cow<'static, str>` (via `Cow::Owned`)

fixed now.

Fixes #3524

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests