### PR TITLE
chore: bump wasm-opt to version_129 in all example crates

### DIFF
--- a/examples/async_clock/Trunk.toml
+++ b/examples/async_clock/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/boids/Trunk.toml
+++ b/examples/boids/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/communication_child_to_parent/Trunk.toml
+++ b/examples/communication_child_to_parent/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/communication_grandchild_with_grandparent/Trunk.toml
+++ b/examples/communication_grandchild_with_grandparent/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/communication_grandparent_to_grandchild/Trunk.toml
+++ b/examples/communication_grandparent_to_grandchild/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/communication_parent_to_child/Trunk.toml
+++ b/examples/communication_parent_to_child/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/contexts/Trunk.toml
+++ b/examples/contexts/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/counter/Trunk.toml
+++ b/examples/counter/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/counter_functional/Trunk.toml
+++ b/examples/counter_functional/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/dyn_create_destroy_apps/Trunk.toml
+++ b/examples/dyn_create_destroy_apps/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/file_upload/Trunk.toml
+++ b/examples/file_upload/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/function_delayed_input/Trunk.toml
+++ b/examples/function_delayed_input/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/function_memory_game/Trunk.toml
+++ b/examples/function_memory_game/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/function_router/Trunk.toml
+++ b/examples/function_router/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/function_todomvc/Trunk.toml
+++ b/examples/function_todomvc/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/futures/Trunk.toml
+++ b/examples/futures/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/game_of_life/Trunk.toml
+++ b/examples/game_of_life/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/immutable/Trunk.toml
+++ b/examples/immutable/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/inner_html/Trunk.toml
+++ b/examples/inner_html/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/js_callback/Trunk.toml
+++ b/examples/js_callback/Trunk.toml
@@ -1,5 +1,5 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"
 
 [[hooks]]
 stage = "pre_build"

--- a/examples/keyed_list/Trunk.toml
+++ b/examples/keyed_list/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/mount_point/Trunk.toml
+++ b/examples/mount_point/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/nested_list/Trunk.toml
+++ b/examples/nested_list/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/node_refs/Trunk.toml
+++ b/examples/node_refs/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/password_strength/Trunk.toml
+++ b/examples/password_strength/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/portals/Trunk.toml
+++ b/examples/portals/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/router/Trunk.toml
+++ b/examples/router/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/suspense/Trunk.toml
+++ b/examples/suspense/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/timer/Trunk.toml
+++ b/examples/timer/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/timer_functional/Trunk.toml
+++ b/examples/timer_functional/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/todomvc/Trunk.toml
+++ b/examples/todomvc/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/two_apps/Trunk.toml
+++ b/examples/two_apps/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/web_worker_fib/Trunk.toml
+++ b/examples/web_worker_fib/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/web_worker_prime/Trunk.toml
+++ b/examples/web_worker_prime/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"

--- a/examples/webgl/Trunk.toml
+++ b/examples/webgl/Trunk.toml
@@ -1,2 +1,2 @@
 [tools]
-wasm_opt = "version_128"
+wasm_opt = "version_129"


### PR DESCRIPTION
[release 17 hours ago](https://github.com/WebAssembly/binaryen/releases/tag/version_129)
