### PR TITLE
Validate attribute names

### DIFF
--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -235,7 +235,7 @@ impl ToTokens for HtmlElement {
                             if value.chars().any(|c| c > '\u{FFFF}') {
                                 tokens.extend(quote_spanned! {dashed_name.span()=>::core::compile_error!(
                                     "Identifier contains characters above \\u{FFFF}. This is known to cause browser \
-                                    incompatibilites and inconsistent parsing behaviour and is not allowed."
+                                    incompatibilities and inconsistent parsing behaviour and is not allowed."
                                 )})
                             } else {
                                 dashed_name.to_tokens(tokens)

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -423,7 +423,7 @@ impl ToTokens for HtmlElement {
                 .chain(boolean_attrs)
                 .chain(class_attr)
                 .collect::<Vec<(Key, Value, Option<PropDirective>)>>();
-            // Refer to `Attributes::*_unchecked` for
+            // Refer to `Attributes::*_unchecked` for why this checks ssr safety
             let all_attrs_ssr_safe = attrs.iter().all(|(key, ..)| key.can_use_unchecked_attrs());
             try_into_static(&attrs, all_attrs_ssr_safe).or_else(|| try_into_dynamic(&attrs, all_attrs_ssr_safe)).unwrap_or_else(|| {
                 let results = attrs.iter()

--- a/packages/yew-macro/src/html_tree/html_element.rs
+++ b/packages/yew-macro/src/html_tree/html_element.rs
@@ -204,6 +204,15 @@ impl ToTokens for HtmlElement {
                 Dynamic(Expr),
             }
 
+            impl Key {
+                fn can_use_unchecked_attrs(&self) -> bool {
+                    match self {
+                        Self::Static(_) => true,
+                        Self::Dynamic(_) => false,
+                    }
+                }
+            }
+
             impl From<&PropLabel> for Key {
                 fn from(value: &PropLabel) -> Self {
                     match value {
@@ -216,7 +225,22 @@ impl ToTokens for HtmlElement {
             impl ToTokens for Key {
                 fn to_tokens(&self, tokens: &mut TokenStream) {
                     match self {
-                        Key::Static(dashed_name) => dashed_name.to_tokens(tokens),
+                        Key::Static(dashed_name) => {
+                            let value = dashed_name.value();
+                            // `value` is always a html dashed name, hence consists of chars with
+                            // XID_Continue, or XID_Start. Those notable
+                            // do not include whitespace or control characters, nor the special
+                            // sets. We do want to check though for
+                            // "high" unicode chars above \uFFFF
+                            if value.chars().any(|c| c > '\u{FFFF}') {
+                                tokens.extend(quote_spanned! {dashed_name.span()=>::core::compile_error!(
+                                    "Identifier contains characters above \\u{FFFF}. This is known to cause browser \
+                                    incompatibilites and inconsistent parsing behaviour and is not allowed."
+                                )})
+                            } else {
+                                dashed_name.to_tokens(tokens)
+                            }
+                        }
                         Key::Dynamic(expr) => expr.to_tokens(tokens),
                     }
                 }
@@ -307,7 +331,10 @@ impl ToTokens for HtmlElement {
                     });
 
             /// Try to turn attribute list into a `::yew::virtual_dom::Attributes::Static`
-            fn try_into_static(src: &[(Key, Value, Option<PropDirective>)]) -> Option<TokenStream> {
+            fn try_into_static(
+                src: &[(Key, Value, Option<PropDirective>)],
+                all_attr_names_ssr_safe: bool,
+            ) -> Option<TokenStream> {
                 if src.iter().any(|(k, _, d)| {
                     matches!(k, Key::Dynamic(_))
                         || matches!(d, Some(PropDirective::ApplyAsProperty(_)))
@@ -334,13 +361,19 @@ impl ToTokens for HtmlElement {
                     };
                     kv.push(quote! { ( #k, #v) });
                 }
+                let to_attributes = if all_attr_names_ssr_safe {
+                    quote! { ::yew::virtual_dom::Attributes::from_static_unchecked }
+                } else {
+                    quote! { ::yew::virtual_dom::Attributes::from_static }
+                };
 
-                Some(quote! { ::yew::virtual_dom::Attributes::Static(&[#(#kv),*]) })
+                Some(quote! { #to_attributes( &[#(#kv),*] ) })
             }
 
             /// Try to turn attribute list into a `::yew::virtual_dom::Attributes::Dynamic`
             fn try_into_dynamic(
                 src: &[(Key, Value, Option<PropDirective>)],
+                all_attr_names_ssr_safe: bool,
             ) -> Option<TokenStream> {
                 if src.iter().any(|(k, ..)| {
                     !matches!(
@@ -373,11 +406,16 @@ impl ToTokens for HtmlElement {
                     };
                     quote! { #value }
                 });
+                let to_attributes = if all_attr_names_ssr_safe {
+                    quote! { ::yew::virtual_dom::Attributes::from_dynamic_values_unchecked }
+                } else {
+                    quote! { ::yew::virtual_dom::Attributes::from_dynamic_values }
+                };
                 Some(quote! {
-                    ::yew::virtual_dom::Attributes::Dynamic{
-                        keys: &[#(#keys),*],
-                        values: ::std::boxed::Box::new([#(#values),*]),
-                    }
+                    #to_attributes (
+                        &[#(#keys),*],
+                        ::std::boxed::Box::new([#(#values),*]),
+                    )
                 })
             }
 
@@ -385,7 +423,9 @@ impl ToTokens for HtmlElement {
                 .chain(boolean_attrs)
                 .chain(class_attr)
                 .collect::<Vec<(Key, Value, Option<PropDirective>)>>();
-            try_into_static(&attrs).or_else(|| try_into_dynamic(&attrs)).unwrap_or_else(|| {
+            // Refer to `Attributes::*_unchecked` for
+            let all_attrs_ssr_safe = attrs.iter().all(|(key, ..)| key.can_use_unchecked_attrs());
+            try_into_static(&attrs, all_attrs_ssr_safe).or_else(|| try_into_dynamic(&attrs, all_attrs_ssr_safe)).unwrap_or_else(|| {
                 let results = attrs.iter()
                     .map(|(k, v, directive)| {
                         let value = match directive {
@@ -406,7 +446,7 @@ impl ToTokens for HtmlElement {
                         quote! { (::std::convert::Into::into(#k), #value) }
                     });
                 quote! {
-                    ::yew::virtual_dom::Attributes::IndexMap(
+                    ::yew::virtual_dom::Attributes::from_index_map(
                         ::std::rc::Rc::new(
                             ::std::iter::Iterator::collect(
                                 ::std::iter::Iterator::filter_map(

--- a/packages/yew-macro/tests/html_macro/node-fail.rs
+++ b/packages/yew-macro/tests/html_macro/node-fail.rs
@@ -1,3 +1,4 @@
+#![allow(uncommon_codepoints)]
 use yew::prelude::*;
 
 fn compile_fail() {
@@ -15,6 +16,8 @@ fn compile_fail() {
     html! {
         not_node()
     };
+
+    html! { <a 𐊖𐊗𐊒𐊓="value"></a> };
 }
 
 fn main() {}

--- a/packages/yew-macro/tests/html_macro/node-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/node-fail.stderr
@@ -18,7 +18,7 @@ error: byte-strings can't be converted to HTML text
 13 |     html! {  <span>{ b"str" }</span> };
    |                      ^^^^^^
 
-error: Identifier contains characters above \u{FFFF}. This is known to cause browser incompatibilites and inconsistent parsing behaviour and is not allowed.
+error: Identifier contains characters above \u{FFFF}. This is known to cause browser incompatibilities and inconsistent parsing behaviour and is not allowed.
   --> tests/html_macro/node-fail.rs:20:16
    |
 20 |     html! { <a 𐊖𐊗𐊒𐊓="value"></a> };

--- a/packages/yew-macro/tests/html_macro/node-fail.stderr
+++ b/packages/yew-macro/tests/html_macro/node-fail.stderr
@@ -1,33 +1,39 @@
 error: unexpected token, expected `}`
- --> tests/html_macro/node-fail.rs:4:29
+ --> tests/html_macro/node-fail.rs:5:29
   |
-4 |     html! { <span>{ "valid" "invalid" }</span> };
+5 |     html! { <span>{ "valid" "invalid" }</span> };
   |                             ^^^^^^^^^
 
 error: byte-strings can't be converted to HTML text
                                 note: remove the `b` prefix or convert this to a `String`
-  --> tests/html_macro/node-fail.rs:10:14
+  --> tests/html_macro/node-fail.rs:11:14
    |
-10 |     html! {  b"str" };
+11 |     html! {  b"str" };
    |              ^^^^^^
 
 error: byte-strings can't be converted to HTML text
                                 note: remove the `b` prefix or convert this to a `String`
-  --> tests/html_macro/node-fail.rs:12:22
+  --> tests/html_macro/node-fail.rs:13:22
    |
-12 |     html! {  <span>{ b"str" }</span> };
+13 |     html! {  <span>{ b"str" }</span> };
    |                      ^^^^^^
 
+error: Identifier contains characters above \u{FFFF}. This is known to cause browser incompatibilites and inconsistent parsing behaviour and is not allowed.
+  --> tests/html_macro/node-fail.rs:20:16
+   |
+20 |     html! { <a 𐊖𐊗𐊒𐊓="value"></a> };
+   |                ^^^^
+
 error[E0425]: cannot find value `invalid` in this scope
- --> tests/html_macro/node-fail.rs:6:13
+ --> tests/html_macro/node-fail.rs:7:13
   |
-6 |     html! { invalid };
+7 |     html! { invalid };
   |             ^^^^^^^ not found in this scope
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
- --> tests/html_macro/node-fail.rs:5:13
+ --> tests/html_macro/node-fail.rs:6:13
   |
-5 |     html! { () };
+6 |     html! { () };
   |             ^^ `()` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `()`
@@ -47,9 +53,9 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: this error originates in the macro `html` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> tests/html_macro/node-fail.rs:16:9
+  --> tests/html_macro/node-fail.rs:17:9
    |
-16 |         not_node()
+17 |         not_node()
    |         ^^^^^^^^ `()` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`

--- a/packages/yew-macro/tests/html_macro_test.rs
+++ b/packages/yew-macro/tests/html_macro_test.rs
@@ -41,3 +41,9 @@ fn html_nested_macro_on_html_element() {
         <input/>
     };
 }
+
+#[test]
+#[should_panic(expected = "\"x onerror=\\\"prompt('failed')\" is not a valid attribute name")]
+fn dynamic_attrs_catch_bad_names() {
+    let _ = html! { <div "x onerror=\"prompt('failed')"=";"></div> };
+}

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -136,6 +136,7 @@ impl Attributes {
         fn collect(src: &Attributes) -> HashMap<&str, &AttributeOrProperty> {
             use Attributes::*;
 
+            #[expect(deprecated)]
             match src {
                 Static(arr) => (*arr).iter().map(|(k, v)| (*k, v)).collect(),
                 Dynamic { keys, values } => keys
@@ -199,6 +200,7 @@ impl Apply for Attributes {
     type Element = Element;
 
     fn apply(self, _root: &BSubtree, el: &Element) -> Self {
+        #[expect(deprecated)]
         match &self {
             Self::Static(arr) => {
                 for (k, v) in arr.iter() {
@@ -229,6 +231,7 @@ impl Apply for Attributes {
 
         let ancestor = std::mem::replace(bundle, self);
         let bundle = &*bundle; // reborrow it immutably from here
+        #[expect(deprecated)]
         match (bundle, ancestor) {
             // Hot path
             (Self::Static(new), Self::Static(old)) if ptr_eq(new, old) => (),

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -317,7 +317,7 @@ mod tests {
             AttrValue::Static("href") => AttributeOrProperty::Property(JsValue::from_str("https://example.com/")),
             AttrValue::Static("alt") => AttributeOrProperty::Property(JsValue::from_str("somewhere")),
         };
-        let attrs = Attributes::IndexMap(Rc::new(attrs));
+        let attrs = Attributes::from_index_map(Rc::new(attrs));
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
         assert_eq!(
@@ -344,7 +344,7 @@ mod tests {
             AttrValue::Static("href") => AttributeOrProperty::Attribute(AttrValue::from("https://example.com/")),
             AttrValue::Static("alt") => AttributeOrProperty::Property(JsValue::from_str("somewhere")),
         };
-        let attrs = Attributes::IndexMap(Rc::new(attrs));
+        let attrs = Attributes::from_index_map(Rc::new(attrs));
         let (element, btree) = create_element();
         attrs.apply(&btree, &element);
         assert_eq!(
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn class_is_always_attrs() {
-        let attrs = Attributes::Static(&[(
+        let attrs = Attributes::from_static(&[(
             "class",
             AttributeOrProperty::Attribute(AttrValue::Static("thing")),
         )]);

--- a/packages/yew/src/virtual_dom/mod.rs
+++ b/packages/yew/src/virtual_dom/mod.rs
@@ -183,20 +183,64 @@ pub enum AttributeOrProperty {
     Property(JsValue),
 }
 
+fn is_valid_attr_name(attr: &str) -> bool {
+    // https://dom.spec.whatwg.org/#valid-attribute-local-name specifies:
+    // > at least one character, no ASCII whitespace, no \x00, \x2F (/), \x3D (=), \x3E (>)
+    // Browsers are more strict in setAttribute(), and the parser for a html document is too.
+    // The parser specifies that names must consist of
+    // > one or more [unicode] characters other than the space characters [ \t\r\n\f],
+    // > U+0000 NULL, U+0022 QUOTATION MARK ("), U+0027 APOSTROPHE ('), U+003E GREATER-THAN SIGN
+    // > (>),
+    // > U+002F SOLIDUS (/), and U+003D EQUALS SIGN (=) characters, the control characters , [...]
+    // ref https://w3c.github.io/html-reference/syntax.html#attribute-name
+    // A fun thing is trying to use non-ascii-whitespace WHITE_SPACE characters such as " "
+    // as part of an attribute name, which seem to get accepted by the parser but not by
+    // setAttribute.
+
+    // Anyway, the goal here is to allow a reasonable subset of names that will parse correctly
+    // in all browsers when delivered via SSR and also work correctly when used in calls to
+    // setAttribute. Here is what we will prohibit:
+    // - all whitespace characters (unicode WS) and control characters (unicode Cc)
+    // - all syntactically special characters for XHTML parsing [/"'>=]
+    // - disallow "high" unicode characters in the range [#x10000-#xEFFFF]
+    // see also: https://github.com/whatwg/dom/issues/849
+
+    // If you really need attribute names that are not covered by this open an issue and a self-help
+    // group. Know that I do care for your pain.
+    !attr.is_empty()
+        && attr.chars().all(|c| match c {
+            c if c.is_control() => false,
+            '/' | '"' | '\'' | '>' | '=' => false,
+            c if c.is_whitespace() => false,
+            // For example, try the following in a browser of your choice:
+            // ```
+            // let d = document.createElement("div")
+            // d.setAttribute("𐊖𐊗𐊒𐊓", "value2")
+            // ```
+            // At the time of writing, the above works in chrome (131) but not in firefox (136)
+            '\u{10000}'.. => false,
+            _ => true,
+        })
+}
+
+#[track_caller]
+fn validate_attr_name(attr: &str) {
+    assert!(
+        is_valid_attr_name(attr),
+        "{attr:?} is not a valid attribute name"
+    );
+}
+
 /// A collection of attributes for an element
 #[derive(PartialEq, Clone, Debug)]
+#[non_exhaustive]
 pub enum Attributes {
-    /// Static list of attributes.
-    ///
-    /// Allows optimizing comparison to a simple pointer equality check and reducing allocations,
-    /// if the attributes do not change on a node.
+    #[doc(hidden)]
+    #[deprecated = "Attribute names are not validated. Use one of the conversion functions"]
     Static(&'static [(&'static str, AttributeOrProperty)]),
 
-    /// Static list of attribute keys with possibility to exclude attributes and dynamic attribute
-    /// values.
-    ///
-    /// Allows optimizing comparison to a simple pointer equality check and reducing allocations,
-    /// if the attributes keys do not change on a node.
+    #[doc(hidden)]
+    #[deprecated = "Attribute names are not validated. Use one of the conversion functions"]
     Dynamic {
         /// Attribute keys. Includes both always set and optional attribute keys.
         keys: &'static [&'static str],
@@ -206,12 +250,85 @@ pub enum Attributes {
         values: Box<[Option<AttributeOrProperty>]>,
     },
 
-    /// IndexMap is used to provide runtime attribute deduplication in cases where the html! macro
-    /// was not used to guarantee it.
+    #[doc(hidden)]
+    #[deprecated = "Attribute names are not validated. Use one of the conversion functions"]
     IndexMap(Rc<IndexMap<AttrValue, AttributeOrProperty>>),
 }
 
 impl Attributes {
+    /// Static list of attributes.
+    ///
+    /// Allows optimizing comparison to a simple pointer equality check and reducing allocations,
+    /// if the attributes do not change on a node.
+    #[track_caller]
+    pub fn from_static(statics: &'static [(&'static str, AttributeOrProperty)]) -> Self {
+        for &(key, _) in statics {
+            validate_attr_name(key); // Not in a closure for #[track_caller]
+        }
+        Self::from_static_unchecked(statics)
+    }
+
+    /// Same as [Self::from_static] but without verifying keys. This can lead to loss of
+    /// validity of an SSR document!
+    pub fn from_static_unchecked(statics: &'static [(&'static str, AttributeOrProperty)]) -> Self {
+        #[expect(deprecated)]
+        Self::Static(statics)
+    }
+
+    /// Static list of attribute keys with possibility to exclude attributes and dynamic attribute
+    /// values.
+    ///
+    /// Allows optimizing comparison to a simple pointer equality check and reducing allocations,
+    /// if the attributes keys do not change on a node.
+    #[track_caller]
+    pub fn from_dynamic_values(
+        keys: &'static [&'static str],
+        values: Box<[Option<AttributeOrProperty>]>,
+    ) -> Self {
+        for &key in keys {
+            validate_attr_name(key); // Not in a closure for #[track_caller]
+        }
+        Self::from_dynamic_values_unchecked(keys, values)
+    }
+
+    /// Same as [Self::from_dynamic_values] but without verifying keys. This can lead to loss of
+    /// validity of an SSR document!
+    pub fn from_dynamic_values_unchecked(
+        keys: &'static [&'static str],
+        values: Box<[Option<AttributeOrProperty>]>,
+    ) -> Self {
+        #[expect(deprecated)]
+        Self::Dynamic { keys, values }
+    }
+
+    /// IndexMap is used to provide runtime attribute deduplication in cases where the html! macro
+    /// was not used to guarantee it.
+    #[track_caller]
+    pub fn from_index_map(map: Rc<IndexMap<AttrValue, AttributeOrProperty>>) -> Self {
+        for (key, _) in map.iter() {
+            validate_attr_name(key); // Not in a closure for #[track_caller]
+        }
+        Self::from_index_map_unchecked(map)
+    }
+
+    /// Same as [Self::from_index_map] but without verifying keys. This can lead to loss of validity
+    /// of an SSR document!
+    pub fn from_index_map_unchecked(map: Rc<IndexMap<AttrValue, AttributeOrProperty>>) -> Self {
+        #[expect(deprecated)]
+        Self::IndexMap(map)
+    }
+
+    /// Validate a single attribute name for validity to be used as a key for an attribute or
+    /// property. All keys must be valid according to this method when constructing
+    /// [`Attributes`]. Usually, this is ensured by the usage context.
+    ///
+    /// Specifically, this checks that the passed string is a valid XHTML attribute name. This
+    /// implies that it consists of at least one character, does not contain whitespace or other
+    /// special characters.
+    pub fn is_valid_attr_key(name: &str) -> bool {
+        is_valid_attr_name(name)
+    }
+
     /// Construct a default Attributes instance
     pub fn new() -> Self {
         Self::default()
@@ -222,6 +339,7 @@ impl Attributes {
     ///
     /// This function only returns attributes
     pub fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&'a str, &'a str)> + 'a> {
+        #[expect(deprecated)]
         match self {
             Self::Static(arr) => Box::new(arr.iter().filter_map(|(k, v)| match v {
                 AttributeOrProperty::Attribute(v) => Some((*k, v.as_ref())),
@@ -240,11 +358,23 @@ impl Attributes {
         }
     }
 
+    /// Get a mutable reference to the underlying `IndexMap`. Deprecated for
+    /// [`Self::get_mut_index_map_unchecked`].
+    #[doc(hidden)]
+    #[deprecated = "Attribute names are not validated. Use `get_mut_index_map_unchecked` to signal \
+                    this properly and validate your modifications."]
+    pub fn get_mut_index_map(&mut self) -> &mut IndexMap<AttrValue, AttributeOrProperty> {
+        self.get_mut_index_map_unchecked()
+    }
+
     /// Get a mutable reference to the underlying `IndexMap`.
     /// If the attributes are stored in the `Vec` variant, it will be converted.
-    pub fn get_mut_index_map(&mut self) -> &mut IndexMap<AttrValue, AttributeOrProperty> {
+    /// The caller is responsible to check that inserted attribute names are valid, see
+    /// [`Self::is_valid_attr_key`]
+    pub fn get_mut_index_map_unchecked(&mut self) -> &mut IndexMap<AttrValue, AttributeOrProperty> {
         macro_rules! unpack {
             () => {
+                #[expect(deprecated)]
                 match self {
                     Self::IndexMap(m) => Rc::make_mut(m),
                     // SAFETY: unreachable because we set self to the `IndexMap` variant above.
@@ -253,6 +383,7 @@ impl Attributes {
             };
         }
 
+        #[expect(deprecated)]
         match self {
             Self::IndexMap(m) => Rc::make_mut(m),
             Self::Static(arr) => {
@@ -262,7 +393,7 @@ impl Attributes {
                 unpack!()
             }
             Self::Dynamic { keys, values } => {
-                *self = Self::IndexMap(Rc::new(
+                *self = Self::from_index_map_unchecked(Rc::new(
                     std::mem::take(values)
                         .iter_mut()
                         .zip(keys.iter())
@@ -281,7 +412,7 @@ impl From<IndexMap<AttrValue, AttrValue>> for Attributes {
             .into_iter()
             .map(|(k, v)| (k, AttributeOrProperty::Attribute(v)))
             .collect();
-        Self::IndexMap(Rc::new(v))
+        Self::from_index_map(Rc::new(v))
     }
 }
 
@@ -291,7 +422,7 @@ impl From<IndexMap<&'static str, AttrValue>> for Attributes {
             .into_iter()
             .map(|(k, v)| (AttrValue::Static(k), (AttributeOrProperty::Attribute(v))))
             .collect();
-        Self::IndexMap(Rc::new(v))
+        Self::from_index_map(Rc::new(v))
     }
 }
 
@@ -301,12 +432,12 @@ impl From<IndexMap<&'static str, JsValue>> for Attributes {
             .into_iter()
             .map(|(k, v)| (AttrValue::Static(k), (AttributeOrProperty::Property(v))))
             .collect();
-        Self::IndexMap(Rc::new(v))
+        Self::from_index_map(Rc::new(v))
     }
 }
 
 impl Default for Attributes {
     fn default() -> Self {
-        Self::Static(&[])
+        Self::from_static(&[])
     }
 }

--- a/packages/yew/src/virtual_dom/vtag.rs
+++ b/packages/yew/src/virtual_dom/vtag.rs
@@ -381,8 +381,13 @@ impl VTag {
     ///
     /// Not every attribute works when it set as an attribute. We use workarounds for:
     /// `value` and `checked`.
+    #[track_caller]
     pub fn add_attribute(&mut self, key: &'static str, value: impl Into<AttrValue>) {
-        self.attributes.get_mut_index_map().insert(
+        assert!(
+            Attributes::is_valid_attr_key(key),
+            "{key:?} is not a valid attribute name"
+        );
+        self.attributes.get_mut_index_map_unchecked().insert(
             AttrValue::Static(key),
             AttributeOrProperty::Attribute(value.into()),
         );
@@ -391,8 +396,13 @@ impl VTag {
     /// Set the given key as property on the element
     ///
     /// [`js_sys::Reflect`] is used for setting properties.
+    #[track_caller]
     pub fn add_property(&mut self, key: &'static str, value: impl Into<JsValue>) {
-        self.attributes.get_mut_index_map().insert(
+        assert!(
+            Attributes::is_valid_attr_key(key),
+            "{key:?} is not a valid attribute name"
+        );
+        self.attributes.get_mut_index_map_unchecked().insert(
             AttrValue::Static(key),
             AttributeOrProperty::Property(value.into()),
         );
@@ -408,7 +418,11 @@ impl VTag {
 
     #[doc(hidden)]
     pub fn __macro_push_attr(&mut self, key: &'static str, value: impl IntoPropValue<AttrValue>) {
-        self.attributes.get_mut_index_map().insert(
+        debug_assert!(
+            Attributes::is_valid_attr_key(key),
+            "{key:?} is not a valid attribute name"
+        );
+        self.attributes.get_mut_index_map_unchecked().insert(
             AttrValue::from(key),
             AttributeOrProperty::Attribute(value.into_prop_value()),
         );
@@ -729,5 +743,20 @@ mod ssr_tests {
             s,
             r#"<style>html { background: black } body > a { color: white } </style>"#
         );
+    }
+
+    #[cfg_attr(not(target_os = "wasi"), test)]
+    #[cfg_attr(target_os = "wasi", test(flavor = "current_thread"))]
+    #[should_panic(expected = "\"x onerror=\\\"prompt('failed')\" is not a valid attribute name")]
+    async fn test_should_panic_invalid_attr() {
+        #[component]
+        fn Comp() -> Html {
+            html! { <div "x onerror=\"prompt('failed')"=";"></div> }
+        }
+
+        ServerRenderer::<Comp>::new()
+            .hydratable(false)
+            .render()
+            .await;
     }
 }


### PR DESCRIPTION
#### Description

Attribute names are written to the HTML in SSR without escaping (no such escaping is part of the HTML spec). This means they need to be validated to avoid surprises when they are parsed back in the browser.

Note that in normal usage, Rust identifiers always form valid attribute names. To catch browser incompat, high unicode (0x10000..) chars are failed.

`_unchecked` methods are available. The previous enum constructors are now `doc(hidden)` and deprecated for a good migration path.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
  <!-- If this is a bug fix, these tests will fail if the bug is present (to stop it from cropping up again) -->
  <!-- If this is a feature, my tests prove that the feature works -->
