### PR TITLE
fix(website): strip rustdoc `# ` hidden lines in Docusaurus code blocks

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,4 +1,5 @@
 const { API_BUTTON } = require('./src/constants')
+const rustDocHiddenLines = require('./src/remark/rustDocHiddenLines')
 
 const editUrl = 'https://github.com/yewstack/yew/blob/master/website/'
 
@@ -169,6 +170,7 @@ module.exports = {
                     sidebarPath: require.resolve('./sidebars/docs.js'),
                     editUrl,
                     routeBasePath: '/docs',
+                    remarkPlugins: [rustDocHiddenLines],
                 },
                 blog: {
                     path: 'blog',
@@ -193,6 +195,7 @@ module.exports = {
                 sidebarPath: require.resolve('./sidebars/community.js'),
                 routeBasePath: '/community',
                 editUrl,
+                remarkPlugins: [rustDocHiddenLines],
             },
         ],
         [

--- a/website/src/remark/rustDocHiddenLines.js
+++ b/website/src/remark/rustDocHiddenLines.js
@@ -1,0 +1,31 @@
+const { visit } = require('unist-util-visit')
+
+function rustDocHiddenLines() {
+    return (tree) => {
+        visit(tree, 'code', (node) => {
+            if (!node.lang || !node.lang.startsWith('rust')) return
+
+            const lines = node.value.split('\n')
+            const result = []
+
+            for (const line of lines) {
+                if (line === '#') {
+                    continue
+                }
+                if (line.startsWith('# ')) {
+                    continue
+                }
+                if (line.startsWith('## ')) {
+                    // escape
+                    result.push(line.slice(2))
+                    continue
+                }
+                result.push(line)
+            }
+
+            node.value = result.join('\n')
+        })
+    }
+}
+
+module.exports = rustDocHiddenLines


### PR DESCRIPTION
#### Description

fixes #4132 

An item in #2312

I looked at the extensible magic-comment approach and found a custom plugin might work better.

The `#` syntax is more familiar to rust devs. 

This is also less dom weight as the magic-comment approach can hides the code with `display: none` but the custom plugin approach strips the hidden lines at docusaurus compile time.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
