### PR TITLE
fix: add #[must_use] to Hook trait to warn on invalid placement

### DIFF
--- a/packages/yew-macro/tests/hook_attr/hook-must-use-fail.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-must-use-fail.rs
@@ -1,0 +1,9 @@
+#![deny(unused_must_use)]
+
+use yew::prelude::*;
+
+fn not_a_hook() {
+    use_effect_with((), |_| {});
+}
+
+fn main() {}

--- a/packages/yew-macro/tests/hook_attr/hook-must-use-fail.stderr
+++ b/packages/yew-macro/tests/hook_attr/hook-must-use-fail.stderr
@@ -1,0 +1,12 @@
+error: unused implementer of `Hook` that must be used
+ --> tests/hook_attr/hook-must-use-fail.rs:6:5
+  |
+6 |     use_effect_with((), |_| {});
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: hooks do nothing unless called inside a `#[hook]` or `#[component]` function
+note: the lint level is defined here
+ --> tests/hook_attr/hook-must-use-fail.rs:1:9
+  |
+1 | #![deny(unused_must_use)]
+  |         ^^^^^^^^^^^^^^^

--- a/packages/yew-macro/tests/hook_attr/hook-must-use-pass.rs
+++ b/packages/yew-macro/tests/hook_attr/hook-must-use-pass.rs
@@ -1,0 +1,17 @@
+#![deny(unused_must_use)]
+
+use yew::prelude::*;
+
+#[hook]
+fn use_my_effect() {
+    use_effect_with((), |_| {});
+}
+
+#[component]
+fn Comp() -> Html {
+    use_effect_with((), |_| {});
+    use_my_effect();
+    html! {}
+}
+
+fn main() {}

--- a/packages/yew/src/functional/hooks/mod.rs
+++ b/packages/yew/src/functional/hooks/mod.rs
@@ -28,6 +28,7 @@ use crate::functional::HookContext;
 /// Hooks are defined via the [`#[hook]`](crate::functional::hook) macro. It provides rewrites to
 /// hook invocations and ensures that hooks can only be called at the top-level of a function
 /// component or a hook. Please refer to its documentation on how to implement hooks.
+#[must_use = "hooks do nothing unless called inside a `#[hook]` or `#[component]` function"]
 pub trait Hook {
     /// The return type when a hook is run.
     type Output;


### PR DESCRIPTION
#### Description

Fixes the silent failure described in #4045: hooks called from plain functions (without `#[hook]` or `#[component]`) return an `impl Hook` value that gets dropped without ever executing. This is especially harmful for unit-returning hooks like `use_effect_with`, where there is no type mismatch to catch the mistake.

Adding `#[must_use]` to the `Hook` trait causes the compiler to emit a warning when a hook's return value is unused, with a message directing users to annotate their function with `#[hook]` or `#[component]`.

```
error: unused implementer of `Hook` that must be used
 --> src/app.rs:6:5
  |
6 |     use_effect_with((), |_| {});
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: hooks do nothing unless called inside a `#[hook]` or `#[component]` function
```

Hooks inside `#[hook]` or `#[component]` are unaffected because the macro rewrites calls to `Hook::run(...)`, which consumes the value.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [x] I have reviewed my own code
- [x] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
