### PR TITLE
fix(html): support iterating & Children in html for-loops

### DIFF
--- a/packages/yew-macro/tests/html_macro/for-pass.rs
+++ b/packages/yew-macro/tests/html_macro/for-pass.rs
@@ -73,4 +73,13 @@ fn main() {
             </div>
         }
     }
+
+    let children = ::yew::Children::new(::std::vec![::yew::html! { <span>{"x"}</span> }]);
+    _ = ::yew::html! {
+        <ul>
+            for child in &children {
+                <li>{child}</li>
+            }
+        </ul>
+    };
 }

--- a/packages/yew/src/html/component/children.rs
+++ b/packages/yew/src/html/component/children.rs
@@ -261,6 +261,15 @@ impl<T: Clone> IntoIterator for ChildrenRenderer<T> {
     }
 }
 
+impl<T: Clone> IntoIterator for &ChildrenRenderer<T> {
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type Item = T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter().collect::<Vec<_>>().into_iter()
+    }
+}
+
 impl From<ChildrenRenderer<Html>> for Html {
     fn from(mut val: ChildrenRenderer<Html>) -> Self {
         if let Some(children) = val.children.as_mut() {


### PR DESCRIPTION
- Added reference iteration support for Children so html for-loops can work with &children style.
- Added a compile-pass macro test that uses for child in &children.