### PR TITLE
fix: update sibling_slot immediately on component reuse

### DIFF
--- a/packages/yew/src/html/component/scope.rs
+++ b/packages/yew/src/html/component/scope.rs
@@ -581,6 +581,19 @@ mod feat_csr {
         }
 
         pub(crate) fn reuse(&self, props: Rc<COMP::Properties>, slot: DomSlot) {
+            if let Some(state) = self.state.borrow_mut().as_mut() {
+                match &state.render_state {
+                    ComponentRenderState::Render { sibling_slot, .. } => {
+                        sibling_slot.reassign(slot.clone());
+                    }
+                    #[cfg(feature = "hydration")]
+                    ComponentRenderState::Hydration { sibling_slot, .. } => {
+                        sibling_slot.reassign(slot.clone());
+                    }
+                    #[cfg(feature = "ssr")]
+                    ComponentRenderState::Ssr { .. } => {}
+                }
+            }
             schedule_props_update(self.state.clone(), props, slot)
         }
     }

--- a/packages/yew/tests/use_state.rs
+++ b/packages/yew/tests/use_state.rs
@@ -413,3 +413,60 @@ async fn use_state_handle_as_prop_triggers_child_rerender_issue_4058() {
         CHILD_RENDER_COUNT.load(Ordering::Relaxed)
     );
 }
+
+#[wasm_bindgen_test]
+async fn toggle_conditional_with_empty_component_no_crash() {
+    use wasm_bindgen::JsCast;
+    use web_sys::HtmlElement;
+
+    #[component]
+    fn Empty() -> Html {
+        html! {}
+    }
+
+    #[component]
+    fn App() -> Html {
+        let toggled = use_state(|| false);
+
+        let onclick = {
+            let toggled = toggled.clone();
+            Callback::from(move |_: MouseEvent| {
+                toggled.set(!*toggled);
+            })
+        };
+
+        html! {
+            <>
+                if *toggled {
+                    <span></span>
+                }
+                <Empty />
+                if !*toggled { <div>{"old"}</div> }
+                <button id="toggle-btn" {onclick}>{"Toggle"}</button>
+                <div id="result">{ if *toggled { "toggled" } else { "initial" } }</div>
+            </>
+        }
+    }
+
+    yew::Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
+        .render();
+    scheduler::flush().await;
+
+    let result = obtain_result();
+    assert_eq!(result.as_str(), "initial");
+
+    gloo::utils::document()
+        .get_element_by_id("toggle-btn")
+        .unwrap()
+        .unchecked_into::<HtmlElement>()
+        .click();
+
+    scheduler::flush().await;
+
+    let result = obtain_result();
+    assert_eq!(
+        result.as_str(),
+        "toggled",
+        "Toggling conditional blocks with empty components must not crash (issue #4092)"
+    );
+}


### PR DESCRIPTION
Fixes #4092

#### Impacted usage patterns

The bug requires three children in a sibling list, left to right:

1. A child that transitions from no DOM output to some
2. A component rendering zero DOM nodes
3. A child whose DOM node is removed in the current render

##### Opposing conditionals with an empty component between them

```rust
if *toggled { <span/> }
<Empty/>
if !*toggled { <div>{"old"}</div> }
```

##### State-driven show/hide swap

```rust
if *state == View::New { <NewPanel/> }
<Empty/>
if *state == View::Old { <OldPanel/> }
```

##### Empty list gaining items while a sibling disappears

```rust
{ for items.iter().map(|i| html!{ <span>{i}</span> }) }
<Empty/>
if show_footer { <footer/> }
```


##### Multiple empty components

```rust
if *toggled { <span/> }
<EmptyA/>
<EmptyB/>
if !*toggled { <div>{"old"}</div> }
```

In all cases, the "empty component" can be anything whose rendered output produces zero DOM nodes: `html! {}`, `html! { if false { <div/> } }`, or a component wrapping another empty component.



#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
