### PR TITLE
fix timer and futures example lint

### DIFF
--- a/examples/futures/src/markdown.rs
+++ b/examples/futures/src/markdown.rs
@@ -240,7 +240,9 @@ impl TagWriter {
             Event::Rule => self.add_child(VTag::new("hr").into()),
             Event::SoftBreak => self.add_child(VText::new("\n").into()),
             Event::HardBreak => self.add_child(VTag::new("br").into()),
-            _ => gloo::console::log!(format!("Unhandled event: {ev:#?}")),
+            _ => {
+                gloo::console::log!(format!("Unhandled event: {ev:#?}"));
+            }
         };
     }
 }

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -37,8 +37,9 @@ impl Component for App {
     type Properties = ();
 
     fn create(ctx: &Context<Self>) -> Self {
-        let standalone_handle =
-            Interval::new(10, || console::debug!("Example of a standalone callback."));
+        let standalone_handle = Interval::new(10, || {
+            console::debug!("Example of a standalone callback.");
+        });
 
         let clock_handle = {
             let link = ctx.link().clone();


### PR DESCRIPTION
Both impacted by trailing semicolon in macro used in expression position, which is a lint that became active recently in nightly rust.

This means that examples will currently not build with nightly rust on the main branch for size comparison, but that is fine.