### PR TITLE
fix: bump cargo-release to 1.1.1 and disable consolidated commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-release
-          version: =0.23.1
+          version: =1.1.1
 
       - name: Cargo login
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}

--- a/release.toml
+++ b/release.toml
@@ -1,2 +1,3 @@
+consolidate-commits = false
 pre-release-commit-message = "(cargo-release) version {{crate_name}}-v{{version}}"
 post-release-commit-message = "(cargo-release) start next development iteration {{crate_name}}-v{{next_version}}"


### PR DESCRIPTION
In workspaces, `cargo-release` does not populate `{{crate_name}}` or `{{version}}` template variables, leaving them as raw literals in commit messages. For example, 4a108b72:

```
(cargo-release) version {{crate_name}}-v{{version}}
```

This is a known upstream issue (crate-ci/cargo-release#701) and the maintainer has stated it is by design for consolidated commits (crate-ci/cargo-release#917). The only fix on our side is to set `consolidate-commits = false` so each package gets its own commit with properly rendered variables.

## `cargo-release` version bump

the way cargo-release is setup in our CI escapes dependabot detection. It hasn't been bumped since 2022
