### PR TITLE
fix: support multi package release body in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,9 +64,9 @@ jobs:
       - name: Release yew
         run: cargo release ${{ github.event.inputs.level }} --execute --no-confirm ${{ env.pkg }}
 
-      - name: Get tag
-        id: gettag
-        uses: WyriHaximus/github-action-get-previous-tag@v2
+      - name: Collect release info
+        id: releaseinfo
+        run: cargo run -p collect-release-info -- ${{ github.event.inputs.packages }}
 
       - name: Create a version branch
         if: github.event.inputs.level != 'patch'
@@ -74,21 +74,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: ${{ steps.gettag.outputs.tag }}
+          branch: ${{ steps.releaseinfo.outputs.version_branch }}
 
-      - name: Extract changelog
-        id: changelog
+      - name: Create releases
+        env:
+          GH_TOKEN: ${{ secrets.YEWTEMPBOT_TOKEN }}
+          RELEASES: ${{ steps.releaseinfo.outputs.releases }}
         run: |
-          body=$(cargo run -p extract-changelog-section -- "${{ steps.gettag.outputs.tag }}")
-          {
-            echo "body<<CHANGELOG_EOF"
-            echo "$body"
-            echo "CHANGELOG_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Create a Release
-        uses: softprops/action-gh-release@v2
-        with:
-          token: ${{ secrets.YEWTEMPBOT_TOKEN }}
-          tag_name: ${{ steps.gettag.outputs.tag }}
-          body: ${{ steps.changelog.outputs.body }}
+          echo "$RELEASES" | jq -c '.[]' | while read -r release; do
+            tag=$(echo "$release" | jq -r '.tag')
+            name=$(echo "$release" | jq -r '.name')
+            body=$(echo "$release" | jq -r '.body')
+            gh release create "$tag" --title "$name" --notes "$body"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,6 @@
 
  - **MSRV raised to 1.84.0.** [[@Siyuan Yan](https://github.com/Madoshakalaka), [#3900](https://github.com/yewstack/yew/pull/3900)]
 
-----
 
 ## ✨ yew **0.21.0** *(2023-09-23)*
 
@@ -173,7 +172,6 @@
 
 - Agent v2. [[@Kaede Hoshikawa](https://github.com/Kaede Hoshikawa), [#2773](https://github.com/yewstack/yew/pull/2773)]
 
-----
 
 ## ✨ yew **0.20.0** *(2022-11-xx)*
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "collect-release-info"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde_json",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,13 +820,6 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "extract-changelog-section"
-version = "0.1.0"
-dependencies = [
- "anyhow",
 ]
 
 [[package]]

--- a/tools/collect-release-info/Cargo.toml
+++ b/tools/collect-release-info/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "extract-changelog-section"
+name = "collect-release-info"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+serde_json.workspace = true

--- a/tools/collect-release-info/src/main.rs
+++ b/tools/collect-release-info/src/main.rs
@@ -1,6 +1,10 @@
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
 use std::{env, fs};
 
 use anyhow::{bail, Context, Result};
+use serde_json::json;
 
 fn parse_tag(tag: &str) -> Result<(&str, &str)> {
     let (package, version) = tag
@@ -68,22 +72,128 @@ fn extract_section(content: &str, package: &str, version: &str) -> Result<String
     Ok(trimmed.to_string())
 }
 
+fn find_latest_tag(package: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args([
+            "describe",
+            "--tags",
+            "--match",
+            &format!("{package}-v*"),
+            "--abbrev=0",
+        ])
+        .output()
+        .context("failed to run git describe")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("no tag found for package {package}: {stderr}");
+    }
+
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+fn count_rust_lines(dir: &Path) -> usize {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut total = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            total += count_rust_lines(&path);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            if let Ok(content) = fs::read_to_string(&path) {
+                total += content.lines().count();
+            }
+        }
+    }
+    total
+}
+
+struct ReleaseInfo {
+    tag: String,
+    package: String,
+    version: String,
+    body: String,
+    line_count: usize,
+}
+
 fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
+    let packages: Vec<String> = env::args().skip(1).collect();
+    if packages.is_empty() {
         bail!(
-            "Usage: extract-changelog-section <tag>\nExample: extract-changelog-section \
-             yew-v0.23.0"
+            "Usage: collect-release-info <package> [<package>...]\nExample: collect-release-info \
+             yew yew-router"
         );
     }
 
-    let tag = &args[1];
-    let (package, version) = parse_tag(tag)?;
-
     let changelog = fs::read_to_string("CHANGELOG.md").context("failed to read CHANGELOG.md")?;
 
-    let section = extract_section(&changelog, package, version)?;
-    print!("{section}");
+    let mut releases = Vec::new();
+
+    for package in &packages {
+        let tag = find_latest_tag(package)?;
+        let (pkg, version) = parse_tag(&tag)?;
+        let pkg = pkg.to_string();
+        let version = version.to_string();
+
+        let body = match extract_section(&changelog, &pkg, &version) {
+            Ok(section) => section,
+            Err(e) => {
+                eprintln!("warning: {e}");
+                String::new()
+            }
+        };
+
+        let pkg_dir = Path::new("packages").join(package);
+        let line_count = count_rust_lines(&pkg_dir);
+
+        releases.push(ReleaseInfo {
+            tag,
+            package: pkg,
+            version,
+            body,
+            line_count,
+        });
+    }
+
+    releases.sort_by_key(|r| r.line_count);
+
+    let single = releases.len() == 1;
+    let releases_json: Vec<serde_json::Value> = releases
+        .iter()
+        .map(|r| {
+            let body = if single || r.body.is_empty() {
+                r.body.clone()
+            } else {
+                format!("## {} v{}\n\n{}", r.package, r.version, r.body)
+            };
+            json!({
+                "tag": r.tag,
+                "name": format!("{} v{}", r.package, r.version),
+                "body": body,
+            })
+        })
+        .collect();
+
+    let version_branch = releases.last().map(|r| r.tag.as_str()).unwrap_or("");
+    let releases_str = serde_json::to_string(&releases_json)?;
+
+    if let Ok(path) = env::var("GITHUB_OUTPUT") {
+        let mut file = fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("failed to open GITHUB_OUTPUT at {path}"))?;
+        writeln!(file, "releases<<RELEASES_EOF")?;
+        writeln!(file, "{releases_str}")?;
+        writeln!(file, "RELEASES_EOF")?;
+        writeln!(file, "version_branch={version_branch}")?;
+    }
+
+    for r in &releases {
+        eprintln!("{}: {} lines", r.package, r.line_count);
+    }
+    print!("{releases_str}");
 
     Ok(())
 }
@@ -190,5 +300,20 @@ mod tests {
 - A change
 ";
         assert!(extract_section(content, "yew", "0.23.0").is_err());
+    }
+
+    #[test]
+    fn test_yew_has_more_code_than_yew_agent() {
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+        let yew_lines = count_rust_lines(&workspace_root.join("packages/yew"));
+        let agent_lines = count_rust_lines(&workspace_root.join("packages/yew-agent"));
+        assert!(
+            yew_lines > agent_lines,
+            "expected yew ({yew_lines}) > yew-agent ({agent_lines})"
+        );
     }
 }


### PR DESCRIPTION
When the publish workflow is dispatched with multiple packages, say "yew yew-router yew-agent", previously `WyriHaximus/github-action-get-previous-tag` only returned one tag, so multi-package publishes would only create a release for whichever tag it picked (symptom: during the 0.22.0 release, the input was "yew yew-router yew-agent", the workflow created https://github.com/yewstack/yew/releases/tag/yew-agent-v0.4.0 , the body was edited later by me)

This PR fixed publish workflow to support multi-package releases. Each release and tag gets a release body.

- Sort packages by Rust line count (ascending) so smaller crates release first, larger crates last
- Create one GitHub Release per package via `gh release create` instead of a single combined release
- Name the version branch after the largest crate's tag (previously used an arbitrary single tag)
- Single-package releases omit the redundant `## pkg vX.Y.Z` heading in the body

- [x] I have reviewed my own code
