### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -188,6 +188,7 @@ module.exports = {
     ],
     plugins: [
         'docusaurus-plugin-sass',
+        'docusaurus-plugin-copy-page-button',
         [
             '@docusaurus/plugin-content-docs',
             {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,6 +14,7 @@
                 "@mdx-js/react": "^3.1.1",
                 "@svgr/webpack": "^8.1.0",
                 "clsx": "^2.1.1",
+                "docusaurus-plugin-copy-page-button": "^0.8.3",
                 "docusaurus-plugin-sass": "^0.2.6",
                 "file-loader": "^6.2.0",
                 "react": "^19.1.1",
@@ -8118,6 +8119,19 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/docusaurus-plugin-copy-page-button": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.8.3.tgz",
+            "integrity": "sha512-2/k4H/ePsuZUVv5S91XC2zhnIWLufHzEPTdo/6jYcvonQqHKcLK9vfOp24L5qwMO16VGhHRIEYcEVrXOshxaBw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0"
+            },
+            "peerDependencies": {
+                "@docusaurus/core": "^3.0.0",
+                "react": "^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/docusaurus-plugin-sass": {

--- a/website/package.json
+++ b/website/package.json
@@ -23,6 +23,7 @@
         "@mdx-js/react": "^3.1.1",
         "@svgr/webpack": "^8.1.0",
         "clsx": "^2.1.1",
+        "docusaurus-plugin-copy-page-button": "^0.8.3",
         "docusaurus-plugin-sass": "^0.2.6",
         "file-loader": "^6.2.0",
         "react": "^19.1.1",


### PR DESCRIPTION
Hi! This PR adds [docusaurus-plugin-copy-page-button](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) to the docs site.

It adds a "Copy page" button to each docs page that lets readers copy the page as clean markdown or open it directly in ChatGPT / Claude / Perplexity / Gemini — handy for anyone pulling docs into an LLM.

**Changes**
- Added the plugin to the `plugins` array in `website/docusaurus.config.js`
- Added `docusaurus-plugin-copy-page-button` to `dependencies`

The plugin is zero-config and auto-injects the button into the table-of-contents sidebar (falls back to the top of the article on mobile / no-TOC pages). `docusaurus build` passes locally with the plugin added.

Happy to adjust placement, styling, or which AI actions show — there are config options for all of it. Demo/showcase: https://portdeveloper.github.io/copy-page-button-showcase/

Thanks for taking a look!
