### PR TITLE
fix: skip packages with no tags in collect-release-info

### DIFF
--- a/tools/collect-release-info/src/main.rs
+++ b/tools/collect-release-info/src/main.rs
@@ -132,7 +132,13 @@ fn main() -> Result<()> {
     let mut releases = Vec::new();
 
     for package in &packages {
-        let tag = find_latest_tag(package)?;
+        let tag = match find_latest_tag(package) {
+            Ok(tag) => tag,
+            Err(e) => {
+                eprintln!("skipping {package}: {e}");
+                continue;
+            }
+        };
         let (pkg, version) = parse_tag(&tag)?;
         let pkg = pkg.to_string();
         let version = version.to_string();


### PR DESCRIPTION
bug from recent #4061 and #4062 changes. the tool should not fail when it doesn't find tags for the yew-foo-macro crates. Those crates are not supposed to be tagged.
