### PR TITLE
add hydrate_set(Attributes) and hydrate(trait Apply) methods

### DIFF
--- a/packages/yew/Cargo.toml
+++ b/packages/yew/Cargo.toml
@@ -92,7 +92,13 @@ trybuild = { workspace = true }
 
 [dev-dependencies.web-sys]
 workspace = true
-features = ["ShadowRootInit", "ShadowRootMode", "HtmlButtonElement"]
+features = [
+  "ShadowRootInit",
+  "ShadowRootMode",
+  "HtmlButtonElement",
+  "MutationObserver",
+  "MutationObserverInit",
+]
 
 [features]
 ssr = ["dep:html-escape", "dep:base64ct", "dep:bincode"]

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -181,16 +181,22 @@ impl Attributes {
         }
     }
 
-    /// Like [`set`](Self::set), but skips writing an `Attribute` when the
-    /// element already carries the same value.
+    /// Applies a value during hydration.
+    ///
+    /// Hydration assumes the DOM already matches the server-rendered HTML, so
+    /// attributes are left untouched: re-writing them would needlessly trigger
+    /// side effects. In debug builds we only assert that the existing attribute
+    /// matches the expected value. Properties are not reflected in the HTML, so
+    /// they are always set.
     #[cfg(feature = "hydration")]
-    fn set_if_changed(el: &Element, key: &str, value: &AttributeOrProperty) {
+    fn hydrate_set(el: &Element, key: &str, value: &AttributeOrProperty) {
         match value {
             AttributeOrProperty::Attribute(value) => {
-                let key = intern(key);
-                if el.get_attribute(key).as_deref() != Some(value.as_ref()) {
-                    el.set_attribute(key, value).expect("invalid attribute key");
-                }
+                debug_assert_eq!(
+                    el.get_attribute(key).as_deref(),
+                    Some(value.as_ref()),
+                    "attribute `{key}` does not match the server-rendered value during hydration",
+                );
             }
             AttributeOrProperty::Property(_) => Self::set(el, key, value),
         }
@@ -244,19 +250,19 @@ impl Apply for Attributes {
         match &self {
             Self::Static(arr) => {
                 for (k, v) in arr.iter() {
-                    Self::set_if_changed(el, k, v);
+                    Self::hydrate_set(el, k, v);
                 }
             }
             Self::Dynamic { keys, values } => {
                 for (k, v) in keys.iter().zip(values.iter()) {
                     if let Some(v) = v {
-                        Self::set_if_changed(el, k, v)
+                        Self::hydrate_set(el, k, v)
                     }
                 }
             }
             Self::IndexMap(m) => {
                 for (k, v) in m.iter() {
-                    Self::set_if_changed(el, k, v)
+                    Self::hydrate_set(el, k, v)
                 }
             }
         }

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -192,12 +192,6 @@ impl Attributes {
                     el.set_attribute(key, value).expect("invalid attribute key");
                 }
             }
-            AttributeOrProperty::Static(value) => {
-                let key = intern(key);
-                if el.get_attribute(key).as_deref() != Some(*value) {
-                    el.set_attribute(key, value).expect("invalid attribute key");
-                }
-            }
             AttributeOrProperty::Property(_) => Self::set(el, key, value),
         }
     }
@@ -246,6 +240,7 @@ impl Apply for Attributes {
 
     #[cfg(feature = "hydration")]
     fn hydrate(self, _root: &BSubtree, el: &Element) -> Self {
+        #[expect(deprecated)]
         match &self {
             Self::Static(arr) => {
                 for (k, v) in arr.iter() {

--- a/packages/yew/src/dom_bundle/btag/attributes.rs
+++ b/packages/yew/src/dom_bundle/btag/attributes.rs
@@ -181,6 +181,27 @@ impl Attributes {
         }
     }
 
+    /// Like [`set`](Self::set), but skips writing an `Attribute` when the
+    /// element already carries the same value.
+    #[cfg(feature = "hydration")]
+    fn set_if_changed(el: &Element, key: &str, value: &AttributeOrProperty) {
+        match value {
+            AttributeOrProperty::Attribute(value) => {
+                let key = intern(key);
+                if el.get_attribute(key).as_deref() != Some(value.as_ref()) {
+                    el.set_attribute(key, value).expect("invalid attribute key");
+                }
+            }
+            AttributeOrProperty::Static(value) => {
+                let key = intern(key);
+                if el.get_attribute(key).as_deref() != Some(*value) {
+                    el.set_attribute(key, value).expect("invalid attribute key");
+                }
+            }
+            AttributeOrProperty::Property(_) => Self::set(el, key, value),
+        }
+    }
+
     fn remove(el: &Element, key: &str, old_value: &AttributeOrProperty) {
         match old_value {
             AttributeOrProperty::Attribute(_) => el
@@ -217,6 +238,30 @@ impl Apply for Attributes {
             Self::IndexMap(m) => {
                 for (k, v) in m.iter() {
                     Self::set(el, k, v)
+                }
+            }
+        }
+        self
+    }
+
+    #[cfg(feature = "hydration")]
+    fn hydrate(self, _root: &BSubtree, el: &Element) -> Self {
+        match &self {
+            Self::Static(arr) => {
+                for (k, v) in arr.iter() {
+                    Self::set_if_changed(el, k, v);
+                }
+            }
+            Self::Dynamic { keys, values } => {
+                for (k, v) in keys.iter().zip(values.iter()) {
+                    if let Some(v) = v {
+                        Self::set_if_changed(el, k, v)
+                    }
+                }
+            }
+            Self::IndexMap(m) => {
+                for (k, v) in m.iter() {
+                    Self::set_if_changed(el, k, v)
                 }
             }
         }

--- a/packages/yew/src/dom_bundle/btag/mod.rs
+++ b/packages/yew/src/dom_bundle/btag/mod.rs
@@ -35,6 +35,17 @@ trait Apply {
 
     /// Apply diff between [self] and `bundle` to [Element](Self::Element).
     fn apply_diff(self, root: &BSubtree, el: &Self::Element, bundle: &mut Self::Bundle);
+
+    /// Apply contained values to an existing [Element](Self::Element).
+    ///
+    /// The default implementation delegates to [`apply`](Self::apply).
+    #[cfg(feature = "hydration")]
+    fn hydrate(self, root: &BSubtree, el: &Self::Element) -> Self::Bundle
+    where
+        Self: Sized,
+    {
+        self.apply(root, el)
+    }
 }
 
 /// [BTag] fields that are specific to different [BTag] kinds.
@@ -401,8 +412,8 @@ mod feat_hydration {
                     );
                 }
             }
-            // We simply register listeners and update all attributes.
-            let attributes = attributes.apply(root, &el);
+            // Register listeners and attributes.
+            let attributes = attributes.hydrate(root, &el);
             let listeners = listeners.apply(root, &el);
 
             // For input and textarea elements, we update their value anyways.

--- a/packages/yew/tests/hydration.rs
+++ b/packages/yew/tests/hydration.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "hydration")]
 #![cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 
+use std::cell::RefCell;
 use std::ops::Range;
 use std::rc::Rc;
 use std::time::Duration;
@@ -9,6 +10,7 @@ mod common;
 
 use common::{obtain_result, obtain_result_by_id};
 use wasm_bindgen::JsCast;
+use wasm_bindgen::closure::Closure;
 use wasm_bindgen_futures::spawn_local;
 use wasm_bindgen_test::*;
 use web_sys::{HtmlElement, HtmlTextAreaElement};
@@ -1259,4 +1261,61 @@ async fn hydration_suspended_child_does_not_trap_sibling_slot() {
         result.as_str(),
         r#"<p class="new-sibling">new sibling</p><div class="suspended">child</div>"#,
     );
+}
+
+#[wasm_bindgen_test]
+async fn hydration_does_not_reapply_matching_attributes() {
+    #[component(App)]
+    fn app() -> Html {
+        html! {
+            <div id="result">
+                <img class="pic" src="/picture.png" alt="a picture" />
+            </div>
+        }
+    }
+
+    let s = ServerRenderer::<App>::new().render().await;
+
+    gloo::utils::document()
+        .query_selector("#output")
+        .unwrap()
+        .unwrap()
+        .set_inner_html(&s);
+
+    scheduler::flush().await;
+
+    let img = gloo::utils::document()
+        .query_selector("#output .pic")
+        .unwrap()
+        .unwrap();
+
+    let mutations = Rc::new(RefCell::new(0usize));
+    let observer = {
+        let mutations = mutations.clone();
+        let callback = Closure::<dyn FnMut(js_sys::Array)>::new(move |records: js_sys::Array| {
+            *mutations.borrow_mut() += records.length() as usize;
+        });
+        let observer = web_sys::MutationObserver::new(callback.as_ref().unchecked_ref()).unwrap();
+        callback.forget();
+        observer
+    };
+    let init = web_sys::MutationObserverInit::new();
+    init.set_attributes(true);
+    observer.observe_with_options(&img, &init).unwrap();
+
+    Renderer::<App>::with_root(gloo::utils::document().get_element_by_id("output").unwrap())
+        .hydrate();
+
+    scheduler::flush().await;
+    observer.disconnect();
+
+    assert_eq!(
+        *mutations.borrow(),
+        0,
+        "hydration must not re-apply attributes that already match the DOM",
+    );
+
+    assert_eq!(img.get_attribute("src").as_deref(), Some("/picture.png"));
+    assert_eq!(img.get_attribute("alt").as_deref(), Some("a picture"));
+    assert_eq!(img.get_attribute("class").as_deref(), Some("pic"));
 }


### PR DESCRIPTION
#### Description
Introduce an optimized hydration path for DOM attributes - skip unnecessary set_attribute calls when SSR has already written the correct value.

Fixes #4157

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests
