### PR TITLE
fix: remove unsupported post-release-commit-message config

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,2 @@
 consolidate-commits = false
 pre-release-commit-message = "(cargo-release) version {{crate_name}}-v{{version}}"
-post-release-commit-message = "(cargo-release) start next development iteration {{crate_name}}-v{{next_version}}"


### PR DESCRIPTION
config removed in cargo-release 0.24.0
