### PR TITLE
chore: Stop rust-analyzer from marking all #[hook] macros as inactive…

### DIFF
--- a/packages/yew-macro/src/hook/mod.rs
+++ b/packages/yew-macro/src/hook/mod.rs
@@ -240,6 +240,7 @@ pub fn hook_impl(hook: HookFn) -> syn::Result<TokenStream> {
         }
 
         #[cfg(doctest)]
+        #[allow(rust_analyzer::inactive_code)]
         #original_fn
     };
 


### PR DESCRIPTION
#### Description

This 1-line change adds `#[allow(rust_analyzer::inactive_code)]` to the
`#[cfg(doctest)]` copy of a hooked function that `#[hook]` emits alongside the
real implementation.  A recent rust-analyzer change now diagnoses inactive
`#[cfg]` branches whose tokens trace back to user-written source, and since
that doctest-only copy reuses the original function spans verbatim, it makes
rust-analyzer grey out the hook's real body in the editor. The allow is scoped
to that inert copy only, so genuine `#[cfg]` usage inside a hook's own body is
still diagnosed normally.

<img width="730" height="217" alt="Screenshot 2026-08-23 at 11 10 04 PM" src="https://github.com/user-attachments/assets/7c4e6547-d6e5-4e3c-8f85-c5e02f7c44ca" />

This was tested by patching my local project. The inactive code warning goes away and the code is no longer greyed out.

For anyone experiencing this, a workaround in the meantime before this is merged and released is to add this to your lib.rs or main.rs:

```rust
#![allow(rust_analyzer::inactive_code)]
```

#### Checklist

- [x] I have reviewed my own code
- [x] I have added tests (N/A -- not testable because this is a rust-analyzer issue)
