### PR TITLE
chore: bump nanoid to 0.5 and propagate getrandom wasm_js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,7 @@ dependencies = [
 name = "function_memory_game"
 version = "0.1.0"
 dependencies = [
+ "getrandom 0.3.4",
  "getrandom 0.4.2",
  "gloo",
  "nanoid",
@@ -2574,7 +2575,7 @@ version = "0.9.1"
 source = "git+https://github.com/mgeisler/lipsum.git?rev=233e48a#233e48a36df40641a609a9476fe9009d928757c5"
 dependencies = [
  "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand_chacha",
 ]
 
 [[package]]
@@ -2718,11 +2719,11 @@ dependencies = [
 
 [[package]]
 name = "nanoid"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+checksum = "8628de41fe064cc3f0cf07f3d299ee3e73521adaff72278731d5c8cae3797873"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -3173,22 +3174,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -3205,31 +3195,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]

--- a/examples/function_memory_game/Cargo.toml
+++ b/examples/function_memory_game/Cargo.toml
@@ -11,9 +11,10 @@ serde = { workspace = true, features = ["derive"] }
 strum.workspace = true
 strum_macros.workspace = true
 gloo.workspace = true
-nanoid = "0.4"
+nanoid = "0.5"
 rand.workspace = true
 getrandom = { workspace = true }
+getrandom_03 = { workspace = true }
 yew = { path = "../../packages/yew", features = ["csr"] }
 
 [dependencies.web-sys]


### PR DESCRIPTION
#### Description

Bumps `nanoid` to `0.5` in `examples/function_memory_game` and adds the `getrandom_03` workspace dep so the `wasm_js` Cargo feature is activated for the transitive `getrandom 0.3` brought in by nanoid 0.5's `rand 0.9`.

##### Why this is needed

`nanoid 0.5` swaps its `rand 0.8` dep for `rand 0.9`, which transitively pulls in `getrandom 0.3.4` instead of `getrandom 0.2.17`. On `wasm32-unknown-unknown`, getrandom 0.3 hard-errors at compile time unless the `wasm_js` feature is activated:

```
The "wasm_js" backend requires the `wasm_js` feature for `getrandom`.
```

Trunk builds each example with `--manifest-path`, so feature unification has to happen inside each example's own dep graph. The workspace already aliases `getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }` for exactly this purpose. Adding `getrandom_03 = { workspace = true }` to `function_memory_game` mirrors the workaround landed in 493fe1ca for `examples/router` and `examples/function_router` (lipsum's rand 0.9).

##### Code changes for nanoid 0.5 features

Reviewed nanoid 0.5.0 release notes: new `HEX_LOWERCASE` / `HEX_UPPERCASE` alphabets, `thread_local` rng source, `FnMut` random generator, expression-arg `nanoid!` macro, power-of-two alphabet fast path. Our only call site is `nanoid!()` with no args (`examples/function_memory_game/src/helper.rs:16`), which is unaffected. No source changes needed.

##### Context

Surfaced by dependabot PR #4153 which bumps nanoid as part of a broader cargo-deps group bump and fails the size-cmp CI step on `function_memory_game`. Landing this preemptively on master so dependabot's rebase will pick it up.

#### Checklist

- [x] I have reviewed my own code
- [ ] I have added tests

