### PR TITLE
chore: update NO_TRUNK_EXAMPLES for renamed SSR examples

### DIFF
--- a/tools/build-examples/src/lib.rs
+++ b/tools/build-examples/src/lib.rs
@@ -5,7 +5,12 @@ use serde::Deserialize;
 use toml::Table;
 
 /// Examples that don't use Trunk for building
-pub const NO_TRUNK_EXAMPLES: [&str; 3] = ["simple_ssr", "ssr_router", "wasi_ssr_module"];
+pub const NO_TRUNK_EXAMPLES: [&str; 4] = [
+    "simple_ssr",
+    "actix_ssr_router",
+    "axum_ssr_router",
+    "wasi_ssr_module",
+];
 
 #[derive(Deserialize)]
 struct GitHubRelease {


### PR DESCRIPTION
#### Description

PR #4027 renamed the `ssr_router` example to `axum_ssr_router` and added a new `actix_ssr_router`, but `NO_TRUNK_EXAMPLES` in `tools/build-examples/src/lib.rs` still listed the old `ssr_router`. As a result the size-cmp job iterates over both new SSR examples (which have no `Trunk.toml`), `is_wasm_opt_outdated` returns `true` for any example without a `Trunk.toml`, and CI emits warning:

```
2 example crates do not have up-to-date wasm_opt: actix_ssr_router, axum_ssr_router
```

This PR replaces `"ssr_router"` with `"actix_ssr_router"` and `"axum_ssr_router"` in `NO_TRUNK_EXAMPLES` so the size-cmp tool skips them like the other SSR examples.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests
